### PR TITLE
perf(api): gzip-compress responses via GZipMiddleware

### DIFF
--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -11,6 +11,7 @@ from weakref import WeakSet
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.gzip import GZipMiddleware
 
 from roxabi_live import reconciler
 from roxabi_live.api.issues import router as issues_router
@@ -60,6 +61,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(title="Roxabi Live", version="0.1.0", lifespan=lifespan)
+
+# Compress large JSON responses (e.g. /api/graph ~1.3 MB) at gzip level 9.
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 app.include_router(issues_router)
 app.include_router(dep_graph_v6_router)

--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -62,8 +62,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(title="Roxabi Live", version="0.1.0", lifespan=lifespan)
 
-# Compress large JSON responses (e.g. /api/graph ~1.3 MB) at gzip level 9.
-app.add_middleware(GZipMiddleware, minimum_size=1000)
+# Compress large JSON responses (e.g. /api/graph ~1.3 MB). compresslevel
+# pinned explicitly so the intent survives any future Starlette default change.
+app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=9)
 
 app.include_router(issues_router)
 app.include_router(dep_graph_v6_router)

--- a/tests/test_gzip.py
+++ b/tests/test_gzip.py
@@ -1,0 +1,73 @@
+"""Assert GZipMiddleware compresses GET /api/graph responses.
+
+httpx auto-decodes the body but preserves the Content-Encoding response header,
+so we assert on the header.  /api/graph easily exceeds minimum_size=1000 bytes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from roxabi_live.app import app
+from roxabi_live.corpus.schema import SCHEMA_SQL
+
+_COLUMNS = (
+    "key, repo, number, title, state, url, "
+    "milestone, lane, priority, size, status, is_stub"
+)
+
+
+def _row(i: int) -> tuple[object, ...]:
+    """One issue row with enough text to bulk up the JSON payload."""
+    return (
+        f"Roxabi/lyra#{i}",
+        "Roxabi/lyra",
+        i,
+        f"Issue title number {i} — a longer title to bulk up the payload",
+        "OPEN",
+        f"https://github.com/Roxabi/lyra/issues/{i}",
+        "M0 — NATS hardening",
+        "infra",
+        "P1",
+        "M",
+        "In Progress",
+        0,
+    )
+
+
+# 20 issues comfortably exceed GZipMiddleware's minimum_size=1000 threshold.
+_ROWS = [_row(i) for i in range(1, 21)]
+_INSERT_ISSUES = f"INSERT INTO issues ({_COLUMNS}) VALUES ({', '.join('?' * 12)})"
+
+
+@pytest.fixture()
+def graph_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Temp SQLite DB populated with 20 issues so the JSON exceeds 1000 bytes.
+
+    GZipMiddleware only compresses responses above minimum_size=1000.  An empty
+    graph (23 bytes) would not be compressed; 20 issues comfortably exceed the
+    threshold (each node serialises to ~300 bytes).
+    """
+    db_path = tmp_path / "corpus_gzip_test.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA_SQL)
+    conn.executemany(_INSERT_ISSUES, _ROWS)
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
+    return db_path
+
+
+async def test_api_graph_gzip_compressed(graph_db: Path) -> None:
+    """/api/graph with Accept-Encoding: gzip must return Content-Encoding: gzip."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/graph", headers={"Accept-Encoding": "gzip"})
+
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip"

--- a/tests/test_gzip.py
+++ b/tests/test_gzip.py
@@ -62,6 +62,7 @@ def graph_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return db_path
 
 
+@pytest.mark.asyncio
 async def test_api_graph_gzip_compressed(graph_db: Path) -> None:
     """/api/graph with Accept-Encoding: gzip must return Content-Encoding: gzip."""
     async with AsyncClient(


### PR DESCRIPTION
## Why

`/api/graph` returned **~1.34 MB uncompressed JSON** — the FastAPI app had no compression middleware. Over Tailscale Funnel this dominated page load:

| Metric | Before |
|---|---|
| TTFB (server compute) | ~100–240 ms (fast) |
| Total | **1.25–1.86 s** |
| Payload | 1.34 MB |
| gzip-9 ratio (measured) | **9.6×** → ~140 KB |

Bottleneck was download, not compute. Cloudflare is not in the path (Tailscale Funnel; cloudflared deferred) — so no edge compression to rely on.

## What

- `app.add_middleware(GZipMiddleware, minimum_size=1000)` in `src/roxabi_live/app.py` — compresses any response >1 KB when the client sends `Accept-Encoding: gzip`.
- New `tests/test_gzip.py` — asserts `Content-Encoding: gzip` on `GET /api/graph` with a populated corpus.

Expected: `/api/graph` download ~1.2 s → ~150–200 ms.

## Test

- `pytest`: 658 passed
- `ruff check` / `pyright`: clean

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)