### PR TITLE
fix(reconciler): per-repo concurrency lock instead of global bool

### DIFF
--- a/src/roxabi_live/reconciler.py
+++ b/src/roxabi_live/reconciler.py
@@ -36,7 +36,7 @@ _AUTH_FAILURE_THRESHOLD = 2
 _auth_failures: int = 0
 _halted: asyncio.Event = asyncio.Event()
 _state_lock: asyncio.Lock = asyncio.Lock()
-_sync_in_flight: bool = False
+_sync_in_flight: set[str] = set()
 
 
 class TriggerHeal(Protocol):
@@ -274,7 +274,7 @@ def _reset_state_for_tests() -> None:
     """Reset all module-level sync state. Call from test fixtures only."""
     global _auth_failures, _sync_in_flight
     _auth_failures = 0
-    _sync_in_flight = False
+    _sync_in_flight.clear()
     _halted.clear()
 
 
@@ -285,10 +285,12 @@ def make_trigger_heal(
     """Factory: build a TriggerHeal closure capturing settings + the WeakSet.
 
     The returned callable:
-    1. Acquires _state_lock and checks _sync_in_flight; returns if already running.
+    1. Acquires _state_lock and checks _sync_in_flight; returns if this repo is
+       already running.
     2. Checks sync_state staleness (>1h or missing) for the repo.
-    3. If stale, sets _sync_in_flight = True and schedules a task calling
-       run_repo_once(settings, repo).  The task clears _sync_in_flight on finish.
+    3. If stale, adds repo to _sync_in_flight and schedules a task calling
+       run_repo_once(settings, repo).  The task removes repo from
+       _sync_in_flight on finish.
     4. Registers the task in background_tasks WeakSet.
     5. Attaches _log_exc as a done-callback to surface exceptions in logs.
 
@@ -304,9 +306,8 @@ def make_trigger_heal(
     async def _trigger_heal(
         repo: str, conn: aiosqlite.Connection, *, force: bool = False
     ) -> None:
-        global _sync_in_flight
         async with _state_lock:
-            if _sync_in_flight:
+            if repo in _sync_in_flight:
                 return
             if not force:
                 cur = await conn.execute(
@@ -325,15 +326,14 @@ def make_trigger_heal(
                     ).total_seconds() > settings.corpus_sync_interval_seconds
                 if not stale:
                     return
-            _sync_in_flight = True
+            _sync_in_flight.add(repo)
 
         async def _run_and_clear() -> None:
-            global _sync_in_flight
             try:
                 await run_repo_once(settings, repo)
             finally:
                 async with _state_lock:
-                    _sync_in_flight = False
+                    _sync_in_flight.discard(repo)
 
         task: asyncio.Task[None] = asyncio.create_task(_run_and_clear())
         background_tasks.add(task)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,4 +21,4 @@ def reset_reconciler_auth_state() -> None:
     if hasattr(reconciler, "_halted"):
         reconciler._halted.clear()  # type: ignore[attr-defined]
     if hasattr(reconciler, "_sync_in_flight"):
-        reconciler._sync_in_flight = False  # type: ignore[attr-defined]
+        reconciler._sync_in_flight.clear()  # type: ignore[attr-defined]

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -558,8 +558,8 @@ class TestTriggerHealForce:
         tasks: WeakSet[asyncio.Task[None]] = WeakSet()
         trigger_heal = reconciler.make_trigger_heal(s, tasks)
 
-        # Set _sync_in_flight = True
-        reconciler._sync_in_flight = True  # type: ignore[attr-defined]
+        # Mark repo as in-flight
+        reconciler._sync_in_flight.add("Roxabi/lyra")  # type: ignore[attr-defined]
 
         async with aiosqlite.connect(db_path) as conn:
             await trigger_heal("Roxabi/lyra", conn, force=True)
@@ -571,4 +571,43 @@ class TestTriggerHealForce:
         )
 
         # Cleanup
-        reconciler._sync_in_flight = False  # type: ignore[attr-defined]
+        reconciler._sync_in_flight.clear()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_per_repo_isolation_allows_concurrent_heals(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A heal in-flight for repo A must NOT block a heal for repo B."""
+        import sqlite3
+
+        db_path = tmp_path / "corpus.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            "CREATE TABLE IF NOT EXISTS sync_state"
+            " (repo TEXT PRIMARY KEY, last_synced_at TEXT);"
+        )
+        conn.commit()
+        conn.close()
+
+        mock_run_repo_once = AsyncMock(return_value=None)
+        monkeypatch.setattr("roxabi_live.reconciler.run_repo_once", mock_run_repo_once)
+
+        s = _settings(tmp_path)
+        tasks: WeakSet[asyncio.Task[None]] = WeakSet()
+        trigger_heal = reconciler.make_trigger_heal(s, tasks)
+
+        # Mark repo A as in-flight (simulating an active heal)
+        reconciler._sync_in_flight.add("Roxabi/lyra")  # type: ignore[attr-defined]
+
+        async with aiosqlite.connect(db_path) as conn:
+            # Repo B should still be allowed to heal
+            await trigger_heal("Roxabi/llmCLI", conn, force=True)
+
+        await asyncio.sleep(0)
+
+        assert mock_run_repo_once.call_count == 1, (
+            "Per-repo isolation: repo B heal must not be blocked by repo A in-flight"
+        )
+
+        # Cleanup
+        reconciler._sync_in_flight.clear()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- Change `_sync_in_flight` from a module-level `bool` to a `set[str]` keyed by repo slug, allowing concurrent heals for different repositories while still deduping heals for the same repo.
- Update tests to assert per-repo isolation.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #84: fix(reconciler): per-repo concurrency lock instead of global _sync_in_flight bool | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/84-fix-reconciler-per-repo-concurrency-lock` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new) | Passed |

## Test Plan
- [ ] Run `pytest tests/test_reconciler.py` — verify per-repo isolation test passes
- [ ] Verify `tests/test_reconciler_lifecycle.py` dedup test still passes (same-repo dedup unchanged)

Closes #84

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`