### PR TITLE
fix(webhook): point-fetch downstream issue deps on cross-repo blocked_by

### DIFF
--- a/src/roxabi_live/corpus/graphql.py
+++ b/src/roxabi_live/corpus/graphql.py
@@ -72,6 +72,45 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 """
 
+SINGLE_ISSUE_DEPS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number
+      blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
+      blocking(first: 50) { nodes { number repository { nameWithOwner } } }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+"""
+
+
+def fetch_issue_deps(owner: str, name: str, number: int) -> dict[str, list[str]]:
+    """Fetch blockedBy + blocking lists for a single issue via GraphQL.
+
+    Returns a dict with keys ``blocked_by`` and ``blocking``, each a list of
+    canonical 'owner/repo#N' keys.  Uses canonical_key logic inline to avoid
+    a circular import (sync.py imports graphql.py).
+
+    Raises GraphQLError on network / auth failure (caller caps retries).
+    """
+    response = gh_graphql(
+        SINGLE_ISSUE_DEPS_QUERY,
+        {"owner": owner, "name": name, "number": number},
+    )
+    issue_node = response["data"]["repository"]["issue"]
+    if issue_node is None:
+        return {"blocked_by": [], "blocking": []}
+
+    def _nodes_to_keys(nodes: list[dict[str, Any]]) -> list[str]:
+        return [f"{n['repository']['nameWithOwner']}#{n['number']}" for n in nodes]
+
+    return {
+        "blocked_by": _nodes_to_keys(issue_node.get("blockedBy", {}).get("nodes", [])),
+        "blocking": _nodes_to_keys(issue_node.get("blocking", {}).get("nodes", [])),
+    }
+
 
 def _build_variable_flags(variables: dict[str, Any]) -> list[str]:
     """Build -F / -f flags for `gh api graphql` from a variables dict.

--- a/src/roxabi_live/corpus/mutations.py
+++ b/src/roxabi_live/corpus/mutations.py
@@ -18,6 +18,7 @@ import aiosqlite
 
 from roxabi_live.corpus.sync import (
     DELETE_EDGE_SQL,
+    DELETE_EDGES_BY_KIND_SQL,
     DELETE_LABELS_SQL,
     INSERT_EDGE_SQL,
     INSERT_LABEL_SQL,
@@ -100,3 +101,31 @@ async def delete_issue_async(conn: aiosqlite.Connection, key: str) -> None:
     Runs inside the caller's transaction — no commit() here.
     """
     await conn.execute("DELETE FROM issues WHERE key = ?", (key,))
+
+
+async def upsert_edges_async(
+    conn: aiosqlite.Connection,
+    issue_key: str,
+    blocked_by: list[str],
+    blocking: list[str],
+    kind: str = "parent",
+) -> None:
+    """Async mirror of corpus.sync.upsert_edges for use in the webhook layer.
+
+    Wipes all edges touching issue_key (as src OR dst) of the given kind, then
+    rewrites from blocked_by + blocking.
+
+    Canonical direction:
+    - Every blocker b in blocked_by -> row (src=b, dst=issue_key).
+    - Every blockee b in blocking  -> row (src=issue_key, dst=b).
+
+    Runs inside the caller's transaction — no commit() here.
+    """
+    await conn.execute(DELETE_EDGES_BY_KIND_SQL, (issue_key, issue_key, kind))
+    rows: list[tuple[str, str, str]] = []
+    for blocker in blocked_by:
+        rows.append((blocker, issue_key, kind))
+    for blockee in blocking:
+        rows.append((issue_key, blockee, kind))
+    if rows:
+        await conn.executemany(INSERT_EDGE_SQL, rows)

