### PR TITLE
feat(api): #56 harden public API surface

### DIFF
--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -187,3 +187,67 @@ supervisorctl stop cloudflared live
 ```
 
 Set `autostart=false` for both programs on M₂ to prevent them from restarting after reboot.
+
+## Cloudflare Access (zero-trust gate)
+
+`corpus.db` contains issues from private repos. Cloudflare Access sits in front of the tunnel and redirects unauthenticated browsers to an identity provider. The GitHub webhook bypasses the gate via a service-token policy so deliveries still land at `/webhook/github`.
+
+### Step A — Create the Access application
+
+1. Zero Trust dashboard → **Access** → **Applications** → **Add application** → **Self-hosted**.
+2. Application name: `Roxabi Live Dashboard`.
+3. Subdomain: `dashboard`. Domain: `roxabi.dev`.
+4. Session duration: `24h`.
+5. **Policies** → **Add policy**
+   - Name: `Allow owner`
+   - Action: `Allow`
+   - Include selector: `Emails` → `mickael@bouly.io`
+6. Save the application.
+
+### Step B — Bypass webhook via service token
+
+1. Zero Trust → **Access** → **Service Auth** → **Service Tokens** → **Create Service Token**.
+2. Name: `github-webhook`. Duration: non-expiring (or set a rotation cadence).
+3. Copy `Client ID` and `Client Secret` immediately — the secret is shown once.
+4. Back in the `Roxabi Live Dashboard` application → **Policies** → **Add policy**
+   - Name: `GitHub webhook bypass`
+   - Action: `Service Auth`
+   - Include selector: `Service Token` → `github-webhook`
+5. Keep this policy *above* any `Deny` / `Require` policies so it evaluates first for tokenized requests. Save.
+
+### Step C — Attach the service token to the GitHub webhook
+
+GitHub's built-in webhook UI does not support custom headers directly. Two options:
+
+- **Option 1 — Cloudflare Worker trampoline (recommended):** deploy a small worker on a separate subdomain (e.g. `webhook-ingest.roxabi.dev`, not protected by Access) that injects `CF-Access-Client-Id` + `CF-Access-Client-Secret` on every inbound request and proxies to `https://dashboard.roxabi.dev/webhook/github`. Point the GitHub webhook at the worker URL.
+- **Option 2 — GitHub App with custom headers:** replace the repo webhook with a GitHub App; GitHub Apps allow custom headers via their delivery config.
+
+Either way, every proxied request to `dashboard.roxabi.dev/webhook/github` must carry:
+
+```
+CF-Access-Client-Id: <client-id>
+CF-Access-Client-Secret: <client-secret>
+```
+
+Store `Client Secret` in the worker's secret binding (never commit). Rotate via Step B on secret leak.
+
+### Step D — Verify
+
+Unauthenticated browser / curl:
+
+```bash
+curl -sI https://dashboard.roxabi.dev/api/issues | head -1
+# expected:  HTTP/2 302
+# Location redirect to <team>.cloudflareaccess.com
+```
+
+Webhook delivery:
+
+1. GitHub repo → **Settings** → **Webhooks** → pick `/webhook/github` → **Recent Deliveries**.
+2. Hit **Redeliver** on the most recent event.
+3. Response must be `200 OK`. If `302` is returned, the service-token headers are not reaching Cloudflare — re-check Step C.
+
+### Rotation
+
+- Rotate the service token: Zero Trust → Service Tokens → `github-webhook` → **Refresh**. Update the worker secret. Redeliver a test webhook to confirm.
+- Rotate the identity-provider allowlist: edit the `Allow owner` policy (Step A.5).

--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -251,3 +251,4 @@ Webhook delivery:
 
 - Rotate the service token: Zero Trust → Service Tokens → `github-webhook` → **Refresh**. Update the worker secret. Redeliver a test webhook to confirm.
 - Rotate the identity-provider allowlist: edit the `Allow owner` policy (Step A.5).
+- After a `_halted` reconciler event (CRITICAL log emitted due to repeated auth failures): rotate the GitHub token, then restart the `live` supervisor program to clear the sticky halt state: `supervisorctl restart live`. The reconciler will resume on the next hourly tick.

--- a/src/roxabi_live/api/issues.py
+++ b/src/roxabi_live/api/issues.py
@@ -26,6 +26,9 @@ def _parse_key(key: str) -> tuple[str, int | None]:
     return key, None
 
 
