### PR TITLE
fix(v6): read lane/priority/size/status from corpus columns

### DIFF
--- a/src/roxabi_live/dep_graph/v6/api.py
+++ b/src/roxabi_live/dep_graph/v6/api.py
@@ -11,7 +11,7 @@ from typing import TypedDict
 
 import aiosqlite
 
-from .parse import derive_lane_size, derive_priority, parse_milestone
+from .parse import parse_milestone
 
 
 class Node(TypedDict):
@@ -29,6 +29,7 @@ class Node(TypedDict):
     priority: str | None
     lane: str | None
     size: str | None
+    status: str | None
     is_stub: bool
 
 
@@ -55,15 +56,14 @@ async def build_graph_json(db_path: Path) -> GraphPayload:
 
         nodes: list[Node] = []
         async with db.execute(
-            "SELECT key, repo, number, title, state, url, milestone, is_stub "
-            "FROM issues"
+            "SELECT key, repo, number, title, state, url, milestone, "
+            "lane, priority, size, status, is_stub FROM issues"
         ) as cur:
             async for row in cur:
                 issue_labels = labels_by_issue.get(row["key"], [])
                 milestone_code, milestone_name, milestone_sort_key = parse_milestone(
                     row["milestone"]
                 )
-                lane, size = derive_lane_size(issue_labels)
                 nodes.append(
                     Node(
                         key=row["key"],
@@ -77,9 +77,10 @@ async def build_graph_json(db_path: Path) -> GraphPayload:
                         milestone_name=milestone_name,
                         milestone_sort_key=milestone_sort_key,
                         labels=issue_labels,
-                        priority=derive_priority(issue_labels),
-                        lane=lane,
-                        size=size,
+                        priority=row["priority"],
+                        lane=row["lane"],
+                        size=row["size"],
+                        status=row["status"],
                         is_stub=bool(row["is_stub"]),
                     )
                 )