--- a/src/roxabi_live/webhook/handlers.py
+++ b/src/roxabi_live/webhook/handlers.py
@@ -104,7 +104,13 @@ async def _point_fetch_and_upsert_deps(
     surface quickly) and rewrites all ``blocks`` edges for the issue via
     ``upsert_edges_async``.
     """
-    number: int = blocked_issue["number"]
+    number = blocked_issue.get("number")
+    if number is None:
+        log.warning(
+            "handle_deps: missing number in blocked_issue — keys=%s",
+            list(blocked_issue.keys()),
+        )
+        return
     full_name: str = repo.get("full_name", "")
     owner, _, name = full_name.partition("/")
     if not owner or not name:
@@ -117,21 +123,20 @@ async def _point_fetch_and_upsert_deps(
     issue_key = canonical_key(number, full_name)
 
     try:
-        deps = await asyncio.get_event_loop().run_in_executor(
-            None, fetch_issue_deps, owner, name, number
+        deps = await asyncio.to_thread(fetch_issue_deps, owner, name, number)
+        await upsert_edges_async(
+            conn,
+            issue_key,
+            deps["blocked_by"],
+            deps["blocking"],
+            "blocks",
         )
     except GraphQLError as exc:
         log.warning("handle_deps: point-fetch failed for %s — %s", issue_key, exc)
         return
-
-    await upsert_edges_async(
-        conn,
-        issue_key,
-        deps["blocked_by"],
-        deps["blocking"],
-        "blocks",
-    )
-    await conn.commit()
+    except Exception:
+        log.error("handle_deps: unexpected error for %s", issue_key, exc_info=True)
+        return
 
 
 async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> None:
@@ -175,6 +180,7 @@ async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> No
     if blocking_issue is None:
         repo_obj: dict[str, Any] = payload.get("repository") or {}
         await _point_fetch_and_upsert_deps(conn, blocked_issue, repo_obj)
+        await conn.commit()
         return
 
     # Same-repo fast path: both sides are in the payload — use them directly.

--- a/src/roxabi_live/webhook/handlers.py
+++ b/src/roxabi_live/webhook/handlers.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, cast
 
 import aiosqlite
 
+from roxabi_live.corpus.graphql import GraphQLError, fetch_issue_deps
 from roxabi_live.corpus.mutations import (
     add_edge_async,
     delete_issue_async,
     remove_edge_async,
     replace_labels_async,
+    upsert_edges_async,
     upsert_issue_async,
 )
-from roxabi_live.corpus.sync import extract_from_labels
+from roxabi_live.corpus.sync import canonical_key, extract_from_labels
 
 log = logging.getLogger(__name__)
 
@@ -88,11 +91,59 @@ def _issue_key(
     return f"{full_name}#{issue['number']}"
 
 
+async def _point_fetch_and_upsert_deps(
+    conn: aiosqlite.Connection,
+    blocked_issue: dict[str, Any],
+    repo: dict[str, Any],
+) -> None:
+    """Point-fetch the current blockedBy/blocking state for a single issue and
+    upsert edges into corpus.db.
+
+    Used when GitHub omits ``blocking_issue`` from cross-repo dependency
+    payloads.  Fetches via GraphQL (1 attempt — no retry loop so auth failures
+    surface quickly) and rewrites all ``blocks`` edges for the issue via
+    ``upsert_edges_async``.
+    """
+    number: int = blocked_issue["number"]
+    full_name: str = repo.get("full_name", "")
+    owner, _, name = full_name.partition("/")
+    if not owner or not name:
+        log.warning(
+            "handle_deps: cannot point-fetch — malformed repository.full_name=%r",
+            full_name,
+        )
+        return
+
+    issue_key = canonical_key(number, full_name)
+
+    try:
+        deps = await asyncio.get_event_loop().run_in_executor(
+            None, fetch_issue_deps, owner, name, number
+        )
+    except GraphQLError as exc:
+        log.warning("handle_deps: point-fetch failed for %s — %s", issue_key, exc)
+        return
+
+    await upsert_edges_async(
+        conn,
+        issue_key,
+        deps["blocked_by"],
+        deps["blocking"],
+        "blocks",
+    )
+    await conn.commit()
+
+
 async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> None:
     """Process a GitHub `issue_dependencies` webhook event.
 
     Acted upon: blocked_by_added, blocked_by_removed.
     Ignored (duplicate-direction): blocking_added, blocking_removed.
