### PR TITLE
fix(lifespan): apply schema migrations on startup

### DIFF
--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -15,6 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from roxabi_live import reconciler
 from roxabi_live.api.issues import router as issues_router
 from roxabi_live.config import Settings, get_settings
+from roxabi_live.corpus import schema as corpus_schema
 from roxabi_live.dep_graph.v5.serve import router as dep_graph_v5_router
 from roxabi_live.dep_graph.v6.repos import router as repos_router
 from roxabi_live.dep_graph.v6.routes import router as dep_graph_v6_router
@@ -35,6 +36,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
     app.state.background_tasks = bg_tasks
     app.state.trigger_heal = reconciler.make_trigger_heal(settings, bg_tasks)
+
+    # Apply pending schema migrations before accepting traffic so endpoints
+    # never observe a half-migrated DB.
+    corpus_schema.bootstrap(settings.corpus_db_path)
 
     log.info("reconciler startup sync scheduled")
     await reconciler.run_once(settings)

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -24,6 +24,7 @@ from weakref import WeakSet
 import aiosqlite
 
 from roxabi_live.config import Settings
+from roxabi_live.corpus import schema as corpus_schema
 from roxabi_live.corpus import sync as corpus_sync
 
 log = logging.getLogger(__name__)
@@ -102,6 +103,9 @@ async def run_once(settings: Settings) -> None:
         return
 
     def _sync() -> dict[str, int]:
+        # Apply any pending schema migrations before opening the sync connection
+        # so a redeploy at a new SCHEMA_VERSION doesn't crash with "no such table".
+        corpus_schema.bootstrap(settings.corpus_db_path)
         conn = sqlite3.connect(settings.corpus_db_path)
         try:
             return corpus_sync.run_sync(conn, settings.github_org)


### PR DESCRIPTION
## Summary

- Call `corpus_schema.bootstrap()` in FastAPI lifespan before reconciler runs and traffic is accepted
- Same call in `reconciler.run_once._sync()` as defense-in-depth (covers DB recreated/moved at runtime)

## Why

PR #73 bumped schema to v5 (`repo_allowlist` table). Reconciler opens a raw `sqlite3.connect()` without calling `schema.bootstrap`, so the migration never ran on app restart — service crashed with `no such table: repo_allowlist` until I ran `roxabi-corpus init` on M₁ manually.

Lifespan-level bootstrap guarantees migrations are applied before any HTTP traffic; reconciler-level is belt-and-suspenders.

## Test plan

- [x] `uv run pytest` — 565 passed
- [x] `uv run ruff check .` + `uv run pyright src/` clean
- [ ] After deploy: verify clean restart with no `OperationalError` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)