### PR TITLE
fix(corpus): scope webhook heal to single repo and dedup concurrent triggers

### DIFF
--- a/src/roxabi_live/corpus/sync.py
+++ b/src/roxabi_live/corpus/sync.py
@@ -439,6 +439,29 @@ def closed_hop_pass(conn: sqlite3.Connection) -> int:
     return inserted
 
 
+def run_single_repo_sync(conn: sqlite3.Connection, repo: str) -> dict[str, int]:
+    """Sync ONE repo. Used by webhook-driven heal — does NOT enumerate the
+    org and does NOT run closed_hop_pass (those stay in the hourly run_sync).
+
+    Args:
+        conn: SQLite connection.
+        repo: Repository in 'owner/name' form (e.g. 'Roxabi/lyra').
+
+    Returns counts: {"pages": N, "issues": N}.
+
+    Raises ValueError on malformed repo.
+    """
+    owner, sep, name = repo.partition("/")
+    if not owner or not sep or not name:
+        raise ValueError(f"repo must be in 'owner/name' form, got: {repo!r}")
+    row = conn.execute(
+        "SELECT last_synced_at FROM sync_state WHERE repo = ?",
+        (repo,),
+    ).fetchone()
+    since: str | None = row[0] if row else None
+    return run_repo_sync(conn, owner, name, since=since)
+
+
 def run_sync(conn: sqlite3.Connection, org: str, full: bool = False) -> dict[str, int]:
     """Org-wide sync: enumerate repos, per-repo sync with since cursor, closed-hop pass.
 

--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -34,6 +34,7 @@ _AUTH_FAILURE_THRESHOLD = 2
 _auth_failures: int = 0
 _halted: asyncio.Event = asyncio.Event()
 _state_lock: asyncio.Lock = asyncio.Lock()
+_sync_in_flight: bool = False
 
 
 class TriggerHeal(Protocol):
@@ -138,6 +139,49 @@ async def run_once(settings: Settings) -> None:
         log.exception("reconciler run_once failed")
 
 
+async def run_repo_once(settings: Settings, repo: str) -> None:
+    """Single-repo sync cycle for webhook-driven heal.
+
+    Mirrors run_once's auth-halt handling but calls run_single_repo_sync
+    instead of run_sync. Never raises.
+    """
+    global _auth_failures
+    if _halted.is_set():
+        return
+
+    def _sync() -> dict[str, int]:
+        conn = sqlite3.connect(settings.corpus_db_path)
+        try:
+            return corpus_sync.run_single_repo_sync(conn, repo)
+        finally:
+            conn.close()
+
+    try:
+        await asyncio.to_thread(_sync)
+        async with _state_lock:
+            _auth_failures = 0
+    except Exception as exc:
+        if _is_auth_error(exc):
+            async with _state_lock:
+                _auth_failures += 1
+                should_halt = _auth_failures >= _AUTH_FAILURE_THRESHOLD
+                failures = _auth_failures
+            if should_halt and not _halted.is_set():
+                _halted.set()
+                log.critical(
+                    "reconciler halted: %d consecutive auth failures",
+                    failures,
+                )
+            else:
+                log.warning(
+                    "reconciler auth error %d/%d",
+                    failures,
+                    _AUTH_FAILURE_THRESHOLD,
+                )
+            return
+        log.exception("reconciler run_repo_once failed (repo=%s)", repo)
+
+
 def hourly_loop(settings: Settings) -> asyncio.Task[None]:
     """Start a background task that calls run_once on a fixed interval.
 
@@ -162,6 +206,14 @@ def hourly_loop(settings: Settings) -> asyncio.Task[None]:
     return asyncio.create_task(_loop())
 
 
