### PR TITLE
feat(corpus): drop ProjectV2, source size/priority/lane from labels

### DIFF
--- a/src/roxabi_live/corpus/graphql.py
+++ b/src/roxabi_live/corpus/graphql.py
@@ -35,25 +35,6 @@ query($owner: String!, $name: String!, $cursor: String, $since: DateTime) {
         parent { number repository { nameWithOwner } }
         blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
         blocking(first: 50) { nodes { number repository { nameWithOwner } } }
-        projectItems(first: 5) {
-          nodes {
-            project {
-              title
-            }
-            fieldValues(first: 20) {
-              nodes {
-                ... on ProjectV2ItemFieldSingleSelectValue {
-                  name
-                  field {
-                    ... on ProjectV2FieldCommon {
-                      name
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
       }
     }
   }

--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -88,47 +88,6 @@ def _extract_from_labels(labels: list[str]) -> dict[str, str | None]:
     }
 
 
-def _parse_project_fields(node: dict[str, Any], repo: str) -> dict[str, str | None]:
-    """Extract lane/priority/size/status from a GraphQL issue node's projectItems.
-
-    Picks the board whose title matches `{repo_short_name} board` (convention).
-    Returns all-None dict when no matching board is found.
-    """
-    null_result: dict[str, str | None] = {
-        "lane": None,
-        "priority": None,
-        "size": None,
-        "status": None,
-    }
-    short_name = repo.split("/", 1)[-1]
-    expected_title = f"{short_name} board"
-    project_items: dict[str, Any] = node.get("projectItems") or {}
-    items: list[Any] = project_items.get("nodes") or []
-    for item in items:
-        item_dict: dict[str, Any] = item or {}
-        project: dict[str, Any] = item_dict.get("project") or {}
-        if project.get("title") != expected_title:
-            continue
-        fields: dict[str, str | None] = {
-            "lane": None,
-            "priority": None,
-            "size": None,
-            "status": None,
-        }
-        fv_container: dict[str, Any] = item_dict.get("fieldValues") or {}
-        fv_nodes: list[Any] = fv_container.get("nodes") or []
-        for fv in fv_nodes:
-            fv_dict: dict[str, Any] = fv or {}
-            field_obj: dict[str, Any] = fv_dict.get("field") or {}
-            raw_name: Any = field_obj.get("name")
-            fname = (str(raw_name) if raw_name is not None else "").lower()
-            if fname in fields:
-                raw_val: Any = fv_dict.get("name")
-                fields[fname] = str(raw_val) if raw_val is not None else None
-        return fields
-    return null_result
-
-
 def canonical_key(ref: int | str, repo: str) -> str:
     """Canonicalise an issue reference to 'owner/repo#N' form.
 
@@ -294,10 +253,11 @@ def run_repo_sync(
                 ),
                 "is_stub": 0,
             }
-            issue.update(_parse_project_fields(node, repo))
+            labels = [n["name"] for n in node["labels"]["nodes"]]
+            issue.update(_extract_from_labels(labels))
+            issue["status"] = None
             upsert_issue(conn, issue)
 
-            labels = [n["name"] for n in node["labels"]["nodes"]]
             upsert_labels(conn, key, labels)
 
             # Parent/child relationships (subIssues/parent)

--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -25,6 +25,68 @@ _BARE_INT = re.compile(r"^\d+$")
 _SHORT_FORM = re.compile(r"^#(\d+)$")
 _FULL_KEY = re.compile(r"^[\w.-]+/[\w.-]+#\d+$")
 
+_LANE_PREFIX = "graph:lane/"
+_SIZE_PREFIX = "size:"
+_LEGACY_SIZE_RAW = {"XS", "S", "M", "L", "XL"}
+_LEGACY_SIZE_MAP = {"M": "F-lite"}  # closed-issue drift → canonical
+
+_PRIORITY_EXACT: dict[str, str] = {
+    "P0": "P0",
+    "priority:P0": "P0",
+    "P1-high": "P1",
+    "priority:high": "P1",
+    "priority:P1": "P1",
+    "P2-medium": "P2",
+    "priority:medium": "P2",
+    "priority:P2": "P2",
+    "P3-low": "P3",
+    "priority:low": "P3",
+    "priority: low": "P3",
+    "priority:P3": "P3",
+}
+
+
+def _derive_lane(labels: list[str]) -> str | None:
+    for lbl in labels:
+        if lbl.startswith(_LANE_PREFIX):
+            return lbl[len(_LANE_PREFIX) :]
+    return None
+
+
+def _derive_priority(labels: list[str]) -> str | None:
+    for lbl in labels:
+        if lbl in _PRIORITY_EXACT:
+            return _PRIORITY_EXACT[lbl]
+    return None
+
+
+def _derive_size(labels: list[str]) -> str | None:
+    for lbl in labels:
+        if lbl.startswith(_SIZE_PREFIX):
+            raw = lbl[len(_SIZE_PREFIX) :]
+            return _LEGACY_SIZE_MAP.get(raw, raw)
+    for lbl in labels:
+        if lbl in _LEGACY_SIZE_RAW:
+            return lbl
+    return None
+
+
+def _extract_from_labels(labels: list[str]) -> dict[str, str | None]:
+    """Derive lane/priority/size from an issue's label list.
+
+    Vocabulary (first match wins per field):
+    - lane:     ``graph:lane/<x>`` → ``<x>``
+    - priority: canonical ``priority:P0..P3`` / bare ``P0``; legacy
+                ``P1-high`` / ``priority:high`` → ``P1`` (and P2/P3 variants)
+    - size:     canonical ``size:S|F-lite|F-full``; legacy ``size:M`` →
+                ``F-lite``; fallback to raw ``XS|S|M|L|XL`` bare labels
+    """
+    return {
+        "lane": _derive_lane(labels),
+        "priority": _derive_priority(labels),
+        "size": _derive_size(labels),
+    }
+
 
 def _parse_project_fields(node: dict[str, Any], repo: str) -> dict[str, str | None]:
     """Extract lane/priority/size/status from a GraphQL issue node's projectItems.

--- a/tests/corpus/test_sync.py
+++ b/tests/corpus/test_sync.py
@@ -79,7 +79,6 @@ def _base_node(extra: dict[str, Any] | None = None) -> dict[str, Any]:
         "parent": None,
         "blockedBy": {"nodes": []},
         "blocking": {"nodes": []},
-        "projectItems": {"nodes": []},
     }
     if extra:
         node.update(extra)
@@ -245,12 +244,12 @@ def test_closed_hop_triggers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
 
 
 # ---------------------------------------------------------------------------
-# New V2 tests — projectV2 field hydration
+# Label-sourced lane/priority/size hydration (#54)
 # ---------------------------------------------------------------------------
 
 
-def test_upsert_issue_stores_projectv2_fields(tmp_path: Path) -> None:
-    """upsert_issue writes lane/priority/size/status columns (AC-5)."""
+def test_upsert_issue_stores_lane_priority_size(tmp_path: Path) -> None:
+    """upsert_issue writes lane/priority/size/status columns."""
     db_path = tmp_path / "corpus.db"
     bootstrap(db_path)
     conn = connect(db_path)
@@ -259,8 +258,8 @@ def test_upsert_issue_stores_projectv2_fields(tmp_path: Path) -> None:
             **_BASE_ISSUE,
             "lane": "a1",
             "priority": "P1",
-            "size": "M",
-            "status": "In Progress",
+            "size": "F-lite",
+            "status": None,
         }
         upsert_issue(conn, issue)
         conn.commit()
@@ -268,55 +267,36 @@ def test_upsert_issue_stores_projectv2_fields(tmp_path: Path) -> None:
             "SELECT lane, priority, size, status FROM issues WHERE key = ?",
             ("Roxabi/lyra#1",),
         ).fetchone()
-        assert row == ("a1", "P1", "M", "In Progress"), f"Got {row}"
+        assert row == ("a1", "P1", "F-lite", None), f"Got {row}"
     finally:
         conn.close()
 
 
-def test_run_repo_sync_hydrates_projectv2_fields(
+def test_run_repo_sync_populates_from_labels(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """run_repo_sync with a mocked gh_graphql writes project fields (AC-7)."""
+    """run_repo_sync derives lane/priority/size from labels; status stays NULL."""
     from roxabi_live.corpus.sync import run_repo_sync  # noqa: PLC0415
 
     db_path = tmp_path / "corpus.db"
     bootstrap(db_path)
     conn = connect(db_path)
 
-    project_node = _base_node(
+    node = _base_node(
         {
-            "projectItems": {
+            "labels": {
                 "nodes": [
-                    {
-                        "project": {"title": "lyra board"},
-                        "fieldValues": {
-                            "nodes": [
-                                {
-                                    "name": "a1",
-                                    "field": {"name": "Lane"},
-                                },
-                                {
-                                    "name": "P1",
-                                    "field": {"name": "Priority"},
-                                },
-                                {
-                                    "name": "M",
-                                    "field": {"name": "Size"},
-                                },
-                                {
-                                    "name": "In Progress",
-                                    "field": {"name": "Status"},
-                                },
-                            ]
-                        },
-                    }
+                    {"name": "size:F-lite"},
+                    {"name": "priority:P2"},
+                    {"name": "graph:lane/a1"},
+                    {"name": "random"},
                 ]
             }
         }
     )
 
     def fake_gh_graphql(q: str, v: dict[str, Any]) -> dict[str, Any]:
-        return _make_graphql_response(project_node)
+        return _make_graphql_response(node)
 
     monkeypatch.setattr("roxabi_live.corpus.sync.gh_graphql", fake_gh_graphql)
 
@@ -326,13 +306,13 @@ def test_run_repo_sync_hydrates_projectv2_fields(
         "SELECT lane, priority, size, status FROM issues LIMIT 1"
     ).fetchone()
     conn.close()
-    assert row == ("a1", "P1", "M", "In Progress"), f"Got {row}"
+    assert row == ("a1", "P2", "F-lite", None), f"Got {row}"
 
 
-def test_run_repo_sync_null_project_fields_on_no_enrollment(
+def test_run_repo_sync_null_fields_when_no_labels(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """projectItems nodes=[] -> all four columns NULL, no error (AC-8)."""
+    """Issue with no size/priority/lane labels → all three columns NULL, no error."""
     from roxabi_live.corpus.sync import run_repo_sync  # noqa: PLC0415
 
     db_path = tmp_path / "corpus.db"

--- a/tests/corpus/test_sync.py
+++ b/tests/corpus/test_sync.py
@@ -14,6 +14,7 @@ import pytest
 
 from roxabi_live.corpus.schema import bootstrap, connect
 from roxabi_live.corpus.sync import (
+    _extract_from_labels,
     canonical_key,
     log_rate_limit,
     upsert_edges,
@@ -83,6 +84,68 @@ def _base_node(extra: dict[str, Any] | None = None) -> dict[str, Any]:
     if extra:
         node.update(extra)
     return node
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_labels — derive lane/priority/size from label vocab (#54)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_from_labels_canonical_size() -> None:
+    assert _extract_from_labels(["size:S"]) == {
+        "lane": None,
+        "priority": None,
+        "size": "S",
+    }
+    assert _extract_from_labels(["size:F-lite"])["size"] == "F-lite"
+    assert _extract_from_labels(["size:F-full"])["size"] == "F-full"
+
+
+def test_extract_from_labels_canonical_priority() -> None:
+    assert _extract_from_labels(["priority:P0"])["priority"] == "P0"
+    assert _extract_from_labels(["priority:P1"])["priority"] == "P1"
+    assert _extract_from_labels(["priority:P2"])["priority"] == "P2"
+    assert _extract_from_labels(["priority:P3"])["priority"] == "P3"
+    assert _extract_from_labels(["P0"])["priority"] == "P0"
+
+
+def test_extract_from_labels_legacy_priority() -> None:
+    assert _extract_from_labels(["P1-high"])["priority"] == "P1"
+    assert _extract_from_labels(["priority:high"])["priority"] == "P1"
+    assert _extract_from_labels(["P2-medium"])["priority"] == "P2"
+    assert _extract_from_labels(["priority:medium"])["priority"] == "P2"
+    assert _extract_from_labels(["P3-low"])["priority"] == "P3"
+    assert _extract_from_labels(["priority:low"])["priority"] == "P3"
+    assert _extract_from_labels(["priority: low"])["priority"] == "P3"
+
+
+def test_extract_from_labels_legacy_size_m_maps_to_flite() -> None:
+    """Legacy drift: `size:M` (seen only on closed issues) → canonical F-lite."""
+    assert _extract_from_labels(["size:M"])["size"] == "F-lite"
+
+
+def test_extract_from_labels_lane() -> None:
+    assert _extract_from_labels(["graph:lane/a1"])["lane"] == "a1"
+    assert _extract_from_labels(["graph:lane/standalone"])["lane"] == "standalone"
+
+
+def test_extract_from_labels_all_fields() -> None:
+    result = _extract_from_labels(
+        ["size:F-lite", "priority:P2", "graph:lane/a1", "random-label"]
+    )
+    assert result == {"lane": "a1", "priority": "P2", "size": "F-lite"}
+
+
+def test_extract_from_labels_empty() -> None:
+    assert _extract_from_labels([]) == {"lane": None, "priority": None, "size": None}
+
+
+def test_extract_from_labels_first_match_wins() -> None:
+    """First matching label wins per field — mirrors dep_graph/v6/parse.py semantics."""
+    result = _extract_from_labels(["size:S", "size:F-full"])
+    assert result["size"] == "S"
+    result = _extract_from_labels(["priority:P1", "priority:P3"])
+    assert result["priority"] == "P1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace the `projectItems` GraphQL branch in `ISSUES_QUERY` with a label-driven derivation — `lane`/`priority`/`size` now come from `graph:lane/*`, `priority:*`, and `size:*` labels (canonical + legacy variants)
- `status` column is written NULL (already computed frontend-side from `state` + edges); schema unchanged
- Smaller GraphQL footprint (one less nested fragment + fewer sub-selections per issue) and one canonical source for issue metadata

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #54: feat(corpus): drop ProjectV2, source size/priority/lane from labels | OPEN |
| Frame | [54-drop-projectv2-source-from-labels-frame.mdx](artifacts/frames/54-drop-projectv2-source-from-labels-frame.mdx) | Approved |
| Spec | [54-drop-projectv2-source-from-labels-spec.mdx](artifacts/specs/54-drop-projectv2-source-from-labels-spec.mdx) | Approved |
| Plan | [54-drop-projectv2-source-from-labels-plan.mdx](artifacts/plans/54-drop-projectv2-source-from-labels-plan.mdx) | 9 tasks, F-lite |
| Implementation | 2 commits on `feat/54-drop-projectv2-source-from-labels` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (508 pass, 8 new) | Passed |

## Test Plan
- [ ] Post-merge: reconciler rebuild of `~/.roxabi/corpus.db` populates `lane` on open issues (`SELECT COUNT(*) FROM issues WHERE lane IS NOT NULL` > 0, was 0)
- [ ] `priority` and `size` values match what `dep_graph/v6/parse.py` derives from the same labels
- [ ] Webhook path (no code change needed — shares `run_repo_sync` helpers) still populates the three columns on a test issue update

Closes #54

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`