### PR TITLE
feat(corpus): sync private repos with opt-in allowlist

### DIFF
--- a/src/roxabi_live/corpus/cli.py
+++ b/src/roxabi_live/corpus/cli.py
@@ -75,6 +75,65 @@ def cmd_sync(args: argparse.Namespace) -> int:
         conn.close()
 
 
+_REPO_RE = re.compile(r"^[\w.-]+/[\w.-]+$")
+
+
+def _validate_repo(repo: str) -> bool:
+    return bool(_REPO_RE.match(repo))
+
+
+def cmd_repo(args: argparse.Namespace) -> int:
+    db_path = Path(args.db)
+    if not db_path.exists():
+        print(f"ERROR: {db_path} not found — run `init` first", file=sys.stderr)
+        return 1
+    conn = schema.connect(db_path)
+    try:
+        action = args.repo_action
+        if action == "list":
+            rows = conn.execute(
+                "SELECT repo FROM repo_allowlist ORDER BY repo"
+            ).fetchall()
+            if rows:
+                for (repo,) in rows:
+                    print(repo)
+            else:
+                print("(empty)")
+            return 0
+
+        repo = args.repo_name
+        if not _validate_repo(repo):
+            print(
+                f"ERROR: repo must be OWNER/NAME, got: {repo!r}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if action == "add":
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO repo_allowlist(repo) VALUES(?)", (repo,)
+            )
+            conn.commit()
+            if cur.rowcount:
+                print(f"added {repo}")
+            else:
+                print(f"already present {repo}")
+            return 0
+
+        if action == "remove":
+            cur = conn.execute("DELETE FROM repo_allowlist WHERE repo = ?", (repo,))
+            conn.commit()
+            if cur.rowcount:
+                print(f"removed {repo}")
+            else:
+                print(f"not in allowlist {repo}")
+            return 0
+
+    finally:
+        conn.close()
+    return 0  # unreachable — satisfies type checker
+
+
 def cmd_stats(args: argparse.Namespace) -> int:
     db_path = Path(args.db)
     if not db_path.exists():
@@ -118,6 +177,20 @@ def main(argv: list[str] | None = None) -> int:
 
     p_stats = subparsers.add_parser("stats", help="Print row counts from the corpus DB")
     p_stats.set_defaults(func=cmd_stats)
