### PR TITLE
fix(v6): restore lane label fallback in API

### DIFF
--- a/src/roxabi_live/dep_graph/v6/api.py
+++ b/src/roxabi_live/dep_graph/v6/api.py
@@ -13,6 +13,16 @@ import aiosqlite
 
 from .parse import parse_milestone
 
+_LANE_LABEL_PREFIX = "graph:lane/"
+
+
+def _lane_from_labels(labels: list[str]) -> str | None:
+    """Fallback: derive lane from `graph:lane/X` label when board field unset."""
+    for lbl in labels:
+        if lbl.startswith(_LANE_LABEL_PREFIX):
+            return lbl[len(_LANE_LABEL_PREFIX):]
+    return None
+
 
 class Node(TypedDict):
     key: str
@@ -78,7 +88,7 @@ async def build_graph_json(db_path: Path) -> GraphPayload:
                         milestone_sort_key=milestone_sort_key,
                         labels=issue_labels,
                         priority=row["priority"],
-                        lane=row["lane"],
+                        lane=row["lane"] or _lane_from_labels(issue_labels),
                         size=row["size"],
                         status=row["status"],
                         is_stub=bool(row["is_stub"]),

--- a/src/roxabi_live/dep_graph/v6/frontend/pivot.js
+++ b/src/roxabi_live/dep_graph/v6/frontend/pivot.js
@@ -11,19 +11,9 @@ const LANE_TONES = {
   'd': 'd', 'e': 'e', 'f': 'f', 'g': 'g', 'h': 'h', 'i': 'i'
 };
 
-// Repo → tone fallback (deterministic) when lane is unset.
-// TODO: drop once Lane field is populated on every project board.
-const REPO_TONE_PALETTE = ['a1', 'a2', 'b', 'c1', 'd', 'e', 'f', 'g', 'h', 'i'];
-function repoTone(repo) {
-  if (!repo) return '';
-  let h = 0;
-  for (let i = 0; i < repo.length; i++) h = (h * 31 + repo.charCodeAt(i)) | 0;
-  return REPO_TONE_PALETTE[Math.abs(h) % REPO_TONE_PALETTE.length];
-}
-
 function getTone(node) {
   const lane = node.lane?.toLowerCase();
-  return LANE_TONES[lane] || repoTone(node.repo);
+  return LANE_TONES[lane] || '';
 }
 
 // ─── Collapse tracking for epic groups ───────────────────────────────────────

--- a/src/roxabi_live/dep_graph/v6/frontend/render_graph.js
+++ b/src/roxabi_live/dep_graph/v6/frontend/render_graph.js
@@ -11,19 +11,9 @@ const LANE_TONES = {
   'd': 'd', 'e': 'e', 'f': 'f', 'g': 'g', 'h': 'h', 'i': 'i'
 };
 
-// Repo → tone fallback (deterministic) when lane is unset.
-// TODO: drop once Lane field is populated on every project board.
-const REPO_TONE_PALETTE = ['a1', 'a2', 'b', 'c1', 'd', 'e', 'f', 'g', 'h', 'i'];
-function repoTone(repo) {
-  if (!repo) return 'accent';
-  let h = 0;
-  for (let i = 0; i < repo.length; i++) h = (h * 31 + repo.charCodeAt(i)) | 0;
-  return REPO_TONE_PALETTE[Math.abs(h) % REPO_TONE_PALETTE.length];
-}
-
 function getTone(node) {
   const lane = node.lane?.toLowerCase();
-  return LANE_TONES[lane] || repoTone(node.repo);
+  return LANE_TONES[lane] || 'accent';
 }
 
 // ── Render nodes as .gg-node dots + .gg-ilabel labels (v4.8 style) ───────────


### PR DESCRIPTION
Per-repo tone fallback was useless when one repo dominates. Read lane from graph:lane/X label when board Lane field is unset.