### PR TITLE
feat(corpus): hydrate projectV2 fields, swap dep-graph reader (#872)

### DIFF
--- a/src/roxabi_live/corpus/graphql.py
+++ b/src/roxabi_live/corpus/graphql.py
@@ -35,6 +35,25 @@ query($owner: String!, $name: String!, $cursor: String, $since: DateTime) {
         parent { number repository { nameWithOwner } }
         blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
         blocking(first: 50) { nodes { number repository { nameWithOwner } } }
+        projectItems(first: 5) {
+          nodes {
+            project {
+              id
+            }
+            fieldValues(first: 20) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field {
+                    ... on ProjectV2FieldCommon {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/roxabi_live/corpus/schema.py
+++ b/src/roxabi_live/corpus/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pathlib
 import sqlite3
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS issues (
@@ -19,7 +19,11 @@ CREATE TABLE IF NOT EXISTS issues (
     updated_at  TEXT,
     closed_at   TEXT,
     milestone   TEXT,
-    is_stub     INTEGER NOT NULL DEFAULT 0
+    is_stub     INTEGER NOT NULL DEFAULT 0,
+    lane        TEXT,
+    priority    TEXT,
+    size        TEXT,
+    status      TEXT
 );
 
 CREATE TABLE IF NOT EXISTS labels (
@@ -48,14 +52,29 @@ CREATE INDEX IF NOT EXISTS ix_labels_name ON labels(name);
 """
 
 
-def _migrate(conn: sqlite3.Connection) -> None:
-    """Apply incremental migrations to existing DBs."""
+def _alter_column(conn: sqlite3.Connection, sql: str) -> None:
+    """Execute an ALTER TABLE ADD COLUMN statement, ignoring duplicate-column errors."""
     try:
-        conn.execute("ALTER TABLE edges ADD COLUMN kind TEXT NOT NULL DEFAULT 'parent'")
+        conn.execute(sql)
         conn.commit()
     except sqlite3.OperationalError as exc:
         if "duplicate column" not in str(exc).lower():
             raise
+
+
+def _migrate(conn: sqlite3.Connection) -> None:
+    """Apply incremental migrations to existing DBs."""
+    # Migration 1 — edges.kind (SCHEMA_VERSION 1 -> 2)
+    _alter_column(
+        conn, "ALTER TABLE edges ADD COLUMN kind TEXT NOT NULL DEFAULT 'parent'"
+    )
+
+    # Migration 2 — projectV2 fields on issues (SCHEMA_VERSION 2 -> 3)
+    # One call per column so a failure on column N is not swallowed by column N+1.
+    _alter_column(conn, "ALTER TABLE issues ADD COLUMN lane TEXT")
+    _alter_column(conn, "ALTER TABLE issues ADD COLUMN priority TEXT")
+    _alter_column(conn, "ALTER TABLE issues ADD COLUMN size TEXT")
+    _alter_column(conn, "ALTER TABLE issues ADD COLUMN status TEXT")
 
 
 def bootstrap(db_path: pathlib.Path) -> None:

--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -72,19 +72,28 @@ def _parse_project_fields(
     }
     if not canonical_project_id:
         return null_result
-    items = node.get("projectItems", {}).get("nodes", [])
+    project_items: dict[str, Any] = node.get("projectItems") or {}
+    items: list[Any] = project_items.get("nodes") or []
     for item in items:
-        if (item.get("project") or {}).get("id") == canonical_project_id:
+        item_dict: dict[str, Any] = item or {}
+        project: dict[str, Any] = item_dict.get("project") or {}
+        if project.get("id") == canonical_project_id:
             fields: dict[str, str | None] = {
                 "lane": None,
                 "priority": None,
                 "size": None,
                 "status": None,
             }
-            for fv in (item.get("fieldValues") or {}).get("nodes", []):
-                fname = ((fv.get("field") or {}).get("name") or "").lower()
+            fv_container: dict[str, Any] = item_dict.get("fieldValues") or {}
+            fv_nodes: list[Any] = fv_container.get("nodes") or []
+            for fv in fv_nodes:
+                fv_dict: dict[str, Any] = fv or {}
+                field_obj: dict[str, Any] = fv_dict.get("field") or {}
+                raw_name: Any = field_obj.get("name")
+                fname = (str(raw_name) if raw_name is not None else "").lower()
                 if fname in fields:
-                    fields[fname] = fv.get("name")
+                    raw_val: Any = fv_dict.get("name")
+                    fields[fname] = str(raw_val) if raw_val is not None else None
             return fields
     if items:
         print(
@@ -256,7 +265,9 @@ def run_repo_sync(
                 "created_at": node["createdAt"],
                 "updated_at": node["updatedAt"],
                 "closed_at": node["closedAt"],
-                "milestone": (node["milestone"] or {}).get("title"),
+                "milestone": (
+                    (node["milestone"] or {}).get("title")  # type: ignore[union-attr]
+                ),
                 "is_stub": 0,
             }
             issue.update(_parse_project_fields(node, canonical_project_id))

--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -7,6 +7,7 @@ in roxabi_live.corpus.graphql.
 
 from __future__ import annotations
 
+import os
 import re
 import sqlite3
 import sys
@@ -26,13 +27,81 @@ _SHORT_FORM = re.compile(r"^#(\d+)$")
 _FULL_KEY = re.compile(r"^[\w.-]+/[\w.-]+#\d+$")
 
 
+def _load_project_ids() -> dict[str, str]:
+    """Parse CORPUS_PROJECT_IDS=owner/repo:project_node_id,... into a dict.
+
+    Defaults to the four known Roxabi hub project IDs when env var is absent.
+    """
+    raw = os.environ.get("CORPUS_PROJECT_IDS", "")
+    if raw.strip():
+        result: dict[str, str] = {}
+        for pair in raw.split(","):
+            pair = pair.strip()
+            if ":" in pair:
+                repo, _, project_id = pair.partition(":")
+                if repo and project_id:
+                    result[repo.strip()] = project_id.strip()
+        return result
+    # Default: four known Roxabi hub project IDs
+    return {
+        "Roxabi/lyra": "PVT_kwDOB8J6DM4BQrDj",
+        "Roxabi/llmCLI": "PVT_kwDOB8J6DM4BU-5r",
+        "Roxabi/voiceCLI": "PVT_kwDOB8J6DM4BQrEv",
+        "Roxabi/imageCLI": "PVT_kwDOB8J6DM4BQzJC",
+    }
+
+
+_CORPUS_PROJECT_IDS: dict[str, str] = _load_project_ids()
+
+
+def _parse_project_fields(
+    node: dict[str, Any], canonical_project_id: str | None
+) -> dict[str, str | None]:
+    """Extract lane/priority/size/status from a GraphQL issue node's projectItems.
+
+    Returns all-None dict when canonical_project_id is None or when the issue
+    is not enrolled in the canonical project. Logs a stderr warning when
+    projectItems nodes exist but none match the configured project ID
+    (signals misconfiguration vs. genuine non-enrollment).
+    """
+    null_result: dict[str, str | None] = {
+        "lane": None,
+        "priority": None,
+        "size": None,
+        "status": None,
+    }
+    if not canonical_project_id:
+        return null_result
+    items = node.get("projectItems", {}).get("nodes", [])
+    for item in items:
+        if (item.get("project") or {}).get("id") == canonical_project_id:
+            fields: dict[str, str | None] = {
+                "lane": None,
+                "priority": None,
+                "size": None,
+                "status": None,
+            }
+            for fv in (item.get("fieldValues") or {}).get("nodes", []):
+                fname = ((fv.get("field") or {}).get("name") or "").lower()
+                if fname in fields:
+                    fields[fname] = fv.get("name")
+            return fields
+    if items:
+        print(
+            f"[corpus] projectItems present but none matched project"
+            f" {canonical_project_id!r} — check CORPUS_PROJECT_IDS config",
+            file=sys.stderr,
+        )
+    return null_result
+
+
 def canonical_key(ref: int | str, repo: str) -> str:
     """Canonicalise an issue reference to 'owner/repo#N' form.
 
-    - int 42 + 'Roxabi/lyra' → 'Roxabi/lyra#42'
-    - '42' + 'Roxabi/lyra' → 'Roxabi/lyra#42'
-    - '#9' + 'Roxabi/lyra' → 'Roxabi/lyra#9'
-    - 'Roxabi/voiceCLI#7' + anything → 'Roxabi/voiceCLI#7' (pass-through)
+    - int 42 + 'Roxabi/lyra' -> 'Roxabi/lyra#42'
+    - '42' + 'Roxabi/lyra' -> 'Roxabi/lyra#42'
+    - '#9' + 'Roxabi/lyra' -> 'Roxabi/lyra#9'
+    - 'Roxabi/voiceCLI#7' + anything -> 'Roxabi/voiceCLI#7' (pass-through)
 
     Raises ValueError on invalid input.
     """
@@ -55,15 +124,16 @@ def upsert_issue(conn: sqlite3.Connection, issue: dict[str, Any]) -> None:
     Uses ON CONFLICT DO UPDATE so FK children (labels) are preserved across
     upserts — INSERT OR REPLACE would trigger ON DELETE CASCADE first.
     Expected keys: key, repo, number, title, state, url, created_at,
-    updated_at, closed_at (nullable), milestone (nullable), is_stub (0 or 1).
+    updated_at, closed_at (nullable), milestone (nullable), is_stub (0 or 1),
+    lane (nullable), priority (nullable), size (nullable), status (nullable).
     """
     conn.execute(
         """
         INSERT INTO issues
             (key, repo, number, title, state, url, created_at, updated_at,
-             closed_at, milestone, is_stub)
+             closed_at, milestone, is_stub, lane, priority, size, status)
         VALUES
-            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(key) DO UPDATE SET
             repo = excluded.repo,
             number = excluded.number,
@@ -74,7 +144,11 @@ def upsert_issue(conn: sqlite3.Connection, issue: dict[str, Any]) -> None:
             updated_at = excluded.updated_at,
             closed_at = excluded.closed_at,
             milestone = excluded.milestone,
-            is_stub = excluded.is_stub
+            is_stub = excluded.is_stub,
+            lane = excluded.lane,
+            priority = excluded.priority,
+            size = excluded.size,
+            status = excluded.status
         """,
         (
             issue["key"],
@@ -88,6 +162,10 @@ def upsert_issue(conn: sqlite3.Connection, issue: dict[str, Any]) -> None:
             issue["closed_at"],
             issue["milestone"],
             issue["is_stub"],
+            issue["lane"],
+            issue["priority"],
+            issue["size"],
+            issue["status"],
         ),
     )
 
@@ -108,11 +186,11 @@ def upsert_edges(
     blocking: list[str],
     kind: str = "parent",
 ) -> None:
-    """Wipe all edges touching issue_key (as src OR dst) of the same kind, then rewrite rows.
+    """Wipe all edges touching issue_key (as src OR dst) of the same kind, then rewrite.
 
     Canonical direction:
-    - Every blocker b in blocked_by → row (src=b, dst=issue_key).
-    - Every blockee b in blocking → row (src=issue_key, dst=b).
+    - Every blocker b in blocked_by -> row (src=b, dst=issue_key).
+    - Every blockee b in blocking -> row (src=issue_key, dst=b).
 
     Idempotent. Duplicate (src, dst) pairs coalesce via PRIMARY KEY.
     All inputs are assumed already canonical — caller must use canonical_key first.
@@ -151,6 +229,7 @@ def run_repo_sync(
     Returns counts dict: {"pages": N, "issues": N}.
     """
     repo = f"{owner}/{name}"
+    canonical_project_id = _CORPUS_PROJECT_IDS.get(repo)
     cursor: str | None = None
     pages = 0
     total_issues = 0
@@ -167,7 +246,7 @@ def run_repo_sync(
 
         for node in nodes:
             key = canonical_key(node["number"], repo)
-            issue = {
+            issue: dict[str, Any] = {
                 "key": key,
                 "repo": repo,
                 "number": node["number"],
@@ -180,6 +259,7 @@ def run_repo_sync(
                 "milestone": (node["milestone"] or {}).get("title"),
                 "is_stub": 0,
             }
+            issue.update(_parse_project_fields(node, canonical_project_id))
             upsert_issue(conn, issue)
 
             labels = [n["name"] for n in node["labels"]["nodes"]]
@@ -192,7 +272,16 @@ def run_repo_sync(
                 for t in node.get("subIssues", {}).get("nodes", [])
             ]
             parent_node = node.get("parent")
-            parents = [canonical_key(parent_node["number"], parent_node["repository"]["nameWithOwner"])] if parent_node else []
+            parents = (
+                [
+                    canonical_key(
+                        parent_node["number"],
+                        parent_node["repository"]["nameWithOwner"],
+                    )
+                ]
+                if parent_node
+                else []
+            )
 
             # Dependency relationships (blockedBy/blocking)
             # Edge direction: src=blocker, dst=blocked
@@ -252,7 +341,7 @@ def enumerate_org_repos(org: str) -> list[tuple[str, str]]:
 def closed_hop_pass(conn: sqlite3.Connection) -> int:
     """Find edge rows whose endpoints are missing from issues and stub-fetch them.
 
-    Select DISTINCT keys from edges (src_key ∪ dst_key) that don't appear in issues.
+    Select DISTINCT keys from edges (src_key u dst_key) that don't appear in issues.
     For each missing key, fetch minimal metadata via GraphQL and INSERT with is_stub=1.
 
     Returns the number of stubs inserted.
@@ -300,6 +389,10 @@ def closed_hop_pass(conn: sqlite3.Connection) -> int:
             "closed_at": node["closedAt"],
             "milestone": None,
             "is_stub": 1,
+            "lane": None,
+            "priority": None,
+            "size": None,
+            "status": None,
         }
         upsert_issue(conn, stub)
         inserted += 1

--- a/src/roxabi_live/dep_graph/v5/data/corpus.py
+++ b/src/roxabi_live/dep_graph/v5/data/corpus.py
@@ -14,8 +14,6 @@ from roxabi_live.corpus.schema import connect as _connect_corpus
 
 DEFAULT_DB = Path.home() / ".roxabi" / "corpus.db"
 
-LANE_LABEL_PREFIX = "graph:lane/"
-SIZE_LABEL_PREFIX = "size:"
 STANDALONE_LABEL = "graph:standalone"
 DEFER_LABEL = "graph:defer"
 
@@ -49,34 +47,27 @@ def load_issues(db_path: Path | None = None) -> dict[str, dict[str, Any]]:
         conn.close()
 
 
-def _project_lane_size(labels: list[str]) -> tuple[str | None, str | None]:
-    """Project lane_label + size from a label list.
+def _project_fields(
+    lane: str | None,
+    priority: str | None,
+    size: str | None,
+    status: str | None,
+) -> dict[str, str | None]:
+    """Map corpus.db projectV2 column values to the v5 projected-dict keys.
 
-    SINGLE SWAP POINT for the cross-repo taxonomy migration:
-      1. `Roxabi/roxabi-plugins#119` enrolls every issue in the Roxabi Hub
-         Project V2 and backfills the Lane/Size single-select fields.
-      2. `Roxabi/lyra#872` then extends corpus.db with `lane` / `size`
-         columns pulled from `projectV2.items`, and flips the body of this
-         function to read those columns instead of the label prefixes.
-
-    Do NOT inline this function into load_issues — the indirection is the
-    point; the whole migration is one function's worth of code change.
+    Key `lane_label` is preserved (not renamed to `lane`) — v5 consumers
+    already reference issue["lane_label"] and renaming would break all
+    downstream callers without a separate migration.
     """
-    lane: str | None = None
-    size: str | None = None
-
-    for lbl in labels:
-        if lane is None and lbl.startswith(LANE_LABEL_PREFIX):
-            lane = lbl[len(LANE_LABEL_PREFIX) :]
-        if size is None and lbl.startswith(SIZE_LABEL_PREFIX):
-            size = lbl[len(SIZE_LABEL_PREFIX) :]
-        if lane is not None and size is not None:
-            break
-
-    return lane, size
+    return {
+        "lane_label": lane,
+        "priority": priority,
+        "size": size,
+        "status": status,
+    }
 
 
-# ─── Private helpers ──────────────────────────────────────────────────────────
+# --- Private helpers ----------------------------------------------------------
 
 
 def _fetch_labels(conn: sqlite3.Connection) -> dict[str, list[str]]:
@@ -107,8 +98,8 @@ def _fetch_edges(
     """Return (blocking_by_key, blocked_by_key) from the edges table.
 
     edge (src, dst) means src blocks dst:
-      blocking_by_key[src]  → refs of issues that src blocks
-      blocked_by_key[dst]   → refs of issues that block dst
+      blocking_by_key[src]  -> refs of issues that src blocks
+      blocked_by_key[dst]   -> refs of issues that block dst
     """
     blocking_by_key: dict[str, list[dict[str, Any]]] = {}
     blocked_by_key: dict[str, list[dict[str, Any]]] = {}
@@ -131,7 +122,8 @@ def _fetch_issues(
 
     for row in conn.execute(
         "SELECT key, repo, number, title, state, url, "
-        "created_at, updated_at, closed_at, milestone, is_stub "
+        "created_at, updated_at, closed_at, milestone, is_stub, "
+        "lane, priority, size, status "
         "FROM issues"
     ):
         (
@@ -146,13 +138,17 @@ def _fetch_issues(
             closed_at,
             milestone,
             is_stub,
+            lane,
+            priority,
+            size,
+            status,
         ) = row
 
         # Copy the label list so downstream mutation of the projected dict's
         # `labels` cannot alias back into labels_by_key (which feeds derived
         # fields below).
         labels = list(labels_by_key.get(key, []))
-        lane_label, size = _project_lane_size(labels)
+        fields = _project_fields(lane, priority, size, status)
 
         result[key] = {
             "repo": repo,
@@ -166,8 +162,10 @@ def _fetch_issues(
             "milestone": milestone,
             "is_stub": bool(is_stub),
             "labels": labels,
-            "lane_label": lane_label,
-            "size": size,
+            "lane_label": fields["lane_label"],
+            "size": fields["size"],
+            "priority": fields["priority"],
+            "status": fields["status"],
             "standalone": STANDALONE_LABEL in labels,
             "defer": DEFER_LABEL in labels,
             "blocking": blocking_by_key.get(key, []),

--- a/tests/corpus/test_schema.py
+++ b/tests/corpus/test_schema.py
@@ -16,7 +16,49 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from roxabi_live.corpus.schema import bootstrap
+from roxabi_live.corpus.schema import SCHEMA_VERSION, bootstrap
+
+# V2-era schema: issues table without the four projectV2 columns.
+# Used to seed a pre-migration DB for migration tests.
+_V2_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS issues (
+    key         TEXT PRIMARY KEY,
+    repo        TEXT NOT NULL,
+    number      INTEGER NOT NULL,
+    title       TEXT,
+    state       TEXT NOT NULL,
+    url         TEXT,
+    created_at  TEXT,
+    updated_at  TEXT,
+    closed_at   TEXT,
+    milestone   TEXT,
+    is_stub     INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS labels (
+    issue_key   TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    PRIMARY KEY (issue_key, name),
+    FOREIGN KEY (issue_key) REFERENCES issues(key) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    src_key     TEXT NOT NULL,
+    dst_key     TEXT NOT NULL,
+    kind        TEXT NOT NULL DEFAULT 'parent',
+    PRIMARY KEY (src_key, dst_key)
+);
+
+CREATE TABLE IF NOT EXISTS sync_state (
+    repo            TEXT PRIMARY KEY,
+    last_cursor     TEXT,
+    last_synced_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS ix_edges_dst ON edges(dst_key);
+CREATE INDEX IF NOT EXISTS ix_issues_repo_state ON issues(repo, state);
+CREATE INDEX IF NOT EXISTS ix_labels_name ON labels(name);
+"""
 
 
 def test_bootstrap_idempotent(tmp_path: Path) -> None:
@@ -79,3 +121,37 @@ def test_schema_has_no_body_column(tmp_path: Path) -> None:
     assert "body_hash" not in columns, (
         "Column 'body_hash' found in issues table — spec says to drop it"
     )
+
+
+def test_migrate_adds_projectv2_columns(tmp_path: Path) -> None:
+    """bootstrap() on a v2 DB adds lane/priority/size/status without error."""
+    # Arrange — seed a v2-era DB (issues table without the four columns)
+    db_path = tmp_path / "corpus.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_V2_SCHEMA_SQL)
+    conn.close()
+
+    # Act — bootstrap must apply migration 2
+    bootstrap(db_path)
+
+    # Assert — all four new columns exist
+    conn = sqlite3.connect(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(issues)").fetchall()}
+        user_version = conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert {"lane", "priority", "size", "status"} <= cols, (
+        f"Missing projectV2 columns. Found: {cols}"
+    )
+    assert user_version == SCHEMA_VERSION, (
+        f"Expected user_version={SCHEMA_VERSION}, got {user_version}"
+    )
+
+
+def test_migrate_idempotent_on_v3(tmp_path: Path) -> None:
+    """Calling bootstrap() twice on a v3 DB is safe (duplicate column guard)."""
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    bootstrap(db_path)  # must not raise

--- a/tests/corpus/test_sync.py
+++ b/tests/corpus/test_sync.py
@@ -20,121 +20,130 @@ from roxabi_live.corpus.sync import (
     upsert_issue,
 )
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_ISSUE: dict[str, Any] = {
+    "key": "Roxabi/lyra#1",
+    "repo": "Roxabi/lyra",
+    "number": 1,
+    "title": "x",
+    "state": "open",
+    "url": "https://github.com/Roxabi/lyra/issues/1",
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+    "closed_at": None,
+    "milestone": None,
+    "is_stub": 0,
+    "lane": None,
+    "priority": None,
+    "size": None,
+    "status": None,
+}
+
+
+def _make_graphql_response(issue_node: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a single issue node in the full GraphQL response envelope."""
+    return {
+        "data": {
+            "repository": {
+                "issues": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [issue_node],
+                }
+            },
+            "rateLimit": {
+                "cost": 1,
+                "remaining": 4999,
+                "resetAt": "2026-04-21T10:00:00Z",
+            },
+        }
+    }
+
+
+def _base_node(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Minimal GraphQL issue node with empty relationship fields."""
+    node: dict[str, Any] = {
+        "number": 1,
+        "title": "Test issue",
+        "state": "OPEN",
+        "url": "https://github.com/Roxabi/lyra/issues/1",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "closedAt": None,
+        "milestone": None,
+        "labels": {"nodes": []},
+        "subIssues": {"nodes": []},
+        "parent": None,
+        "blockedBy": {"nodes": []},
+        "blocking": {"nodes": []},
+        "projectItems": {"nodes": []},
+    }
+    if extra:
+        node.update(extra)
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Existing tests (unchanged contract)
+# ---------------------------------------------------------------------------
+
 
 def test_edge_dedup(tmp_path: Path) -> None:
-    """upsert_edges() called twice must not create duplicate rows.
-
-    The canonical direction is always (blocker → blocked), so a
-    blocked_by=["Roxabi/lyra#2"] on src "Roxabi/lyra#1" must produce the
-    row src_key="Roxabi/lyra#2", dst_key="Roxabi/lyra#1".
-    """
-    # Arrange
+    """upsert_edges() called twice must not create duplicate rows."""
     db_path = tmp_path / "corpus.db"
     bootstrap(db_path)
     conn = connect(db_path)
     try:
-        upsert_issue(
-            conn,
-            {
-                "key": "Roxabi/lyra#1",
-                "repo": "Roxabi/lyra",
-                "number": 1,
-                "title": "x",
-                "state": "open",
-                "url": "https://github.com/Roxabi/lyra/issues/1",
-                "created_at": "2026-01-01T00:00:00Z",
-                "updated_at": "2026-01-01T00:00:00Z",
-                "closed_at": None,
-                "milestone": None,
-                "is_stub": 0,
-            },
-        )
-
-        # Act — call twice with identical data
-        upsert_edges(
-            conn,
-            "Roxabi/lyra#1",
-            blocked_by=["Roxabi/lyra#2"],
-            blocking=[],
-        )
-        upsert_edges(
-            conn,
-            "Roxabi/lyra#1",
-            blocked_by=["Roxabi/lyra#2"],
-            blocking=[],
-        )
-
-        # Assert — exactly one edge row
+        upsert_issue(conn, _BASE_ISSUE)
+        upsert_edges(conn, "Roxabi/lyra#1", blocked_by=["Roxabi/lyra#2"], blocking=[])
+        upsert_edges(conn, "Roxabi/lyra#1", blocked_by=["Roxabi/lyra#2"], blocking=[])
         count = conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
         assert count == 1, f"Expected 1 edge row, got {count}"
-
-        # Assert — canonical direction: blocker is src, blocked is dst
         row = conn.execute("SELECT src_key, dst_key FROM edges").fetchone()
-        assert row == ("Roxabi/lyra#2", "Roxabi/lyra#1"), (
-            f"Expected canonical (blocker→blocked) row, got {row}"
-        )
+        assert row == ("Roxabi/lyra#2", "Roxabi/lyra#1")
     finally:
         conn.close()
 
 
 def test_canonical_key() -> None:
-    """canonical_key() normalises issue refs to 'owner/repo#N' form."""
-    # Arrange / Act / Assert — bare integer in repo context
     assert canonical_key(42, "Roxabi/lyra") == "Roxabi/lyra#42"
-
-    # Arrange / Act / Assert — already-qualified cross-repo ref passes through
     assert canonical_key("Roxabi/voiceCLI#7", "Roxabi/lyra") == "Roxabi/voiceCLI#7"
-
-    # Arrange / Act / Assert — same-repo short form "#N" resolves to full key
     assert canonical_key("#9", "Roxabi/lyra") == "Roxabi/lyra#9"
 
 
-def test_rate_limit_log(capsys) -> None:
-    """log_rate_limit() writes a structured line to stderr."""
-    # Arrange
+def test_rate_limit_log(capsys: pytest.CaptureFixture[str]) -> None:
     rl = {"cost": 3, "remaining": 4997, "resetAt": "2026-04-21T10:00:00Z"}
-
-    # Act
     log_rate_limit(rl)
-
-    # Assert
     captured = capsys.readouterr()
     assert re.search(
         r"\[corpus\] cost=3 remaining=4997 reset=2026-04-21T10:00:00Z",
         captured.err,
-    ), f"Expected structured rate-limit line in stderr, got: {captured.err!r}"
+    )
 
 
 def test_closed_hop_triggers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """closed_hop_pass must fetch stubs for referenced-but-missing blocker keys."""
     from roxabi_live.corpus.sync import closed_hop_pass  # noqa: PLC0415
 
-    # Arrange
     db_path = tmp_path / "corpus.db"
     bootstrap(db_path)
     conn = connect(db_path)
-
-    # One open issue in Roxabi/lyra, blocked by a key that is NOT yet in issues.
     upsert_issue(
         conn,
         {
+            **_BASE_ISSUE,
             "key": "Roxabi/lyra#100",
-            "repo": "Roxabi/lyra",
             "number": 100,
             "title": "needs closed ancestor",
-            "state": "open",
             "url": "https://github.com/Roxabi/lyra/issues/100",
-            "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-02T00:00:00Z",
-            "closed_at": None,
-            "milestone": None,
-            "is_stub": 0,
         },
     )
     upsert_edges(conn, "Roxabi/lyra#100", blocked_by=["Roxabi/lyra#42"], blocking=[])
     conn.commit()
 
-    # Mock gh_graphql so closed_hop_pass receives a canned response for #42.
     def fake_gh_graphql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
         return {
             "data": {
@@ -158,18 +167,136 @@ def test_closed_hop_triggers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
         }
 
     monkeypatch.setattr("roxabi_live.corpus.sync.gh_graphql", fake_gh_graphql)
-
-    # Act
     closed_hop_pass(conn)
 
-    # Assert — stub row exists with is_stub=1
     row = conn.execute(
         "SELECT key, state, is_stub, title FROM issues WHERE key = ?",
         ("Roxabi/lyra#42",),
     ).fetchone()
     conn.close()
-    assert row is not None, "closed_hop_pass should have upserted Roxabi/lyra#42"
+    assert row is not None
     assert row[0] == "Roxabi/lyra#42"
     assert row[1] == "closed"
     assert row[2] == 1
     assert row[3] == "ancient closed blocker"
+
+
+# ---------------------------------------------------------------------------
+# New V2 tests — projectV2 field hydration
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_issue_stores_projectv2_fields(tmp_path: Path) -> None:
+    """upsert_issue writes lane/priority/size/status columns (AC-5)."""
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+    try:
+        issue = {
+            **_BASE_ISSUE,
+            "lane": "a1",
+            "priority": "P1",
+            "size": "M",
+            "status": "In Progress",
+        }
+        upsert_issue(conn, issue)
+        conn.commit()
+        row = conn.execute(
+            "SELECT lane, priority, size, status FROM issues WHERE key = ?",
+            ("Roxabi/lyra#1",),
+        ).fetchone()
+        assert row == ("a1", "P1", "M", "In Progress"), f"Got {row}"
+    finally:
+        conn.close()
+
+
+def test_run_repo_sync_hydrates_projectv2_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_repo_sync with a mocked gh_graphql writes project fields (AC-7)."""
+    from roxabi_live.corpus import sync  # noqa: PLC0415
+    from roxabi_live.corpus.sync import run_repo_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+
+    project_node = _base_node(
+        {
+            "projectItems": {
+                "nodes": [
+                    {
+                        "project": {"id": "PVT_TEST"},
+                        "fieldValues": {
+                            "nodes": [
+                                {
+                                    "name": "a1",
+                                    "field": {"name": "Lane"},
+                                },
+                                {
+                                    "name": "P1",
+                                    "field": {"name": "Priority"},
+                                },
+                                {
+                                    "name": "M",
+                                    "field": {"name": "Size"},
+                                },
+                                {
+                                    "name": "In Progress",
+                                    "field": {"name": "Status"},
+                                },
+                            ]
+                        },
+                    }
+                ]
+            }
+        }
+    )
+
+    monkeypatch.setattr(
+        "roxabi_live.corpus.sync.gh_graphql",
+        lambda q, v: _make_graphql_response(project_node),
+    )
+    monkeypatch.setattr(
+        sync,
+        "_CORPUS_PROJECT_IDS",
+        {"Roxabi/lyra": "PVT_TEST"},
+    )
+
+    run_repo_sync(conn, "Roxabi", "lyra")
+
+    row = conn.execute(
+        "SELECT lane, priority, size, status FROM issues LIMIT 1"
+    ).fetchone()
+    conn.close()
+    assert row == ("a1", "P1", "M", "In Progress"), f"Got {row}"
+
+
+def test_run_repo_sync_null_project_fields_on_no_enrollment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """projectItems nodes=[] -> all four columns NULL, no error (AC-8)."""
+    from roxabi_live.corpus import sync  # noqa: PLC0415
+    from roxabi_live.corpus.sync import run_repo_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+
+    monkeypatch.setattr(
+        "roxabi_live.corpus.sync.gh_graphql",
+        lambda q, v: _make_graphql_response(_base_node()),
+    )
+    monkeypatch.setattr(
+        sync,
+        "_CORPUS_PROJECT_IDS",
+        {"Roxabi/lyra": "PVT_TEST"},
+    )
+
+    run_repo_sync(conn, "Roxabi", "lyra")
+
+    row = conn.execute(
+        "SELECT lane, priority, size, status FROM issues LIMIT 1"
+    ).fetchone()
+    conn.close()
+    assert row == (None, None, None, None), f"Got {row}"

--- a/tests/dep_graph/v5/test_corpus.py
+++ b/tests/dep_graph/v5/test_corpus.py
@@ -55,10 +55,7 @@ def test_project_fields_exact_ac9() -> None:
 
 def test_no_label_prefix_constants_in_v5_corpus() -> None:
     """AC-3: LANE_LABEL_PREFIX and SIZE_LABEL_PREFIX must not appear in corpus.py."""
-    src = (
-        Path(__file__).parents[3]
-        / "src/roxabi_live/dep_graph/v5/data/corpus.py"
-    )
+    src = Path(__file__).parents[3] / "src/roxabi_live/dep_graph/v5/data/corpus.py"
     for constant in ("LANE_LABEL_PREFIX", "SIZE_LABEL_PREFIX"):
         result = subprocess.run(
             ["grep", "-n", constant, str(src)],
@@ -151,10 +148,10 @@ def test_load_issues_projects_all_fields(tmp_path: Path) -> None:
     assert issue["title"] == "Test issue"
     assert issue["state"] == "open"
     assert set(issue["labels"]) == {"graph:lane/a1", "size:M", "graph:standalone"}
-    assert issue["lane_label"] == "a1"      # sourced from DB column
-    assert issue["size"] == "M"             # sourced from DB column
-    assert issue["priority"] == "P1"        # sourced from DB column
-    assert issue["status"] == "Ready"       # sourced from DB column
+    assert issue["lane_label"] == "a1"  # sourced from DB column
+    assert issue["size"] == "M"  # sourced from DB column
+    assert issue["priority"] == "P1"  # sourced from DB column
+    assert issue["status"] == "Ready"  # sourced from DB column
     assert issue["standalone"] is True
     assert issue["defer"] is False
     assert issue["milestone"] == "M1 alpha"

--- a/tests/dep_graph/v5/test_corpus.py
+++ b/tests/dep_graph/v5/test_corpus.py
@@ -1,78 +1,81 @@
-"""Tests for v5.data.corpus — corpus.db adapter + lane/size projector.
-
-RED state: scripts/dep-graph/v5/data/corpus.py does not exist yet.
-All tests will fail with ModuleNotFoundError until T2 (implementation) lands.
+"""Tests for v5.data.corpus — corpus.db adapter + projectV2 field reader.
 
 Tests cover:
-- _project_lane_size() — unit tests for the isolated label projector
+- _project_fields() — unit tests for the column-based projector
 - load_issues() — integration tests seeding a real sqlite DB via
   roxabi_live.corpus.schema.bootstrap + raw INSERTs, asserting the projected
   issue dict shape matches spec §Data Model.
+- Static grep gate: LANE_LABEL_PREFIX / SIZE_LABEL_PREFIX must not appear
+  in the production corpus.py (AC-3).
 """
 
 from __future__ import annotations
 
 import sqlite3
+import subprocess
 from pathlib import Path
 
 import pytest
 
-from roxabi_live.dep_graph.v5.data.corpus import _project_lane_size, load_issues
+from roxabi_live.dep_graph.v5.data.corpus import _project_fields, load_issues
 
-# ─── Unit: _project_lane_size ────────────────────────────────────────────────
-
-
-def test_project_lane_size_strips_prefixes() -> None:
-    """First graph:lane/* and size:* labels are stripped to bare values."""
-    # Arrange
-    labels = ["graph:lane/a2", "size:S", "foo"]
-
-    # Act
-    lane, size = _project_lane_size(labels)
-
-    # Assert
-    assert lane == "a2"
-    assert size == "S"
+# --- Unit: _project_fields ---------------------------------------------------
 
 
-def test_project_lane_size_first_wins() -> None:
-    """When multiple matching labels exist, the first match wins."""
-    # Arrange
-    labels = ["graph:lane/a1", "graph:lane/a2", "size:S", "size:M"]
-
-    # Act
-    lane, size = _project_lane_size(labels)
-
-    # Assert
-    assert lane == "a1"
-    assert size == "S"
+def test_project_fields_reads_columns() -> None:
+    """_project_fields() returns correct dict from column values (AC-9)."""
+    fields = _project_fields("a2", "P1", "S", "Ready")
+    assert fields == {
+        "lane_label": "a2",
+        "priority": "P1",
+        "size": "S",
+        "status": "Ready",
+    }
 
 
-def test_project_lane_size_returns_none_when_absent() -> None:
-    """Returns (None, None) when neither graph:lane/ nor size: labels present."""
-    # Arrange
-    labels = ["graph:standalone", "priority:high", "unrelated"]
-
-    # Act
-    lane, size = _project_lane_size(labels)
-
-    # Assert
-    assert lane is None
-    assert size is None
+def test_project_fields_none_columns() -> None:
+    """All-None column args -> all-None dict values (AC-9)."""
+    fields = _project_fields(None, None, None, None)
+    assert all(v is None for v in fields.values())
 
 
-def test_project_lane_size_empty_labels() -> None:
-    """Degenerate case: empty label list → (None, None) — exercised for
-    every issue with no labels in _fetch_issues."""
-    assert _project_lane_size([]) == (None, None)
+def test_project_fields_exact_ac9() -> None:
+    """AC-9 exact assertion: _project_fields('a1','P1','M','In Progress')."""
+    result = _project_fields("a1", "P1", "M", "In Progress")
+    assert result == {
+        "lane_label": "a1",
+        "priority": "P1",
+        "size": "M",
+        "status": "In Progress",
+    }
 
 
-# ─── Integration: load_issues ────────────────────────────────────────────────
+# --- Static grep gate (AC-3) -------------------------------------------------
+
+
+def test_no_label_prefix_constants_in_v5_corpus() -> None:
+    """AC-3: LANE_LABEL_PREFIX and SIZE_LABEL_PREFIX must not appear in corpus.py."""
+    src = (
+        Path(__file__).parents[3]
+        / "src/roxabi_live/dep_graph/v5/data/corpus.py"
+    )
+    for constant in ("LANE_LABEL_PREFIX", "SIZE_LABEL_PREFIX"):
+        result = subprocess.run(
+            ["grep", "-n", constant, str(src)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, (
+            f"{constant} still referenced in corpus.py:\n{result.stdout}"
+        )
+
+
+# --- Integration: load_issues ------------------------------------------------
 
 
 def _seed_db(db_path: Path) -> None:
     """Bootstrap schema and insert one issue with labels, no edges."""
-    from roxabi_live.corpus.schema import bootstrap
+    from roxabi_live.corpus.schema import bootstrap  # noqa: PLC0415
 
     bootstrap(db_path)
     conn = sqlite3.connect(db_path)
@@ -101,15 +104,45 @@ def _seed_db(db_path: Path) -> None:
 
 
 def test_load_issues_projects_all_fields(tmp_path: Path) -> None:
-    """Projected dict carries every field documented in spec §Data Model."""
-    # Arrange
-    db_path = tmp_path / "corpus.db"
-    _seed_db(db_path)
+    """Projected dict carries every field documented in spec §Data Model (AC-4, AC-10)."""
+    from roxabi_live.corpus.schema import bootstrap  # noqa: PLC0415
 
-    # Act
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+
+    # Seed with explicit column values for all four projectV2 fields
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """INSERT INTO issues
+                   (key, repo, number, title, state, milestone, is_stub,
+                    lane, priority, size, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "Roxabi/lyra#1",
+                "Roxabi/lyra",
+                1,
+                "Test issue",
+                "open",
+                "M1 alpha",
+                0,
+                "a1",
+                "P1",
+                "M",
+                "Ready",
+            ),
+        )
+        for label in ["graph:lane/a1", "size:M", "graph:standalone"]:
+            conn.execute(
+                "INSERT INTO labels (issue_key, name) VALUES (?, ?)",
+                ("Roxabi/lyra#1", label),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
     issues = load_issues(db_path)
 
-    # Assert
     assert "Roxabi/lyra#1" in issues
     issue = issues["Roxabi/lyra#1"]
 
@@ -118,19 +151,20 @@ def test_load_issues_projects_all_fields(tmp_path: Path) -> None:
     assert issue["title"] == "Test issue"
     assert issue["state"] == "open"
     assert set(issue["labels"]) == {"graph:lane/a1", "size:M", "graph:standalone"}
-    assert issue["lane_label"] == "a1"
+    assert issue["lane_label"] == "a1"      # sourced from DB column
+    assert issue["size"] == "M"             # sourced from DB column
+    assert issue["priority"] == "P1"        # sourced from DB column
+    assert issue["status"] == "Ready"       # sourced from DB column
     assert issue["standalone"] is True
     assert issue["defer"] is False
     assert issue["milestone"] == "M1 alpha"
-    assert issue["size"] == "M"
     assert issue["blocking"] == []
     assert issue["blocked_by"] == []
 
 
 def test_edges_populate_blocking_and_blocked_by(tmp_path: Path) -> None:
-    """Edge src blocks dst → A.blocking has B ref; B.blocked_by has A ref."""
-    # Arrange
-    from roxabi_live.corpus.schema import bootstrap
+    """Edge src blocks dst -> A.blocking has B ref; B.blocked_by has A ref."""
+    from roxabi_live.corpus.schema import bootstrap  # noqa: PLC0415
 
     db_path = tmp_path / "corpus.db"
     bootstrap(db_path)
@@ -152,16 +186,12 @@ def test_edges_populate_blocking_and_blocked_by(tmp_path: Path) -> None:
     finally:
         conn.close()
 
-    # Act
     issues = load_issues(db_path)
 
-    # Assert — A blocks B
     assert issues["Roxabi/lyra#1"]["blocking"] == [
         {"repo": "Roxabi/voiceCLI", "issue": 10}
     ]
     assert issues["Roxabi/lyra#1"]["blocked_by"] == []
-
-    # Assert — B is blocked by A
     assert issues["Roxabi/voiceCLI#10"]["blocked_by"] == [
         {"repo": "Roxabi/lyra", "issue": 1}
     ]
@@ -170,18 +200,14 @@ def test_edges_populate_blocking_and_blocked_by(tmp_path: Path) -> None:
 
 def test_missing_db_hints_make_corpus_sync(tmp_path: Path) -> None:
     """Missing db_path raises FileNotFoundError hinting at make corpus-sync."""
-    # Arrange
     db_path = tmp_path / "nonexistent.db"
-
-    # Act / Assert
     with pytest.raises(FileNotFoundError, match="make corpus-sync"):
         load_issues(db_path)
 
 
 def test_load_issues_is_stub_true_projection(tmp_path: Path) -> None:
-    """is_stub=1 in SQLite → is_stub: True in projected dict."""
-    # Arrange
-    from roxabi_live.corpus.schema import bootstrap
+    """is_stub=1 in SQLite -> is_stub: True in projected dict."""
+    from roxabi_live.corpus.schema import bootstrap  # noqa: PLC0415
 
     db_path = tmp_path / "corpus.db"
     bootstrap(db_path)
@@ -196,18 +222,13 @@ def test_load_issues_is_stub_true_projection(tmp_path: Path) -> None:
     finally:
         conn.close()
 
-    # Act
     issues = load_issues(db_path)
-
-    # Assert
     assert issues["Roxabi/lyra#1"]["is_stub"] is True
 
 
 def test_load_issues_dangling_edge_produces_orphan_ref(tmp_path: Path) -> None:
-    """Edge whose dst_key has no issues row → src.blocking still lists the
-    orphan ref (downstream compute_visible filters on `rk in issues`)."""
-    # Arrange
-    from roxabi_live.corpus.schema import bootstrap
+    """Edge whose dst_key has no issues row -> src.blocking still lists the orphan ref."""
+    from roxabi_live.corpus.schema import bootstrap  # noqa: PLC0415
 
     db_path = tmp_path / "corpus.db"
     bootstrap(db_path)
@@ -218,7 +239,6 @@ def test_load_issues_dangling_edge_produces_orphan_ref(tmp_path: Path) -> None:
                VALUES (?, ?, ?, ?, ?, ?)""",
             ("Roxabi/lyra#1", "Roxabi/lyra", 1, "A", "open", 0),
         )
-        # Edge points at a key that has no issues row.
         conn.execute(
             "INSERT INTO edges (src_key, dst_key) VALUES (?, ?)",
             ("Roxabi/lyra#1", "Roxabi/voiceCLI#999"),
@@ -227,10 +247,8 @@ def test_load_issues_dangling_edge_produces_orphan_ref(tmp_path: Path) -> None:
     finally:
         conn.close()
 
-    # Act
     issues = load_issues(db_path)
 
-    # Assert — orphan ref present on src side; no phantom issues entry.
     assert issues["Roxabi/lyra#1"]["blocking"] == [
         {"repo": "Roxabi/voiceCLI", "issue": 999}
     ]

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -5,4 +5,4 @@ src/roxabi_live/dep_graph/v1/fetch.py  # 474 lines — legacy v1, frozen for v6 
 src/roxabi_live/dep_graph/v1/milestone.py  # 580 lines — legacy v1, frozen for v6 migration
 src/roxabi_live/dep_graph/v1/audit.py  # 419 lines — legacy v1, frozen for v6 migration
 src/roxabi_live/dep_graph/v1/derive.py  # 308 lines — legacy v1, frozen for v6 migration
-src/roxabi_live/corpus/sync.py  # 320 lines — migrated from lyra, minor over limit
+src/roxabi_live/corpus/sync.py  # 431 lines — #872 adds _parse_project_fields + upsert 11->15

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -5,4 +5,4 @@ src/roxabi_live/dep_graph/v1/fetch.py  # 474 lines — legacy v1, frozen for v6 
 src/roxabi_live/dep_graph/v1/milestone.py  # 580 lines — legacy v1, frozen for v6 migration
 src/roxabi_live/dep_graph/v1/audit.py  # 419 lines — legacy v1, frozen for v6 migration
 src/roxabi_live/dep_graph/v1/derive.py  # 308 lines — legacy v1, frozen for v6 migration
-src/roxabi_live/corpus/sync.py  # 431 lines — #872 adds _parse_project_fields + upsert 11->15
+src/roxabi_live/corpus/sync.py  # 442 lines — #872 adds _parse_project_fields + upsert 11->15


### PR DESCRIPTION
## Summary

- **Schema migration v2→v3**: adds `lane`, `priority`, `size`, `status` columns to the corpus `issues` table (SQLite `ALTER TABLE` migration with null-safe defaults)
- **GraphQL projectV2 hydration**: new extension in `corpus/` calls GitHub GraphQL API to resolve ProjectV2 field values per issue and writes them into the corpus after each sync
- **dep-graph reader swap**: v5 reader now reads `lane`/`priority`/`size`/`status` directly from corpus columns instead of parsing labels — removes brittle label-fallback logic

Closes Roxabi/lyra#872

## Commits

| SHA | Message |
|-----|---------|
| `39b8b80` | feat(corpus): add lane/priority/size/status columns to issues schema |
| `271a3ac` | feat(corpus): hydrate projectV2 fields via GraphQL extension |
| `e44d7d8` | refactor(dep-graph): swap v5 reader to use corpus columns; remove label fallback |
| `7128fba` | fix(corpus): satisfy pyright strict on _parse_project_fields + update exemption |

## Acceptance Criteria

- [x] Schema v3 migration runs cleanly on existing corpus (null-safe)
- [x] ProjectV2 fields hydrated after sync — `lane`, `priority`, `size`, `status` populated
- [x] dep-graph reader reads corpus columns (no label parsing fallback)
- [x] 20 pytest passed, ruff clean, pyright 0 errors
- [x] `file_exemptions` updated for new module