--- a/src/roxabi_live/dep_graph/v6/frontend/app.js
+++ b/src/roxabi_live/dep_graph/v6/frontend/app.js
@@ -80,7 +80,6 @@ function render() {
 
   pivotControls.style.display = isTable ? '' : 'none';
   if (listControls) listControls.style.display = isList ? '' : 'none';
-  if (graphControls) graphControls.style.display = isGraph ? '' : 'none';
 
   searchClear.hidden = !state.search;
   updateSubtitle();
@@ -142,10 +141,11 @@ function buildGraphSegs() {
   parentsSeg.type = 'button';
   parentsSeg.className = 'seg' + (state.showParents ? ' on' : '');
   parentsSeg.textContent = 'Parents';
+  parentsSeg.title = 'Show parent (epic) issues';
   parentsSeg.addEventListener('click', () => {
     setState({ showParents: !state.showParents });
     buildGraphSegs();
-    initGraph();
+    render();
   });
   container.innerHTML = '';
   container.appendChild(parentsSeg);

--- a/src/roxabi_live/dep_graph/v6/frontend/graph.js
+++ b/src/roxabi_live/dep_graph/v6/frontend/graph.js
@@ -109,16 +109,9 @@ export async function initGraph() {
   const panel = document.getElementById('graph-panel');
   if (!panel) return;
 
-  // Graph filters by repo/milestone/priority/status, but search uses highlight
-  let nodes = filteredNodesForGraph();
-
-  // When showParents=false, exclude nodes that are parents (have children)
-  if (!state.showParents) {
-    const parentKeys = new Set(
-      state.edges.filter(e => e.kind === 'parent').map(e => e.src)
-    );
-    nodes = nodes.filter(n => !parentKeys.has(n.key));
-  }
+  // Graph filters by repo/milestone/priority/status, but search uses highlight.
+  // Parent-node filtering (showParents=false) is applied inside applyFilters.
+  const nodes = filteredNodesForGraph();
 
   const nodeKeys = new Set(nodes.map(n => n.key));
 

--- a/src/roxabi_live/dep_graph/v6/frontend/index.html
+++ b/src/roxabi_live/dep_graph/v6/frontend/index.html
@@ -79,10 +79,9 @@
       <div class="segs" id="list-group2-segs" role="group" aria-label="Secondary grouping"></div>
     </span>
 
-    <!-- Graph-only: Parent edges toggle -->
-    <span class="graph-controls" id="graph-controls" style="display:none">
-      <span class="toolbar-label">Edges</span>
-      <div class="segs" id="graph-edge-segs" role="group" aria-label="Edge visibility"></div>
+    <!-- Shared: hide parent issues in all views (+ parent edges in graph) -->
+    <span class="graph-controls" id="graph-controls">
+      <div class="segs" id="graph-edge-segs" role="group" aria-label="Parent visibility"></div>
     </span>
   </div>
 </div>

--- a/src/roxabi_live/dep_graph/v6/frontend/state.js
+++ b/src/roxabi_live/dep_graph/v6/frontend/state.js
@@ -188,7 +188,11 @@ export function dimValue(node, dim) {
 // ─── Filter application ───────────────────────────────────────────────────
 export function applyFilters(nodes, filters) {
   const q = (filters.search ?? '').trim().toLowerCase();
+  const parentKeys = state.showParents
+    ? null
+    : new Set(state.edges.filter(e => e.kind === 'parent').map(e => e.src));
   return nodes.filter(n => {
+    if (parentKeys && parentKeys.has(n.key)) return false;
     if (filters.repo.length && !filters.repo.includes(n.repo)) return false;
     const msCode = n.milestone_code ?? '(None)';
     if (filters.milestone.length && !filters.milestone.includes(msCode)) return false;

--- a/tests/dep_graph/v6/test_api.py
+++ b/tests/dep_graph/v6/test_api.py
@@ -27,21 +27,17 @@ def db(tmp_path: Path) -> Path:
     conn.executescript(
         """
         INSERT INTO issues
-          (key, repo, number, title, state, url, milestone, is_stub)
+          (key, repo, number, title, state, url, milestone,
+           lane, priority, size, status, is_stub)
         VALUES
           ('Roxabi/x#1', 'Roxabi/x', 1, 't1', 'OPEN', 'https://x/1',
-           'M0 — NATS hardening', 0),
+           'M0 — NATS hardening', 'infra', 'P1', 'S', 'Ready', 0),
           ('Roxabi/x#2', 'Roxabi/x', 2, 't2', 'CLOSED', 'https://x/2',
-           'Phase 0 — Foundation', 0),
+           'Phase 0 — Foundation', NULL, 'P2', 'M', 'Done', 0),
           ('Roxabi/y#3', 'Roxabi/y', 3, 't3', 'OPEN', 'https://y/3',
-           'Final Initiatives', 0);
+           'Final Initiatives', NULL, 'P3', NULL, NULL, 0);
         INSERT INTO labels (issue_key, name) VALUES
-          ('Roxabi/x#1', 'S'),
-          ('Roxabi/x#1', 'P1-high'),
-          ('Roxabi/x#1', 'graph:lane/infra'),
-          ('Roxabi/x#2', 'size:M'),
-          ('Roxabi/x#2', 'priority:medium'),
-          ('Roxabi/y#3', 'priority:low');
+          ('Roxabi/x#1', 'graph:lane/infra');
         INSERT INTO edges (src_key, dst_key, kind) VALUES
           ('Roxabi/x#2', 'Roxabi/x#1', 'parent'),
           ('Roxabi/x#1', 'Roxabi/y#3', 'blocks');


### PR DESCRIPTION
## Summary

- v6 API was missed by #872 — still parsed lane/size/priority from labels via `derive_lane_size`/`derive_priority`. Now reads the projectV2 columns directly from `issues`.
- Adds `status` to the Node payload (was missing).
- Updates `tests/dep_graph/v6/test_api.py` fixture to seed the new columns.

Also folds in pending frontend work that broadens the `showParents` toggle from graph-only to all views (table/list).

## Test plan
- [x] `uv run pytest` — 449 passed
- [x] `uv run ruff check .` — clean
- [ ] visual: open `http://localhost:8000/v6/`, confirm Size column populated for #716 and friends

🤖 Generated with [Claude Code](https://claude.com/claude-code)