+
+    Cross-repo case: GitHub omits ``blocking_issue`` from payloads when the
+    blocker is in a different repo.  When that field is absent we fall back to a
+    point-fetch of the affected issue's current dependency lists and rewrite all
+    its ``blocks`` edges via ``upsert_edges``.
     """
     action = payload.get("action")
 
@@ -110,7 +161,7 @@ async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> No
     )
     blocking_repo: dict[str, Any] | None = payload.get("blocking_issue_repo")
 
-    if blocking_issue is None or blocked_issue is None:
+    if blocked_issue is None:
         log.warning(
             "handle_deps: unexpected payload shape for %s — keys=%s payload=%s",
             action,
@@ -119,6 +170,14 @@ async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> No
         )
         return
 
+    # Cross-repo case: blocking_issue absent — point-fetch the downstream issue's
+    # current dep graph and derive edges from the authoritative GitHub state.
+    if blocking_issue is None:
+        repo_obj: dict[str, Any] = payload.get("repository") or {}
+        await _point_fetch_and_upsert_deps(conn, blocked_issue, repo_obj)
+        return
+
+    # Same-repo fast path: both sides are in the payload — use them directly.
     blocker_key = _issue_key(blocking_issue, blocking_repo)
     blocked_key = _issue_key(blocked_issue, payload.get("repository"))  # type: ignore[arg-type]
 

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -752,3 +752,196 @@ class TestHandleIssuesTransaction:
         assert raw_sql_lines == [], (
             f"handlers.py contains raw SQL strings: {raw_sql_lines}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for cross-repo deps tests
+# ---------------------------------------------------------------------------
+
+
+def _make_cross_repo_deps_payload(
+    action: str,
+    blocked_repo: str = "Roxabi/llmCLI",
+    blocked_number: int = 64,
+    event_repo: str = "Roxabi/llmCLI",
+) -> dict[str, Any]:
+    """Build a minimal cross-repo `issue_dependencies` payload.
+
+    Mirrors the actual GitHub delivery shape observed 2026-05-21:
+    ``blocking_issue`` and ``blocking_issue_repo`` are absent; only
+    ``blocked_issue`` (and/or ``issue``) + ``repository`` are present.
+    """
+    repo_owner, repo_name = event_repo.split("/", 1)
+    return {
+        "action": action,
+        "blocked_issue_id": blocked_number,
+        "blocked_issue": _make_issue_obj(blocked_repo, blocked_number),
+        "repository": {
+            "full_name": event_repo,
+            "name": repo_name,
+            "owner": {"login": repo_owner},
+        },
+        "organization": {"login": repo_owner},
+        "sender": {"login": "test-user"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests — cross-repo handle_deps (point-fetch path)
+# ---------------------------------------------------------------------------
+
+
+class TestDepsWebhookHandlerCrossRepo:
+    """handle_deps() cross-repo path — point-fetch fallback when blocking_issue absent.
+
+    Covers the GitHub schema gap where cross-repo blocked_by payloads omit
+    ``blocking_issue``.
+    """
+
+    async def test_cross_repo_blocked_by_added_writes_edge(
+        self,
+        db: aiosqlite.Connection,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cross-repo blocked_by_added: missing blocking_issue triggers point-fetch.
+
+        Mock fetch_issue_deps to return a known blockedBy list and assert that the
+        corresponding blocks edge is written to corpus.db.
+        """
+
+        # Blocker is Roxabi/lyra#1063, blocked issue is Roxabi/llmCLI#64
+        def _mock_fetch(owner: str, name: str, number: int) -> dict[str, list[str]]:
+            assert owner == "Roxabi"
+            assert name == "llmCLI"
+            assert number == 64
+            return {
+                "blocked_by": ["Roxabi/lyra#1063"],
+                "blocking": [],
+            }
+
+        monkeypatch.setattr(
+            "roxabi_live.webhook.handlers.fetch_issue_deps", _mock_fetch
+        )
+
+        payload = _make_cross_repo_deps_payload(
+            action="blocked_by_added",
+            blocked_repo="Roxabi/llmCLI",
+            blocked_number=64,
+            event_repo="Roxabi/llmCLI",
+        )
+        await handle_deps(payload, db)
+
+        row = await _fetch_edge(db, "Roxabi/lyra#1063", "Roxabi/llmCLI#64", "blocks")
+        assert row is not None, (
+            "Expected edge (Roxabi/lyra#1063 → Roxabi/llmCLI#64, blocks) after"
+            " cross-repo blocked_by_added"
+        )
+        assert row == ("Roxabi/lyra#1063", "Roxabi/llmCLI#64", "blocks")
+
+    async def test_cross_repo_blocked_by_removed_removes_edge(
+        self,
+        db: aiosqlite.Connection,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cross-repo blocked_by_removed: point-fetch returns empty blockedBy;
+        upsert_edges wipes the previous edge for this issue.
+        """
+        # Seed the edge that should disappear after the removal event
+        await _seed_edge(db, "Roxabi/lyra#1063", "Roxabi/llmCLI#64", "blocks")
+
+        def _mock_fetch(owner: str, name: str, number: int) -> dict[str, list[str]]:
+            # GitHub now reports no blockers (the dep was removed)
+            return {"blocked_by": [], "blocking": []}
+
+        monkeypatch.setattr(
+            "roxabi_live.webhook.handlers.fetch_issue_deps", _mock_fetch
+        )
+
+        payload = _make_cross_repo_deps_payload(
+            action="blocked_by_removed",
+            blocked_repo="Roxabi/llmCLI",
+            blocked_number=64,
+            event_repo="Roxabi/llmCLI",
+        )
+        await handle_deps(payload, db)
+
+        row = await _fetch_edge(db, "Roxabi/lyra#1063", "Roxabi/llmCLI#64", "blocks")
+        assert row is None, (
+            "Expected edge to be removed after cross-repo blocked_by_removed"
+        )
+
+    async def test_same_repo_blocked_by_added_regression(
+        self,
+        db: aiosqlite.Connection,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Same-repo blocked_by_added: fast path uses payload directly, NO GraphQL.
+
+        Regression guard — the old behavior must still work when blocking_issue
+        IS present in the payload.
+        """
+        fetch_called: list[bool] = []
+
+        def _mock_fetch(
+            owner: str, name: str, number: int
+        ) -> dict[str, list[str]]:  # pragma: no cover
+            fetch_called.append(True)
+            return {"blocked_by": [], "blocking": []}
+
+        monkeypatch.setattr(
+            "roxabi_live.webhook.handlers.fetch_issue_deps", _mock_fetch
+        )
+
+        payload = _make_deps_payload(
+            action="blocked_by_added",
+            issue_repo="Roxabi/lyra",
+            issue_number=10,
+            blocking_repo="Roxabi/lyra",
+            blocking_number=5,
+        )
+        await handle_deps(payload, db)
+
+        # Fast path: edge written directly from payload, no GraphQL call
+        assert fetch_called == [], "GraphQL fetch must NOT be called for same-repo path"
+        row = await _fetch_edge(db, "Roxabi/lyra#5", "Roxabi/lyra#10", "blocks")
+        assert row is not None, (
+            "Expected direct edge insert for same-repo blocked_by_added"
+        )
+
+    async def test_cross_repo_graphql_failure_logs_and_returns_cleanly(
+        self,
+        db: aiosqlite.Connection,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """GraphQL fetch failure: handler logs warning and returns cleanly.
+
+        No exception should bubble — webhooks must return 200.
+        """
+        from roxabi_live.corpus.graphql import GraphQLError
+
+        def _mock_fetch(owner: str, name: str, number: int) -> dict[str, list[str]]:
+            raise GraphQLError("gh exited 1: authentication failed")
+
+        monkeypatch.setattr(
+            "roxabi_live.webhook.handlers.fetch_issue_deps", _mock_fetch
+        )
+
+        payload = _make_cross_repo_deps_payload(
+            action="blocked_by_added",
+            blocked_repo="Roxabi/llmCLI",
+            blocked_number=64,
+            event_repo="Roxabi/llmCLI",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="roxabi_live.webhook.handlers"):
+            # Must NOT raise — handler swallows GraphQL errors
+            await handle_deps(payload, db)
+
+        assert any("point-fetch failed" in rec.message for rec in caplog.records), (
+            "Expected a warning log when GraphQL fetch fails"
+        )
+
+        # No edge should have been written
+        row = await _fetch_edge(db, "Roxabi/lyra#1063", "Roxabi/llmCLI#64", "blocks")
+        assert row is None, "No edge should be written when GraphQL fetch fails"

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -947,11 +947,16 @@ class TestDepsWebhookHandlerCrossRepo:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """GraphQL fetch failure: handler logs warning and returns cleanly.
+        """GraphQL fetch failure: handler logs warning, returns cleanly, preserves DB.
 
+        Pre-seeds an unrelated edge for the same downstream issue so we can assert
+        the edge is NOT wiped by an accidental upsert_edges_async([], []) call.
         No exception should bubble — webhooks must return 200.
         """
         from roxabi_live.corpus.graphql import GraphQLError
+
+        # Arrange: pre-seed an unrelated edge for the same downstream issue
+        await _seed_edge(db, "Roxabi/lyra#999", "Roxabi/llmCLI#64", "blocks")
 
         def _mock_fetch(owner: str, name: str, number: int) -> dict[str, list[str]]:
             raise GraphQLError("gh exited 1: authentication failed")
@@ -975,6 +980,9 @@ class TestDepsWebhookHandlerCrossRepo:
             "Expected a warning log when GraphQL fetch fails"
         )
 
-        # No edge should have been written
-        row = await _fetch_edge(db, "Roxabi/lyra#1063", "Roxabi/llmCLI#64", "blocks")
-        assert row is None, "No edge should be written when GraphQL fetch fails"
+        # Pre-seeded edge must NOT have been wiped by an accidental upsert call
+        row = await _fetch_edge(db, "Roxabi/lyra#999", "Roxabi/llmCLI#64", "blocks")
+        assert row is not None, (
+            "Pre-seeded edge must survive a GraphQL fetch failure"
+            " — upsert_edges_async must not be called on error"
+        )

--- a/tests/test_webhook_handlers.py
+++ b/tests/test_webhook_handlers.py
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS edges (
     src_key     TEXT NOT NULL,
     dst_key     TEXT NOT NULL,
     kind        TEXT NOT NULL DEFAULT 'parent',
-    PRIMARY KEY (src_key, dst_key)
+    PRIMARY KEY (src_key, dst_key, kind)
 );
 """
 
@@ -565,6 +565,39 @@ class TestDepsWebhookHandler:
         row_b = await _fetch_edge(db, "Roxabi/lyra#10", "Roxabi/lyra#5", "blocks")
         assert row_a is None and row_b is None, (
             "Expected no edge for blocking_added noop"
+        )
+
+    async def test_blocked_by_added_malformed_payload_logged_not_raised(
+        self,
+        db: aiosqlite.Connection,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Malformed blocked_by_added (missing blocked_issue/issue fields) must
+        log a warning and return rather than raise — webhooks must return 200."""
+        payload: dict[str, Any] = {
+            "action": "blocked_by_added",
+            "repository": {
+                "full_name": "Roxabi/lyra",
+                "name": "lyra",
+                "owner": {"login": "Roxabi"},
+            },
+            # Intentionally omit both 'blocked_issue' and 'issue' keys
+            # so that blocked_issue resolves to None inside handle_deps.
+        }
+
+        with caplog.at_level(logging.WARNING, logger="roxabi_live.webhook.handlers"):
+            await handle_deps(payload, db)
+
+        assert any(
+            "unexpected payload shape" in rec.message for rec in caplog.records
+        ), "Expected a warning log for malformed payload"
+
+        # No edge should have been written
+        cursor = await db.execute("SELECT COUNT(*) FROM edges")
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row[0] == 0, (
+            f"Expected no edges written for malformed payload, got {row[0]}"
         )
 
 


### PR DESCRIPTION
## Summary

- `handle_deps` previously rejected `issue_dependencies.blocked_by_added` payloads when the blocker is in a different repo (GitHub omits the `blocking_issue` field for cross-repo events). Result: corpus.db never received the edge until the next hourly sync — and even that missed it because adding a `blocked_by` does not bump the issue's `updatedAt`, so `ISSUES_QUERY`'s `since` filter excluded the change too.
- New cross-repo fallback: single-issue GraphQL point-fetch (`SINGLE_ISSUE_DEPS_QUERY`) re-derives the full `blocks`-kind edge set for the affected downstream issue and upserts via async `upsert_edges_async`. Same-repo fast path is unchanged.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#77](https://github.com/Roxabi/roxabi-live/issues/77): fix(webhook): point-fetch downstream on blocked_by_added when blocking_issue missing | OPEN |
| Implementation | 1 commit on `fix/77-webhook-point-fetch` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new, 23 total) | Passed |

## Test Plan

- [ ] Trigger a cross-repo `blocked_by_added` (e.g. `triage.ts set Roxabi/imageCLI#N --blocked-by Roxabi/lyra#M`) → confirm corpus.db edge written within seconds
- [ ] Trigger a cross-repo `blocked_by_removed` → confirm edge removed
- [ ] Same-repo `blocked_by_added` regression — confirm no GraphQL fetch occurs (fast path preserved)

## Out of scope

- Bug 2 (trigger_heal debounce in `reconciler.py`) — follow-up
- Bug 3 broadly (`ISSUES_QUERY` `since` filter) — point-fetch sidesteps it for the webhook path; full-sync mode is a separate concern

Closes #77

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`