### PR TITLE
perf(startup): non-blocking lifespan — background reconciler sync

### DIFF
--- a/src/roxabi_live/app.py
+++ b/src/roxabi_live/app.py
@@ -42,8 +42,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # never observe a half-migrated DB.
     corpus_schema.bootstrap(settings.corpus_db_path)
 
-    log.info("reconciler startup sync scheduled")
-    await reconciler.run_once(settings)
+    # Schedule startup sync as a background task so lifespan returns immediately.
+    # corpus.db is persistent — endpoints serve existing data while the sync
+    # refreshes it in the background. No HTTP 502 window on restart.
+    startup_sync: asyncio.Task[None] = asyncio.create_task(
+        reconciler.run_once(settings)
+    )
+    # _log_exc is a no-op while run_once swallows its own exceptions, but kept
+    # for parity with the heal tasks and to stay correct if that ever changes.
+    startup_sync.add_done_callback(reconciler._log_exc)
+    # WeakSet is safe here: the event loop holds a strong ref for the task's
+    # lifetime; the finally block cancels + gathers it on shutdown.
+    bg_tasks.add(startup_sync)
+    log.info("reconciler startup sync scheduled (background)")
     loop_task = reconciler.hourly_loop(settings)
     try:
         yield

--- a/tests/test_nonblocking_startup.py
+++ b/tests/test_nonblocking_startup.py
@@ -1,0 +1,78 @@
+"""Test that lifespan startup does NOT block on the reconciler corpus sync.
+
+SC-89: run_once must be scheduled as a background task; if startup awaited it
+directly, a slow/hanging sync would delay all traffic for up to ~16s per restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+import roxabi_live.reconciler as rec_module
+from roxabi_live.app import lifespan
+from roxabi_live.corpus.schema import bootstrap
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "corpus.db"
+    bootstrap(path)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_startup_does_not_block_on_run_once(
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lifespan startup completes without waiting for run_once to finish.
+
+    Patches run_once with a coroutine that sets a "started" flag then blocks
+    forever on an Event. If startup awaited run_once, the lifespan context
+    manager would never yield and this test would hang (caught by the implicit
+    asyncio timeout on the test runner).
+    """
+    monkeypatch.setenv("CORPUS_DB_PATH", str(db_path))
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+
+    sync_started = asyncio.Event()
+    sync_proceed = asyncio.Event()
+
+    async def _blocking_run_once(settings: object) -> None:
+        sync_started.set()
+        # Block until the test releases us so cleanup works cleanly.
+        await sync_proceed.wait()
+
+    monkeypatch.setattr(rec_module, "run_once", _blocking_run_once)
+
+    test_app = FastAPI(lifespan=lifespan)
+
+    try:
+        async with lifespan(test_app):
+            # If we reach here, startup did NOT block — the lifespan yielded
+            # before _blocking_run_once finished (which it hasn't yet).
+
+            # Deterministically wait for the background task to start — no
+            # fixed sleep (flaky under load). If startup had awaited run_once
+            # this point is never reached; the wait_for guards against a hang.
+            await asyncio.wait_for(sync_started.wait(), timeout=5.0)
+            assert sync_started.is_set(), (
+                "run_once was never started — startup_sync task was not scheduled"
+            )
+
+            # The background task should be tracked in app.state.background_tasks.
+            tracked = list(test_app.state.background_tasks)
+            assert any(isinstance(t, asyncio.Task) for t in tracked), (
+                "startup_sync task not found in app.state.background_tasks"
+            )
+
+            # Release the blocked coroutine before exiting lifespan so the
+            # finally block can cancel+gather it cleanly.
+            sync_proceed.set()
+    finally:
+        # Safety net: ensure the event is set so no dangling coroutine lingers.
+        sync_proceed.set()


### PR DESCRIPTION
## Why

`lifespan` awaited `reconciler.run_once()` **before** `yield`, so uvicorn refused traffic until the full corpus GraphQL sync completed → **~16s of HTTP 502 on every restart** (observed on M₁ after the #88 deploy).

## What

- Schedule `run_once` as a background task tracked in `bg_tasks` (already cancelled + gathered on shutdown) instead of awaiting it.
- `corpus_schema.bootstrap()` stays synchronous before `yield` (endpoints need a migrated schema).
- `corpus.db` is persistent → endpoints serve existing data immediately; the background task refreshes it. **No restart downtime.**

## Test

`tests/test_nonblocking_startup.py` — patches `run_once` with a coroutine that blocks forever; asserts lifespan startup completes and the sync task is scheduled/tracked. Reverting to `await run_once(...)` makes this test hang (timeout), so it genuinely guards the property.

## Review

Fresh backend-dev + tester review → Approve, 0 bugs. Applied nits: deterministic `wait_for` (no flaky sleep), `@pytest.mark.asyncio`, clarifying comments (WeakSet strong-ref safety, `_log_exc` rationale).

- `pytest`: 659 passed · `ruff` / `pyright`: clean

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)