### PR TITLE
chore(deploy): remove residual supervisor wiring for live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,5 +109,6 @@ Rules: add/delete/move → update P | new `src/roxabi_live/` subdir → nearest 
 ## Deploy pattern
 
 M₁ (prod): `deploy/systemd/live.service` — systemd user unit, installed to `~/.config/systemd/user/live.service`, enabled via linger.
+Service control on M₁: `systemctl --user {start,stop,status,restart} live.service` (no `make live` wrapper — supervisor no longer manages this service).
 M₂ (dev): start manually with `uv run roxabi-live`.
 Log dir: `~/.local/state/roxabi-live/logs/`

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,6 @@
 SHELL := /bin/bash -o pipefail
 
-SUPERVISOR_HUB ?= $(HOME)/projects
-HUB_SERVICES   := live
--include $(SUPERVISOR_HUB)/hub.mk
-
-# Fallback SVC_CMD parsing when hub.mk is not present (e.g. prod).
-ifndef SVC_CMD
-ifneq (,$(filter $(HUB_SERVICES),$(firstword $(MAKECMDGOALS))))
-  SVC_CMD := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-  ifneq (,$(SVC_CMD))
-    $(eval $(SVC_CMD):;@:)
-  endif
-endif
-endif
-
-.PHONY: install lint typecheck test format live sync full-sync register
+.PHONY: install lint typecheck test format sync full-sync
 
 # ── Dev ──────────────────────────────────────────────────────────────────────
 
@@ -33,43 +19,11 @@ test:                ## run pytest
 format:              ## auto-format with ruff
 	uv run ruff format . && uv run ruff check --fix .
 
-# ── Service control (supervisor-managed FastAPI + corpus sync) ───────────────
-# Actions:
-#   (empty)  alias of `start`
-#   start    start the FastAPI server via supervisor
-#   stop     stop the server
-#   status   supervisor status for program:live
-#   reload   restart the server
-#   logs     tail live.log
-#   errlogs  tail live_error.log
-#   sync     run corpus sync against GitHub (one-shot; --repo OWNER/NAME to scope)
+# ── Corpus sync ───────────────────────────────────────────────────────────────
 
-live:
-	$(ensure_hub)
-	@_cmd="$(firstword $(SVC_CMD))"; \
-	case "$$_cmd" in \
-		sync)   uv run roxabi-corpus sync $(wordlist 2,$(words $(SVC_CMD)),$(SVC_CMD)) ;; \
-		status) $(HUB_SVC) live status || true ;; \
-		"")     uv run roxabi-corpus sync && $(HUB_SVC) live start ;; \
-		*)      $(HUB_SVC) live $(SVC_CMD) ;; \
-	esac
-
-# Top-level `sync` target — needed so `make live sync` works from the hub
-# root (hub dispatcher routes non-supervisor actions as standalone targets).
-sync:                ## sync corpus with GitHub (alias for `make live sync`)
+sync:                ## sync corpus with GitHub
 	uv run roxabi-corpus sync $(ARGS)
 
 full-sync:           ## full sync (clear sync_state, re-fetch all issues)
 	sqlite3 $(HOME)/.roxabi/corpus.db "DELETE FROM sync_state"
 	uv run roxabi-corpus sync
-
-# ── Registration ─────────────────────────────────────────────────────────────
-
-register:            ## register roxabi-live with the supervisor hub
-	@echo "Registering roxabi-live with supervisor hub at $(SUPERVISOR_HUB)..."
-	@$(HUB_GEN_MK) roxabi-live "$(abspath .)" live
-	$(call hub-link-conf,live,deploy/supervisor/conf.d/live.conf)
-	@mkdir -p "$(HOME)/.local/state/roxabi-live/logs"
-	$(hub_reread)
-	@echo ""
-	@echo "Done. Use: make live | make live sync | make live status | make live stop"

--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -185,7 +185,7 @@ curl https://dashboard.roxabi.dev/health
 
 Confirm `db_reachable: true` and that `issue_count` reflects current corpus state.
 
-**Step 6 — Stop cloudflared and FastAPI on M₂**
+**Step 6 — Stop cloudflared on M₂**
 
 Once M₁ is confirmed serving traffic:
 
@@ -194,7 +194,7 @@ Once M₁ is confirmed serving traffic:
 supervisorctl stop cloudflared
 ```
 
-Set `autostart=false` for both programs on M₂ to prevent them from restarting after reboot.
+Set `autostart=false` for cloudflared on M₂ to prevent it from restarting after reboot.
 
 ## Cloudflare Access (zero-trust gate)
 

--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -191,7 +191,7 @@ Once M₁ is confirmed serving traffic:
 
 ```bash
 # On M₂
-supervisorctl stop cloudflared live
+supervisorctl stop cloudflared
 ```
 
 Set `autostart=false` for both programs on M₂ to prevent them from restarting after reboot.


### PR DESCRIPTION
## Summary
- Remove `live` Makefile target, `register` target, and `HUB_SERVICES := live` — `live` is managed by systemd (`live.service`) since f602d8e, not supervisor.
- Drop dead Makefile plumbing (`SUPERVISOR_HUB`, `hub.mk` include, `SVC_CMD` fallback) and fix stale `supervisorctl stop cloudflared live` line in `docs/cloudflared-setup.md`.
- Document in `CLAUDE.md`: M₁ service control = `systemctl --user {start,stop,status,restart} live.service`.

Hub conf cleanup done on M₂ (`roxabi-live.mk` + dangling `live.conf` symlink removed). **Manual follow-up on M₁:** `rm ~/projects/conf.d/roxabi-live.mk ~/projects/conf.d/live.conf`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #71: chore(deploy): remove residual supervisor wiring for live | Open |
| Implementation | 1 commit on `worktree-71-supervisor-cleanup` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests N/A (no code change) | Passed |

## Test Plan
- [ ] `make -n install lint typecheck test format sync` parses cleanly
- [ ] `grep -n "supervisor\|hub-link\|register" Makefile` returns nothing
- [ ] On M₁ after manual cleanup: `make ps` (hub) shows no orphan `live` entry
- [ ] `systemctl --user status live.service` on M₁ still active

Closes #71

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`