### PR TITLE
fix(#43): close spec-compliance gap missed by PR #55

### DIFF
--- a/deploy/supervisor/conf.d/cloudflared.conf
+++ b/deploy/supervisor/conf.d/cloudflared.conf
@@ -5,7 +5,7 @@ environment=HOME="%(ENV_HOME)s",PATH="%(ENV_PATH)s",CLOUDFLARED_TUNNEL_NAME="%(E
 user=mickael
 priority=200
 autostart=false
-autorestart=true
+autorestart=false
 startsecs=5
 startretries=3
 stopwaitsecs=10

--- a/src/roxabi_live/api/issues.py
+++ b/src/roxabi_live/api/issues.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import re
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -16,18 +18,30 @@ def _db_path() -> Path:
     return Path(os.environ.get("CORPUS_DB_PATH", Path.home() / ".roxabi" / "corpus.db"))
 
 
+def _parse_key(key: str) -> tuple[str, int | None]:
+    """Parse 'owner/repo#N' → (repo, number).  Returns (key, None) on failure."""
+    m = re.match(r"^(.+)#(\d+)$", key)
+    if m:
+        return m.group(1), int(m.group(2))
+    return key, None
+
+
 @router.get("/issues")
 async def list_issues(
     repo: str | None = None,
     state: str | None = None,
     label: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """Return all issues matching the given filters.
 
     Query params (all optional, combinable):
-      - repo:  exact repo name match
-      - state: exact state match (open / closed)
-      - label: issue must have this label (EXISTS subquery)
+      - repo:   exact repo name match
+      - state:  exact state match (open / closed)
+      - label:  issue must have this label (EXISTS subquery)
+      - limit:  max rows to return (default 100)
+      - offset: row offset for pagination (default 0)
     """
     conditions: list[str] = []
     params: list[Any] = []
@@ -51,39 +65,60 @@ async def list_issues(
 
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
-    sql = f"""
+    count_sql = f"SELECT COUNT(*) FROM issues {where}"
+
+    data_sql = f"""
         SELECT issues.key, issues.repo, issues.number, issues.title,
-               issues.state, issues.updated_at
+               issues.state, issues.url, issues.milestone, issues.is_stub,
+               issues.created_at, issues.updated_at, issues.closed_at
         FROM issues
         {where}
         ORDER BY issues.updated_at ASC
+        LIMIT ? OFFSET ?
     """
 
     async with aiosqlite.connect(_db_path()) as db:
         db.row_factory = aiosqlite.Row
-        async with db.execute(sql, params) as cur:
+
+        async with db.execute(count_sql, params) as cnt_cur:
+            cnt_row = await cnt_cur.fetchone()
+        total = cnt_row[0] if cnt_row else 0
+
+        async with db.execute(data_sql, [*params, limit, offset]) as cur:
             rows = await cur.fetchall()
 
-        items: list[dict[str, Any]] = []
+        labels_by_key: dict[str, list[str]] = defaultdict(list)
+        if rows:
+            keys = [row["key"] for row in rows]
+            placeholders = ",".join("?" * len(keys))
+            lbl_sql = (
+                f"SELECT issue_key, name FROM labels"
+                f" WHERE issue_key IN ({placeholders}) ORDER BY name"
+            )
+            async with db.execute(lbl_sql, keys) as lc:
+                async for lr in lc:
+                    labels_by_key[str(lr["issue_key"])].append(str(lr["name"]))
+
+        issues: list[dict[str, Any]] = []
         for row in rows:
-            async with db.execute(
-                "SELECT name FROM labels WHERE issue_key = ? ORDER BY name",
-                (row["key"],),
-            ) as lc:
-                label_rows = await lc.fetchall()
-            items.append(
+            issues.append(
                 {
                     "key": row["key"],
                     "repo": row["repo"],
                     "number": row["number"],
                     "title": row["title"],
                     "state": row["state"],
+                    "url": row["url"],
+                    "labels": labels_by_key[row["key"]],
+                    "milestone": row["milestone"],
+                    "is_stub": bool(row["is_stub"]),
+                    "created_at": row["created_at"],
                     "updated_at": row["updated_at"],
-                    "labels": [lr["name"] for lr in label_rows],
+                    "closed_at": row["closed_at"],
                 }
             )
 
-    return {"total": len(items), "items": items}
+    return {"issues": issues, "total": total, "limit": limit, "offset": offset}
 
 
 @router.get("/issues/{key:path}")
@@ -93,7 +128,8 @@ async def get_issue(key: str) -> dict[str, Any]:
         db.row_factory = aiosqlite.Row
 
         sql = (
-            "SELECT key, repo, number, title, state, updated_at"
+            "SELECT key, repo, number, title, state, url, milestone, is_stub,"
+            " created_at, updated_at, closed_at"
             " FROM issues WHERE key = ?"
         )
         async with db.execute(sql, (key,)) as cur:
@@ -108,21 +144,55 @@ async def get_issue(key: str) -> dict[str, Any]:
         ) as lc:
             labels = [r["name"] for r in await lc.fetchall()]
 
+        # blocking: edges where this issue is src (kind=blocks) → dst issues
         async with db.execute(
-            "SELECT dst_key FROM edges WHERE src_key = ? AND kind = 'blocks'",
+            "SELECT e.dst_key, i.number, i.repo"
+            " FROM edges e"
+            " LEFT JOIN issues i ON i.key = e.dst_key"
+            " WHERE e.src_key = ? AND e.kind = 'blocks'",
             (key,),
         ) as bc:
-            blocking = [r["dst_key"] for r in await bc.fetchall()]
+            blocking_rows = await bc.fetchall()
 
+        # blocked_by: edges where this issue is dst (kind=blocks) → src issues
         async with db.execute(
-            "SELECT src_key FROM edges WHERE dst_key = ? AND kind = 'blocks'",
+            "SELECT e.src_key, i.number, i.repo"
+            " FROM edges e"
+            " LEFT JOIN issues i ON i.key = e.src_key"
+            " WHERE e.dst_key = ? AND e.kind = 'blocks'",
             (key,),
         ) as bbc:
-            blocked_by = [r["src_key"] for r in await bbc.fetchall()]
+            blocked_by_rows = await bbc.fetchall()
+
+    def _edge_item(
+        edge_key: str, number: int | None, edge_repo: str | None
+    ) -> dict[str, Any]:
+        if number is None or edge_repo is None:
+            # Stub fallback: parse from key
+            parsed_repo, parsed_number = _parse_key(edge_key)
+            return {"key": edge_key, "number": parsed_number, "repo": parsed_repo}
+        return {"key": edge_key, "number": number, "repo": edge_repo}
+
+    blocking = [
+        _edge_item(r["dst_key"], r["number"], r["repo"]) for r in blocking_rows
+    ]
+    blocked_by = [
+        _edge_item(r["src_key"], r["number"], r["repo"]) for r in blocked_by_rows
+    ]
 
     return {
-        **dict(row),
+        "key": row["key"],
+        "repo": row["repo"],
+        "number": row["number"],
+        "title": row["title"],
+        "state": row["state"],
+        "url": row["url"],
         "labels": labels,
+        "milestone": row["milestone"],
+        "is_stub": bool(row["is_stub"]),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "closed_at": row["closed_at"],
         "blocking": blocking,
         "blocked_by": blocked_by,
     }

--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -2,9 +2,11 @@
 
 import asyncio
 import logging
+import os
+import sqlite3
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
@@ -19,11 +21,17 @@ from roxabi_live.webhook.router import router as webhook_router
 
 log = logging.getLogger(__name__)
 
+_DEFAULT_DB = Path.home() / ".roxabi" / "corpus.db"
+
+
+def _db_path() -> Path:
+    return Path(os.environ.get("CORPUS_DB_PATH", _DEFAULT_DB))
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     log.info("reconciler startup sync scheduled")
-    asyncio.create_task(reconciler.run_once())
+    await reconciler.run_once()
     loop_task = reconciler.hourly_loop()
     try:
         yield
@@ -53,9 +61,26 @@ async def _root() -> RedirectResponse:
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
-    """Health check — smoke test only.
-
-    Full implementation (db_reachable, issue_count) lands in spec #866 slice 3.
-    """
-    return {"status": "ok"}
+async def health() -> dict[str, Any]:
+    """Health check — returns db path, reachability, and issue count."""
+    db = _db_path()
+    db_reachable = False
+    issue_count = 0
+    try:
+        conn = sqlite3.connect(db)
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM issues").fetchone()
+            issue_count = row[0]
+            db_reachable = True
+        except sqlite3.OperationalError:
+            pass
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return {
+        "status": "ok",
+        "db": str(db),
+        "db_reachable": db_reachable,
+        "issue_count": issue_count,
+    }

--- a/src/roxabi_live/dep_graph/v6/repos.py
+++ b/src/roxabi_live/dep_graph/v6/repos.py
@@ -1,9 +1,10 @@
-"""v6 repos route — distinct repos from the corpus DB."""
+"""v6 repos route — repos and sync state from corpus DB."""
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 import aiosqlite
 from fastapi import APIRouter
@@ -16,9 +17,21 @@ def _db_path() -> Path:
 
 
 @router.get("/repos")
-async def get_repos() -> list[str]:
-    """Return distinct repos from issues, sorted alphabetically."""
+async def get_repos() -> dict[str, Any]:
+    """Return repos and their sync state from sync_state table."""
     async with aiosqlite.connect(_db_path()) as db:
-        async with db.execute("SELECT DISTINCT repo FROM issues ORDER BY repo") as cur:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT repo, last_synced_at, last_cursor FROM sync_state ORDER BY repo"
+        ) as cur:
             rows = await cur.fetchall()
-    return [row[0] for row in rows]
+    return {
+        "repos": [
+            {
+                "repo": row["repo"],
+                "last_synced_at": row["last_synced_at"],
+                "last_cursor": row["last_cursor"],
+            }
+            for row in rows
+        ]
+    }

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -68,7 +68,7 @@ def hourly_loop(interval_seconds: float | None = None) -> asyncio.Task[None]:
 
     async def _loop() -> None:
         while True:
-            await run_once()
             await asyncio.sleep(interval_seconds)  # type: ignore[arg-type]
+            await run_once()
 
     return asyncio.create_task(_loop())

--- a/tests/dep_graph/v6/test_api.py
+++ b/tests/dep_graph/v6/test_api.py
@@ -175,5 +175,7 @@ async def test_get_repos(db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         resp = await client.get("/api/repos")
 
     assert resp.status_code == 200
-    repos = resp.json()
-    assert repos == ["Roxabi/x", "Roxabi/y"]
+    data = resp.json()
+    assert "repos" in data
+    # DB fixture has no sync_state rows → empty list
+    assert data["repos"] == []

--- a/tests/test_api_issues.py
+++ b/tests/test_api_issues.py
@@ -110,9 +110,12 @@ async def test_list_returns_all_issues(corpus_db: Path) -> None:
     # Assert
     assert status == 200, f"Expected 200, got {status}"
     assert body["total"] == 3
-    assert len(body["items"]) == 3
-    expected_keys = {"key", "repo", "number", "title", "state", "labels", "updated_at"}
-    for item in body["items"]:
+    assert len(body["issues"]) == 3
+    expected_keys = {
+        "key", "repo", "number", "title", "state", "labels", "updated_at",
+        "url", "milestone", "is_stub", "created_at", "closed_at",
+    }
+    for item in body["issues"]:
         assert expected_keys <= item.keys(), f"Missing keys in item: {item.keys()}"
 
 
@@ -124,7 +127,7 @@ async def test_list_filter_by_repo(corpus_db: Path) -> None:
     # Assert
     assert status == 200
     assert body["total"] == 2
-    assert all(item["repo"] == "repo-a" for item in body["items"])
+    assert all(item["repo"] == "repo-a" for item in body["issues"])
 
 
 async def test_list_filter_by_state(corpus_db: Path) -> None:
@@ -135,7 +138,7 @@ async def test_list_filter_by_state(corpus_db: Path) -> None:
     # Assert
     assert status == 200
     assert body["total"] == 2
-    assert all(item["state"] == "open" for item in body["items"])
+    assert all(item["state"] == "open" for item in body["issues"])
 
 
 async def test_list_filter_by_label(corpus_db: Path) -> None:
@@ -146,8 +149,8 @@ async def test_list_filter_by_label(corpus_db: Path) -> None:
     # Assert
     assert status == 200
     assert body["total"] == 1
-    assert body["items"][0]["key"] == "repo-a#1"
-    assert "bug" in body["items"][0]["labels"]
+    assert body["issues"][0]["key"] == "repo-a#1"
+    assert "bug" in body["issues"][0]["labels"]
 
 
 async def test_list_combined_filters(corpus_db: Path) -> None:
@@ -158,9 +161,9 @@ async def test_list_combined_filters(corpus_db: Path) -> None:
     # Assert
     assert status == 200
     assert body["total"] == 1
-    assert body["items"][0]["key"] == "repo-a#1"
-    assert body["items"][0]["state"] == "open"
-    assert body["items"][0]["repo"] == "repo-a"
+    assert body["issues"][0]["key"] == "repo-a#1"
+    assert body["issues"][0]["state"] == "open"
+    assert body["issues"][0]["repo"] == "repo-a"
 
 
 # ---------------------------------------------------------------------------
@@ -236,14 +239,18 @@ async def test_get_returns_issue_with_edges(issues_db: Path) -> None:
     assert body_blocker["number"] == 1
     assert body_blocker["title"] == "Blocker issue"
     assert "feat" in body_blocker["labels"]
-    assert body_blocker["blocking"] == ["repo1#2"]
+    assert body_blocker["blocking"] == [
+        {"key": "repo1#2", "number": 2, "repo": "repo1"}
+    ]
     assert body_blocker["blocked_by"] == []
 
     # Assert — blockee (repo1#2 is blocked by repo1#1)
     assert status_blockee == 200
     assert body_blockee["key"] == "repo1#2"
     assert body_blockee["blocking"] == []
-    assert body_blockee["blocked_by"] == ["repo1#1"]
+    assert body_blockee["blocked_by"] == [
+        {"key": "repo1#1", "number": 1, "repo": "repo1"}
+    ]
 
 
 async def test_get_unknown_key_returns_404(issues_db: Path) -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -14,4 +14,8 @@ async def test_health_ok() -> None:
         response = await client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "db" in body
+    assert isinstance(body["db_reachable"], bool)
+    assert isinstance(body["issue_count"], int)

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -81,21 +82,19 @@ class TestRunOnce:
 
     @pytest.mark.asyncio
     async def test_run_once_logs_on_error(
-        self, capfd: pytest.CaptureFixture[str]
+        self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """run_once must log (stderr or logging) when an error is caught."""
+        """run_once must log at ERROR level when an error is caught."""
         # Arrange
-        with patch(
-            "roxabi_live.corpus.sync.run_sync",
-            side_effect=RuntimeError("unexpected failure"),
-        ):
-            # Act
-            await reconciler.run_once()
-        # Assert — some indication of error in output (stderr or captured log)
-        captured = capfd.readouterr()
-        combined = captured.out + captured.err
-        # Flexible: accept any non-empty error indication
-        assert combined or True  # softer gate — stronger once implementation exists
+        with caplog.at_level(logging.ERROR, logger="roxabi_live.reconciler"):
+            with patch(
+                "roxabi_live.corpus.sync.run_sync",
+                side_effect=RuntimeError("unexpected failure"),
+            ):
+                # Act
+                await reconciler.run_once()
+        # Assert — an ERROR-level log record must have been emitted
+        assert any(rec.levelno == logging.ERROR for rec in caplog.records)
 
 
 class TestHourlyLoop:

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -114,7 +114,7 @@ def db_path(tmp_path: Path) -> Path:
 
     import asyncio
 
-    asyncio.get_event_loop().run_until_complete(_init())
+    asyncio.run(_init())
     return path
 
 
@@ -194,7 +194,7 @@ def test_post_valid_signature_issues_event(
 
     import asyncio
 
-    assert asyncio.get_event_loop().run_until_complete(_check()), (
+    assert asyncio.run(_check()), (
         "Expected issue row Roxabi/lyra#42 to be present in db"
     )
 
@@ -286,7 +286,7 @@ def test_stale_sync_triggers_reconcile(
     assert resp.status_code == 200
 
     # Drain the event loop so the fire-and-forget task executes
-    asyncio.get_event_loop().run_until_complete(asyncio.sleep(0))
+    asyncio.run(asyncio.sleep(0))
     mock_run_once.assert_called_once()
 
 
@@ -322,7 +322,7 @@ def test_fresh_sync_does_not_trigger_reconcile(
     )
     assert resp.status_code == 200
 
-    asyncio.get_event_loop().run_until_complete(asyncio.sleep(0))
+    asyncio.run(asyncio.sleep(0))
     mock_run_once.assert_not_called()
 
 
@@ -353,5 +353,5 @@ def test_missing_sync_state_triggers_reconcile(
     )
     assert resp.status_code == 200
 
-    asyncio.get_event_loop().run_until_complete(asyncio.sleep(0))
+    asyncio.run(asyncio.sleep(0))
     mock_run_once.assert_called_once()


### PR DESCRIPTION
## Summary

PR #55 merged to staging without a set of spec-compliance fixes — the code-review agents applied edits to the worktree that were never committed. This PR re-commits those fixes against the merged staging.

## What changed

| Surface | Fix |
|---|---|
| `GET /api/issues` | Returns `{issues, total, limit, offset}` with spec fields (`url, milestone, is_stub, created_at, updated_at, closed_at`); `limit`/`offset` pagination; bulk `WHERE issue_key IN (...)` label query (no N+1) |
| `GET /api/issues/:key` | `blocking`/`blocked_by` as `{key, number, repo}` objects; full field set |
| `GET /api/repos` | Queries `sync_state` → `{"repos": [{repo, last_synced_at, last_cursor}]}` |
| `GET /health` | Probes `corpus.db` → `{status, db, db_reachable, issue_count}` |
| `app.py` lifespan | Awaits `reconciler.run_once()` directly (no `create_task` orphan) |
| `reconciler.hourly_loop()` | Sleep-first pattern — avoids double startup sync |
| `cloudflared.conf` | `autorestart=false` (M₂ convention) |
| Tests | Updated to new response shapes; `caplog` for logs-on-error; `asyncio.run()` over deprecated `get_event_loop()` |

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #43: corpus live access | recovery PR |
| Implementation | 1 commit on `fix/43-spec-compliance` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (493 passing) | Passed |

## Test Plan

- [x] `uv run ruff check .` → clean
- [x] `uv run pyright` → 0 errors
- [x] `uv run pytest` → 493 passed
- [ ] CI green on PR
- [ ] Hit `/health` on deployed staging, verify `db_reachable: true` + `issue_count` present
- [ ] Hit `/api/issues?limit=5`, verify response shape matches spec

## Why it happened

During code-review, review agents with `Edit` permission (architect/backend-dev/tester/product-lead) silently patched the worktree to satisfy findings, but the fixes were never staged or committed. Subsequent `Read` calls returned the unsaved state, making the changes look already applied. Tracked for prevention in future review runs.

---
Generated with [Claude Code](https://claude.com/claude-code)