+
+    p_repo = subparsers.add_parser("repo", help="Manage repo allowlist")
+    p_repo.set_defaults(func=cmd_repo)
+    repo_sub = p_repo.add_subparsers(dest="repo_action", required=True)
+
+    repo_sub.add_parser("list", help="List repos in allowlist")
+
+    p_repo_add = repo_sub.add_parser("add", help="Add a repo to the allowlist")
+    p_repo_add.add_argument("repo_name", metavar="OWNER/NAME")
+
+    p_repo_remove = repo_sub.add_parser(
+        "remove", help="Remove a repo from the allowlist"
+    )
+    p_repo_remove.add_argument("repo_name", metavar="OWNER/NAME")
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/src/roxabi_live/corpus/graphql.py
+++ b/src/roxabi_live/corpus/graphql.py
@@ -50,7 +50,6 @@ query($org: String!, $cursor: String) {
       first: 100
       after: $cursor
       isArchived: false
-      privacy: PUBLIC
       orderBy: { field: NAME, direction: ASC }
     ) {
       pageInfo { hasNextPage endCursor }

--- a/src/roxabi_live/corpus/schema.py
+++ b/src/roxabi_live/corpus/schema.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import pathlib
 import sqlite3
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS repo_allowlist (
+    repo TEXT PRIMARY KEY  -- "owner/name"
+);
+
 CREATE TABLE IF NOT EXISTS issues (
     key         TEXT PRIMARY KEY,
     repo        TEXT NOT NULL,
@@ -120,6 +124,18 @@ def _migrate(conn: sqlite3.Connection) -> None:
     # Migration 3 — edges PK includes `kind` (SCHEMA_VERSION 3 -> 4).
     # CREATE TABLE IF NOT EXISTS above cannot alter an existing PK.
     _migrate_edges_pk(conn)
+
+    # Migration 4 — repo_allowlist (SCHEMA_VERSION 4 -> 5).
+    # Seed from existing issues only if the allowlist is currently empty,
+    # so existing DBs get their current repos on first upgrade (opt-in).
+    # Fresh DBs start empty (allowlist table created above via SCHEMA_SQL).
+    count = conn.execute("SELECT COUNT(*) FROM repo_allowlist").fetchone()[0]
+    if count == 0:
+        conn.execute(
+            "INSERT OR IGNORE INTO repo_allowlist(repo)"
+            " SELECT DISTINCT repo FROM issues"
+        )
+        conn.commit()
 
 
 def bootstrap(db_path: pathlib.Path) -> None:

--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -450,6 +450,25 @@ def run_sync(conn: sqlite3.Connection, org: str, full: bool = False) -> dict[str
     Returns counts: {"repos": N, "pages": N, "issues": N, "stubs": N, "errors": N}.
     """
     repos = enumerate_org_repos(org)
+
+    # Filter by allowlist; warn and bail if empty.
+    allowlist = {row[0] for row in conn.execute("SELECT repo FROM repo_allowlist")}
+    if not allowlist:
+        print(
+            "[corpus] repo_allowlist is empty — nothing to sync."
+            " Add repos with `corpus repo add OWNER/NAME`.",
+            file=sys.stderr,
+        )
+        return {
+            "repos": 0,
+            "pages": 0,
+            "issues": 0,
+            "stubs": 0,
+            "errors": 0,
+            "pruned": 0,
+        }
+    repos = [(o, n) for (o, n) in repos if f"{o}/{n}" in allowlist]
+
     active_keys = {f"{owner}/{name}" for owner, name in repos}
     cur = conn.execute("SELECT repo FROM sync_state")
     stale = [row[0] for row in cur.fetchall() if row[0] not in active_keys]

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -100,6 +100,7 @@ async def run_once(settings: Settings) -> None:
     global _auth_failures
     if _halted.is_set():
         return
+
     def _sync() -> dict[str, int]:
         conn = sqlite3.connect(settings.corpus_db_path)
         try:

--- a/tests/corpus/test_cli_repo.py
+++ b/tests/corpus/test_cli_repo.py
@@ -1,0 +1,112 @@
+"""Tests for `corpus repo` subcommand (add / remove / list)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from roxabi_live.corpus.cli import main
+from roxabi_live.corpus.schema import bootstrap
+
+
+def _allowlist(db_path: Path) -> list[str]:
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT repo FROM repo_allowlist ORDER BY repo").fetchall()
+    conn.close()
+    return [r[0] for r in rows]
+
+
+def test_repo_list_empty(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    rc = main(["--db", str(db_path), "repo", "list"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "(empty)" in out
+
+
+def test_repo_add(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    rc = main(["--db", str(db_path), "repo", "add", "Roxabi/lyra"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "added Roxabi/lyra" in out
+    assert _allowlist(db_path) == ["Roxabi/lyra"]
+
+
+def test_repo_add_idempotent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    main(["--db", str(db_path), "repo", "add", "Roxabi/lyra"])
+    capsys.readouterr()
+    rc = main(["--db", str(db_path), "repo", "add", "Roxabi/lyra"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "already present Roxabi/lyra" in out
+    assert _allowlist(db_path) == ["Roxabi/lyra"]
+
+
+def test_repo_remove(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    main(["--db", str(db_path), "repo", "add", "Roxabi/lyra"])
+    capsys.readouterr()
+    rc = main(["--db", str(db_path), "repo", "remove", "Roxabi/lyra"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "removed Roxabi/lyra" in out
+    assert _allowlist(db_path) == []
+
+
+def test_repo_remove_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    rc = main(["--db", str(db_path), "repo", "remove", "Roxabi/lyra"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "not in allowlist Roxabi/lyra" in out
+
+
+def test_repo_list_with_entries(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    main(["--db", str(db_path), "repo", "add", "Roxabi/lyra"])
+    main(["--db", str(db_path), "repo", "add", "Roxabi/voiceCLI"])
+    capsys.readouterr()
+    rc = main(["--db", str(db_path), "repo", "list"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    lines = [line for line in out.splitlines() if line]
+    assert "Roxabi/lyra" in lines
+    assert "Roxabi/voiceCLI" in lines
+
+
+def test_repo_add_invalid_format(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    rc = main(["--db", str(db_path), "repo", "add", "notaslash"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "OWNER/NAME" in err
+
+
+def test_repo_remove_invalid_format(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    rc = main(["--db", str(db_path), "repo", "remove", "bad format!"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "OWNER/NAME" in err

--- a/tests/corpus/test_schema.py
+++ b/tests/corpus/test_schema.py
@@ -286,3 +286,103 @@ def test_migration_v3_to_v4_idempotent(tmp_path: Path) -> None:
 
     assert count == 1
     assert pk_cols == ["src_key", "dst_key", "kind"]
+
+
+# ---------------------------------------------------------------------------
+# Migration 4 — repo_allowlist (SCHEMA_VERSION 4 -> 5)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_db_has_empty_repo_allowlist(tmp_path: Path) -> None:
+    """A fresh bootstrap must create repo_allowlist with zero rows."""
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM repo_allowlist").fetchone()[0]
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert "repo_allowlist" in tables
+    assert count == 0, f"Expected empty allowlist on fresh DB, got {count} rows"
+
+
+def test_migration_v4_seeds_allowlist_from_issues(tmp_path: Path) -> None:
+    """Upgrading a v4 DB with issues seeds repo_allowlist with DISTINCT repos."""
+    db_path = tmp_path / "corpus.db"
+
+    # Build a v4-era DB manually (no repo_allowlist table, issues present)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_V2_SCHEMA_SQL)  # gives us the base tables
+    # Add the v3->v4 edges PK (not critical for this test, just realistic)
+    conn.execute("PRAGMA user_version = 4")
+    conn.executemany(
+        "INSERT INTO issues(key, repo, number, title, state, url,"
+        " created_at, updated_at, closed_at, milestone, is_stub)"
+        " VALUES (?, ?, ?, 'T', 'open', 'u', 'c', 'u', NULL, NULL, 0)",
+        [
+            ("Roxabi/lyra#1", "Roxabi/lyra", 1),
+            ("Roxabi/lyra#2", "Roxabi/lyra", 2),
+            ("Roxabi/voiceCLI#1", "Roxabi/voiceCLI", 1),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    # bootstrap applies migration 4
+    bootstrap(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        repos = {
+            r[0] for r in conn.execute("SELECT repo FROM repo_allowlist").fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert repos == {"Roxabi/lyra", "Roxabi/voiceCLI"}
+
+
+def test_migration_v4_seed_idempotent(tmp_path: Path) -> None:
+    """Migration 4 must NOT re-seed when allowlist already has rows (idempotent)."""
+    db_path = tmp_path / "corpus.db"
+
+    # Fully initialise to v5
+    bootstrap(db_path)
+
+    # Manually add a row to the allowlist
+    conn = sqlite3.connect(db_path)
+    conn.execute("INSERT INTO repo_allowlist(repo) VALUES('Roxabi/lyra')")
+    conn.commit()
+    conn.close()
+
+    # Add an issue with a different repo, then bootstrap again
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO issues(key, repo, number, title, state, url,"
+        " created_at, updated_at, closed_at, milestone, is_stub)"
+        " VALUES ('Roxabi/other#1', 'Roxabi/other', 1, 'T', 'open',"
+        " 'u', 'c', 'u', NULL, NULL, 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    bootstrap(db_path)  # migration 4 must not re-seed
+
+    conn = sqlite3.connect(db_path)
+    try:
+        repos = {
+            r[0] for r in conn.execute("SELECT repo FROM repo_allowlist").fetchall()
+        }
+    finally:
+        conn.close()
+
+    # Should still be only the manually added row — no re-seed
+    assert repos == {"Roxabi/lyra"}

--- a/tests/corpus/test_sync.py
+++ b/tests/corpus/test_sync.py
@@ -384,3 +384,103 @@ def test_upsert_edges_delete_one_kind_preserves_other(
         ("A", "K", surviving_kind),
         ("K", "Z", surviving_kind),
     }
+
+
+# ---------------------------------------------------------------------------
+# run_sync allowlist filtering
+# ---------------------------------------------------------------------------
+
+
+def _make_repos_response(repos: list[tuple[str, str]]) -> dict[str, Any]:
+    """Wrap repo list in the GraphQL org repositories envelope."""
+    return {
+        "data": {
+            "organization": {
+                "repositories": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [{"owner": {"login": o}, "name": n} for o, n in repos],
+                }
+            },
+            "rateLimit": {
+                "cost": 1,
+                "remaining": 4999,
+                "resetAt": "2026-04-21T10:00:00Z",
+            },
+        }
+    }
+
+
+def test_run_sync_empty_allowlist_returns_zeros(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """run_sync with an empty allowlist returns zero counts and prints a warning."""
+    from roxabi_live.corpus.sync import run_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+
+    # enumerate_org_repos returns something but allowlist is empty
+    def fake_enum_empty(_org: str) -> list[tuple[str, str]]:
+        return [("Roxabi", "lyra"), ("Roxabi", "voiceCLI")]
+
+    monkeypatch.setattr("roxabi_live.corpus.sync.enumerate_org_repos", fake_enum_empty)
+
+    result = run_sync(conn, "Roxabi")
+    conn.close()
+
+    assert result == {
+        "repos": 0,
+        "pages": 0,
+        "issues": 0,
+        "stubs": 0,
+        "errors": 0,
+        "pruned": 0,
+    }
+    err = capsys.readouterr().err
+    assert "repo_allowlist is empty" in err
+    assert "corpus repo add" in err
+
+
+def test_run_sync_filters_by_allowlist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_sync with allowlist=[lyra] only calls run_repo_sync for lyra, not others."""
+    from roxabi_live.corpus.sync import run_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+
+    # Seed allowlist with only lyra
+    conn.execute("INSERT INTO repo_allowlist(repo) VALUES('Roxabi/lyra')")
+    conn.commit()
+
+    def fake_enum_three(_org: str) -> list[tuple[str, str]]:
+        return [("Roxabi", "lyra"), ("Roxabi", "voiceCLI"), ("Roxabi", "noise")]
+
+    monkeypatch.setattr(
+        "roxabi_live.corpus.sync.enumerate_org_repos", fake_enum_three
+    )
+
+    synced: list[str] = []
+
+    def fake_run_repo_sync(
+        c: Any, owner: str, name: str, since: str | None = None
+    ) -> dict[str, int]:
+        synced.append(f"{owner}/{name}")
+        return {"pages": 1, "issues": 2}
+
+    monkeypatch.setattr("roxabi_live.corpus.sync.run_repo_sync", fake_run_repo_sync)
+    # closed_hop_pass also needs mocking to avoid DB issues
+    def fake_closed_hop(_c: Any) -> int:
+        return 0
+
+    monkeypatch.setattr("roxabi_live.corpus.sync.closed_hop_pass", fake_closed_hop)
+
+    result = run_sync(conn, "Roxabi")
+    conn.close()
+
+    assert synced == ["Roxabi/lyra"], f"Expected only lyra to be synced, got {synced}"
+    assert result["repos"] == 1
+    assert result["issues"] == 2


### PR DESCRIPTION
## Summary

- Drop `privacy: PUBLIC` from `REPOS_QUERY` so private org repos sync too (fixes `roxabi-1page` disappearing from `/api/repos` after it was flipped private)
- Add `repo_allowlist` table (schema v5) — **opt-in** gate: sync does nothing if empty
- Migration seeds allowlist from `SELECT DISTINCT repo FROM issues` so existing deployments inherit current intent (incl. stale rows like `roxabi-1page`)
- New CLI: `roxabi-corpus repo {add,remove,list} OWNER/NAME`

## Why

`roxabi-1page` went private → `enumerate_org_repos` (filtered `privacy: PUBLIC`) excluded it → `sync_state` cleanup pruned it → it vanished from the `/v6/` repo filter dropdown, while 29 stale issues stayed in the `issues` table.

Dropping the `PUBLIC` filter alone would also flood the corpus with noise (`demo-repository`, `old.ClaudeCodeDevKit`, `Framework`, `roxabi-claude-config`). The allowlist gives explicit control.

## Migration behavior

Verified against a copy of the live `~/.roxabi/corpus.db`: bootstrap seeds 14 repos incl. `Roxabi/roxabi-1page`, schema version → 5.

## Test plan

- [x] `uv run pytest` — 565 passed (+13 new)
- [x] `uv run ruff check .` + `uv run pyright src/` clean
- [x] CLI smoke-test on fresh DB: `init → repo list (empty) → repo add → repo list → repo remove`
- [x] Migration on copy of prod `corpus.db` seeds correct repos
- [ ] After merge + deploy on M₁: verify `roxabi-1page` reappears in `/api/repos` after next reconciler sync tick

## Notes

- Fresh DBs start with **empty** allowlist (sync no-ops with a warning). Operator must `repo add` to activate.
- If after deploy you want to drop a noisy repo: `roxabi-corpus repo remove Roxabi/<name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)