+ISSUE_KEY_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$")
+
+
 @router.get("/issues")
 async def list_issues(
     repo: str | None = None,
@@ -124,6 +127,11 @@ async def list_issues(
 @router.get("/issues/{key:path}")
 async def get_issue(key: str) -> dict[str, Any]:
     """Return a single issue by key, including blocking/blocked_by edge arrays."""
+    if not ISSUE_KEY_RE.fullmatch(key):
+        raise HTTPException(
+            status_code=400,
+            detail="invalid issue key; expected '<owner>/<repo>#<number>'",
+        )
     async with aiosqlite.connect(_db_path()) as db:
         db.row_factory = aiosqlite.Row
 
@@ -173,9 +181,7 @@ async def get_issue(key: str) -> dict[str, Any]:
             return {"key": edge_key, "number": parsed_number, "repo": parsed_repo}
         return {"key": edge_key, "number": number, "repo": edge_repo}
 
-    blocking = [
-        _edge_item(r["dst_key"], r["number"], r["repo"]) for r in blocking_rows
-    ]
+    blocking = [_edge_item(r["dst_key"], r["number"], r["repo"]) for r in blocking_rows]
     blocked_by = [
         _edge_item(r["src_key"], r["number"], r["repo"]) for r in blocked_by_rows
     ]

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -2,6 +2,11 @@
 
 Wraps the synchronous corpus.sync.run_sync in an async-friendly interface and
 provides a long-running hourly loop suitable for background task execution.
+
+Auth-halt behaviour: two consecutive GitHub 401/403 errors cause the loop to
+exit permanently and emit a CRITICAL log.  Transient errors (OSError, non-auth
+HTTP errors) do not increment the auth-failure counter.  A successful sync
+resets the counter to zero.
 """
 
 from __future__ import annotations
@@ -20,6 +25,10 @@ _DEFAULT_INTERVAL = 3600.0
 _DEFAULT_DB_PATH = Path.home() / ".roxabi" / "corpus.db"
 _DEFAULT_ORG = "Roxabi"
 
+_AUTH_FAILURE_THRESHOLD = 2
+_auth_failures: int = 0
+_halted: bool = False
+
 
 def _db_path() -> Path:
     return Path(os.environ.get("CORPUS_DB_PATH", _DEFAULT_DB_PATH))
@@ -29,6 +38,16 @@ def _org() -> str:
     return os.environ.get("GITHUB_ORG", _DEFAULT_ORG)
 
 
+def _is_auth_error(exc: BaseException) -> bool:
+    """True when exc looks like a GitHub 401/403."""
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if status in (401, 403):
+        return True
+    status = getattr(exc, "status", None)  # PyGithub GithubException
+    return status in (401, 403)
+
+
 async def run_once() -> None:
     """Run a single corpus sync cycle.
 
@@ -36,7 +55,14 @@ async def run_once() -> None:
     connection.  All exceptions are caught and logged — this function never
     raises so that callers (e.g. hourly_loop) remain alive through transient
     failures.
+
+    Auth-halt: two consecutive 401/403 errors set _halted=True and emit a
+    CRITICAL log.  Transient errors (OSError, non-auth HTTP errors) do not
+    increment the auth-failure counter.  A successful sync resets the counter.
     """
+    global _auth_failures, _halted
+    if _halted:
+        return
     try:
         db = _db_path()
         org = _org()
@@ -45,7 +71,17 @@ async def run_once() -> None:
             await asyncio.to_thread(corpus_sync.run_sync, conn, org)
         finally:
             conn.close()
-    except Exception:
+        _auth_failures = 0
+    except Exception as exc:
+        if _is_auth_error(exc):
+            _auth_failures += 1
+            if _auth_failures >= _AUTH_FAILURE_THRESHOLD:
+                _halted = True
+                log.critical(
+                    "reconciler halted: %d consecutive auth failures",
+                    _auth_failures,
+                )
+                return
         log.exception("reconciler run_once failed")
 
 
@@ -60,15 +96,20 @@ def hourly_loop(interval_seconds: float | None = None) -> asyncio.Task[None]:
     Returns:
         The running :class:`asyncio.Task`.  Cancel it to stop the loop; the
         task will raise :exc:`asyncio.CancelledError` on await after
-        cancellation.
+        cancellation.  The task may also exit normally if the reconciler is
+        halted due to consecutive auth failures.
     """
     if interval_seconds is None:
         raw = os.environ.get("CORPUS_SYNC_INTERVAL_SECONDS", "")
         interval_seconds = float(raw) if raw else _DEFAULT_INTERVAL
 
     async def _loop() -> None:
-        while True:
+        while not _halted:
             await asyncio.sleep(interval_seconds)  # type: ignore[arg-type]
+            if _halted:
+                break
             await run_once()
+            if _halted:
+                break
 
     return asyncio.create_task(_loop())

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -16,6 +16,7 @@ import logging
 import os
 import sqlite3
 from pathlib import Path
+from typing import cast
 
 from roxabi_live.corpus import sync as corpus_sync
 
@@ -27,7 +28,8 @@ _DEFAULT_ORG = "Roxabi"
 
 _AUTH_FAILURE_THRESHOLD = 2
 _auth_failures: int = 0
-_halted: bool = False
+_halted: asyncio.Event = asyncio.Event()
+_state_lock: asyncio.Lock = asyncio.Lock()
 
 
 def _db_path() -> Path:
@@ -39,13 +41,30 @@ def _org() -> str:
 
 
 def _is_auth_error(exc: BaseException) -> bool:
-    """True when exc looks like a GitHub 401/403."""
+    """True when exc looks like a GitHub 401/403 credential failure.
+
+    Excludes GitHub secondary rate-limit 403s (self-resolving, not an auth
+    problem) by inspecting the response body / PyGithub exception data.
+    """
     response = getattr(exc, "response", None)
     status = getattr(response, "status_code", None)
-    if status in (401, 403):
-        return True
-    status = getattr(exc, "status", None)  # PyGithub GithubException
-    return status in (401, 403)
+    if status is None:
+        status = getattr(exc, "status", None)
+    if status not in (401, 403):
+        return False
+    # 403 may be rate limit — check body
+    if status == 403:
+        text = ""
+        if response is not None:
+            text = getattr(response, "text", "") or ""
+        data: object = getattr(exc, "data", None)
+        if isinstance(data, dict):
+            typed_data = cast("dict[str, object]", data)
+            msg = typed_data.get("message", "")
+            text += " " + (str(msg) if msg is not None else "")
+        if "secondary rate limit" in text.lower() or "rate limit" in text.lower():
+            return False
+    return True
 
 
 async def run_once() -> None:
@@ -56,12 +75,12 @@ async def run_once() -> None:
     raises so that callers (e.g. hourly_loop) remain alive through transient
     failures.
 
-    Auth-halt: two consecutive 401/403 errors set _halted=True and emit a
+    Auth-halt: two consecutive 401/403 errors set _halted and emit a
     CRITICAL log.  Transient errors (OSError, non-auth HTTP errors) do not
     increment the auth-failure counter.  A successful sync resets the counter.
     """
-    global _auth_failures, _halted
-    if _halted:
+    global _auth_failures
+    if _halted.is_set():
         return
     try:
         db = _db_path()
@@ -71,17 +90,27 @@ async def run_once() -> None:
             await asyncio.to_thread(corpus_sync.run_sync, conn, org)
         finally:
             conn.close()
-        _auth_failures = 0
+        async with _state_lock:
+            _auth_failures = 0
     except Exception as exc:
         if _is_auth_error(exc):
-            _auth_failures += 1
-            if _auth_failures >= _AUTH_FAILURE_THRESHOLD:
-                _halted = True
+            async with _state_lock:
+                _auth_failures += 1
+                should_halt = _auth_failures >= _AUTH_FAILURE_THRESHOLD
+                failures = _auth_failures
+            if should_halt and not _halted.is_set():
+                _halted.set()
                 log.critical(
                     "reconciler halted: %d consecutive auth failures",
-                    _auth_failures,
+                    failures,
                 )
-                return
+            else:
+                log.warning(
+                    "reconciler auth error %d/%d",
+                    failures,
+                    _AUTH_FAILURE_THRESHOLD,
+                )
+            return
         log.exception("reconciler run_once failed")
 
 
@@ -104,12 +133,10 @@ def hourly_loop(interval_seconds: float | None = None) -> asyncio.Task[None]:
         interval_seconds = float(raw) if raw else _DEFAULT_INTERVAL
 
     async def _loop() -> None:
-        while not _halted:
+        while not _halted.is_set():
             await asyncio.sleep(interval_seconds)  # type: ignore[arg-type]
-            if _halted:
+            if _halted.is_set():
                 break
             await run_once()
-            if _halted:
-                break
 
     return asyncio.create_task(_loop())

--- a/src/roxabi_live/webhook/hmac_auth.py
+++ b/src/roxabi_live/webhook/hmac_auth.py
@@ -22,5 +22,5 @@ def verify(body: bytes, header: str | None, secret: str) -> bool:
     if not header or not header.startswith(PREFIX):
         return False
     expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
-    received = header[len(PREFIX):]
+    received = header[len(PREFIX) :]
     return hmac.compare_digest(expected, received)

--- a/src/roxabi_live/webhook/router.py
+++ b/src/roxabi_live/webhook/router.py
@@ -45,6 +45,19 @@ async def _maybe_trigger_heal(repo: str, conn: aiosqlite.Connection) -> None:
 
 
 async def _read_capped_body(request: Request) -> bytes:
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > MAX_WEBHOOK_BODY_BYTES:
+                log.warning(
+                    "webhook content-length %s exceeds cap %d; rejecting",
+                    declared,
+                    MAX_WEBHOOK_BODY_BYTES,
+                )
+                raise HTTPException(status_code=413, detail="payload too large")
+        except ValueError:
+            # Malformed Content-Length — fall through to streaming guard
+            pass
     total = 0
     chunks: list[bytes] = []
     async for chunk in request.stream():
@@ -66,14 +79,20 @@ async def github_webhook(
     x_hub_signature_256: str | None = Header(default=None),
 ) -> dict[str, object]:
     """Receive and dispatch GitHub webhook events."""
-    body = await _read_capped_body(request)
+    try:
+        body = await asyncio.wait_for(_read_capped_body(request), timeout=30.0)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=408, detail="request timeout") from None
     secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
     if not secret:
         raise HTTPException(status_code=503, detail="webhook not configured")
     if not hmac_auth.verify(body, x_hub_signature_256, secret):
         raise HTTPException(status_code=401, detail="invalid signature")
 
-    payload = json.loads(body)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="invalid JSON payload") from None
 
     async with aiosqlite.connect(_db_path()) as conn:
         if x_github_event == "issues":

--- a/src/roxabi_live/webhook/router.py
+++ b/src/roxabi_live/webhook/router.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +15,10 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from roxabi_live import reconciler
 from roxabi_live.webhook import hmac_auth
 from roxabi_live.webhook.handlers import handle_deps, handle_issues, handle_sub_issues
+
+log = logging.getLogger(__name__)
+
+MAX_WEBHOOK_BODY_BYTES = 25 * 1024 * 1024  # 25 MB
 
 router = APIRouter(tags=["webhook"])
 
@@ -38,6 +44,21 @@ async def _maybe_trigger_heal(repo: str, conn: aiosqlite.Connection) -> None:
         asyncio.create_task(reconciler.run_once())
 
 
+async def _read_capped_body(request: Request) -> bytes:
+    total = 0
+    chunks: list[bytes] = []
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > MAX_WEBHOOK_BODY_BYTES:
+            log.warning(
+                "webhook body exceeded %d bytes; rejecting",
+                MAX_WEBHOOK_BODY_BYTES,
+            )
+            raise HTTPException(status_code=413, detail="payload too large")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 @router.post("/webhook/github")
 async def github_webhook(
     request: Request,
@@ -45,14 +66,14 @@ async def github_webhook(
     x_hub_signature_256: str | None = Header(default=None),
 ) -> dict[str, object]:
     """Receive and dispatch GitHub webhook events."""
-    body = await request.body()
+    body = await _read_capped_body(request)
     secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
     if not secret:
         raise HTTPException(status_code=503, detail="webhook not configured")
     if not hmac_auth.verify(body, x_hub_signature_256, secret):
         raise HTTPException(status_code=401, detail="invalid signature")
 
-    payload = await request.json()
+    payload = json.loads(body)
 
     async with aiosqlite.connect(_db_path()) as conn:
         if x_github_event == "issues":

--- a/tests/test_api_issues.py
+++ b/tests/test_api_issues.py
@@ -48,9 +48,9 @@ CREATE TABLE IF NOT EXISTS labels (
 
 _SEED_ISSUES = [
     # (key, repo, number, title, state, updated_at)
-    ("repo-a#1", "repo-a", 1, "Issue A1 open",   "open",   "2024-01-01T00:00:00Z"),
+    ("repo-a#1", "repo-a", 1, "Issue A1 open", "open", "2024-01-01T00:00:00Z"),
     ("repo-a#2", "repo-a", 2, "Issue A2 closed", "closed", "2024-01-02T00:00:00Z"),
-    ("repo-b#1", "repo-b", 1, "Issue B1 open",   "open",   "2024-01-03T00:00:00Z"),
+    ("repo-b#1", "repo-b", 1, "Issue B1 open", "open", "2024-01-03T00:00:00Z"),
 ]
 
 _SEED_LABELS = [
@@ -90,6 +90,7 @@ def corpus_db(
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 async def _get(path: str) -> tuple[int, dict[str, Any]]:
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -102,6 +103,7 @@ async def _get(path: str) -> tuple[int, dict[str, Any]]:
 # Tests — all must return 404 until the route is implemented
 # ---------------------------------------------------------------------------
 
+
 async def test_list_returns_all_issues(corpus_db: Path) -> None:
     """No filters → total equals seeded count, items carry expected keys."""
     # Arrange — DB seeded by fixture (3 issues)
@@ -112,8 +114,18 @@ async def test_list_returns_all_issues(corpus_db: Path) -> None:
     assert body["total"] == 3
     assert len(body["issues"]) == 3
     expected_keys = {
-        "key", "repo", "number", "title", "state", "labels", "updated_at",
-        "url", "milestone", "is_stub", "created_at", "closed_at",
+        "key",
+        "repo",
+        "number",
+        "title",
+        "state",
+        "labels",
+        "updated_at",
+        "url",
+        "milestone",
+        "is_stub",
+        "created_at",
+        "closed_at",
     }
     for item in body["issues"]:
         assert expected_keys <= item.keys(), f"Missing keys in item: {item.keys()}"
@@ -185,7 +197,7 @@ CREATE TABLE IF NOT EXISTS edges (
 def issues_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """DB seeded with 2 issues and 1 blocks edge; CORPUS_DB_PATH is overridden.
 
-    repo1#1 (blocker)  --blocks-->  repo1#2 (blockee)
+    owner/repo1#1 (blocker)  --blocks-->  owner/repo1#2 (blockee)
     """
     p = tmp_path / "issues_corpus.db"
     conn = sqlite3.connect(p)
@@ -197,20 +209,20 @@ def issues_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
           (key, repo, number, title, state, url,
            created_at, updated_at, closed_at, is_stub)
         VALUES
-          ('repo1#1', 'repo1', 1, 'Blocker issue', 'open',
-           'https://github.com/repo1/issues/1',
+          ('owner/repo1#1', 'owner/repo1', 1, 'Blocker issue', 'open',
+           'https://github.com/owner/repo1/issues/1',
            '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z', NULL, 0),
-          ('repo1#2', 'repo1', 2, 'Blocked issue', 'open',
-           'https://github.com/repo1/issues/2',
+          ('owner/repo1#2', 'owner/repo1', 2, 'Blocked issue', 'open',
+           'https://github.com/owner/repo1/issues/2',
            '2026-01-01T00:00:00Z', '2026-01-03T00:00:00Z', NULL, 0);
 
         INSERT INTO labels (issue_key, name) VALUES
-          ('repo1#1', 'feat'),
-          ('repo1#2', 'bug');
+          ('owner/repo1#1', 'feat'),
+          ('owner/repo1#2', 'bug');
 
         -- src_key blocks dst_key
         INSERT INTO edges (src_key, dst_key, kind)
-        VALUES ('repo1#1', 'repo1#2', 'blocks');
+        VALUES ('owner/repo1#1', 'owner/repo1#2', 'blocks');
         """
     )
     conn.commit()
@@ -229,27 +241,27 @@ async def test_get_returns_issue_with_edges(issues_db: Path) -> None:
     """Seed 2 issues + 1 blocks edge; GET each and verify blocking/blocked_by arrays."""
     # Arrange — DB seeded by issues_db fixture
     # Act
-    status_blocker, body_blocker = await _get("/api/issues/repo1%231")
-    status_blockee, body_blockee = await _get("/api/issues/repo1%232")
+    status_blocker, body_blocker = await _get("/api/issues/owner%2Frepo1%231")
+    status_blockee, body_blockee = await _get("/api/issues/owner%2Frepo1%232")
 
-    # Assert — blocker (repo1#1 blocks repo1#2)
+    # Assert — blocker (owner/repo1#1 blocks owner/repo1#2)
     assert status_blocker == 200
-    assert body_blocker["key"] == "repo1#1"
-    assert body_blocker["repo"] == "repo1"
+    assert body_blocker["key"] == "owner/repo1#1"
+    assert body_blocker["repo"] == "owner/repo1"
     assert body_blocker["number"] == 1
     assert body_blocker["title"] == "Blocker issue"
     assert "feat" in body_blocker["labels"]
     assert body_blocker["blocking"] == [
-        {"key": "repo1#2", "number": 2, "repo": "repo1"}
+        {"key": "owner/repo1#2", "number": 2, "repo": "owner/repo1"}
     ]
     assert body_blocker["blocked_by"] == []
 
-    # Assert — blockee (repo1#2 is blocked by repo1#1)
+    # Assert — blockee (owner/repo1#2 is blocked by owner/repo1#1)
     assert status_blockee == 200
-    assert body_blockee["key"] == "repo1#2"
+    assert body_blockee["key"] == "owner/repo1#2"
     assert body_blockee["blocking"] == []
     assert body_blockee["blocked_by"] == [
-        {"key": "repo1#1", "number": 1, "repo": "repo1"}
+        {"key": "owner/repo1#1", "number": 1, "repo": "owner/repo1"}
     ]
 
 
@@ -257,32 +269,113 @@ async def test_get_unknown_key_returns_404(issues_db: Path) -> None:
     """GET /api/issues/{key} with an unknown key must return 404."""
     # Arrange — no issue with number 999
     # Act
-    status, body = await _get("/api/issues/repo1%23999")
+    status, body = await _get("/api/issues/owner%2Frepo1%23999")
     # Assert
     assert status == 404
     assert body == {"detail": "Issue not found"}
 
 
 async def test_get_url_encoded_hash(issues_db: Path) -> None:
-    """Key ``repo1#42`` is accessed via URL ``/api/issues/repo1%2342``.
+    """Key ``owner/repo1#42`` is accessed via URL ``/api/issues/owner%2Frepo1%2342``.
 
-    %23 is the percent-encoding for '#'.  The route must decode it before
-    looking up the issue in the DB.
+    %23 is the percent-encoding for '#', %2F for '/'.  The route must decode
+    them before looking up the issue in the DB.
     """
     # Arrange — insert an extra issue specifically for this key
     conn = sqlite3.connect(issues_db)
     conn.execute(
         "INSERT INTO issues (key, repo, number, title, state, url, is_stub) "
-        "VALUES ('repo1#42', 'repo1', 42, 'URL-encoded hash test', 'open', "
-        "'https://github.com/repo1/issues/42', 0)"
+        "VALUES ('owner/repo1#42', 'owner/repo1', 42, 'URL-encoded hash test', 'open', "
+        "'https://github.com/owner/repo1/issues/42', 0)"
     )
     conn.commit()
     conn.close()
 
     # Act
-    status, body = await _get("/api/issues/repo1%2342")
+    status, body = await _get("/api/issues/owner%2Frepo1%2342")
 
     # Assert
     assert status == 200
-    assert body["key"] == "repo1#42"
+    assert body["key"] == "owner/repo1#42"
     assert body["number"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Tests — T4 [RED]: strict key validation on GET /api/issues/{key:path}
+# Production regex: ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        "foo",
+        "not-a-key",
+        "owner/repo",
+        "no-slash#42",
+        "a/b#notanumber",
+    ],
+)
+async def test_get_issue_invalid_key_returns_400(issues_db: Path, bad_key: str) -> None:
+    """Malformed key (not matching <owner>/<repo>#<number>) must return 400.
+
+    The route must reject the request before touching the DB.
+    """
+    # Arrange — bad_key does not match ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$
+    encoded = bad_key.replace("#", "%23").replace("/", "%2F")
+    # Act
+    status, body = await _get(f"/api/issues/{encoded}")
+    # Assert
+    assert status == 400, f"Expected 400 for key {bad_key!r}, got {status}"
+    assert "detail" in body
+    detail = body["detail"].lower()
+    # Detail must hint at the expected shape
+    assert "<owner>" in detail or "owner" in detail or "#" in detail, (
+        f"Detail does not mention expected shape: {body['detail']!r}"
+    )
+
+
+async def test_get_issue_traversal_returns_400(issues_db: Path) -> None:
+    """Path-traversal attempt must be rejected with 400, never 404 or 500."""
+    # Arrange — percent-encoded traversal sequence
+    traversal_path = "..%2F..%2Fetc%2Fpasswd"
+    # Act
+    status, body = await _get(f"/api/issues/{traversal_path}")
+    # Assert
+    assert status == 400, f"Expected 400 for traversal path, got {status}"
+    assert "detail" in body
+
+
+async def test_get_issue_valid_present_returns_200(issues_db: Path) -> None:
+    """A valid-shaped key that exists in the DB must return 200.
+
+    Uses owner/repo#N format (Roxabi/roxabi-live style) seeded explicitly.
+    """
+    # Arrange — insert a fully-qualified owner/repo#N issue
+    conn = sqlite3.connect(issues_db)
+    conn.execute(
+        "INSERT INTO issues (key, repo, number, title, state, url, is_stub) "
+        "VALUES ('Roxabi/roxabi-live#1', 'Roxabi/roxabi-live', 1, "
+        "'Valid key test', 'open', 'https://github.com/Roxabi/roxabi-live/issues/1', 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    encoded_key = "Roxabi%2Froxabi-live%231"
+    # Act
+    status, body = await _get(f"/api/issues/{encoded_key}")
+    # Assert
+    assert status == 200, f"Expected 200 for valid present key, got {status}"
+    assert body["key"] == "Roxabi/roxabi-live#1"
+    assert body["number"] == 1
+
+
+async def test_get_issue_valid_absent_returns_404(issues_db: Path) -> None:
+    """A valid-shaped key that is absent from the DB must return 404, not 400/500."""
+    # Arrange — key has correct shape but is not seeded
+    encoded_key = "Roxabi%2Froxabi-live%2399999"
+    # Act
+    status, body = await _get(f"/api/issues/{encoded_key}")
+    # Assert
+    assert status == 404, f"Expected 404 for valid-shaped absent key, got {status}"
+    assert body == {"detail": "Issue not found"}

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -15,8 +15,33 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests.exceptions
 
 from roxabi_live import reconciler  # noqa: F401 — expected ImportError in RED phase
+
+
+def _make_http_error(status_code: int) -> requests.exceptions.HTTPError:
+    """Build a requests.exceptions.HTTPError with a fake response."""
+    exc = requests.exceptions.HTTPError("HTTP error")
+    exc.response = MagicMock(status_code=status_code)
+    return exc
+
+
+def _success_dict() -> dict[str, int]:
+    return {"repos": 1, "pages": 1, "issues": 10, "stubs": 0, "errors": 0}
+
+
+@pytest.fixture(autouse=True)
+def reset_reconciler_auth_state() -> None:
+    """Reset auth-failure counters before each test (no-op in RED phase).
+
+    Once T8 adds _auth_failures / _halted to the reconciler module these
+    assignments ensure tests start from a clean state.
+    """
+    if hasattr(reconciler, "_auth_failures"):
+        reconciler._auth_failures = 0  # type: ignore[attr-defined]
+    if hasattr(reconciler, "_halted"):
+        reconciler._halted = False  # type: ignore[attr-defined]
 
 
 class TestRunOnce:
@@ -30,7 +55,11 @@ class TestRunOnce:
             "roxabi_live.corpus.sync.run_sync",
             new_callable=MagicMock,
             return_value={
-                "repos": 1, "pages": 1, "issues": 10, "stubs": 0, "errors": 0
+                "repos": 1,
+                "pages": 1,
+                "issues": 10,
+                "stubs": 0,
+                "errors": 0,
             },
         ):
             # Act
@@ -152,6 +181,7 @@ class TestHourlyLoop:
     async def test_hourly_loop_cancels_cleanly(self) -> None:
         """Cancelling the task returned by hourly_loop must not raise unhandled
         exceptions."""
+
         # Arrange
         async def fake_run_once() -> None:
             pass
@@ -191,4 +221,138 @@ class TestHourlyLoop:
         # Assert
         assert call_count >= 2, (
             f"hourly_loop should use env interval; got {call_count} calls"
+        )
+
+
+class TestAuthHalt:
+    """reconciler.hourly_loop() — auth-aware halt on consecutive 401/403 errors."""
+
+    @pytest.mark.asyncio
+    async def test_two_consecutive_auth_errors_halt_loop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Two consecutive 401 errors from run_sync must exit hourly_loop and emit
+        a CRITICAL log mentioning 'halt' or 'auth'."""
+        # Arrange
+        monkeypatch.setenv("CORPUS_DB_PATH", str(tmp_path / "corpus.db"))
+        err_401 = _make_http_error(401)
+        with caplog.at_level(logging.CRITICAL, logger="roxabi_live.reconciler"):
+            with patch(
+                "roxabi_live.corpus.sync.run_sync",
+                side_effect=[err_401, err_401],
+            ):
+                # Act — hourly_loop should exit on its own (not require cancellation)
+                task = reconciler.hourly_loop(interval_seconds=0.01)
+                await asyncio.wait_for(task, timeout=1.0)
+
+        # Assert — task completed without TimeoutError/CancelledError
+        assert task.done() and not task.cancelled()
+        critical_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.CRITICAL
+            and r.name == "roxabi_live.reconciler"
+            and ("halt" in r.message.lower() or "auth" in r.message.lower())
+        ]
+        assert critical_records, (
+            "Expected a CRITICAL log mentioning 'halt' or 'auth' on "
+            f"roxabi_live.reconciler; got records: {caplog.records}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_auth_error_then_success_resets_counter(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A single 401 followed by successful syncs must reset _auth_failures to 0
+        and keep _halted False."""
+        # Arrange
+        monkeypatch.setenv("CORPUS_DB_PATH", str(tmp_path / "corpus.db"))
+        err_401 = _make_http_error(401)
+        with patch(
+            "roxabi_live.corpus.sync.run_sync",
+            side_effect=[err_401, _success_dict(), _success_dict()],
+        ):
+            # Act — allow a few ticks
+            task = reconciler.hourly_loop(interval_seconds=0.01)
+            await asyncio.sleep(0.08)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Assert — counter reset, loop not halted
+        failures = reconciler._auth_failures  # type: ignore[attr-defined]
+        assert failures == 0, (
+            f"Expected _auth_failures == 0 after success, got {failures}"
+        )
+        assert reconciler._halted is False  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_transient_oserror_does_not_increment_counter(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Transient OSErrors must NOT increment _auth_failures and must NOT halt
+        the loop."""
+        # Arrange
+        monkeypatch.setenv("CORPUS_DB_PATH", str(tmp_path / "corpus.db"))
+        with patch(
+            "roxabi_live.corpus.sync.run_sync",
+            side_effect=[OSError("connection reset"), OSError("connection reset")],
+        ):
+            # Act — allow two ticks
+            task = reconciler.hourly_loop(interval_seconds=0.01)
+            await asyncio.sleep(0.05)
+
+        # Assert — counter untouched, loop still running
+        assert reconciler._auth_failures == 0  # type: ignore[attr-defined]
+        assert reconciler._halted is False  # type: ignore[attr-defined]
+        assert not task.done(), "Loop must still be running after transient OSErrors"
+
+        # Cleanup
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_403_also_counts_as_auth(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Two consecutive 403 errors must halt the loop the same way as 401s."""
+        # Arrange
+        monkeypatch.setenv("CORPUS_DB_PATH", str(tmp_path / "corpus.db"))
+        err_403 = _make_http_error(403)
+        with caplog.at_level(logging.CRITICAL, logger="roxabi_live.reconciler"):
+            with patch(
+                "roxabi_live.corpus.sync.run_sync",
+                side_effect=[err_403, err_403],
+            ):
+                # Act
+                task = reconciler.hourly_loop(interval_seconds=0.01)
+                await asyncio.wait_for(task, timeout=1.0)
+
+        # Assert — same halt behaviour as 401
+        assert task.done() and not task.cancelled()
+        critical_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.CRITICAL
+            and r.name == "roxabi_live.reconciler"
+            and ("halt" in r.message.lower() or "auth" in r.message.lower())
+        ]
+        assert critical_records, (
+            "Expected a CRITICAL log mentioning 'halt' or 'auth' for 403 errors; "
+            f"got records: {caplog.records}"
         )

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -41,7 +41,7 @@ def reset_reconciler_auth_state() -> None:
     if hasattr(reconciler, "_auth_failures"):
         reconciler._auth_failures = 0  # type: ignore[attr-defined]
     if hasattr(reconciler, "_halted"):
-        reconciler._halted = False  # type: ignore[attr-defined]
+        reconciler._halted.clear()  # type: ignore[attr-defined]
 
 
 class TestRunOnce:
@@ -291,7 +291,7 @@ class TestAuthHalt:
         assert failures == 0, (
             f"Expected _auth_failures == 0 after success, got {failures}"
         )
-        assert reconciler._halted is False  # type: ignore[attr-defined]
+        assert not reconciler._halted.is_set()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_transient_oserror_does_not_increment_counter(
@@ -313,7 +313,7 @@ class TestAuthHalt:
 
         # Assert — counter untouched, loop still running
         assert reconciler._auth_failures == 0  # type: ignore[attr-defined]
-        assert reconciler._halted is False  # type: ignore[attr-defined]
+        assert not reconciler._halted.is_set()  # type: ignore[attr-defined]
         assert not task.done(), "Loop must still be running after transient OSErrors"
 
         # Cleanup

--- a/tests/test_webhook_body_cap.py
+++ b/tests/test_webhook_body_cap.py
@@ -188,7 +188,10 @@ def test_post_body_at_cap_passes_through(
     )
 
     # Assert — size gate must not reject exactly-at-cap bodies
-    assert resp.status_code != 413
+    assert resp.status_code != 413, "25 MB body should pass the size gate"
+    assert resp.status_code != 500, (
+        "25 MB raw-bytes body should map to a 4xx (invalid JSON), not 500"
+    )
 
 
 def test_post_body_one_byte_over_cap_returns_413(
@@ -242,3 +245,34 @@ def test_post_body_under_cap_unchanged(client: TestClient) -> None:
     # Assert — normal dispatch path unaffected by the cap
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+
+
+def test_post_malformed_json_returns_400(client: TestClient, db_path: Path) -> None:
+    body = b"not json"
+    sig = "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    resp = client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": sig,
+            "X-GitHub-Event": "issues",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 400
+    assert "invalid JSON" in resp.json()["detail"]
+
+
+def test_post_body_over_cap_bad_sig_returns_413(client: TestClient) -> None:
+    """413 fires before HMAC — even with a wrong signature."""
+    body = b"A" * (26 * 1024 * 1024)
+    resp = client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": "sha256=deadbeef",
+            "X-GitHub-Event": "issues",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 413

--- a/tests/test_webhook_body_cap.py
+++ b/tests/test_webhook_body_cap.py
@@ -1,0 +1,244 @@
+"""Tests for 25 MB body cap on POST /webhook/github (T1 — RED phase, issue #56).
+
+Covers:
+  - test_post_body_over_cap_returns_413
+  - test_post_body_at_cap_passes_through
+  - test_post_body_one_byte_over_cap_returns_413
+  - test_post_body_under_cap_unchanged
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+import pytest
+from fastapi.testclient import TestClient
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS issues (
+    key         TEXT PRIMARY KEY,
+    repo        TEXT NOT NULL,
+    number      INTEGER NOT NULL,
+    title       TEXT,
+    state       TEXT NOT NULL,
+    url         TEXT,
+    created_at  TEXT,
+    updated_at  TEXT,
+    closed_at   TEXT,
+    milestone   TEXT,
+    is_stub     INTEGER NOT NULL DEFAULT 0,
+    lane        TEXT,
+    priority    TEXT,
+    size        TEXT,
+    status      TEXT
+);
+
+CREATE TABLE IF NOT EXISTS labels (
+    issue_key   TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    PRIMARY KEY (issue_key, name),
+    FOREIGN KEY (issue_key) REFERENCES issues(key) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    src_key     TEXT NOT NULL,
+    dst_key     TEXT NOT NULL,
+    kind        TEXT NOT NULL DEFAULT 'parent',
+    PRIMARY KEY (src_key, dst_key)
+);
+
+CREATE TABLE IF NOT EXISTS sync_state (
+    repo            TEXT PRIMARY KEY,
+    last_cursor     TEXT,
+    last_synced_at  TEXT
+);
+"""
+
+_SECRET = "cap-test-secret"
+_CAP_BYTES = 25 * 1024 * 1024  # 25 MB
+
+
+def _sign(body: bytes, secret: str = _SECRET) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _issues_payload(
+    action: str = "opened",
+    number: int = 1,
+    title: str = "Cap test issue",
+    state: str = "open",
+    repo: str = "Roxabi/lyra",
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "issue": {
+            "number": number,
+            "title": title,
+            "state": state,
+            "html_url": f"https://github.com/{repo}/issues/{number}",
+            "labels": [],
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-04-24T12:00:00Z",
+            "closed_at": None,
+            "milestone": None,
+        },
+        "repository": {
+            "full_name": repo,
+            "name": repo.split("/", 1)[-1],
+            "owner": {"login": repo.split("/", 1)[0]},
+        },
+    }
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    """Create a real sqlite file with the corpus schema and return its path."""
+    path = tmp_path / "corpus.db"
+
+    async def _init() -> None:
+        async with aiosqlite.connect(path) as conn:
+            await conn.executescript(_SCHEMA_SQL)
+            await conn.commit()
+
+    asyncio.run(_init())
+    return path
+
+
+@pytest.fixture()
+def client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """TestClient with env vars pointing at the tmp db."""
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
+
+    # Import app AFTER env vars are set so _db_path() resolves correctly
+    from roxabi_live.app import app
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_post_body_over_cap_returns_413(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST body of 26 MB (1 MB over cap) → 413 Request Entity Too Large."""
+    # Arrange
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
+
+    from roxabi_live.app import app
+
+    # raise_server_exceptions=False so oversized bodies return a response
+    # rather than re-raising internal errors (before the cap middleware exists,
+    # the server will 500; after implementation it should 413).
+    client = TestClient(app, raise_server_exceptions=False)
+
+    body = b"A" * (26 * 1024 * 1024)
+    sig = _sign(body)
+
+    # Act
+    resp = client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "issues",
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": sig,
+        },
+    )
+
+    # Assert
+    assert resp.status_code == 413
+
+
+def test_post_body_at_cap_passes_through(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST body of exactly 25 MB (at cap) → not 413 (size gate allows through)."""
+    # Arrange
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
+
+    from roxabi_live.app import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    body = b"A" * _CAP_BYTES
+    sig = _sign(body)
+
+    # Act
+    resp = client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "issues",
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": sig,
+        },
+    )
+
+    # Assert — size gate must not reject exactly-at-cap bodies
+    assert resp.status_code != 413
+
+
+def test_post_body_one_byte_over_cap_returns_413(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST body of 25 MB + 1 byte → 413 (boundary: one byte over the cap)."""
+    # Arrange
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
+
+    from roxabi_live.app import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    body = b"A" * (_CAP_BYTES + 1)
+    sig = _sign(body)
+
+    # Act
+    resp = client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "issues",
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": sig,
+        },
+    )
+
+    # Assert
+    assert resp.status_code == 413
+
+
+def test_post_body_under_cap_unchanged(client: TestClient) -> None:
+    """Small valid payload with correct HMAC → normal 200 behaviour preserved."""
+    # Arrange
+    payload = _issues_payload(action="opened", number=99)
+    body = json.dumps(payload).encode()
+    sig = _sign(body)
+
+    # Act
+    resp = client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "issues",
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": sig,
+        },
+    )
+
+    # Assert — normal dispatch path unaffected by the cap
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -146,9 +146,7 @@ async def _seed_issue(  # noqa: PLR0913
     await conn.commit()
 
 
-async def _fetch_issue(
-    conn: aiosqlite.Connection, key: str
-) -> aiosqlite.Row | None:
+async def _fetch_issue(conn: aiosqlite.Connection, key: str) -> aiosqlite.Row | None:
     """Return (key, repo, number, title, state) for the given issue key."""
     cursor = await conn.execute(
         "SELECT key, repo, number, title, state FROM issues WHERE key = ?",
@@ -230,9 +228,7 @@ class TestIssuesWebhookHandler:
         labels = await _fetch_labels(db, "Roxabi/lyra#7")
         assert labels == ["a", "b", "c"], f"Expected [a, b, c], got {labels}"
 
-    async def test_issues_closed_updates_state(
-        self, db: aiosqlite.Connection
-    ) -> None:
+    async def test_issues_closed_updates_state(self, db: aiosqlite.Connection) -> None:
         """action=closed transitions state to 'closed'."""
         # Arrange — pre-seed open issue
         await _seed_issue(
@@ -258,9 +254,7 @@ class TestIssuesWebhookHandler:
         _key, _repo, _number, _title, state = row
         assert state == "closed", f"Expected state='closed', got '{state}'"
 
-    async def test_issues_edited_updates_title(
-        self, db: aiosqlite.Connection
-    ) -> None:
+    async def test_issues_edited_updates_title(self, db: aiosqlite.Connection) -> None:
         """action=edited with new title updates the title column."""
         # Arrange — pre-seed issue with original title
         await _seed_issue(
@@ -286,9 +280,7 @@ class TestIssuesWebhookHandler:
         _key, _repo, _number, title, _state = row
         assert title == "Updated title", f"Expected 'Updated title', got '{title}'"
 
-    async def test_issues_deleted_removes_row(
-        self, db: aiosqlite.Connection
-    ) -> None:
+    async def test_issues_deleted_removes_row(self, db: aiosqlite.Connection) -> None:
         """action=deleted removes the issue row and its labels."""
         # Arrange — pre-seed issue with labels
         await _seed_issue(
@@ -447,9 +439,7 @@ class TestDepsWebhookHandler:
         row = await _fetch_edge(db, "Roxabi/lyra#5", "Roxabi/lyra#10", "blocks")
         assert row is None, "Expected edge to be deleted after blocked_by_removed"
 
-    async def test_deps_blocking_added_is_noop(
-        self, db: aiosqlite.Connection
-    ) -> None:
+    async def test_deps_blocking_added_is_noop(self, db: aiosqlite.Connection) -> None:
         """blocking_added (duplicate-direction) is ignored — no edge inserted."""
         payload = _make_deps_payload(
             action="blocking_added",

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -163,9 +163,7 @@ def test_post_rejects_invalid_signature_401(client: TestClient) -> None:
     assert resp.json()["detail"] == "invalid signature"
 
 
-def test_post_valid_signature_issues_event(
-    client: TestClient, db_path: Path
-) -> None:
+def test_post_valid_signature_issues_event(client: TestClient, db_path: Path) -> None:
     """Valid sig + X-GitHub-Event: issues → 200, issue row inserted in db."""
     payload = _issues_payload(action="opened", number=42)
     body = json.dumps(payload).encode()
@@ -257,9 +255,7 @@ def test_stale_sync_triggers_reconcile(
     db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """sync_state.last_synced_at = 2h ago → reconciler.run_once is called."""
-    two_hours_ago = (
-        datetime.now(timezone.utc) - timedelta(hours=2)
-    ).isoformat()
+    two_hours_ago = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
     _seed_sync_state(db_path, "Roxabi/lyra", two_hours_ago)
 
     mock_run_once = AsyncMock(return_value=None)
@@ -294,9 +290,7 @@ def test_fresh_sync_does_not_trigger_reconcile(
     db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """sync_state.last_synced_at = 5min ago → reconciler.run_once is NOT called."""
-    five_min_ago = (
-        datetime.now(timezone.utc) - timedelta(minutes=5)
-    ).isoformat()
+    five_min_ago = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
     _seed_sync_state(db_path, "Roxabi/lyra", five_min_ago)
 
     mock_run_once = AsyncMock(return_value=None)


### PR DESCRIPTION
## Summary

Four defense-in-depth findings from PR #55 review:

- **SEC-1** — 25 MB streamed-read body cap on `POST /webhook/github`, rejected with 413 before HMAC verify.
- **SEC-2** — `ISSUE_KEY_RE` regex guard on `GET /api/issues/{key:path}`; malformed keys return 400 before any DB call.
- **SEC-3** — Reconciler auth-aware halt: two consecutive 401/403 from `corpus_sync.run_sync` flip `_halted`, emit CRITICAL, exit `hourly_loop`; transient errors (OSError, 5xx) do not increment the counter.
- **SEC-4** — `docs/cloudflared-setup.md` extended with "Cloudflare Access" section (Access app + service-token bypass policy for the webhook, verification + rotation). Cloudflare dashboard config is manual post-merge.

Locked design choices during planning: streamed-read check inside `github_webhook` (simpler than ASGI middleware), service-token exemption (cleaner identity boundary than WAF IP allowlist).

Ruff format also picked up pre-existing whitespace drift in `hmac_auth.py`, `test_webhook_handlers.py`, `test_webhook_router.py`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #56: Harden public API surface (Cloudflare Access, payload cap, path validation) | OPEN |
| Frame | [56-harden-public-api-frame.mdx](artifacts/frames/56-harden-public-api-frame.mdx) | Approved |
| Spec | [56-harden-public-api-spec.mdx](artifacts/specs/56-harden-public-api-spec.mdx) | Approved |
| Plan | [56-harden-public-api-plan.mdx](artifacts/plans/56-harden-public-api-plan.mdx) | Approved (12 tasks, 4 slices) |
| Implementation | 1 commit on `feat/56-harden-public-api` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (516 passed, 1 new test file + 7 new tests) | Passed |

## Test Plan

- [ ] `uv run pytest` — 516 passed
- [ ] `POST /webhook/github` with 26 MB body → 413 before HMAC verify
- [ ] `GET /api/issues/foo` → 400; `GET /api/issues/..%2F..%2Fetc%2Fpasswd` → 400
- [ ] `GET /api/issues/Roxabi/roxabi-live#56` → 200/404 (valid shape)
- [ ] Reconciler: two consecutive 401 → loop exits + CRITICAL log
- [ ] Reconciler: transient \`OSError\` does not increment auth counter

## Post-merge manual steps (Mickael)

Cloudflare Access requires dashboard config, documented in `docs/cloudflared-setup.md` Steps A–D:

- [ ] Create Access app on \`dashboard.roxabi.dev\` with email allowlist
- [ ] Create \`github-webhook\` service token + bypass policy
- [ ] Deploy Cloudflare Worker trampoline (or GitHub App) to inject \`CF-Access-Client-Id/Secret\` headers
- [ ] Verify: \`curl -sI https://dashboard.roxabi.dev/api/issues\` → 302 to cloudflareaccess.com
- [ ] Verify: GitHub webhook redelivery → 200 OK

Closes #56

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`