+def _reset_state_for_tests() -> None:
+    """Reset all module-level sync state. Call from test fixtures only."""
+    global _auth_failures, _sync_in_flight
+    _auth_failures = 0
+    _sync_in_flight = False
+    _halted.clear()
+
+
 def make_trigger_heal(
     settings: Settings,
     background_tasks: WeakSet[asyncio.Task[None]],
@@ -169,10 +221,12 @@ def make_trigger_heal(
     """Factory: build a TriggerHeal closure capturing settings + the WeakSet.
 
     The returned callable:
-    1. Checks sync_state staleness (>1h or missing) for the repo.
-    2. If stale, schedules asyncio.create_task(run_once(settings)).
-    3. Registers the task in background_tasks WeakSet.
-    4. Attaches _log_exc as a done-callback to surface exceptions in logs.
+    1. Acquires _state_lock and checks _sync_in_flight; returns if already running.
+    2. Checks sync_state staleness (>1h or missing) for the repo.
+    3. If stale, sets _sync_in_flight = True and schedules a task calling
+       run_repo_once(settings, repo).  The task clears _sync_in_flight on finish.
+    4. Registers the task in background_tasks WeakSet.
+    5. Attaches _log_exc as a done-callback to surface exceptions in logs.
 
     Args:
         settings: App settings (db path, org, interval).
@@ -184,21 +238,38 @@ def make_trigger_heal(
     """
 
     async def _trigger_heal(repo: str, conn: aiosqlite.Connection) -> None:
-        cur = await conn.execute(
-            "SELECT last_synced_at FROM sync_state WHERE repo = ?", (repo,)
-        )
-        row = await cur.fetchone()
-        now = datetime.now(timezone.utc)
-        stale = True
-        if row is not None:
-            raw = row[0]
-            last = datetime.fromisoformat(raw) if isinstance(raw, str) else raw
-            if last.tzinfo is None:
-                last = last.replace(tzinfo=timezone.utc)
-            stale = (now - last).total_seconds() > settings.corpus_sync_interval_seconds
-        if stale:
-            task: asyncio.Task[None] = asyncio.create_task(run_once(settings))
-            background_tasks.add(task)
-            task.add_done_callback(_log_exc)
+        global _sync_in_flight
+        async with _state_lock:
+            if _sync_in_flight:
+                return
+            cur = await conn.execute(
+                "SELECT last_synced_at FROM sync_state WHERE repo = ?", (repo,)
+            )
+            row = await cur.fetchone()
+            now = datetime.now(timezone.utc)
+            stale = True
+            if row is not None:
+                raw = row[0]
+                last = datetime.fromisoformat(raw) if isinstance(raw, str) else raw
+                if last.tzinfo is None:
+                    last = last.replace(tzinfo=timezone.utc)
+                stale = (
+                    now - last
+                ).total_seconds() > settings.corpus_sync_interval_seconds
+            if not stale:
+                return
+            _sync_in_flight = True
+
+        async def _run_and_clear() -> None:
+            global _sync_in_flight
+            try:
+                await run_repo_once(settings, repo)
+            finally:
+                async with _state_lock:
+                    _sync_in_flight = False
+
+        task: asyncio.Task[None] = asyncio.create_task(_run_and_clear())
+        background_tasks.add(task)
+        task.add_done_callback(_log_exc)
 
     return _trigger_heal  # type: ignore[return-value]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,5 @@ def reset_reconciler_auth_state() -> None:
         reconciler._auth_failures = 0  # type: ignore[attr-defined]
     if hasattr(reconciler, "_halted"):
         reconciler._halted.clear()  # type: ignore[attr-defined]
+    if hasattr(reconciler, "_sync_in_flight"):
+        reconciler._sync_in_flight = False  # type: ignore[attr-defined]

--- a/tests/corpus/test_sync.py
+++ b/tests/corpus/test_sync.py
@@ -387,6 +387,127 @@ def test_upsert_edges_delete_one_kind_preserves_other(
 
 
 # ---------------------------------------------------------------------------
+# run_single_repo_sync
+# ---------------------------------------------------------------------------
+
+
+def test_run_single_repo_sync_calls_run_repo_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_single_repo_sync delegates to run_repo_sync with owner/name/since."""
+    from roxabi_live.corpus.sync import run_single_repo_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+
+    calls: list[tuple[Any, ...]] = []
+
+    def fake_run_repo_sync(
+        c: Any, owner: str, name: str, since: str | None = None
+    ) -> dict[str, int]:
+        calls.append((owner, name, since))
+        return {"pages": 1, "issues": 2}
+
+    monkeypatch.setattr("roxabi_live.corpus.sync.run_repo_sync", fake_run_repo_sync)
+
+    result = run_single_repo_sync(conn, "Roxabi/lyra")
+    conn.close()
+
+    assert result == {"pages": 1, "issues": 2}
+    assert len(calls) == 1
+    assert calls[0][0] == "Roxabi"
+    assert calls[0][1] == "lyra"
+    assert calls[0][2] is None  # no sync_state row → since=None
+
+
+def test_run_single_repo_sync_uses_since_cursor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_single_repo_sync reads since from sync_state when a row exists."""
+    from roxabi_live.corpus.sync import run_single_repo_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_state(repo, last_cursor, last_synced_at)"
+        " VALUES (?, ?, ?)",
+        ("Roxabi/lyra", None, "2026-01-01T00:00:00+00:00"),
+    )
+    conn.commit()
+
+    captured_since: list[str | None] = []
+
+    def fake_run_repo_sync(
+        c: Any, owner: str, name: str, since: str | None = None
+    ) -> dict[str, int]:
+        captured_since.append(since)
+        return {"pages": 0, "issues": 0}
+
+    monkeypatch.setattr("roxabi_live.corpus.sync.run_repo_sync", fake_run_repo_sync)
+
+    run_single_repo_sync(conn, "Roxabi/lyra")
+    conn.close()
+
+    assert captured_since == ["2026-01-01T00:00:00+00:00"]
+
+
+def test_run_single_repo_sync_does_not_call_enumerate_or_hop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_single_repo_sync must NOT call enumerate_org_repos or closed_hop_pass."""
+    from roxabi_live.corpus import sync as sync_mod  # noqa: PLC0415
+    from roxabi_live.corpus.sync import run_single_repo_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+
+    enumerate_called = False
+    hop_called = False
+
+    def fake_enumerate(org: str) -> list[Any]:
+        nonlocal enumerate_called
+        enumerate_called = True
+        return []
+
+    def fake_hop(c: Any) -> int:
+        nonlocal hop_called
+        hop_called = True
+        return 0
+
+    def fake_run_repo_sync(
+        c: Any, owner: str, name: str, since: str | None = None
+    ) -> dict[str, int]:
+        return {"pages": 0, "issues": 0}
+
+    monkeypatch.setattr(sync_mod, "enumerate_org_repos", fake_enumerate)
+    monkeypatch.setattr(sync_mod, "closed_hop_pass", fake_hop)
+    monkeypatch.setattr(sync_mod, "run_repo_sync", fake_run_repo_sync)
+
+    run_single_repo_sync(conn, "Roxabi/lyra")
+    conn.close()
+
+    assert not enumerate_called, "enumerate_org_repos must NOT be called"
+    assert not hop_called, "closed_hop_pass must NOT be called"
+
+
+def test_run_single_repo_sync_malformed_repo_raises(tmp_path: Path) -> None:
+    """run_single_repo_sync raises ValueError for repos without a slash."""
+    from roxabi_live.corpus.sync import run_single_repo_sync  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = connect(db_path)
+    try:
+        with pytest.raises(ValueError, match="owner/name"):
+            run_single_repo_sync(conn, "no-slash-here")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # run_sync allowlist filtering
 # ---------------------------------------------------------------------------
 
@@ -459,9 +580,7 @@ def test_run_sync_filters_by_allowlist(
     def fake_enum_three(_org: str) -> list[tuple[str, str]]:
         return [("Roxabi", "lyra"), ("Roxabi", "voiceCLI"), ("Roxabi", "noise")]
 
-    monkeypatch.setattr(
-        "roxabi_live.corpus.sync.enumerate_org_repos", fake_enum_three
-    )
+    monkeypatch.setattr("roxabi_live.corpus.sync.enumerate_org_repos", fake_enum_three)
 
     synced: list[str] = []
 
@@ -472,6 +591,7 @@ def test_run_sync_filters_by_allowlist(
         return {"pages": 1, "issues": 2}
 
     monkeypatch.setattr("roxabi_live.corpus.sync.run_repo_sync", fake_run_repo_sync)
+
     # closed_hop_pass also needs mocking to avoid DB issues
     def fake_closed_hop(_c: Any) -> int:
         return 0

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -384,3 +384,62 @@ class TestAuthHalt:
             "Expected a CRITICAL log mentioning 'halt' or 'auth' for 403 errors; "
             f"got records: {caplog.records}"
         )
+
+
+class TestRunRepoOnce:
+    """reconciler.run_repo_once(settings, repo) — single-repo webhook-driven heal."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_run_single_repo_sync(self, tmp_path: Path) -> None:
+        """run_repo_once calls corpus_sync.run_single_repo_sync exactly once."""
+        s = _settings(tmp_path)
+        mock_fn = MagicMock(return_value={"pages": 1, "issues": 5})
+        with patch("roxabi_live.corpus.sync.run_single_repo_sync", mock_fn):
+            await reconciler.run_repo_once(s, "Roxabi/lyra")
+        mock_fn.assert_called_once()
+        args = mock_fn.call_args
+        # second positional arg is repo
+        assert args[0][1] == "Roxabi/lyra"
+
+    @pytest.mark.asyncio
+    async def test_auth_halt_after_two_consecutive_errors(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Two consecutive 401 errors via run_repo_once must set _halted and emit
+        CRITICAL."""
+        s = _settings(tmp_path)
+        err_401 = _make_http_error(401)
+        with caplog.at_level(logging.CRITICAL, logger="roxabi_live.reconciler"):
+            with patch(
+                "roxabi_live.corpus.sync.run_single_repo_sync",
+                side_effect=err_401,
+            ):
+                await reconciler.run_repo_once(s, "Roxabi/lyra")
+                await reconciler.run_repo_once(s, "Roxabi/lyra")
+
+        assert reconciler._halted.is_set()  # type: ignore[attr-defined]
+        critical_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.CRITICAL
+            and ("halt" in r.message.lower() or "auth" in r.message.lower())
+        ]
+        assert critical_records, f"Expected CRITICAL log; got: {caplog.records}"
+
+    @pytest.mark.asyncio
+    async def test_success_resets_auth_failures(self, tmp_path: Path) -> None:
+        """A successful run_repo_once resets _auth_failures to 0."""
+        s = _settings(tmp_path)
+        err_401 = _make_http_error(401)
+        # One failure then success
+        with patch(
+            "roxabi_live.corpus.sync.run_single_repo_sync",
+            side_effect=[err_401, {"pages": 1, "issues": 3}],
+        ):
+            await reconciler.run_repo_once(s, "Roxabi/lyra")
+            await reconciler.run_repo_once(s, "Roxabi/lyra")
+
+        assert reconciler._auth_failures == 0  # type: ignore[attr-defined]
+        assert not reconciler._halted.is_set()  # type: ignore[attr-defined]

--- a/tests/test_reconciler_lifecycle.py
+++ b/tests/test_reconciler_lifecycle.py
@@ -63,15 +63,15 @@ class TestHealTaskExceptionLogged:
         bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
         trigger_heal = make_trigger_heal(s, bg_tasks)
 
-        # Monkey-patch run_once to raise inside the scheduled task
+        # Monkey-patch run_repo_once to raise inside the scheduled task
         import roxabi_live.reconciler as rec_module
 
-        original_run_once = rec_module.run_once
+        original_run_repo_once = rec_module.run_repo_once
 
-        async def _bad_run_once(settings: Settings) -> None:
+        async def _bad_run_repo_once(settings: Settings, repo: str) -> None:
             raise RuntimeError("heal task blew up")
 
-        rec_module.run_once = _bad_run_once  # type: ignore[assignment]
+        rec_module.run_repo_once = _bad_run_repo_once  # type: ignore[assignment]
 
         try:
             async with aiosqlite.connect(":memory:") as conn:
@@ -82,7 +82,7 @@ class TestHealTaskExceptionLogged:
                     # Let the event loop run the task to completion
                     await asyncio.sleep(0.05)
         finally:
-            rec_module.run_once = original_run_once  # type: ignore[assignment]
+            rec_module.run_repo_once = original_run_repo_once  # type: ignore[assignment]
 
         error_records = [
             r
@@ -104,7 +104,9 @@ class TestHealTaskExceptionLogged:
         bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
         trigger_heal = make_trigger_heal(s, bg_tasks)
 
-        with patch("roxabi_live.reconciler.run_once", AsyncMock(return_value=None)):
+        with patch(
+            "roxabi_live.reconciler.run_repo_once", AsyncMock(return_value=None)
+        ):
             async with aiosqlite.connect(":memory:") as conn:
                 await conn.executescript(_SCHEMA_SQL)
                 # No sync_state row → stale → task created
@@ -213,3 +215,121 @@ class TestLifespanShutdownCancelsHealTasks:
             )
         finally:
             rec_module.run_once = original  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Dedup / single-repo path / flag-cleared-after
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerHealDedup:
+    """make_trigger_heal schedules at most one task when _sync_in_flight is True."""
+
+    @pytest.mark.asyncio
+    async def test_dedup_concurrent_triggers(self, tmp_path: Path) -> None:
+        """Two concurrent stale trigger_heal calls only schedule ONE task."""
+        from unittest.mock import patch
+
+        import aiosqlite
+
+        import roxabi_live.reconciler as rec_module
+
+        s = _settings(tmp_path)
+        bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
+        trigger_heal = make_trigger_heal(s, bg_tasks)
+
+        call_count = 0
+
+        async def slow_run_repo_once(settings: Settings, repo: str) -> None:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)  # hold the in-flight flag
+
+        with patch.object(rec_module, "run_repo_once", slow_run_repo_once):
+            async with aiosqlite.connect(":memory:") as conn:
+                await conn.executescript(_SCHEMA_SQL)
+                # No sync_state row → both calls see stale state
+                await asyncio.gather(
+                    trigger_heal("Roxabi/foo", conn),
+                    trigger_heal("Roxabi/foo", conn),
+                )
+                # Drain tasks
+                tasks = list(bg_tasks)
+                if tasks:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert call_count == 1, (
+            f"Expected exactly 1 run_repo_once call (dedup); got {call_count}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_repo_path_not_run_once(self, tmp_path: Path) -> None:
+        """trigger_heal schedules run_repo_once, NOT run_once."""
+        from unittest.mock import AsyncMock, patch
+
+        import aiosqlite
+
+        import roxabi_live.reconciler as rec_module
+
+        s = _settings(tmp_path)
+        bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
+        trigger_heal = make_trigger_heal(s, bg_tasks)
+
+        run_once_mock = AsyncMock()
+        run_repo_once_mock = AsyncMock()
+
+        with (
+            patch.object(rec_module, "run_once", run_once_mock),
+            patch.object(rec_module, "run_repo_once", run_repo_once_mock),
+        ):
+            async with aiosqlite.connect(":memory:") as conn:
+                await conn.executescript(_SCHEMA_SQL)
+                await trigger_heal("Roxabi/lyra", conn)
+                tasks = list(bg_tasks)
+                if tasks:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+
+        run_once_mock.assert_not_called()
+        run_repo_once_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_flag_cleared_after_task_completes(self, tmp_path: Path) -> None:
+        """After the heal task finishes, _sync_in_flight is False so a new stale trigger
+        can spawn a fresh task."""
+        from unittest.mock import patch
+
+        import aiosqlite
+
+        import roxabi_live.reconciler as rec_module
+
+        s = _settings(tmp_path)
+        bg_tasks: WeakSet[asyncio.Task[None]] = WeakSet()
+        trigger_heal = make_trigger_heal(s, bg_tasks)
+
+        call_count = 0
+
+        async def counting_run_repo_once(settings: Settings, repo: str) -> None:
+            nonlocal call_count
+            call_count += 1
+
+        with patch.object(rec_module, "run_repo_once", counting_run_repo_once):
+            async with aiosqlite.connect(":memory:") as conn:
+                await conn.executescript(_SCHEMA_SQL)
+                # First trigger
+                await trigger_heal("Roxabi/lyra", conn)
+                tasks = list(bg_tasks)
+                if tasks:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+
+                # Flag must be cleared now
+                assert not rec_module._sync_in_flight  # type: ignore[attr-defined]
+
+                # Second trigger on still-stale state should spawn a new task
+                await trigger_heal("Roxabi/lyra", conn)
+                tasks2 = list(bg_tasks)
+                if tasks2:
+                    await asyncio.gather(*tasks2, return_exceptions=True)
+
+        assert call_count == 2, (
+            f"Expected 2 run_repo_once calls (flag cleared between); got {call_count}"
+        )

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -269,11 +269,9 @@ def test_stale_sync_triggers_reconcile(
     two_hours_ago = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
     _seed_sync_state(db_path, "Roxabi/lyra", two_hours_ago)
 
-    mock_run_once = AsyncMock(return_value=None)
-    # The trigger_heal factory calls roxabi_live.reconciler.run_once.
-    # Patch before TestClient enters lifespan; lifespan startup call = call 1,
-    # webhook-triggered heal = call 2 (total >= 2).
-    monkeypatch.setattr("roxabi_live.reconciler.run_once", mock_run_once)
+    mock_run_repo_once = AsyncMock(return_value=None)
+    # trigger_heal now calls run_repo_once (not run_once) for single-repo heal.
+    monkeypatch.setattr("roxabi_live.reconciler.run_repo_once", mock_run_repo_once)
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
@@ -284,7 +282,6 @@ def test_stale_sync_triggers_reconcile(
     sig = _sign(body)
 
     with TestClient(app) as client:
-        call_count_after_startup = mock_run_once.call_count  # startup call
         resp = client.post(
             "/webhook/github",
             content=body,
@@ -298,9 +295,9 @@ def test_stale_sync_triggers_reconcile(
         # Drain the event loop so the fire-and-forget task executes
         asyncio.run(asyncio.sleep(0))
 
-    # One additional call triggered by the stale webhook heal
-    assert mock_run_once.call_count > call_count_after_startup, (
-        "Expected trigger_heal to schedule an additional run_once call"
+    # One call triggered by the stale webhook heal
+    assert mock_run_repo_once.call_count >= 1, (
+        "Expected trigger_heal to schedule a run_repo_once call"
     )
 
 
@@ -311,8 +308,8 @@ def test_fresh_sync_does_not_trigger_reconcile(
     five_min_ago = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
     _seed_sync_state(db_path, "Roxabi/lyra", five_min_ago)
 
-    mock_run_once = AsyncMock(return_value=None)
-    monkeypatch.setattr("roxabi_live.reconciler.run_once", mock_run_once)
+    mock_run_repo_once = AsyncMock(return_value=None)
+    monkeypatch.setattr("roxabi_live.reconciler.run_repo_once", mock_run_repo_once)
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
@@ -323,7 +320,6 @@ def test_fresh_sync_does_not_trigger_reconcile(
     sig = _sign(body)
 
     with TestClient(app) as client:
-        call_count_after_startup = mock_run_once.call_count
         resp = client.post(
             "/webhook/github",
             content=body,
@@ -336,9 +332,9 @@ def test_fresh_sync_does_not_trigger_reconcile(
         assert resp.status_code == 200
         asyncio.run(asyncio.sleep(0))
 
-    # No additional calls — sync is fresh
-    assert mock_run_once.call_count == call_count_after_startup, (
-        "Expected trigger_heal NOT to schedule run_once for a fresh sync"
+    # No calls — sync is fresh
+    assert mock_run_repo_once.call_count == 0, (
+        "Expected trigger_heal NOT to schedule run_repo_once for a fresh sync"
     )
 
 
@@ -346,8 +342,8 @@ def test_missing_sync_state_triggers_reconcile(
     db_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """No row in sync_state for the repo → trigger_heal schedules run_once."""
-    mock_run_once = AsyncMock(return_value=None)
-    monkeypatch.setattr("roxabi_live.reconciler.run_once", mock_run_once)
+    mock_run_repo_once = AsyncMock(return_value=None)
+    monkeypatch.setattr("roxabi_live.reconciler.run_repo_once", mock_run_repo_once)
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _SECRET)
     monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
 
@@ -358,7 +354,6 @@ def test_missing_sync_state_triggers_reconcile(
     sig = _sign(body)
 
     with TestClient(app) as client:
-        call_count_after_startup = mock_run_once.call_count
         resp = client.post(
             "/webhook/github",
             content=body,
@@ -371,8 +366,8 @@ def test_missing_sync_state_triggers_reconcile(
         assert resp.status_code == 200
         asyncio.run(asyncio.sleep(0))
 
-    assert mock_run_once.call_count > call_count_after_startup, (
-        "Expected trigger_heal to schedule run_once when sync_state is missing"
+    assert mock_run_repo_once.call_count >= 1, (
+        "Expected trigger_heal to schedule run_repo_once when sync_state is missing"
     )
 
 

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -5,4 +5,4 @@ src/roxabi_live/dep_graph/v1/fetch.py  # 474 lines — legacy v1, frozen for v6 
 src/roxabi_live/dep_graph/v1/milestone.py  # 580 lines — legacy v1, frozen for v6 migration
 src/roxabi_live/dep_graph/v1/audit.py  # 419 lines — legacy v1, frozen for v6 migration
 src/roxabi_live/dep_graph/v1/derive.py  # 308 lines — legacy v1, frozen for v6 migration
-src/roxabi_live/corpus/sync.py  # 442 lines — #872 adds _parse_project_fields + upsert 11->15
+src/roxabi_live/corpus/sync.py  # 528 lines — #75 adds run_single_repo_sync; #872 adds _parse_project_fields + upsert 11->15


### PR DESCRIPTION
Closes #75

## Summary

- Webhook-driven heal previously called `run_sync` (full org sync, ~20 repos × 1-2 pages each) and had no in-flight guard.
- A webhook storm (30+ events / 90s observed on M₁ 2026-05-19) fired N concurrent full-org syncs → drained the 5000 pts/h GraphQL quota in **1 second** (`remaining=0` × 2 in 24h).
- This PR scopes the webhook path to a single-repo sync and dedups concurrent triggers via a module-level flag + lock.

## What changed

**`corpus/sync.py`** — new `run_single_repo_sync(conn, repo)`:
- Reads `since` cursor from `sync_state`, calls existing `run_repo_sync`.
- **Skips** `enumerate_org_repos` and `closed_hop_pass` — those stay in the hourly `run_sync` (the safety-net loop).

**`reconciler.py`** — concurrent-trigger guard:
- New module-level `_sync_in_flight: bool` (reset between tests via `conftest.py`).
- New `run_repo_once(settings, repo)` mirroring `run_once` (auth-halt handling) but calling `run_single_repo_sync`.
- `_trigger_heal` now atomically (under `_state_lock`): checks `_sync_in_flight`, runs staleness check, claims the flag if stale, and schedules `run_repo_once`. Task clears the flag in `finally`.

**Hourly behaviour unchanged.** The full-org `run_sync` keeps running every hour as the safety net for missed webhooks + `closed_hop_pass` + stale-state pruning.

## Cost comparison

|                       | Before                   | After                          |
|-----------------------|--------------------------|--------------------------------|
| webhook event (cost)  | ~80 pts (full org)       | ~1-5 pts (single repo)         |
| parallel webhooks     | unbounded → flatline     | dedup via flag + lock          |
| hourly tick           | ~30-50 pts (full org)    | ~30-50 pts (full org, same)    |

## Tests

- `tests/test_reconciler_lifecycle.py` — dedup (2 concurrent triggers schedule only 1 task), single-repo-path, flag-cleared-after.
- `tests/test_reconciler.py` — `run_repo_once` happy path + auth-halt + counter reset.
- `tests/corpus/test_sync.py` — `run_single_repo_sync` calls `run_repo_sync` with `since` cursor, does NOT call `enumerate_org_repos` / `closed_hop_pass`, raises `ValueError` on malformed repo.
- `tests/test_webhook_router.py` — patches updated from `run_once` to `run_repo_once`.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 575 passed
- [ ] Deploy to M₁, observe webhook storm behaviour: only 1 sync at a time, `remaining=` decreases monotonically, no `remaining=0`.

## Out of scope (separate fix)

`handle_sub_issues` raises `KeyError: 'issue'` on certain `sub_issues` payloads (`webhook/handlers.py:136`) → returns 500. Doesn't affect rate limit but pollutes 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)