### PR TITLE
refactor(webhook): cleanup — central config, decoupling, SQL, tracked tasks

### DIFF
--- a/src/roxabi_live/api/issues.py
+++ b/src/roxabi_live/api/issues.py
@@ -35,7 +35,7 @@ ISSUE_KEY_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$")
 
 
 @router.get("/issues")
-async def list_issues(
+async def list_issues(  # noqa: PLR0913 — FastAPI query params, not domain args
     request: Request,
     repo: str | None = None,
     state: str | None = None,

--- a/src/roxabi_live/api/issues.py
+++ b/src/roxabi_live/api/issues.py
@@ -10,17 +10,13 @@ from typing import Any
 import aiosqlite
 from fastapi import APIRouter, HTTPException, Request
 
-from roxabi_live.config import Settings
+from roxabi_live.config import get_settings
 
 router = APIRouter(prefix="/api", tags=["issues"])
 
 
 def _get_db_path(request: Request) -> Path:
-    """Resolve corpus_db_path from app.state.settings if available."""
-    settings: Settings | None = getattr(request.app.state, "settings", None)
-    if settings is not None:
-        return settings.corpus_db_path
-    return Settings.from_env().corpus_db_path
+    return get_settings(request).corpus_db_path
 
 
 def _parse_key(key: str) -> tuple[str, int | None]:

--- a/src/roxabi_live/api/issues.py
+++ b/src/roxabi_live/api/issues.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
-import os
 import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
 import aiosqlite
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+
+from roxabi_live.config import Settings
 
 router = APIRouter(prefix="/api", tags=["issues"])
 
 
-def _db_path() -> Path:
-    return Path(os.environ.get("CORPUS_DB_PATH", Path.home() / ".roxabi" / "corpus.db"))
+def _get_db_path(request: Request) -> Path:
+    """Resolve corpus_db_path from app.state.settings if available."""
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        return settings.corpus_db_path
+    return Settings.from_env().corpus_db_path
 
 
 def _parse_key(key: str) -> tuple[str, int | None]:
@@ -31,6 +36,7 @@ ISSUE_KEY_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$")
 
 @router.get("/issues")
 async def list_issues(
+    request: Request,
     repo: str | None = None,
     state: str | None = None,
     label: str | None = None,
@@ -80,7 +86,7 @@ async def list_issues(
         LIMIT ? OFFSET ?
     """
 
-    async with aiosqlite.connect(_db_path()) as db:
+    async with aiosqlite.connect(_get_db_path(request)) as db:
         db.row_factory = aiosqlite.Row
 
         async with db.execute(count_sql, params) as cnt_cur:
@@ -125,14 +131,14 @@ async def list_issues(
 
 
 @router.get("/issues/{key:path}")
-async def get_issue(key: str) -> dict[str, Any]:
+async def get_issue(request: Request, key: str) -> dict[str, Any]:
     """Return a single issue by key, including blocking/blocked_by edge arrays."""
     if not ISSUE_KEY_RE.fullmatch(key):
         raise HTTPException(
             status_code=400,
             detail="invalid issue key; expected '<owner>/<repo>#<number>'",
         )
-    async with aiosqlite.connect(_db_path()) as db:
+    async with aiosqlite.connect(_get_db_path(request)) as db:
         db.row_factory = aiosqlite.Row
 
         sql = (

--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import os
 import sqlite3
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -14,6 +13,7 @@ from fastapi.staticfiles import StaticFiles
 
 from roxabi_live import reconciler
 from roxabi_live.api.issues import router as issues_router
+from roxabi_live.config import Settings
 from roxabi_live.dep_graph.v5.serve import router as dep_graph_v5_router
 from roxabi_live.dep_graph.v6.repos import router as repos_router
 from roxabi_live.dep_graph.v6.routes import router as dep_graph_v6_router
@@ -21,18 +21,15 @@ from roxabi_live.webhook.router import router as webhook_router
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_DB = Path.home() / ".roxabi" / "corpus.db"
-
-
-def _db_path() -> Path:
-    return Path(os.environ.get("CORPUS_DB_PATH", _DEFAULT_DB))
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    settings = Settings.from_env()
+    app.state.settings = settings
+
     log.info("reconciler startup sync scheduled")
-    await reconciler.run_once()
-    loop_task = reconciler.hourly_loop()
+    await reconciler.run_once(settings)
+    loop_task = reconciler.hourly_loop(settings)
     try:
         yield
     finally:
@@ -63,7 +60,7 @@ async def _root() -> RedirectResponse:
 @app.get("/health")
 async def health() -> dict[str, Any]:
     """Health check — returns db path, reachability, and issue count."""
-    db = _db_path()
+    db = Settings.from_env().corpus_db_path
     db_reachable = False
     issue_count = 0
     try:

--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator
 from weakref import WeakSet
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -67,9 +67,10 @@ async def _root() -> RedirectResponse:
 
 
 @app.get("/health")
-async def health() -> dict[str, Any]:
+async def health(request: Request) -> dict[str, Any]:
     """Health check — returns db path, reachability, and issue count."""
-    db = Settings.from_env().corpus_db_path
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    db = settings.corpus_db_path if settings else Settings.from_env().corpus_db_path
     db_reachable = False
     issue_count = 0
     try:

--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -6,6 +6,7 @@ import sqlite3
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncGenerator
+from weakref import WeakSet
 
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
@@ -26,6 +27,9 @@ log = logging.getLogger(__name__)
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     settings = Settings.from_env()
     app.state.settings = settings
+    bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
+    app.state.background_tasks = bg_tasks
+    app.state.trigger_heal = reconciler.make_trigger_heal(settings, bg_tasks)
 
     log.info("reconciler startup sync scheduled")
     await reconciler.run_once(settings)
@@ -38,6 +42,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             await loop_task
         except asyncio.CancelledError:
             pass
+        # Cancel and await all tracked background heal tasks
+        tasks = list(app.state.background_tasks)
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 app = FastAPI(title="Roxabi Live", version="0.1.0", lifespan=lifespan)

--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -14,7 +14,7 @@ from fastapi.staticfiles import StaticFiles
 
 from roxabi_live import reconciler
 from roxabi_live.api.issues import router as issues_router
-from roxabi_live.config import Settings
+from roxabi_live.config import Settings, get_settings
 from roxabi_live.dep_graph.v5.serve import router as dep_graph_v5_router
 from roxabi_live.dep_graph.v6.repos import router as repos_router
 from roxabi_live.dep_graph.v6.routes import router as dep_graph_v6_router
@@ -27,6 +27,11 @@ log = logging.getLogger(__name__)
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     settings = Settings.from_env()
     app.state.settings = settings
+    if not settings.github_webhook_secret:
+        log.critical(
+            "GITHUB_WEBHOOK_SECRET is empty — /webhook/github will return 503 "
+            "for every request. Set the env var to enable webhook ingestion."
+        )
     bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
     app.state.background_tasks = bg_tasks
     app.state.trigger_heal = reconciler.make_trigger_heal(settings, bg_tasks)
@@ -69,8 +74,7 @@ async def _root() -> RedirectResponse:
 @app.get("/health")
 async def health(request: Request) -> dict[str, Any]:
     """Health check — returns db path, reachability, and issue count."""
-    settings: Settings | None = getattr(request.app.state, "settings", None)
-    db = settings.corpus_db_path if settings else Settings.from_env().corpus_db_path
+    db = get_settings(request).corpus_db_path
     db_reachable = False
     issue_count = 0
     try:

--- a/src/roxabi_live/config.py
+++ b/src/roxabi_live/config.py
@@ -1,0 +1,51 @@
+"""Central configuration for roxabi_live.
+
+Single source of truth for all environment-variable-based settings.
+All consumers (api, webhook, reconciler, app) should read from a
+Settings instance rather than calling os.environ.get() directly.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+_DEFAULT_DB = Path.home() / ".roxabi" / "corpus.db"
+_DEFAULT_ORG = "Roxabi"
+_DEFAULT_INTERVAL = 3600.0
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Immutable application settings derived from environment variables."""
+
+    corpus_db_path: Path
+    github_org: str
+    github_webhook_secret: str
+    corpus_sync_interval_seconds: float
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "Settings":
+        """Build a Settings instance from environment variables.
+
+        Args:
+            env: Mapping to read from. Defaults to ``os.environ``.
+                 Pass a plain dict in tests for isolation.
+
+        Returns:
+            Frozen :class:`Settings` instance.
+        """
+        if env is None:
+            env = os.environ
+
+        raw_interval = env.get("CORPUS_SYNC_INTERVAL_SECONDS", "")
+        interval = float(raw_interval) if raw_interval else _DEFAULT_INTERVAL
+
+        return cls(
+            corpus_db_path=Path(env.get("CORPUS_DB_PATH", _DEFAULT_DB)),
+            github_org=env.get("GITHUB_ORG", _DEFAULT_ORG),
+            github_webhook_secret=env.get("GITHUB_WEBHOOK_SECRET", ""),
+            corpus_sync_interval_seconds=interval,
+        )

--- a/src/roxabi_live/config.py
+++ b/src/roxabi_live/config.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping
+from typing import TYPE_CHECKING, Mapping
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 _DEFAULT_DB = Path.home() / ".roxabi" / "corpus.db"
 _DEFAULT_ORG = "Roxabi"
@@ -58,3 +61,16 @@ class Settings:
             github_webhook_secret=env.get("GITHUB_WEBHOOK_SECRET", ""),
             corpus_sync_interval_seconds=interval,
         )
+
+
+def get_settings(request: Request) -> Settings:
+    """FastAPI-friendly resolver for app settings.
+
+    Reads from ``request.app.state.settings`` when the lifespan has run, and
+    falls back to ``Settings.from_env()`` for tests that bypass lifespan
+    (e.g. bare ``TestClient(app)`` without a ``with`` block).
+    """
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        return settings
+    return Settings.from_env()

--- a/src/roxabi_live/config.py
+++ b/src/roxabi_live/config.py
@@ -41,7 +41,16 @@ class Settings:
             env = os.environ
 
         raw_interval = env.get("CORPUS_SYNC_INTERVAL_SECONDS", "")
-        interval = float(raw_interval) if raw_interval else _DEFAULT_INTERVAL
+        if raw_interval:
+            try:
+                interval = float(raw_interval)
+            except ValueError as exc:
+                raise ValueError(
+                    f"CORPUS_SYNC_INTERVAL_SECONDS={raw_interval!r}"
+                    " is not a valid float"
+                ) from exc
+        else:
+            interval = _DEFAULT_INTERVAL
 
         return cls(
             corpus_db_path=Path(env.get("CORPUS_DB_PATH", _DEFAULT_DB)),

--- a/src/roxabi_live/corpus/mutations.py
+++ b/src/roxabi_live/corpus/mutations.py
@@ -1,0 +1,101 @@
+"""Async corpus mutation helpers for the webhook layer.
+
+These helpers are called by webhook/handlers.py to write corpus data via
+aiosqlite. They share SQL constants with corpus.sync so both paths produce
+identical rows.
+
+Design contract:
+- No commit() inside helpers — the caller controls the transaction boundary.
+- All write helpers accept an aiosqlite.Connection and call execute/executemany.
+- SQL constants are imported from corpus.sync to guarantee a single source.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiosqlite
+
+from roxabi_live.corpus.sync import (
+    DELETE_EDGE_SQL,
+    DELETE_LABELS_SQL,
+    INSERT_EDGE_SQL,
+    INSERT_LABEL_SQL,
+    UPSERT_ISSUE_FROM_WEBHOOK_SQL,
+    _extract_from_labels,
+)
+
+# Re-export for callers that need label derivation without underscore import.
+extract_from_labels = _extract_from_labels
+
+
+async def upsert_issue_async(
+    conn: aiosqlite.Connection, issue_partial: dict[str, Any]
+) -> None:
+    """Insert-or-update an issue row from a webhook payload.
+
+    Uses UPSERT_ISSUE_FROM_WEBHOOK_SQL which preserves milestone, is_stub,
+    lane, priority, size, status on conflict — those columns are only updated
+    by a full corpus.sync run, never by a webhook event.
+
+    Expected keys in issue_partial:
+        key, repo, number, title, state, url, created_at, updated_at, closed_at
+    All other columns (milestone, is_stub, lane, priority, size, status) are
+    preserved from the existing row on conflict.
+    """
+    await conn.execute(
+        UPSERT_ISSUE_FROM_WEBHOOK_SQL,
+        (
+            issue_partial["key"],
+            issue_partial["repo"],
+            issue_partial["number"],
+            issue_partial["title"],
+            issue_partial["state"],
+            issue_partial["url"],
+            issue_partial.get("created_at"),
+            issue_partial.get("updated_at"),
+            issue_partial.get("closed_at"),
+        ),
+    )
+
+
+async def replace_labels_async(
+    conn: aiosqlite.Connection, key: str, names: list[str]
+) -> None:
+    """Wipe all labels for issue key and rewrite them.
+
+    Runs inside the caller's transaction — no commit() here.
+    """
+    await conn.execute(DELETE_LABELS_SQL, (key,))
+    await conn.executemany(
+        INSERT_LABEL_SQL,
+        [(key, name) for name in names],
+    )
+
+
+async def add_edge_async(
+    conn: aiosqlite.Connection, src: str, dst: str, kind: str
+) -> None:
+    """Insert an edge (src, dst, kind) ignoring conflicts (idempotent).
+
+    Runs inside the caller's transaction — no commit() here.
+    """
+    await conn.execute(INSERT_EDGE_SQL, (src, dst, kind))
+
+
+async def remove_edge_async(
+    conn: aiosqlite.Connection, src: str, dst: str, kind: str
+) -> None:
+    """Delete the edge (src, dst, kind) if it exists.
+
+    Runs inside the caller's transaction — no commit() here.
+    """
+    await conn.execute(DELETE_EDGE_SQL, (src, dst, kind))
+
+
+async def delete_issue_async(conn: aiosqlite.Connection, key: str) -> None:
+    """Delete an issue row by key.
+
+    Runs inside the caller's transaction — no commit() here.
+    """
+    await conn.execute("DELETE FROM issues WHERE key = ?", (key,))

--- a/src/roxabi_live/corpus/mutations.py
+++ b/src/roxabi_live/corpus/mutations.py
@@ -22,11 +22,7 @@ from roxabi_live.corpus.sync import (
     INSERT_EDGE_SQL,
     INSERT_LABEL_SQL,
     UPSERT_ISSUE_FROM_WEBHOOK_SQL,
-    _extract_from_labels,
 )
-
-# Re-export for callers that need label derivation without underscore import.
-extract_from_labels = _extract_from_labels
 
 
 async def upsert_issue_async(

--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -82,10 +82,10 @@ INSERT_LABEL_SQL = "INSERT OR IGNORE INTO labels (issue_key, name) VALUES (?, ?)
 DELETE_EDGES_BY_KIND_SQL = (
     "DELETE FROM edges WHERE (src_key = ? OR dst_key = ?) AND kind = ?"
 )
-INSERT_EDGE_SQL = "INSERT OR IGNORE INTO edges (src_key, dst_key, kind) VALUES (?, ?, ?)"
-DELETE_EDGE_SQL = (
-    "DELETE FROM edges WHERE src_key = ? AND dst_key = ? AND kind = ?"
+INSERT_EDGE_SQL = (
+    "INSERT OR IGNORE INTO edges (src_key, dst_key, kind) VALUES (?, ?, ?)"
 )
+DELETE_EDGE_SQL = "DELETE FROM edges WHERE src_key = ? AND dst_key = ? AND kind = ?"
 
 _LANE_PREFIX = "graph:lane/"
 _SIZE_PREFIX = "size:"

--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -25,6 +25,68 @@ _BARE_INT = re.compile(r"^\d+$")
 _SHORT_FORM = re.compile(r"^#(\d+)$")
 _FULL_KEY = re.compile(r"^[\w.-]+/[\w.-]+#\d+$")
 
+# ---------------------------------------------------------------------------
+# SQL constants — shared by corpus.sync (sync path) and corpus.mutations (async path)
+# ---------------------------------------------------------------------------
+
+# Full upsert: used by corpus.sync for complete issue data from GraphQL.
+# Updates ALL columns including milestone, is_stub, lane, priority, size, status.
+UPSERT_ISSUE_SQL = """
+    INSERT INTO issues
+        (key, repo, number, title, state, url, created_at, updated_at,
+         closed_at, milestone, is_stub, lane, priority, size, status)
+    VALUES
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(key) DO UPDATE SET
+        repo       = excluded.repo,
+        number     = excluded.number,
+        title      = excluded.title,
+        state      = excluded.state,
+        url        = excluded.url,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        closed_at  = excluded.closed_at,
+        milestone  = excluded.milestone,
+        is_stub    = excluded.is_stub,
+        lane       = excluded.lane,
+        priority   = excluded.priority,
+        size       = excluded.size,
+        status     = excluded.status
+"""
+
+# Webhook upsert: used by corpus.mutations for partial webhook payload data.
+# Inserts with milestone/is_stub/lane/priority/size/status as NULL on new rows,
+# but on conflict ONLY updates the fields present in a webhook payload so that
+# pre-existing values (set by a full sync) are never overwritten with NULL.
+UPSERT_ISSUE_FROM_WEBHOOK_SQL = """
+    INSERT INTO issues
+        (key, repo, number, title, state, url, created_at, updated_at, closed_at,
+         milestone, is_stub, lane, priority, size, status)
+    VALUES
+        (?, ?, ?, ?, ?, ?, ?, ?, ?,
+         NULL, 0, NULL, NULL, NULL, NULL)
+    ON CONFLICT(key) DO UPDATE SET
+        repo       = excluded.repo,
+        number     = excluded.number,
+        title      = excluded.title,
+        state      = excluded.state,
+        url        = excluded.url,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        closed_at  = excluded.closed_at
+"""
+
+DELETE_LABELS_SQL = "DELETE FROM labels WHERE issue_key = ?"
+INSERT_LABEL_SQL = "INSERT OR IGNORE INTO labels (issue_key, name) VALUES (?, ?)"
+
+DELETE_EDGES_BY_KIND_SQL = (
+    "DELETE FROM edges WHERE (src_key = ? OR dst_key = ?) AND kind = ?"
+)
+INSERT_EDGE_SQL = "INSERT OR IGNORE INTO edges (src_key, dst_key, kind) VALUES (?, ?, ?)"
+DELETE_EDGE_SQL = (
+    "DELETE FROM edges WHERE src_key = ? AND dst_key = ? AND kind = ?"
+)
+
 _LANE_PREFIX = "graph:lane/"
 _SIZE_PREFIX = "size:"
 _LEGACY_SIZE_RAW = {"XS", "S", "M", "L", "XL"}
@@ -121,28 +183,7 @@ def upsert_issue(conn: sqlite3.Connection, issue: dict[str, Any]) -> None:
     lane (nullable), priority (nullable), size (nullable), status (nullable).
     """
     conn.execute(
-        """
-        INSERT INTO issues
-            (key, repo, number, title, state, url, created_at, updated_at,
-             closed_at, milestone, is_stub, lane, priority, size, status)
-        VALUES
-            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-            repo = excluded.repo,
-            number = excluded.number,
-            title = excluded.title,
-            state = excluded.state,
-            url = excluded.url,
-            created_at = excluded.created_at,
-            updated_at = excluded.updated_at,
-            closed_at = excluded.closed_at,
-            milestone = excluded.milestone,
-            is_stub = excluded.is_stub,
-            lane = excluded.lane,
-            priority = excluded.priority,
-            size = excluded.size,
-            status = excluded.status
-        """,
+        UPSERT_ISSUE_SQL,
         (
             issue["key"],
             issue["repo"],
@@ -165,9 +206,9 @@ def upsert_issue(conn: sqlite3.Connection, issue: dict[str, Any]) -> None:
 
 def upsert_labels(conn: sqlite3.Connection, issue_key: str, names: list[str]) -> None:
     """Wipe and rewrite labels for issue_key."""
-    conn.execute("DELETE FROM labels WHERE issue_key = ?", (issue_key,))
+    conn.execute(DELETE_LABELS_SQL, (issue_key,))
     conn.executemany(
-        "INSERT OR IGNORE INTO labels (issue_key, name) VALUES (?, ?)",
+        INSERT_LABEL_SQL,
         [(issue_key, name) for name in names],
     )
 
@@ -189,7 +230,7 @@ def upsert_edges(
     All inputs are assumed already canonical — caller must use canonical_key first.
     """
     conn.execute(
-        "DELETE FROM edges WHERE (src_key = ? OR dst_key = ?) AND kind = ?",
+        DELETE_EDGES_BY_KIND_SQL,
         (issue_key, issue_key, kind),
     )
     rows: list[tuple[str, str, str]] = []
@@ -198,7 +239,7 @@ def upsert_edges(
     for blockee in blocking:
         rows.append((issue_key, blockee, kind))
     conn.executemany(
-        "INSERT OR IGNORE INTO edges (src_key, dst_key, kind) VALUES (?, ?, ?)",
+        INSERT_EDGE_SQL,
         rows,
     )
 

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -13,31 +13,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import sqlite3
-from pathlib import Path
 from typing import cast
 
+from roxabi_live.config import Settings
 from roxabi_live.corpus import sync as corpus_sync
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_INTERVAL = 3600.0
-_DEFAULT_DB_PATH = Path.home() / ".roxabi" / "corpus.db"
-_DEFAULT_ORG = "Roxabi"
 
 _AUTH_FAILURE_THRESHOLD = 2
 _auth_failures: int = 0
 _halted: asyncio.Event = asyncio.Event()
 _state_lock: asyncio.Lock = asyncio.Lock()
-
-
-def _db_path() -> Path:
-    return Path(os.environ.get("CORPUS_DB_PATH", _DEFAULT_DB_PATH))
-
-
-def _org() -> str:
-    return os.environ.get("GITHUB_ORG", _DEFAULT_ORG)
 
 
 def _is_auth_error(exc: BaseException) -> bool:
@@ -67,7 +55,7 @@ def _is_auth_error(exc: BaseException) -> bool:
     return True
 
 
-async def run_once() -> None:
+async def run_once(settings: Settings) -> None:
     """Run a single corpus sync cycle.
 
     Opens a fresh DB connection, calls corpus_sync.run_sync, then closes the
@@ -83,11 +71,9 @@ async def run_once() -> None:
     if _halted.is_set():
         return
     try:
-        db = _db_path()
-        org = _org()
-        conn = sqlite3.connect(db)
+        conn = sqlite3.connect(settings.corpus_db_path)
         try:
-            await asyncio.to_thread(corpus_sync.run_sync, conn, org)
+            await asyncio.to_thread(corpus_sync.run_sync, conn, settings.github_org)
         finally:
             conn.close()
         async with _state_lock:
@@ -114,13 +100,11 @@ async def run_once() -> None:
         log.exception("reconciler run_once failed")
 
 
-def hourly_loop(interval_seconds: float | None = None) -> asyncio.Task[None]:
+def hourly_loop(settings: Settings) -> asyncio.Task[None]:
     """Start a background task that calls run_once on a fixed interval.
 
     Args:
-        interval_seconds: Tick interval in seconds.  When *None* the value is
-            read from the ``CORPUS_SYNC_INTERVAL_SECONDS`` environment variable,
-            falling back to ``3600`` if the variable is unset or empty.
+        settings: Application settings providing the sync interval.
 
     Returns:
         The running :class:`asyncio.Task`.  Cancel it to stop the loop; the
@@ -128,15 +112,13 @@ def hourly_loop(interval_seconds: float | None = None) -> asyncio.Task[None]:
         cancellation.  The task may also exit normally if the reconciler is
         halted due to consecutive auth failures.
     """
-    if interval_seconds is None:
-        raw = os.environ.get("CORPUS_SYNC_INTERVAL_SECONDS", "")
-        interval_seconds = float(raw) if raw else _DEFAULT_INTERVAL
+    interval_seconds = settings.corpus_sync_interval_seconds
 
     async def _loop() -> None:
         while not _halted.is_set():
-            await asyncio.sleep(interval_seconds)  # type: ignore[arg-type]
+            await asyncio.sleep(interval_seconds)
             if _halted.is_set():
                 break
-            await run_once()
+            await run_once(settings)
 
     return asyncio.create_task(_loop())

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -7,6 +7,9 @@ Auth-halt behaviour: two consecutive GitHub 401/403 errors cause the loop to
 exit permanently and emit a CRITICAL log.  Transient errors (OSError, non-auth
 HTTP errors) do not increment the auth-failure counter.  A successful sync
 resets the counter to zero.
+
+Also exposes TriggerHeal protocol and make_trigger_heal factory for DI into
+the webhook router (decoupling the router from this module directly).
 """
 
 from __future__ import annotations
@@ -14,7 +17,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from typing import cast
+from datetime import datetime, timezone
+from typing import Protocol, cast
+from weakref import WeakSet
+
+import aiosqlite
 
 from roxabi_live.config import Settings
 from roxabi_live.corpus import sync as corpus_sync
@@ -26,6 +33,23 @@ _AUTH_FAILURE_THRESHOLD = 2
 _auth_failures: int = 0
 _halted: asyncio.Event = asyncio.Event()
 _state_lock: asyncio.Lock = asyncio.Lock()
+
+
+class TriggerHeal(Protocol):
+    """Protocol for the heal-trigger callable injected into the webhook router.
+
+    Implementations check sync_state staleness for the given repo and, if
+    stale, schedule a background corpus sync task.
+    """
+
+    async def __call__(self, repo: str, conn: aiosqlite.Connection) -> None: ...
+
+
+def _log_exc(task: asyncio.Task[None]) -> None:
+    """Done-callback: log any exception raised by a background task."""
+    exc = task.exception() if not task.cancelled() else None
+    if exc is not None:
+        log.error("background heal task raised an exception", exc_info=exc)
 
 
 def _is_auth_error(exc: BaseException) -> bool:
@@ -122,3 +146,45 @@ def hourly_loop(settings: Settings) -> asyncio.Task[None]:
             await run_once(settings)
 
     return asyncio.create_task(_loop())
+
+
+def make_trigger_heal(
+    settings: Settings,
+    background_tasks: WeakSet[asyncio.Task[None]],
+) -> TriggerHeal:
+    """Factory: build a TriggerHeal closure capturing settings + the WeakSet.
+
+    The returned callable:
+    1. Checks sync_state staleness (>1h or missing) for the repo.
+    2. If stale, schedules asyncio.create_task(run_once(settings)).
+    3. Registers the task in background_tasks WeakSet.
+    4. Attaches _log_exc as a done-callback to surface exceptions in logs.
+
+    Args:
+        settings: App settings (db path, org, interval).
+        background_tasks: WeakSet owned by app.state; populated so lifespan
+            can cancel all tracked tasks on shutdown.
+
+    Returns:
+        An async callable matching the TriggerHeal protocol.
+    """
+
+    async def _trigger_heal(repo: str, conn: aiosqlite.Connection) -> None:
+        cur = await conn.execute(
+            "SELECT last_synced_at FROM sync_state WHERE repo = ?", (repo,)
+        )
+        row = await cur.fetchone()
+        now = datetime.now(timezone.utc)
+        stale = True
+        if row is not None:
+            raw = row[0]
+            last = datetime.fromisoformat(raw) if isinstance(raw, str) else raw
+            if last.tzinfo is None:
+                last = last.replace(tzinfo=timezone.utc)
+            stale = (now - last).total_seconds() > 3600
+        if stale:
+            task: asyncio.Task[None] = asyncio.create_task(run_once(settings))
+            background_tasks.add(task)
+            task.add_done_callback(_log_exc)
+
+    return _trigger_heal  # type: ignore[return-value]

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -46,7 +46,13 @@ class TriggerHeal(Protocol):
 
 
 def _log_exc(task: asyncio.Task[None]) -> None:
-    """Done-callback: log any exception raised by a background task."""
+    """Done-callback: log any exception raised by a background task.
+
+    The cancelled-guard is required because `Task.exception()` *raises*
+    `CancelledError` on cancelled tasks (not returns it); without the
+    guard, normal shutdown would propagate CancelledError into the
+    callback and crash silently.
+    """
     exc = task.exception() if not task.cancelled() else None
     if exc is not None:
         log.error("background heal task raised an exception", exc_info=exc)
@@ -181,7 +187,7 @@ def make_trigger_heal(
             last = datetime.fromisoformat(raw) if isinstance(raw, str) else raw
             if last.tzinfo is None:
                 last = last.replace(tzinfo=timezone.utc)
-            stale = (now - last).total_seconds() > 3600
+            stale = (now - last).total_seconds() > settings.corpus_sync_interval_seconds
         if stale:
             task: asyncio.Task[None] = asyncio.create_task(run_once(settings))
             background_tasks.add(task)

--- a/src/roxabi_live/webhook/handlers.py
+++ b/src/roxabi_live/webhook/handlers.py
@@ -6,11 +6,21 @@ from typing import Any, cast
 
 import aiosqlite
 
+from roxabi_live.corpus.mutations import (
+    add_edge_async,
+    delete_issue_async,
+    remove_edge_async,
+    replace_labels_async,
+    upsert_issue_async,
+)
+
 
 async def handle_issues(payload: dict[str, Any], conn: aiosqlite.Connection) -> None:
     """Process a GitHub `issues` webhook event.
 
     Supported actions: opened, edited, reopened, labeled, unlabeled, closed, deleted.
+    Issue upsert + label replacement are committed atomically: both succeed or
+    neither is persisted (SC9).
     """
     action = payload.get("action")
     issue = payload["issue"]
@@ -18,46 +28,33 @@ async def handle_issues(payload: dict[str, Any], conn: aiosqlite.Connection) -> 
     key = f"{repo}#{issue['number']}"
 
     if action == "deleted":
-        await conn.execute("DELETE FROM issues WHERE key = ?", (key,))
+        await delete_issue_async(conn, key)
         await conn.commit()
         return
 
-    await conn.execute(
-        """
-        INSERT INTO issues
-            (key, repo, number, title, state, url, created_at, updated_at, closed_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(key) DO UPDATE SET
-            title      = excluded.title,
-            state      = excluded.state,
-            url        = excluded.url,
-            updated_at = excluded.updated_at,
-            closed_at  = excluded.closed_at
-        """,
-        (
-            key,
-            repo,
-            issue["number"],
-            issue["title"],
-            issue["state"],
-            issue.get("html_url"),
-            issue.get("created_at"),
-            issue.get("updated_at"),
-            issue.get("closed_at"),
-        ),
-    )
+    # Build partial from webhook payload (non-payload columns preserved by SQL)
+    issue_partial: dict[str, Any] = {
+        "key": key,
+        "repo": repo,
+        "number": issue["number"],
+        "title": issue["title"],
+        "state": issue["state"],
+        "url": issue.get("html_url"),
+        "created_at": issue.get("created_at"),
+        "updated_at": issue.get("updated_at"),
+        "closed_at": issue.get("closed_at"),
+    }
+    await upsert_issue_async(conn, issue_partial)
 
-    await conn.execute("DELETE FROM labels WHERE issue_key = ?", (key,))
     raw_labels: list[Any] = issue.get("labels") or []
+    names: list[str] = []
     for label in raw_labels:
         if isinstance(label, dict):
-            name: str = str(cast(dict[str, Any], label)["name"])
+            names.append(str(cast(dict[str, Any], label)["name"]))
         else:
-            name = str(label)
-        await conn.execute(
-            "INSERT INTO labels (issue_key, name) VALUES (?, ?)", (key, name)
-        )
+            names.append(str(label))
 
+    await replace_labels_async(conn, key, names)
     await conn.commit()
 
 
@@ -77,11 +74,7 @@ async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> No
         blocked = payload["issue"]
         blocker_key = f"{blocker['repository']['full_name']}#{blocker['number']}"
         blocked_key = f"{blocked['repository']['full_name']}#{blocked['number']}"
-        await conn.execute(
-            "INSERT OR IGNORE INTO edges (src_key, dst_key, kind)"
-            " VALUES (?, ?, 'blocks')",
-            (blocker_key, blocked_key),
-        )
+        await add_edge_async(conn, blocker_key, blocked_key, "blocks")
         await conn.commit()
         return
 
@@ -90,10 +83,7 @@ async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> No
         blocked = payload["issue"]
         blocker_key = f"{blocker['repository']['full_name']}#{blocker['number']}"
         blocked_key = f"{blocked['repository']['full_name']}#{blocked['number']}"
-        await conn.execute(
-            "DELETE FROM edges WHERE src_key = ? AND dst_key = ? AND kind = 'blocks'",
-            (blocker_key, blocked_key),
-        )
+        await remove_edge_async(conn, blocker_key, blocked_key, "blocks")
         await conn.commit()
 
 
@@ -115,11 +105,7 @@ async def handle_sub_issues(
         child = payload["sub_issue"]
         parent_key = f"{parent['repository']['full_name']}#{parent['number']}"
         child_key = f"{child['repository']['full_name']}#{child['number']}"
-        await conn.execute(
-            "INSERT OR IGNORE INTO edges (src_key, dst_key, kind)"
-            " VALUES (?, ?, 'parent')",
-            (parent_key, child_key),
-        )
+        await add_edge_async(conn, parent_key, child_key, "parent")
         await conn.commit()
         return
 
@@ -128,8 +114,5 @@ async def handle_sub_issues(
         child = payload["sub_issue"]
         parent_key = f"{parent['repository']['full_name']}#{parent['number']}"
         child_key = f"{child['repository']['full_name']}#{child['number']}"
-        await conn.execute(
-            "DELETE FROM edges WHERE src_key = ? AND dst_key = ? AND kind = 'parent'",
-            (parent_key, child_key),
-        )
+        await remove_edge_async(conn, parent_key, child_key, "parent")
         await conn.commit()

--- a/src/roxabi_live/webhook/handlers.py
+++ b/src/roxabi_live/webhook/handlers.py
@@ -44,8 +44,6 @@ async def handle_issues(payload: dict[str, Any], conn: aiosqlite.Connection) -> 
         "updated_at": issue.get("updated_at"),
         "closed_at": issue.get("closed_at"),
     }
-    await upsert_issue_async(conn, issue_partial)
-
     raw_labels: list[Any] = issue.get("labels") or []
     names: list[str] = []
     for label in raw_labels:
@@ -54,8 +52,17 @@ async def handle_issues(payload: dict[str, Any], conn: aiosqlite.Connection) -> 
         else:
             names.append(str(label))
 
-    await replace_labels_async(conn, key, names)
-    await conn.commit()
+    # Atomic upsert + label replacement (SC9). aiosqlite's connect()
+    # context manager only closes — it does not commit. We do an explicit
+    # commit on success and rollback on any exception so a crash between
+    # the two writes leaves the prior state intact.
+    try:
+        await upsert_issue_async(conn, issue_partial)
+        await replace_labels_async(conn, key, names)
+        await conn.commit()
+    except Exception:
+        await conn.rollback()
+        raise
 
 
 async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> None:

--- a/src/roxabi_live/webhook/router.py
+++ b/src/roxabi_live/webhook/router.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -13,6 +12,7 @@ import aiosqlite
 from fastapi import APIRouter, Header, HTTPException, Request
 
 from roxabi_live import reconciler
+from roxabi_live.config import Settings
 from roxabi_live.webhook import hmac_auth
 from roxabi_live.webhook.handlers import handle_deps, handle_issues, handle_sub_issues
 
@@ -23,8 +23,20 @@ MAX_WEBHOOK_BODY_BYTES = 25 * 1024 * 1024  # 25 MB
 router = APIRouter(tags=["webhook"])
 
 
-def _db_path() -> Path:
-    return Path(os.environ.get("CORPUS_DB_PATH", Path.home() / ".roxabi" / "corpus.db"))
+def _get_db_path(request: Request) -> Path:
+    """Resolve corpus_db_path from app.state.settings if available."""
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        return settings.corpus_db_path
+    return Settings.from_env().corpus_db_path
+
+
+def _get_webhook_secret(request: Request) -> str:
+    """Resolve github_webhook_secret from app.state.settings if available."""
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        return settings.github_webhook_secret
+    return Settings.from_env().github_webhook_secret
 
 
 async def _maybe_trigger_heal(repo: str, conn: aiosqlite.Connection) -> None:
@@ -41,7 +53,7 @@ async def _maybe_trigger_heal(repo: str, conn: aiosqlite.Connection) -> None:
             last = last.replace(tzinfo=timezone.utc)
         stale = (now - last).total_seconds() > 3600
     if stale:
-        asyncio.create_task(reconciler.run_once())
+        asyncio.create_task(reconciler.run_once(Settings.from_env()))
 
 
 async def _read_capped_body(request: Request) -> bytes:
@@ -83,18 +95,18 @@ async def github_webhook(
         body = await asyncio.wait_for(_read_capped_body(request), timeout=30.0)
     except asyncio.TimeoutError:
         raise HTTPException(status_code=408, detail="request timeout") from None
-    secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
+    secret = _get_webhook_secret(request)
     if not secret:
         raise HTTPException(status_code=503, detail="webhook not configured")
     if not hmac_auth.verify(body, x_hub_signature_256, secret):
         raise HTTPException(status_code=401, detail="invalid signature")
 
     try:
-        payload = json.loads(body)
+        payload = json.loads(body or b"{}")
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="invalid JSON payload") from None
 
-    async with aiosqlite.connect(_db_path()) as conn:
+    async with aiosqlite.connect(_get_db_path(request)) as conn:
         if x_github_event == "issues":
             await handle_issues(payload, conn)
             repo: str = payload["repository"]["full_name"]

--- a/src/roxabi_live/webhook/router.py
+++ b/src/roxabi_live/webhook/router.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import aiosqlite
 from fastapi import APIRouter, Header, HTTPException, Request
 
-from roxabi_live import reconciler
 from roxabi_live.config import Settings
 from roxabi_live.webhook import hmac_auth
 from roxabi_live.webhook.handlers import handle_deps, handle_issues, handle_sub_issues
+
+if TYPE_CHECKING:
+    from roxabi_live.reconciler import TriggerHeal
 
 log = logging.getLogger(__name__)
 
@@ -39,21 +41,9 @@ def _get_webhook_secret(request: Request) -> str:
     return Settings.from_env().github_webhook_secret
 
 
-async def _maybe_trigger_heal(repo: str, conn: aiosqlite.Connection) -> None:
-    """Fire-and-forget reconcile if sync_state for repo is stale (> 1h) or missing."""
-    cur = await conn.execute(
-        "SELECT last_synced_at FROM sync_state WHERE repo = ?", (repo,)
-    )
-    row = await cur.fetchone()
-    now = datetime.now(timezone.utc)
-    stale = True
-    if row is not None:
-        last = datetime.fromisoformat(row[0]) if isinstance(row[0], str) else row[0]
-        if last.tzinfo is None:
-            last = last.replace(tzinfo=timezone.utc)
-        stale = (now - last).total_seconds() > 3600
-    if stale:
-        asyncio.create_task(reconciler.run_once(Settings.from_env()))
+def get_trigger_heal(request: Request) -> TriggerHeal:
+    """FastAPI dependency: retrieve the injected TriggerHeal from app.state."""
+    return request.app.state.trigger_heal  # type: ignore[no-any-return]
 
 
 async def _read_capped_body(request: Request) -> bytes:
@@ -101,24 +91,27 @@ async def github_webhook(
     if not hmac_auth.verify(body, x_hub_signature_256, secret):
         raise HTTPException(status_code=401, detail="invalid signature")
 
+    # Body already read above — parse directly, do not call request.json() again.
     try:
-        payload = json.loads(body or b"{}")
+        payload: dict[str, object] = json.loads(body or b"{}")
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="invalid JSON payload") from None
+
+    trigger_heal: TriggerHeal = get_trigger_heal(request)
 
     async with aiosqlite.connect(_get_db_path(request)) as conn:
         if x_github_event == "issues":
             await handle_issues(payload, conn)
-            repo: str = payload["repository"]["full_name"]
-            await _maybe_trigger_heal(repo, conn)
+            repo: str = str(payload["repository"]["full_name"])  # type: ignore[index]
+            await trigger_heal(repo, conn)
         elif x_github_event == "issue_dependencies":
             await handle_deps(payload, conn)
-            repo = payload["repository"]["full_name"]
-            await _maybe_trigger_heal(repo, conn)
+            repo = str(payload["repository"]["full_name"])  # type: ignore[index]
+            await trigger_heal(repo, conn)
         elif x_github_event == "sub_issues":
             await handle_sub_issues(payload, conn)
-            repo = payload["repository"]["full_name"]
-            await _maybe_trigger_heal(repo, conn)
+            repo = str(payload["repository"]["full_name"])  # type: ignore[index]
+            await trigger_heal(repo, conn)
         else:
             return {"ok": True, "ignored": x_github_event}
 

--- a/src/roxabi_live/webhook/router.py
+++ b/src/roxabi_live/webhook/router.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import aiosqlite
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 
-from roxabi_live.config import Settings
+from roxabi_live.config import get_settings
 from roxabi_live.webhook import hmac_auth
 from roxabi_live.webhook.handlers import handle_deps, handle_issues, handle_sub_issues
 
@@ -26,19 +26,11 @@ router = APIRouter(tags=["webhook"])
 
 
 def _get_db_path(request: Request) -> Path:
-    """Resolve corpus_db_path from app.state.settings if available."""
-    settings: Settings | None = getattr(request.app.state, "settings", None)
-    if settings is not None:
-        return settings.corpus_db_path
-    return Settings.from_env().corpus_db_path
+    return get_settings(request).corpus_db_path
 
 
 def _get_webhook_secret(request: Request) -> str:
-    """Resolve github_webhook_secret from app.state.settings if available."""
-    settings: Settings | None = getattr(request.app.state, "settings", None)
-    if settings is not None:
-        return settings.github_webhook_secret
-    return Settings.from_env().github_webhook_secret
+    return get_settings(request).github_webhook_secret
 
 
 def get_trigger_heal(request: Request) -> TriggerHeal:

--- a/src/roxabi_live/webhook/router.py
+++ b/src/roxabi_live/webhook/router.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import aiosqlite
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 
 from roxabi_live.config import Settings
 from roxabi_live.webhook import hmac_auth
@@ -42,8 +42,16 @@ def _get_webhook_secret(request: Request) -> str:
 
 
 def get_trigger_heal(request: Request) -> TriggerHeal:
-    """FastAPI dependency: retrieve the injected TriggerHeal from app.state."""
-    return request.app.state.trigger_heal  # type: ignore[no-any-return]
+    """FastAPI dependency: retrieve the injected TriggerHeal from app.state.
+
+    Raises 503 when lifespan has not run (e.g. bare TestClient(app) without a
+    `with` block), mirroring the guard pattern used by `_get_db_path` and
+    `_get_webhook_secret`.
+    """
+    trigger_heal: TriggerHeal | None = getattr(request.app.state, "trigger_heal", None)
+    if trigger_heal is None:
+        raise HTTPException(status_code=503, detail="trigger_heal not configured")
+    return trigger_heal
 
 
 async def _read_capped_body(request: Request) -> bytes:
@@ -75,10 +83,11 @@ async def _read_capped_body(request: Request) -> bytes:
 
 
 @router.post("/webhook/github")
-async def github_webhook(
+async def github_webhook(  # noqa: PLR0913 — FastAPI deps + headers, not domain args
     request: Request,
     x_github_event: str | None = Header(default=None),
     x_hub_signature_256: str | None = Header(default=None),
+    trigger_heal: TriggerHeal = Depends(get_trigger_heal),
 ) -> dict[str, object]:
     """Receive and dispatch GitHub webhook events."""
     try:
@@ -96,8 +105,6 @@ async def github_webhook(
         payload: dict[str, object] = json.loads(body or b"{}")
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="invalid JSON payload") from None
-
-    trigger_heal: TriggerHeal = get_trigger_heal(request)
 
     async with aiosqlite.connect(_get_db_path(request)) as conn:
         if x_github_event == "issues":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Shared pytest fixtures for the roxabi_live test suite."""
+
+from __future__ import annotations
+
+import pytest
+
+from roxabi_live import reconciler
+
+
+@pytest.fixture(autouse=True)
+def reset_reconciler_auth_state() -> None:
+    """Reset reconciler module-globals before every test.
+
+    `_auth_failures` and `_halted` are process-globals on the reconciler
+    module. A test that triggers the auth-halt path leaves `_halted` set;
+    without this reset, every subsequent test in the same process sees
+    `_halted.is_set() == True` and silently skips all sync calls.
+    """
+    if hasattr(reconciler, "_auth_failures"):
+        reconciler._auth_failures = 0  # type: ignore[attr-defined]
+    if hasattr(reconciler, "_halted"):
+        reconciler._halted.clear()  # type: ignore[attr-defined]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,78 @@
+"""Tests for roxabi_live.config.Settings — T1 [RED].
+
+Covers:
+- Settings.from_env() reads env vars with defaults.
+- Settings.from_env() uses provided env dict for isolation.
+- Fields are typed correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from roxabi_live.config import Settings
+
+
+class TestSettingsFromEnv:
+    """Settings.from_env() reads env vars with fallback defaults."""
+
+    def test_defaults_when_no_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """from_env() returns default values when no relevant env vars are set."""
+        monkeypatch.delenv("CORPUS_DB_PATH", raising=False)
+        monkeypatch.delenv("GITHUB_ORG", raising=False)
+        monkeypatch.delenv("GITHUB_WEBHOOK_SECRET", raising=False)
+        monkeypatch.delenv("CORPUS_SYNC_INTERVAL_SECONDS", raising=False)
+
+        s = Settings.from_env()
+
+        assert isinstance(s.corpus_db_path, Path)
+        assert s.corpus_db_path == Path.home() / ".roxabi" / "corpus.db"
+        assert s.github_org == "Roxabi"
+        assert s.github_webhook_secret == ""
+        assert s.corpus_sync_interval_seconds == 3600.0
+
+    def test_reads_corpus_db_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CORPUS_DB_PATH env var sets corpus_db_path."""
+        monkeypatch.setenv("CORPUS_DB_PATH", "/tmp/test.db")
+        s = Settings.from_env()
+        assert s.corpus_db_path == Path("/tmp/test.db")
+
+    def test_reads_github_org(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GITHUB_ORG env var sets github_org."""
+        monkeypatch.setenv("GITHUB_ORG", "MyOrg")
+        s = Settings.from_env()
+        assert s.github_org == "MyOrg"
+
+    def test_reads_github_webhook_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GITHUB_WEBHOOK_SECRET env var sets github_webhook_secret."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "my-secret")
+        s = Settings.from_env()
+        assert s.github_webhook_secret == "my-secret"
+
+    def test_reads_corpus_sync_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CORPUS_SYNC_INTERVAL_SECONDS env var sets corpus_sync_interval_seconds."""
+        monkeypatch.setenv("CORPUS_SYNC_INTERVAL_SECONDS", "120.5")
+        s = Settings.from_env()
+        assert s.corpus_sync_interval_seconds == 120.5
+
+    def test_from_env_accepts_env_dict(self) -> None:
+        """from_env(env=...) uses provided mapping instead of os.environ."""
+        env = {
+            "CORPUS_DB_PATH": "/data/corpus.db",
+            "GITHUB_ORG": "TestOrg",
+            "GITHUB_WEBHOOK_SECRET": "secret123",
+            "CORPUS_SYNC_INTERVAL_SECONDS": "1800",
+        }
+        s = Settings.from_env(env=env)
+        assert s.corpus_db_path == Path("/data/corpus.db")
+        assert s.github_org == "TestOrg"
+        assert s.github_webhook_secret == "secret123"
+        assert s.corpus_sync_interval_seconds == 1800.0
+
+    def test_settings_is_frozen(self) -> None:
+        """Settings must be a frozen dataclass — mutation raises AttributeError."""
+        s = Settings.from_env(env={})
+        with pytest.raises((AttributeError, TypeError)):
+            s.github_org = "mutate"  # type: ignore[misc]

--- a/tests/test_corpus_mutations.py
+++ b/tests/test_corpus_mutations.py
@@ -172,7 +172,7 @@ class TestUpsertIssueAsync:
                 "a1",  # lane
                 "P1",  # priority
                 "F-lite",  # size
-                None,
+                "In Progress",  # status
             ),
         )
         await db.commit()
@@ -199,15 +199,16 @@ class TestUpsertIssueAsync:
         )
         row = await cur.fetchone()
         assert row is not None
-        title, state, milestone, lane, priority, size, _status = row
+        title, state, milestone, lane, priority, size, status = row
         # Updated fields
         assert title == "Updated title"
         assert state == "closed"
-        # Preserved non-payload fields
+        # Preserved non-payload fields (SC13)
         assert milestone == "v1.0", f"milestone was NULLed: {milestone!r}"
         assert lane == "a1", f"lane was NULLed: {lane!r}"
         assert priority == "P1", f"priority was NULLed: {priority!r}"
         assert size == "F-lite", f"size was NULLed: {size!r}"
+        assert status == "In Progress", f"status was NULLed: {status!r}"
 
     async def test_sync_and_async_produce_identical_rows(self, tmp_path: Path) -> None:
         """Async + sync upserts on the same key produce identical rows.
@@ -289,13 +290,31 @@ class TestUpsertIssueAsync:
             )
             async_row = await cur.fetchone()
 
-        # Core fields should match (async preserves milestone/lane/etc from DB)
+        # All 15 columns must match — both paths share the same SQL constants
+        # so the row layout written by sync upsert_issue and async
+        # upsert_issue_async must be identical (SC7).
         assert sync_row is not None
         assert async_row is not None
-        # key, repo, number, title, state, url match
-        for i in range(6):
+        column_names = (
+            "key",
+            "repo",
+            "number",
+            "title",
+            "state",
+            "url",
+            "created_at",
+            "updated_at",
+            "closed_at",
+            "milestone",
+            "is_stub",
+            "lane",
+            "priority",
+            "size",
+            "status",
+        )
+        for i, name in enumerate(column_names):
             assert sync_row[i] == async_row[i], (
-                f"Column {i} mismatch: {sync_row[i]!r} vs {async_row[i]!r}"
+                f"Column {name}: {sync_row[i]!r} (sync) vs {async_row[i]!r} (async)"
             )
 
 

--- a/tests/test_corpus_mutations.py
+++ b/tests/test_corpus_mutations.py
@@ -144,7 +144,7 @@ class TestUpsertIssueAsync:
     async def test_preserves_non_payload_columns(
         self, db: aiosqlite.Connection
     ) -> None:
-        """upsert_issue_async called twice: second call preserves milestone/lane/priority/size/status.
+        """Second call preserves milestone/lane/priority/size/status from first.
 
         SC13: non-payload columns must not be NULL'd by a webhook upsert.
         """
@@ -167,11 +167,11 @@ class TestUpsertIssueAsync:
                 "2026-01-01T00:00:00Z",
                 "2026-01-01T00:00:00Z",
                 None,
-                "v1.0",   # milestone
+                "v1.0",  # milestone
                 0,
-                "a1",     # lane
-                "P1",     # priority
-                "F-lite", # size
+                "a1",  # lane
+                "P1",  # priority
+                "F-lite",  # size
                 None,
             ),
         )
@@ -199,7 +199,7 @@ class TestUpsertIssueAsync:
         )
         row = await cur.fetchone()
         assert row is not None
-        title, state, milestone, lane, priority, size, status = row
+        title, state, milestone, lane, priority, size, _status = row
         # Updated fields
         assert title == "Updated title"
         assert state == "closed"
@@ -209,10 +209,8 @@ class TestUpsertIssueAsync:
         assert priority == "P1", f"priority was NULLed: {priority!r}"
         assert size == "F-lite", f"size was NULLed: {size!r}"
 
-    async def test_sync_and_async_produce_identical_rows(
-        self, tmp_path: Path
-    ) -> None:
-        """upsert_issue_async then upsert_issue (sync) on same key produce identical rows.
+    async def test_sync_and_async_produce_identical_rows(self, tmp_path: Path) -> None:
+        """Async + sync upserts on the same key produce identical rows.
 
         SC7: SQL constants are shared — both paths write the same column set.
         """
@@ -248,11 +246,21 @@ class TestUpsertIssueAsync:
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    issue["key"], issue["repo"], issue["number"], issue["title"],
-                    issue["state"], issue["url"], issue["created_at"],
-                    issue["updated_at"], issue["closed_at"], issue["milestone"],
-                    issue["is_stub"], issue["lane"], issue["priority"],
-                    issue["size"], issue["status"],
+                    issue["key"],
+                    issue["repo"],
+                    issue["number"],
+                    issue["title"],
+                    issue["state"],
+                    issue["url"],
+                    issue["created_at"],
+                    issue["updated_at"],
+                    issue["closed_at"],
+                    issue["milestone"],
+                    issue["is_stub"],
+                    issue["lane"],
+                    issue["priority"],
+                    issue["size"],
+                    issue["status"],
                 ),
             )
             await aconn.commit()
@@ -281,7 +289,7 @@ class TestUpsertIssueAsync:
             )
             async_row = await cur.fetchone()
 
-        # Core fields should match (async preserves milestone/lane/priority/size from DB)
+        # Core fields should match (async preserves milestone/lane/etc from DB)
         assert sync_row is not None
         assert async_row is not None
         # key, repo, number, title, state, url match
@@ -305,14 +313,15 @@ class TestEdgeAsync:
         await db.commit()
 
         cur = await db.execute(
-            "SELECT src_key, dst_key, kind FROM edges WHERE src_key=? AND dst_key=? AND kind=?",
+            "SELECT src_key, dst_key, kind FROM edges"
+            " WHERE src_key=? AND dst_key=? AND kind=?",
             ("A#1", "B#2", "blocks"),
         )
         row = await cur.fetchone()
         assert row == ("A#1", "B#2", "blocks")
 
     async def test_add_edge_is_idempotent(self, db: aiosqlite.Connection) -> None:
-        """add_edge_async called twice on same (src, dst, kind) does not error or duplicate."""
+        """Calling add_edge_async twice on same (src, dst, kind) is idempotent."""
         await add_edge_async(db, "A#1", "B#2", "blocks")
         await db.commit()
         await add_edge_async(db, "A#1", "B#2", "blocks")
@@ -347,7 +356,7 @@ class TestEdgeAsync:
         await db.commit()
 
         cur = await db.execute("SELECT src_key, dst_key, kind FROM edges")
-        rows = await cur.fetchall()
+        rows = list(await cur.fetchall())
         assert len(rows) == 1
         assert rows[0] == ("A#1", "B#2", "blocks")
 

--- a/tests/test_corpus_mutations.py
+++ b/tests/test_corpus_mutations.py
@@ -1,0 +1,429 @@
+"""Tests for corpus.mutations async helpers — T5 [RED].
+
+Covers:
+- upsert_issue_async + upsert_issue (sync) on same key produce identical rows
+- upsert_issue_async preserves non-payload columns on second call
+- add_edge_async is idempotent
+- remove_edge_async only removes matching kind
+- replace_labels_async wipes and rewrites labels
+- delete_issue_async removes issue row
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+import pytest
+
+from roxabi_live.corpus.mutations import (
+    add_edge_async,
+    delete_issue_async,
+    remove_edge_async,
+    replace_labels_async,
+    upsert_issue_async,
+)
+from roxabi_live.corpus.schema import bootstrap, connect
+from roxabi_live.corpus.sync import upsert_issue
+
+# ---------------------------------------------------------------------------
+# Schema SQL
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS issues (
+    key         TEXT PRIMARY KEY,
+    repo        TEXT NOT NULL,
+    number      INTEGER NOT NULL,
+    title       TEXT,
+    state       TEXT NOT NULL,
+    url         TEXT,
+    created_at  TEXT,
+    updated_at  TEXT,
+    closed_at   TEXT,
+    milestone   TEXT,
+    is_stub     INTEGER NOT NULL DEFAULT 0,
+    lane        TEXT,
+    priority    TEXT,
+    size        TEXT,
+    status      TEXT
+);
+
+CREATE TABLE IF NOT EXISTS labels (
+    issue_key   TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    PRIMARY KEY (issue_key, name),
+    FOREIGN KEY (issue_key) REFERENCES issues(key) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    src_key     TEXT NOT NULL,
+    dst_key     TEXT NOT NULL,
+    kind        TEXT NOT NULL DEFAULT 'parent',
+    PRIMARY KEY (src_key, dst_key, kind)
+);
+"""
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def db() -> AsyncIterator[aiosqlite.Connection]:
+    """In-memory aiosqlite connection with full corpus schema."""
+    conn = await aiosqlite.connect(":memory:")
+    await conn.executescript(_SCHEMA_SQL)
+    await conn.execute("PRAGMA foreign_keys = ON")
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+def _base_issue(
+    key: str = "Roxabi/lyra#1",
+    repo: str = "Roxabi/lyra",
+    number: int = 1,
+    title: str = "Test issue",
+    state: str = "open",
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "repo": repo,
+        "number": number,
+        "title": title,
+        "state": state,
+        "url": f"https://github.com/{repo}/issues/{number}",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "closed_at": None,
+        "milestone": "v1.0",
+        "is_stub": 0,
+        "lane": "a1",
+        "priority": "P1",
+        "size": "F-lite",
+        "status": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests — upsert_issue_async
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertIssueAsync:
+    """upsert_issue_async() — async webhook upsert path."""
+
+    async def test_inserts_new_issue(self, db: aiosqlite.Connection) -> None:
+        """upsert_issue_async inserts a new row on first call."""
+        partial = {
+            "key": "Roxabi/lyra#1",
+            "repo": "Roxabi/lyra",
+            "number": 1,
+            "title": "New issue",
+            "state": "open",
+            "url": "https://github.com/Roxabi/lyra/issues/1",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "closed_at": None,
+        }
+        await upsert_issue_async(db, partial)
+        await db.commit()
+
+        cur = await db.execute(
+            "SELECT key, title, state FROM issues WHERE key = ?", ("Roxabi/lyra#1",)
+        )
+        row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "Roxabi/lyra#1"
+        assert row[1] == "New issue"
+        assert row[2] == "open"
+
+    async def test_preserves_non_payload_columns(
+        self, db: aiosqlite.Connection
+    ) -> None:
+        """upsert_issue_async called twice: second call preserves milestone/lane/priority/size/status.
+
+        SC13: non-payload columns must not be NULL'd by a webhook upsert.
+        """
+        # First call: full sync upsert (sets milestone, lane, priority, size)
+        # We simulate this by directly inserting a row with all columns set
+        await db.execute(
+            """
+            INSERT INTO issues
+                (key, repo, number, title, state, url, created_at, updated_at,
+                 closed_at, milestone, is_stub, lane, priority, size, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "Roxabi/lyra#1",
+                "Roxabi/lyra",
+                1,
+                "Original title",
+                "open",
+                "https://github.com/Roxabi/lyra/issues/1",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+                None,
+                "v1.0",   # milestone
+                0,
+                "a1",     # lane
+                "P1",     # priority
+                "F-lite", # size
+                None,
+            ),
+        )
+        await db.commit()
+
+        # Second call: webhook upsert (without milestone/lane/priority/size)
+        partial = {
+            "key": "Roxabi/lyra#1",
+            "repo": "Roxabi/lyra",
+            "number": 1,
+            "title": "Updated title",
+            "state": "closed",
+            "url": "https://github.com/Roxabi/lyra/issues/1",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-04-24T00:00:00Z",
+            "closed_at": "2026-04-24T00:00:00Z",
+        }
+        await upsert_issue_async(db, partial)
+        await db.commit()
+
+        cur = await db.execute(
+            "SELECT title, state, milestone, lane, priority, size, status"
+            " FROM issues WHERE key = ?",
+            ("Roxabi/lyra#1",),
+        )
+        row = await cur.fetchone()
+        assert row is not None
+        title, state, milestone, lane, priority, size, status = row
+        # Updated fields
+        assert title == "Updated title"
+        assert state == "closed"
+        # Preserved non-payload fields
+        assert milestone == "v1.0", f"milestone was NULLed: {milestone!r}"
+        assert lane == "a1", f"lane was NULLed: {lane!r}"
+        assert priority == "P1", f"priority was NULLed: {priority!r}"
+        assert size == "F-lite", f"size was NULLed: {size!r}"
+
+    async def test_sync_and_async_produce_identical_rows(
+        self, tmp_path: Path
+    ) -> None:
+        """upsert_issue_async then upsert_issue (sync) on same key produce identical rows.
+
+        SC7: SQL constants are shared — both paths write the same column set.
+        """
+        db_path = tmp_path / "corpus.db"
+        bootstrap(db_path)
+        sync_conn = connect(db_path)
+
+        issue = _base_issue()
+        upsert_issue(sync_conn, issue)
+        sync_conn.commit()
+
+        # Read via sync
+        sync_row = sync_conn.execute(
+            "SELECT key, repo, number, title, state, url,"
+            " created_at, updated_at, closed_at, milestone, is_stub,"
+            " lane, priority, size, status"
+            " FROM issues WHERE key = ?",
+            (issue["key"],),
+        ).fetchone()
+        sync_conn.close()
+
+        # Now do the same via async path on fresh db
+        db_path2 = tmp_path / "corpus2.db"
+        bootstrap(db_path2)
+
+        async with aiosqlite.connect(db_path2) as aconn:
+            # Insert with all fields first (simulating pre-existing row with full data)
+            await aconn.execute(
+                """
+                INSERT INTO issues
+                    (key, repo, number, title, state, url, created_at, updated_at,
+                     closed_at, milestone, is_stub, lane, priority, size, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    issue["key"], issue["repo"], issue["number"], issue["title"],
+                    issue["state"], issue["url"], issue["created_at"],
+                    issue["updated_at"], issue["closed_at"], issue["milestone"],
+                    issue["is_stub"], issue["lane"], issue["priority"],
+                    issue["size"], issue["status"],
+                ),
+            )
+            await aconn.commit()
+
+            # Update via async path
+            partial = {
+                "key": issue["key"],
+                "repo": issue["repo"],
+                "number": issue["number"],
+                "title": issue["title"],
+                "state": issue["state"],
+                "url": issue["url"],
+                "created_at": issue["created_at"],
+                "updated_at": issue["updated_at"],
+                "closed_at": issue["closed_at"],
+            }
+            await upsert_issue_async(aconn, partial)
+            await aconn.commit()
+
+            cur = await aconn.execute(
+                "SELECT key, repo, number, title, state, url,"
+                " created_at, updated_at, closed_at, milestone, is_stub,"
+                " lane, priority, size, status"
+                " FROM issues WHERE key = ?",
+                (issue["key"],),
+            )
+            async_row = await cur.fetchone()
+
+        # Core fields should match (async preserves milestone/lane/priority/size from DB)
+        assert sync_row is not None
+        assert async_row is not None
+        # key, repo, number, title, state, url match
+        for i in range(6):
+            assert sync_row[i] == async_row[i], (
+                f"Column {i} mismatch: {sync_row[i]!r} vs {async_row[i]!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests — add_edge_async / remove_edge_async
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeAsync:
+    """add_edge_async and remove_edge_async."""
+
+    async def test_add_edge_inserts(self, db: aiosqlite.Connection) -> None:
+        """add_edge_async inserts an edge row."""
+        await add_edge_async(db, "A#1", "B#2", "blocks")
+        await db.commit()
+
+        cur = await db.execute(
+            "SELECT src_key, dst_key, kind FROM edges WHERE src_key=? AND dst_key=? AND kind=?",
+            ("A#1", "B#2", "blocks"),
+        )
+        row = await cur.fetchone()
+        assert row == ("A#1", "B#2", "blocks")
+
+    async def test_add_edge_is_idempotent(self, db: aiosqlite.Connection) -> None:
+        """add_edge_async called twice on same (src, dst, kind) does not error or duplicate."""
+        await add_edge_async(db, "A#1", "B#2", "blocks")
+        await db.commit()
+        await add_edge_async(db, "A#1", "B#2", "blocks")
+        await db.commit()
+
+        cur = await db.execute("SELECT COUNT(*) FROM edges")
+        row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+    async def test_remove_edge_deletes(self, db: aiosqlite.Connection) -> None:
+        """remove_edge_async removes the specified edge."""
+        await add_edge_async(db, "A#1", "B#2", "blocks")
+        await db.commit()
+        await remove_edge_async(db, "A#1", "B#2", "blocks")
+        await db.commit()
+
+        cur = await db.execute("SELECT COUNT(*) FROM edges")
+        row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    async def test_remove_edge_only_removes_matching_kind(
+        self, db: aiosqlite.Connection
+    ) -> None:
+        """remove_edge_async with kind='parent' does not remove kind='blocks' edges."""
+        await add_edge_async(db, "A#1", "B#2", "parent")
+        await add_edge_async(db, "A#1", "B#2", "blocks")
+        await db.commit()
+
+        await remove_edge_async(db, "A#1", "B#2", "parent")
+        await db.commit()
+
+        cur = await db.execute("SELECT src_key, dst_key, kind FROM edges")
+        rows = await cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0] == ("A#1", "B#2", "blocks")
+
+
+# ---------------------------------------------------------------------------
+# Tests — replace_labels_async
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceLabelsAsync:
+    """replace_labels_async() — wipes and rewrites labels for an issue."""
+
+    async def test_inserts_labels(self, db: aiosqlite.Connection) -> None:
+        """replace_labels_async inserts the given label names."""
+        # Need an issue row first (FK constraint)
+        await db.execute(
+            "INSERT INTO issues (key, repo, number, title, state) VALUES (?,?,?,?,?)",
+            ("K#1", "K", 1, "t", "open"),
+        )
+        await db.commit()
+
+        await replace_labels_async(db, "K#1", ["bug", "enhancement"])
+        await db.commit()
+
+        cur = await db.execute(
+            "SELECT name FROM labels WHERE issue_key=? ORDER BY name", ("K#1",)
+        )
+        rows = await cur.fetchall()
+        assert [r[0] for r in rows] == ["bug", "enhancement"]
+
+    async def test_replaces_existing_labels(self, db: aiosqlite.Connection) -> None:
+        """replace_labels_async wipes old labels before writing new ones."""
+        await db.execute(
+            "INSERT INTO issues (key, repo, number, title, state) VALUES (?,?,?,?,?)",
+            ("K#1", "K", 1, "t", "open"),
+        )
+        await db.execute(
+            "INSERT INTO labels (issue_key, name) VALUES (?,?)", ("K#1", "old-label")
+        )
+        await db.commit()
+
+        await replace_labels_async(db, "K#1", ["new-label"])
+        await db.commit()
+
+        cur = await db.execute(
+            "SELECT name FROM labels WHERE issue_key=? ORDER BY name", ("K#1",)
+        )
+        rows = await cur.fetchall()
+        assert [r[0] for r in rows] == ["new-label"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — delete_issue_async
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteIssueAsync:
+    """delete_issue_async() — removes an issue row."""
+
+    async def test_deletes_existing_issue(self, db: aiosqlite.Connection) -> None:
+        """delete_issue_async removes the issue row."""
+        await db.execute(
+            "INSERT INTO issues (key, repo, number, title, state) VALUES (?,?,?,?,?)",
+            ("K#1", "K", 1, "t", "open"),
+        )
+        await db.commit()
+
+        await delete_issue_async(db, "K#1")
+        await db.commit()
+
+        cur = await db.execute("SELECT COUNT(*) FROM issues WHERE key=?", ("K#1",))
+        row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    async def test_delete_nonexistent_is_noop(self, db: aiosqlite.Connection) -> None:
+        """delete_issue_async on a missing key does not raise."""
+        await delete_issue_async(db, "nonexistent#99")
+        await db.commit()

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -1,9 +1,9 @@
 """Tests for roxabi_live.reconciler — RED phase (module does not exist yet).
 
 Covers:
-- run_once() exists, is async, calls corpus sync entrypoint
-- run_once() tolerates DB/network errors (catches and logs, does not raise)
-- hourly_loop(interval_seconds) returns an asyncio.Task, ticks run_once at
+- run_once(settings) exists, is async, calls corpus sync entrypoint
+- run_once(settings) tolerates DB/network errors (catches and logs, does not raise)
+- hourly_loop(settings) returns an asyncio.Task, ticks run_once at
   least twice within the configured interval, cancels cleanly
 """
 
@@ -18,6 +18,18 @@ import pytest
 import requests.exceptions
 
 from roxabi_live import reconciler  # noqa: F401 — expected ImportError in RED phase
+from roxabi_live.config import Settings
+
+
+def _settings(tmp_path: Path | None = None) -> Settings:
+    """Build a minimal Settings for tests."""
+    db = tmp_path / "corpus.db" if tmp_path else Path("/tmp/corpus_test.db")
+    return Settings(
+        corpus_db_path=db,
+        github_org="Roxabi",
+        github_webhook_secret="",
+        corpus_sync_interval_seconds=3600.0,
+    )
 
 
 def _make_http_error(status_code: int) -> requests.exceptions.HTTPError:
@@ -45,12 +57,13 @@ def reset_reconciler_auth_state() -> None:
 
 
 class TestRunOnce:
-    """reconciler.run_once() — async, delegates to corpus sync."""
+    """reconciler.run_once(settings) — async, delegates to corpus sync."""
 
     @pytest.mark.asyncio
     async def test_run_once_is_coroutine(self) -> None:
         """run_once must be an async function (awaitable)."""
         # Arrange
+        s = _settings()
         with patch(
             "roxabi_live.corpus.sync.run_sync",
             new_callable=MagicMock,
@@ -63,7 +76,7 @@ class TestRunOnce:
             },
         ):
             # Act
-            coro = reconciler.run_once()
+            coro = reconciler.run_once(s)
             # Assert — must be a coroutine, not a plain return value
             assert asyncio.iscoroutine(coro), "run_once() must return a coroutine"
             await coro
@@ -73,76 +86,71 @@ class TestRunOnce:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """run_once must call roxabi_live.corpus.sync.run_sync exactly once."""
-        # Arrange — isolate DB path (CI has no ~/.roxabi/)
-        db_file = tmp_path / "corpus.db"
-        monkeypatch.setenv("CORPUS_DB_PATH", str(db_file))
+        s = _settings(tmp_path)
         mock_run_sync = MagicMock(
             return_value={"repos": 2, "pages": 3, "issues": 42, "stubs": 1, "errors": 0}
         )
         with patch("roxabi_live.corpus.sync.run_sync", mock_run_sync):
-            # Act
-            await reconciler.run_once()
-        # Assert
+            await reconciler.run_once(s)
         mock_run_sync.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_run_once_tolerates_exception_does_not_raise(self) -> None:
         """run_once must catch DB/network errors and not propagate them."""
-        # Arrange — simulate a broken DB connection
+        s = _settings()
         with patch(
             "roxabi_live.corpus.sync.run_sync",
             side_effect=OSError("corpus.db: no such file"),
         ):
-            # Act & Assert — must NOT raise
-            await reconciler.run_once()
+            await reconciler.run_once(s)
 
     @pytest.mark.asyncio
     async def test_run_once_tolerates_graphql_error_does_not_raise(self) -> None:
         """run_once must catch GraphQL/network errors and not propagate them."""
-        # Arrange
         from roxabi_live.corpus.graphql import GraphQLError
 
+        s = _settings()
         with patch(
             "roxabi_live.corpus.sync.run_sync",
             side_effect=GraphQLError("rate limit exceeded"),
         ):
-            # Act & Assert — must NOT raise
-            await reconciler.run_once()
+            await reconciler.run_once(s)
 
     @pytest.mark.asyncio
     async def test_run_once_logs_on_error(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         """run_once must log at ERROR level when an error is caught."""
-        # Arrange
+        s = _settings()
         with caplog.at_level(logging.ERROR, logger="roxabi_live.reconciler"):
             with patch(
                 "roxabi_live.corpus.sync.run_sync",
                 side_effect=RuntimeError("unexpected failure"),
             ):
-                # Act
-                await reconciler.run_once()
-        # Assert — an ERROR-level log record must have been emitted
+                await reconciler.run_once(s)
         assert any(rec.levelno == logging.ERROR for rec in caplog.records)
 
 
 class TestHourlyLoop:
-    """reconciler.hourly_loop() — returns asyncio.Task, ticks run_once periodically."""
+    """reconciler.hourly_loop(settings) — returns asyncio.Task, ticks run_once periodically."""
 
     @pytest.mark.asyncio
     async def test_hourly_loop_returns_task(self) -> None:
         """hourly_loop must return an asyncio.Task immediately (non-blocking)."""
-        # Arrange
         call_count = 0
 
-        async def fake_run_once() -> None:
+        async def fake_run_once(s: Settings) -> None:
             nonlocal call_count
             call_count += 1
 
+        s = Settings(
+            corpus_db_path=Path("/tmp/test.db"),
+            github_org="Roxabi",
+            github_webhook_secret="",
+            corpus_sync_interval_seconds=0.05,
+        )
         with patch.object(reconciler, "run_once", fake_run_once):
-            # Act
-            task = reconciler.hourly_loop(interval_seconds=0.05)
-            # Assert
+            task = reconciler.hourly_loop(s)
             assert isinstance(task, asyncio.Task), (
                 "hourly_loop must return an asyncio.Task"
             )
@@ -155,24 +163,26 @@ class TestHourlyLoop:
     @pytest.mark.asyncio
     async def test_hourly_loop_ticks_run_once_at_least_twice(self) -> None:
         """hourly_loop must call run_once at least twice within 3x the interval."""
-        # Arrange
         call_count = 0
 
-        async def fake_run_once() -> None:
+        async def fake_run_once(s: Settings) -> None:
             nonlocal call_count
             call_count += 1
 
+        s = Settings(
+            corpus_db_path=Path("/tmp/test.db"),
+            github_org="Roxabi",
+            github_webhook_secret="",
+            corpus_sync_interval_seconds=0.05,
+        )
         with patch.object(reconciler, "run_once", fake_run_once):
-            # Act
-            task = reconciler.hourly_loop(interval_seconds=0.05)
-            # Wait long enough for at least 2 ticks (3 × 0.05 = 0.15 s)
+            task = reconciler.hourly_loop(s)
             await asyncio.sleep(0.15)
             task.cancel()
             try:
                 await task
             except asyncio.CancelledError:
                 pass
-        # Assert
         assert call_count >= 2, (
             f"Expected run_once to be called at least 2 times, got {call_count}"
         )
@@ -183,44 +193,47 @@ class TestHourlyLoop:
         exceptions."""
 
         # Arrange
-        async def fake_run_once() -> None:
+        async def fake_run_once(s: Settings) -> None:
             pass
 
+        s = Settings(
+            corpus_db_path=Path("/tmp/test.db"),
+            github_org="Roxabi",
+            github_webhook_secret="",
+            corpus_sync_interval_seconds=0.05,
+        )
         with patch.object(reconciler, "run_once", fake_run_once):
-            task = reconciler.hourly_loop(interval_seconds=0.05)
+            task = reconciler.hourly_loop(s)
             await asyncio.sleep(0.02)
-            # Act
             task.cancel()
-            # Assert — CancelledError is the only exception permitted
             with pytest.raises(asyncio.CancelledError):
                 await task
 
     @pytest.mark.asyncio
-    async def test_hourly_loop_uses_env_interval(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """hourly_loop respects CORPUS_SYNC_INTERVAL_SECONDS env var when interval
-        derived from it."""
-        # Arrange — set env var to a tiny value
-        monkeypatch.setenv("CORPUS_SYNC_INTERVAL_SECONDS", "0.05")
+    async def test_hourly_loop_uses_settings_interval(self) -> None:
+        """hourly_loop uses the interval from Settings."""
         call_count = 0
 
-        async def fake_run_once() -> None:
+        async def fake_run_once(s: Settings) -> None:
             nonlocal call_count
             call_count += 1
 
+        s = Settings(
+            corpus_db_path=Path("/tmp/test.db"),
+            github_org="Roxabi",
+            github_webhook_secret="",
+            corpus_sync_interval_seconds=0.05,
+        )
         with patch.object(reconciler, "run_once", fake_run_once):
-            # Act — call without explicit interval; implementation reads env var
-            task = reconciler.hourly_loop()
+            task = reconciler.hourly_loop(s)
             await asyncio.sleep(0.15)
             task.cancel()
             try:
                 await task
             except asyncio.CancelledError:
                 pass
-        # Assert
         assert call_count >= 2, (
-            f"hourly_loop should use env interval; got {call_count} calls"
+            f"hourly_loop should use settings interval; got {call_count} calls"
         )
 
 

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -132,7 +132,7 @@ class TestRunOnce:
 
 
 class TestHourlyLoop:
-    """reconciler.hourly_loop(settings) — returns asyncio.Task, ticks run_once periodically."""
+    """hourly_loop(settings) returns an asyncio.Task that ticks run_once."""
 
     @pytest.mark.asyncio
     async def test_hourly_loop_returns_task(self) -> None:

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -43,19 +43,6 @@ def _success_dict() -> dict[str, int]:
     return {"repos": 1, "pages": 1, "issues": 10, "stubs": 0, "errors": 0}
 
 
-@pytest.fixture(autouse=True)
-def reset_reconciler_auth_state() -> None:
-    """Reset auth-failure counters before each test (no-op in RED phase).
-
-    Once T8 adds _auth_failures / _halted to the reconciler module these
-    assignments ensure tests start from a clean state.
-    """
-    if hasattr(reconciler, "_auth_failures"):
-        reconciler._auth_failures = 0  # type: ignore[attr-defined]
-    if hasattr(reconciler, "_halted"):
-        reconciler._halted.clear()  # type: ignore[attr-defined]
-
-
 class TestRunOnce:
     """reconciler.run_once(settings) — async, delegates to corpus sync."""
 

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -258,7 +258,14 @@ class TestAuthHalt:
                 side_effect=[err_401, err_401],
             ):
                 # Act — hourly_loop should exit on its own (not require cancellation)
-                task = reconciler.hourly_loop(interval_seconds=0.01)
+                task = reconciler.hourly_loop(
+                    Settings(
+                        corpus_db_path=tmp_path / "corpus.db",
+                        github_org="Roxabi",
+                        github_webhook_secret="",
+                        corpus_sync_interval_seconds=0.01,
+                    )
+                )
                 await asyncio.wait_for(task, timeout=1.0)
 
         # Assert — task completed without TimeoutError/CancelledError
@@ -291,7 +298,14 @@ class TestAuthHalt:
             side_effect=[err_401, _success_dict(), _success_dict()],
         ):
             # Act — allow a few ticks
-            task = reconciler.hourly_loop(interval_seconds=0.01)
+            task = reconciler.hourly_loop(
+                Settings(
+                    corpus_db_path=tmp_path / "corpus.db",
+                    github_org="Roxabi",
+                    github_webhook_secret="",
+                    corpus_sync_interval_seconds=0.01,
+                )
+            )
             await asyncio.sleep(0.08)
             task.cancel()
             try:
@@ -321,7 +335,14 @@ class TestAuthHalt:
             side_effect=[OSError("connection reset"), OSError("connection reset")],
         ):
             # Act — allow two ticks
-            task = reconciler.hourly_loop(interval_seconds=0.01)
+            task = reconciler.hourly_loop(
+                Settings(
+                    corpus_db_path=tmp_path / "corpus.db",
+                    github_org="Roxabi",
+                    github_webhook_secret="",
+                    corpus_sync_interval_seconds=0.01,
+                )
+            )
             await asyncio.sleep(0.05)
 
         # Assert — counter untouched, loop still running
@@ -353,7 +374,14 @@ class TestAuthHalt:
                 side_effect=[err_403, err_403],
             ):
                 # Act
-                task = reconciler.hourly_loop(interval_seconds=0.01)
+                task = reconciler.hourly_loop(
+                    Settings(
+                        corpus_db_path=tmp_path / "corpus.db",
+                        github_org="Roxabi",
+                        github_webhook_secret="",
+                        corpus_sync_interval_seconds=0.01,
+                    )
+                )
                 await asyncio.wait_for(task, timeout=1.0)
 
         # Assert — same halt behaviour as 401

--- a/tests/test_reconciler_lifecycle.py
+++ b/tests/test_reconciler_lifecycle.py
@@ -1,0 +1,205 @@
+"""Tests for task tracking + lifespan shutdown — T13 [RED].
+
+Covers SC14 (heal task exception logged via done_callback) and
+SC15 (shutdown cancels sleeping heal task within 1s).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from weakref import WeakSet
+
+import pytest
+
+from roxabi_live.config import Settings
+from roxabi_live.reconciler import make_trigger_heal
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _settings(tmp_path: Path | None = None) -> Settings:
+    db = tmp_path / "corpus.db" if tmp_path else Path("/tmp/corpus_lifecycle.db")
+    return Settings(
+        corpus_db_path=db,
+        github_org="Roxabi",
+        github_webhook_secret="",
+        corpus_sync_interval_seconds=3600.0,
+    )
+
+
+# Minimal in-memory sync_state table for trigger_heal to query
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS sync_state (
+    repo            TEXT PRIMARY KEY,
+    last_cursor     TEXT,
+    last_synced_at  TEXT
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# SC14 — exception in heal task is logged via done_callback
+# ---------------------------------------------------------------------------
+
+
+class TestHealTaskExceptionLogged:
+    """make_trigger_heal schedules tasks; done_callback logs exceptions (SC14)."""
+
+    @pytest.mark.asyncio
+    async def test_heal_task_exception_captured_in_logs(
+        self, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ) -> None:
+        """A heal task that raises an exception has it captured by the done_callback.
+
+        The exception must appear in caplog at ERROR level (not silently dropped).
+        """
+        import aiosqlite
+
+        s = _settings(tmp_path)
+        bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
+        trigger_heal = make_trigger_heal(s, bg_tasks)
+
+        async def _raise() -> None:
+            raise RuntimeError("heal task blew up")
+
+        # Monkey-patch run_once to raise inside the scheduled task
+        import roxabi_live.reconciler as rec_module
+
+        original_run_once = rec_module.run_once
+
+        async def _bad_run_once(settings: Settings) -> None:
+            raise RuntimeError("heal task blew up")
+
+        rec_module.run_once = _bad_run_once  # type: ignore[assignment]
+
+        try:
+            async with aiosqlite.connect(":memory:") as conn:
+                await conn.executescript(_SCHEMA_SQL)
+                # No sync_state row → stale → heal scheduled
+                with caplog.at_level(logging.ERROR, logger="roxabi_live.reconciler"):
+                    await trigger_heal("Roxabi/lyra", conn)
+                    # Let the event loop run the task to completion
+                    await asyncio.sleep(0.05)
+        finally:
+            rec_module.run_once = original_run_once  # type: ignore[assignment]
+
+        error_records = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "heal task" in r.getMessage().lower()
+        ]
+        assert error_records, (
+            f"Expected an ERROR log for heal task exception. Records: {caplog.records}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_task_registered_in_weakset(self, tmp_path: Path) -> None:
+        """make_trigger_heal adds the scheduled task to background_tasks WeakSet."""
+        from unittest.mock import AsyncMock, patch
+
+        import aiosqlite
+
+        s = _settings(tmp_path)
+        bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
+        trigger_heal = make_trigger_heal(s, bg_tasks)
+
+        with patch("roxabi_live.reconciler.run_once", AsyncMock(return_value=None)):
+            async with aiosqlite.connect(":memory:") as conn:
+                await conn.executescript(_SCHEMA_SQL)
+                # No sync_state row → stale → task created
+                await trigger_heal("Roxabi/lyra", conn)
+
+                tasks = list(bg_tasks)
+                assert len(tasks) >= 1, (
+                    "Expected at least one task in background_tasks WeakSet"
+                )
+                assert all(isinstance(t, asyncio.Task) for t in tasks)
+                # Drain
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# SC15 — lifespan shutdown cancels sleeping heal task within 1s
+# ---------------------------------------------------------------------------
+
+
+class TestLifespanShutdownCancelsHealTasks:
+    """app.py lifespan exit cancels all background_tasks and awaits them (SC15)."""
+
+    @pytest.mark.asyncio
+    async def test_sleeping_heal_task_cancelled_on_shutdown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lifespan shutdown with one sleeping heal task completes within 1s.
+
+        Verifies SC15: no 'Task was destroyed but it is pending' warning.
+        """
+        import warnings
+
+        db_path = tmp_path / "corpus.db"
+        monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "secret")
+
+        # Create a DB with the minimal schema so bootstrap works
+        from roxabi_live.corpus.schema import bootstrap
+
+        bootstrap(db_path)
+
+        long_running_task_started = asyncio.Event()
+
+        async def _long_running(settings: Settings) -> None:
+            long_running_task_started.set()
+            await asyncio.sleep(60)  # much longer than 1s timeout
+
+        # Patch run_once at the module level before app is loaded
+        import roxabi_live.reconciler as rec_module
+
+        original = rec_module.run_once
+
+        async def _fast_run_once(settings: Settings) -> None:
+            pass  # startup call: fast
+
+        rec_module.run_once = _fast_run_once  # type: ignore[assignment]
+
+        try:
+            from fastapi import FastAPI
+
+            from roxabi_live.app import lifespan
+
+            test_app = FastAPI(lifespan=lifespan)
+
+            # Run lifespan startup
+            async with lifespan(test_app):
+                # Now switch run_once to the long-running version so
+                # the next trigger_heal call spawns a long task
+                rec_module.run_once = _long_running  # type: ignore[assignment]
+
+                # Manually inject a sleeping task into background_tasks
+                async def _sleeping() -> None:
+                    await asyncio.sleep(60)
+
+                task: asyncio.Task[None] = asyncio.create_task(_sleeping())
+                test_app.state.background_tasks.add(task)
+
+            # After lifespan exit: task must be cancelled (not pending)
+            assert task.cancelled() or task.done(), (
+                "Expected heal task to be cancelled on lifespan shutdown"
+            )
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                del task
+                # Give GC a chance
+                await asyncio.sleep(0)
+            pending_warnings = [
+                x for x in w if "Task was destroyed but it is pending" in str(x.message)
+            ]
+            assert not pending_warnings, (
+                f"Pending task warning on shutdown: {pending_warnings}"
+            )
+        finally:
+            rec_module.run_once = original  # type: ignore[assignment]

--- a/tests/test_reconciler_lifecycle.py
+++ b/tests/test_reconciler_lifecycle.py
@@ -63,9 +63,6 @@ class TestHealTaskExceptionLogged:
         bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
         trigger_heal = make_trigger_heal(s, bg_tasks)
 
-        async def _raise() -> None:
-            raise RuntimeError("heal task blew up")
-
         # Monkey-patch run_once to raise inside the scheduled task
         import roxabi_live.reconciler as rec_module
 
@@ -166,6 +163,8 @@ class TestLifespanShutdownCancelsHealTasks:
         rec_module.run_once = _fast_run_once  # type: ignore[assignment]
 
         try:
+            import time
+
             from fastapi import FastAPI
 
             from roxabi_live.app import lifespan
@@ -173,21 +172,32 @@ class TestLifespanShutdownCancelsHealTasks:
             test_app = FastAPI(lifespan=lifespan)
 
             # Run lifespan startup
-            async with lifespan(test_app):
-                # Now switch run_once to the long-running version so
-                # the next trigger_heal call spawns a long task
-                rec_module.run_once = _long_running  # type: ignore[assignment]
+            shutdown_start: float = 0.0
+            shutdown_elapsed: float = 0.0
+            try:
+                async with lifespan(test_app):
+                    # Now switch run_once to the long-running version so
+                    # the next trigger_heal call spawns a long task
+                    rec_module.run_once = _long_running  # type: ignore[assignment]
 
-                # Manually inject a sleeping task into background_tasks
-                async def _sleeping() -> None:
-                    await asyncio.sleep(60)
+                    # Manually inject a sleeping task into background_tasks
+                    async def _sleeping() -> None:
+                        await asyncio.sleep(60)
 
-                task: asyncio.Task[None] = asyncio.create_task(_sleeping())
-                test_app.state.background_tasks.add(task)
+                    task: asyncio.Task[None] = asyncio.create_task(_sleeping())
+                    test_app.state.background_tasks.add(task)
+                    shutdown_start = time.monotonic()
+            finally:
+                shutdown_elapsed = time.monotonic() - shutdown_start
 
-            # After lifespan exit: task must be cancelled (not pending)
-            assert task.cancelled() or task.done(), (
-                "Expected heal task to be cancelled on lifespan shutdown"
+            # SC15: lifespan exit must cancel the sleeping task in <1s
+            assert shutdown_elapsed < 1.0, (
+                f"Lifespan shutdown took {shutdown_elapsed:.2f}s; SC15 budget is 1s"
+            )
+            # Task must be done (cancelled) — not still pending
+            assert task.done(), "Expected heal task to be done after lifespan shutdown"
+            assert task.cancelled(), (
+                "Expected heal task to be cancelled, not completed normally"
             )
 
             with warnings.catch_warnings(record=True) as w:

--- a/tests/test_webhook_body_cap.py
+++ b/tests/test_webhook_body_cap.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import hmac
 import json
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
@@ -112,15 +113,21 @@ def db_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    """TestClient with env vars pointing at the tmp db."""
+def client(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[TestClient, None, None]:
+    """TestClient with env vars pointing at the tmp db.
+
+    Uses context-manager form so FastAPI lifespan runs (sets app.state.settings,
+    app.state.trigger_heal, app.state.background_tasks).
+    """
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
-    # Import app AFTER env vars are set so _db_path() resolves correctly
     from roxabi_live.app import app
 
-    return TestClient(app)
+    with TestClient(app) as c:
+        yield c
 
 
 # ---------------------------------------------------------------------------
@@ -141,21 +148,20 @@ def test_post_body_over_cap_returns_413(
     # raise_server_exceptions=False so oversized bodies return a response
     # rather than re-raising internal errors (before the cap middleware exists,
     # the server will 500; after implementation it should 413).
-    client = TestClient(app, raise_server_exceptions=False)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        body = b"A" * (26 * 1024 * 1024)
+        sig = _sign(body)
 
-    body = b"A" * (26 * 1024 * 1024)
-    sig = _sign(body)
-
-    # Act
-    resp = client.post(
-        "/webhook/github",
-        content=body,
-        headers={
-            "X-GitHub-Event": "issues",
-            "Content-Type": "application/json",
-            "X-Hub-Signature-256": sig,
-        },
-    )
+        # Act
+        resp = client.post(
+            "/webhook/github",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issues",
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+            },
+        )
 
     # Assert
     assert resp.status_code == 413
@@ -171,21 +177,20 @@ def test_post_body_at_cap_passes_through(
 
     from roxabi_live.app import app
 
-    client = TestClient(app, raise_server_exceptions=False)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        body = b"A" * _CAP_BYTES
+        sig = _sign(body)
 
-    body = b"A" * _CAP_BYTES
-    sig = _sign(body)
-
-    # Act
-    resp = client.post(
-        "/webhook/github",
-        content=body,
-        headers={
-            "X-GitHub-Event": "issues",
-            "Content-Type": "application/json",
-            "X-Hub-Signature-256": sig,
-        },
-    )
+        # Act
+        resp = client.post(
+            "/webhook/github",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issues",
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+            },
+        )
 
     # Assert — size gate must not reject exactly-at-cap bodies
     assert resp.status_code != 413, "25 MB body should pass the size gate"
@@ -204,21 +209,20 @@ def test_post_body_one_byte_over_cap_returns_413(
 
     from roxabi_live.app import app
 
-    client = TestClient(app, raise_server_exceptions=False)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        body = b"A" * (_CAP_BYTES + 1)
+        sig = _sign(body)
 
-    body = b"A" * (_CAP_BYTES + 1)
-    sig = _sign(body)
-
-    # Act
-    resp = client.post(
-        "/webhook/github",
-        content=body,
-        headers={
-            "X-GitHub-Event": "issues",
-            "Content-Type": "application/json",
-            "X-Hub-Signature-256": sig,
-        },
-    )
+        # Act
+        resp = client.post(
+            "/webhook/github",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issues",
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+            },
+        )
 
     # Assert
     assert resp.status_code == 413

--- a/tests/test_webhook_body_cap.py
+++ b/tests/test_webhook_body_cap.py
@@ -9,7 +9,6 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import hmac
 import json
@@ -17,7 +16,6 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
-import aiosqlite
 import pytest
 from fastapi.testclient import TestClient
 
@@ -100,15 +98,21 @@ def _issues_payload(
 
 @pytest.fixture()
 def db_path(tmp_path: Path) -> Path:
-    """Create a real sqlite file with the corpus schema and return its path."""
+    """Create a real sqlite file with the corpus schema and return its path.
+
+    Uses synchronous sqlite3 — the schema is pure DDL with no async I/O, and
+    avoiding `asyncio.run()` in a sync fixture sidesteps event-loop collisions
+    under pytest-asyncio strict/auto mode.
+    """
+    import sqlite3
+
     path = tmp_path / "corpus.db"
-
-    async def _init() -> None:
-        async with aiosqlite.connect(path) as conn:
-            await conn.executescript(_SCHEMA_SQL)
-            await conn.commit()
-
-    asyncio.run(_init())
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(_SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
     return path
 
 

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -570,11 +570,15 @@ class TestHandleIssuesTransaction:
 
         handlers_src = (
             pathlib.Path(__file__).parent.parent
-            / "src" / "roxabi_live" / "webhook" / "handlers.py"
+            / "src"
+            / "roxabi_live"
+            / "webhook"
+            / "handlers.py"
         ).read_text()
 
         raw_sql_lines = [
-            line.strip() for line in handlers_src.splitlines()
+            line.strip()
+            for line in handlers_src.splitlines()
             if any(kw in line.upper() for kw in ("INSERT ", "UPDATE ", "DELETE "))
             and not line.strip().startswith("#")
         ]

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -564,6 +564,44 @@ class TestHandleIssuesTransaction:
             f"Labels must be committed together with issue: {labels}"
         )
 
+    async def test_handle_issues_rolls_back_on_label_failure(
+        self, db: aiosqlite.Connection, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SC9 rollback: label-write failure must roll back the issue upsert too.
+
+        Patches replace_labels_async to raise after upsert_issue_async has
+        succeeded, then asserts the issue row is absent (rolled back) — proving
+        the explicit rollback path in handle_issues actually triggers.
+        """
+        # Pre-condition: nothing in DB
+        before = await _fetch_issue(db, "Roxabi/lyra#21")
+        assert before is None
+
+        async def _boom(
+            _conn: aiosqlite.Connection, _key: str, _names: list[str]
+        ) -> None:
+            raise RuntimeError("simulated label-write failure")
+
+        monkeypatch.setattr("roxabi_live.webhook.handlers.replace_labels_async", _boom)
+
+        payload = _make_payload(
+            action="opened",
+            number=21,
+            title="Rollback test",
+            state="open",
+            labels=["bug"],
+            repo="Roxabi/lyra",
+        )
+
+        with pytest.raises(RuntimeError, match="simulated label-write failure"):
+            await handle_issues(payload, db)
+
+        # The issue upsert must have been rolled back along with the labels.
+        after = await _fetch_issue(db, "Roxabi/lyra#21")
+        assert after is None, (
+            f"Issue row must be rolled back when label write fails, got: {after}"
+        )
+
     async def test_handle_issues_no_raw_sql_strings(self) -> None:
         """SC8: handlers.py must contain zero raw INSERT/UPDATE/DELETE SQL strings."""
         import pathlib

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -523,3 +523,61 @@ class TestSubIssuesWebhookHandler:
         assert row_a is None and row_b is None, (
             "Expected no edge for parent_issue_added noop"
         )
+
+
+# ---------------------------------------------------------------------------
+# T8 [RED] — Transactional write tests (SC9)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleIssuesTransaction:
+    """handle_issues wraps writes in async with conn: (SC9)."""
+
+    async def test_handle_issues_uses_transaction(
+        self, db: aiosqlite.Connection
+    ) -> None:
+        """handle_issues completes atomically — issue + labels committed together.
+
+        SC9: The handler must use async with conn: so that a crash mid-write
+        rolls back the entire operation rather than leaving a partial state.
+        This test verifies the happy path: both issue and labels are present
+        after a successful call.
+        """
+        payload = _make_payload(
+            action="opened",
+            number=20,
+            title="Transactional test",
+            state="open",
+            labels=["bug", "urgent"],
+            repo="Roxabi/lyra",
+        )
+
+        await handle_issues(payload, db)
+
+        # Verify issue row was committed
+        row = await _fetch_issue(db, "Roxabi/lyra#20")
+        assert row is not None, "Issue row must be committed after handle_issues"
+
+        # Verify labels were committed
+        labels = await _fetch_labels(db, "Roxabi/lyra#20")
+        assert sorted(labels) == ["bug", "urgent"], (
+            f"Labels must be committed together with issue: {labels}"
+        )
+
+    async def test_handle_issues_no_raw_sql_strings(self) -> None:
+        """SC8: handlers.py must contain zero raw INSERT/UPDATE/DELETE SQL strings."""
+        import pathlib
+
+        handlers_src = (
+            pathlib.Path(__file__).parent.parent
+            / "src" / "roxabi_live" / "webhook" / "handlers.py"
+        ).read_text()
+
+        raw_sql_lines = [
+            line.strip() for line in handlers_src.splitlines()
+            if any(kw in line.upper() for kw in ("INSERT ", "UPDATE ", "DELETE "))
+            and not line.strip().startswith("#")
+        ]
+        assert raw_sql_lines == [], (
+            f"handlers.py contains raw SQL strings: {raw_sql_lines}"
+        )

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -105,17 +105,20 @@ def _issues_payload(
 
 @pytest.fixture()
 def db_path(tmp_path: Path) -> Path:
-    """Create a real sqlite file with the corpus schema and return its path."""
+    """Create a real sqlite file with the corpus schema and return its path.
+
+    Uses synchronous sqlite3 — pure DDL needs no async; avoids `asyncio.run`
+    in a sync fixture under pytest-asyncio strict/auto mode.
+    """
+    import sqlite3
+
     path = tmp_path / "corpus.db"
-
-    async def _init() -> None:
-        async with aiosqlite.connect(path) as conn:
-            await conn.executescript(_SCHEMA_SQL)
-            await conn.commit()
-
-    import asyncio
-
-    asyncio.run(_init())
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(_SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
     return path
 
 

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -19,6 +19,7 @@ import hmac
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -119,15 +120,20 @@ def db_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    """TestClient with env vars pointing at the tmp db."""
+def client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """TestClient with env vars pointing at the tmp db.
+
+    Uses context manager form so that the FastAPI lifespan runs (which sets
+    app.state.settings, app.state.trigger_heal, etc.).
+    """
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
-    # Import app AFTER env vars are set so _db_path() resolves correctly
+    # Import app AFTER env vars are set
     from roxabi_live.app import app
 
-    return TestClient(app)
+    with TestClient(app) as c:
+        yield c
 
 
 # ---------------------------------------------------------------------------
@@ -254,85 +260,158 @@ def _seed_sync_state(db_path: Path, repo: str, last_synced_at: str) -> None:
 def test_stale_sync_triggers_reconcile(
     db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """sync_state.last_synced_at = 2h ago → reconciler.run_once is called."""
+    """A 2h-old sync_state triggers the heal scheduler."""
     two_hours_ago = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
     _seed_sync_state(db_path, "Roxabi/lyra", two_hours_ago)
 
     mock_run_once = AsyncMock(return_value=None)
-    monkeypatch.setattr("roxabi_live.webhook.router.reconciler.run_once", mock_run_once)
+    # The trigger_heal factory calls roxabi_live.reconciler.run_once.
+    # Patch before TestClient enters lifespan; lifespan startup call = call 1,
+    # webhook-triggered heal = call 2 (total >= 2).
+    monkeypatch.setattr("roxabi_live.reconciler.run_once", mock_run_once)
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
     from roxabi_live.app import app
 
-    client = TestClient(app)
     payload = _issues_payload(repo="Roxabi/lyra")
     body = json.dumps(payload).encode()
     sig = _sign(body)
 
-    resp = client.post(
-        "/webhook/github",
-        content=body,
-        headers={
-            "X-GitHub-Event": "issues",
-            "Content-Type": "application/json",
-            "X-Hub-Signature-256": sig,
-        },
-    )
-    assert resp.status_code == 200
+    with TestClient(app) as client:
+        call_count_after_startup = mock_run_once.call_count  # startup call
+        resp = client.post(
+            "/webhook/github",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issues",
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+            },
+        )
+        assert resp.status_code == 200
+        # Drain the event loop so the fire-and-forget task executes
+        asyncio.run(asyncio.sleep(0))
 
-    # Drain the event loop so the fire-and-forget task executes
-    asyncio.run(asyncio.sleep(0))
-    mock_run_once.assert_called_once()
+    # One additional call triggered by the stale webhook heal
+    assert mock_run_once.call_count > call_count_after_startup, (
+        "Expected trigger_heal to schedule an additional run_once call"
+    )
 
 
 def test_fresh_sync_does_not_trigger_reconcile(
     db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """sync_state.last_synced_at = 5min ago → reconciler.run_once is NOT called."""
+    """A fresh sync_state (5min ago) skips the heal scheduling."""
     five_min_ago = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
     _seed_sync_state(db_path, "Roxabi/lyra", five_min_ago)
 
     mock_run_once = AsyncMock(return_value=None)
-    monkeypatch.setattr("roxabi_live.webhook.router.reconciler.run_once", mock_run_once)
+    monkeypatch.setattr("roxabi_live.reconciler.run_once", mock_run_once)
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
     from roxabi_live.app import app
 
-    client = TestClient(app)
     payload = _issues_payload(repo="Roxabi/lyra")
     body = json.dumps(payload).encode()
     sig = _sign(body)
 
-    resp = client.post(
-        "/webhook/github",
-        content=body,
-        headers={
-            "X-GitHub-Event": "issues",
-            "Content-Type": "application/json",
-            "X-Hub-Signature-256": sig,
-        },
-    )
-    assert resp.status_code == 200
+    with TestClient(app) as client:
+        call_count_after_startup = mock_run_once.call_count
+        resp = client.post(
+            "/webhook/github",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issues",
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+            },
+        )
+        assert resp.status_code == 200
+        asyncio.run(asyncio.sleep(0))
 
-    asyncio.run(asyncio.sleep(0))
-    mock_run_once.assert_not_called()
+    # No additional calls — sync is fresh
+    assert mock_run_once.call_count == call_count_after_startup, (
+        "Expected trigger_heal NOT to schedule run_once for a fresh sync"
+    )
 
 
 def test_missing_sync_state_triggers_reconcile(
     db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No row in sync_state for the repo → reconciler.run_once is called."""
+    """No row in sync_state for the repo → trigger_heal schedules run_once."""
     mock_run_once = AsyncMock(return_value=None)
-    monkeypatch.setattr("roxabi_live.webhook.router.reconciler.run_once", mock_run_once)
+    monkeypatch.setattr("roxabi_live.reconciler.run_once", mock_run_once)
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
     from roxabi_live.app import app
 
-    client = TestClient(app)
     payload = _issues_payload(repo="Roxabi/lyra")
+    body = json.dumps(payload).encode()
+    sig = _sign(body)
+
+    with TestClient(app) as client:
+        call_count_after_startup = mock_run_once.call_count
+        resp = client.post(
+            "/webhook/github",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issues",
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+            },
+        )
+        assert resp.status_code == 200
+        asyncio.run(asyncio.sleep(0))
+
+    assert mock_run_once.call_count > call_count_after_startup, (
+        "Expected trigger_heal to schedule run_once when sync_state is missing"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T8 [RED] — Decoupling, body fix, transactional handlers
+# ---------------------------------------------------------------------------
+
+
+def test_router_does_not_import_reconciler() -> None:
+    """SC4: webhook/router.py must not have a runtime import of roxabi_live.reconciler.
+
+    TYPE_CHECKING-only imports (inside `if TYPE_CHECKING:` block) are allowed
+    since they are never executed at runtime — they satisfy the decoupling
+    requirement (no runtime dependency on the reconciler module).
+    """
+    router_src = (
+        __import__("pathlib").Path(__file__).parent.parent
+        / "src" / "roxabi_live" / "webhook" / "router.py"
+    ).read_text()
+
+    # Collect lines with reconciler imports, skipping those inside TYPE_CHECKING blocks
+    in_type_checking = False
+    runtime_import_lines = []
+    for line in router_src.splitlines():
+        stripped = line.strip()
+        if "TYPE_CHECKING" in stripped and stripped.startswith("if"):
+            in_type_checking = True
+        # Dedent back to top-level ends the TYPE_CHECKING block
+        if in_type_checking and stripped and not stripped.startswith("#") and not line.startswith(" ") and not line.startswith("\t") and "TYPE_CHECKING" not in stripped:
+            in_type_checking = False
+        if "import" in line and "reconciler" in line and not in_type_checking:
+            runtime_import_lines.append(line)
+
+    assert runtime_import_lines == [], (
+        f"router.py has runtime reconciler imports: {runtime_import_lines}"
+    )
+
+
+def test_json_loads_body_no_request_json(client: TestClient) -> None:
+    """SC10: body parsed via json.loads, not await request.json() after request.body().
+
+    Verifies that a valid webhook with body read once succeeds without 422/500.
+    """
+    payload = _issues_payload(action="opened", number=99)
     body = json.dumps(payload).encode()
     sig = _sign(body)
 
@@ -345,7 +424,6 @@ def test_missing_sync_state_triggers_reconcile(
             "X-Hub-Signature-256": sig,
         },
     )
+    # If body was double-read, the second parse would fail → 500 or empty payload
     assert resp.status_code == 200
-
-    asyncio.run(asyncio.sleep(0))
-    mock_run_once.assert_called_once()
+    assert resp.json() == {"ok": True}

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -17,9 +17,9 @@ import asyncio
 import hashlib
 import hmac
 import json
+from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -120,7 +120,9 @@ def db_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+def client(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[TestClient, None, None]:
     """TestClient with env vars pointing at the tmp db.
 
     Uses context manager form so that the FastAPI lifespan runs (which sets
@@ -385,18 +387,28 @@ def test_router_does_not_import_reconciler() -> None:
     """
     router_src = (
         __import__("pathlib").Path(__file__).parent.parent
-        / "src" / "roxabi_live" / "webhook" / "router.py"
+        / "src"
+        / "roxabi_live"
+        / "webhook"
+        / "router.py"
     ).read_text()
 
     # Collect lines with reconciler imports, skipping those inside TYPE_CHECKING blocks
     in_type_checking = False
-    runtime_import_lines = []
+    runtime_import_lines: list[str] = []
     for line in router_src.splitlines():
         stripped = line.strip()
         if "TYPE_CHECKING" in stripped and stripped.startswith("if"):
             in_type_checking = True
         # Dedent back to top-level ends the TYPE_CHECKING block
-        if in_type_checking and stripped and not stripped.startswith("#") and not line.startswith(" ") and not line.startswith("\t") and "TYPE_CHECKING" not in stripped:
+        if (
+            in_type_checking
+            and stripped
+            and not stripped.startswith("#")
+            and not line.startswith(" ")
+            and not line.startswith("\t")
+            and "TYPE_CHECKING" not in stripped
+        ):
             in_type_checking = False
         if "import" in line and "reconciler" in line and not in_type_checking:
             runtime_import_lines.append(line)


### PR DESCRIPTION
## Summary
- Lands the seven PR #55 review findings on the webhook layer in one coherent backend refactor: central `roxabi_live.config.Settings`, async `corpus.mutations` helpers sharing SQL constants with `corpus.sync`, `TriggerHeal` Protocol so the router no longer imports `reconciler`, transactional label updates, single body read via `json.loads`, and tracked background tasks with done-callback exception logging + clean shutdown cancellation.
- Refines the planned two-SQL-constant approach into a single `UPSERT_ISSUE_SQL` shared by sync + webhook (made viable by #63's label-derived size/priority/lane).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#58: Webhook layer cleanup](https://github.com/Roxabi/roxabi-live/issues/58) | OPEN |
| Frame | [58-webhook-layer-cleanup-frame.mdx](artifacts/frames/58-webhook-layer-cleanup-frame.mdx) | Approved |
| Spec | [58-webhook-layer-cleanup-spec.mdx](artifacts/specs/58-webhook-layer-cleanup-spec.mdx) | Approved (16 SC) |
| Plan | [58-webhook-layer-cleanup-plan.mdx](artifacts/plans/58-webhook-layer-cleanup-plan.mdx) | 14 micro-tasks + 4 RED-GATEs |
| Implementation | 5 commits on `feat/58-webhook-layer-cleanup` | Complete |
| Verification | Lint ✅  Format ✅  Pyright ✅  Pytest ✅ (533 pass, 5 new test files) | Passed |

## Acceptance criteria coverage

| SC | Subject | Evidence |
|----|---------|----------|
| SC1–SC3 | `Settings` module + single `_db_path` definition + no inline `os.environ.get` outside `config.py` | `src/roxabi_live/config.py` + grep clean |
| SC4 | Router has no `reconciler` import | `tests/test_webhook_router.py` static check |
| SC5 | `TriggerHeal` Protocol + DI via `app.state` | `src/roxabi_live/reconciler.py` + router `Depends` |
| SC6, SC7 | `corpus.mutations` async helpers reusing SQL constants in `corpus.sync` | `src/roxabi_live/corpus/mutations.py` |
| SC8, SC9 | Handlers contain zero raw SQL; `handle_issues` wraps in `async with conn:` | `src/roxabi_live/webhook/handlers.py` |
| SC10 | Single body read with `json.loads(body)` | `src/roxabi_live/webhook/router.py` |
| SC11, SC12 | `app.state.background_tasks` WeakSet + lifespan cancels + awaits | `src/roxabi_live/app.py` |
| SC13 | Webhook upserts preserve milestone/lane/priority/size/status | `tests/test_corpus_mutations.py::test_preserves_non_payload_columns` |
| SC14, SC15 | done_callback logs exceptions; shutdown cancels in <1s | `tests/test_reconciler_lifecycle.py` |
| SC16 | All quality gates pass | local QG green |

## Test Plan
- [ ] CI lint + format + pyright + pytest pass
- [ ] Manual: send a synthetic `issues` webhook with HMAC and confirm a row lands with non-payload columns (status) untouched
- [ ] Manual: send a `sub_issues` add then remove, verify `edges` row appears + disappears with `kind='parent'`
- [ ] Manual: kill the app while a heal task is sleeping → no `Task was destroyed but it is pending` warning in logs

Closes #58

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`