### PR TITLE
docs: correct stale roxabi.dev zone status (now on Cloudflare) + supervisor→systemd notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Let:
 - Exposes `~/.roxabi/corpus.db` via live HTTP API (`GET /api/*`)
 - Receives GitHub org webhooks at `POST /webhook/github` (HMAC-gated)
 - Frontend: static HTML/JS (dep-graph tab first, see spec #866)
-- Public via Tailscale Funnel on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (cloudflared setup deferred pending `roxabi.dev` zone migration from OVH)
+- Public via Tailscale Funnel on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (`roxabi.dev` zone migrated to Cloudflare as of 2026-06-05 → Cloudflare Tunnel now unblocked but not yet deployed; Funnel remains the live ingress)
 
 → `docs/ARCHITECTURE.md` (to be created)
 

--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -4,13 +4,16 @@ description: One-time provisioning of the Cloudflare Tunnel that exposes dashboa
 ---
 
 > [!NOTE]
-> **Status (2026-04-24):** this cloudflared setup is **not currently deployed**. The `roxabi.dev` zone remains on OVH, so Cloudflare Tunnel + Access cannot front it without a zone migration. Production ingress is instead served by **Tailscale Funnel** on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (see "Current deployment" below). This document is kept for reference and for the eventual migration to Cloudflare once the zone moves.
+> **Status (updated 2026-06-05):** the `roxabi.dev` zone has **migrated to Cloudflare** (NS: `donald`/`mia.ns.cloudflare.com`), so the previous blocker is gone — Cloudflare Tunnel + Access **can** now front it. This setup is, however, **still not deployed**: production ingress remains **Tailscale Funnel** on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (see "Current deployment" below). This document is the runbook for the eventual migration to Cloudflare Tunnel.
 
 ## Current deployment (Tailscale Funnel)
 
-GitHub org webhooks POST to `https://roxabituwer.goose-logarithm.ts.net/webhook/github`. HMAC (`GITHUB_WEBHOOK_SECRET`) is the sole auth gate — Cloudflare Access is not in front of it. Funnel is started via `sudo tailscale funnel --bg 8000` on M₁ and survives `tailscaled` restarts. To rotate: update the GitHub webhook URL and the Funnel binding (`tailscale funnel --https=443 off` removes all bindings; re-add with `tailscale funnel --bg 8000`).
+GitHub org webhooks POST to `https://roxabituwer.goose-logarithm.ts.net/webhook/github`. HMAC (`GITHUB_WEBHOOK_SECRET`) is the sole auth gate — Cloudflare Access is not in front of it. Funnel is started via `tailscale funnel --bg 8000` on M₁ (operator is set to the host user, so `sudo` is not needed) and survives `tailscaled` restarts. To rotate: update the GitHub webhook URL and the Funnel binding (`tailscale funnel --https=443 off` removes all bindings; re-add with `tailscale funnel --bg 8000`).
 
 ## Overview (cloudflared — deferred)
+
+> [!IMPORTANT]
+> The supervisord unit referenced below (`deploy/supervisor/conf.d/cloudflared.conf`) is **stale** — this project is now systemd-only. When deploying cloudflared, run it as a systemd **user** unit (mirror `deploy/systemd/live.service`) instead of supervisord. The supervisord steps below are kept only as a reference for the command/flags.
 
 `cloudflared` runs as a supervised daemon that creates an outbound-only Cloudflare Tunnel from the host machine to the public domain `dashboard.roxabi.dev`. All HTTP traffic arriving at that domain is forwarded to the local FastAPI process on port 8000. No inbound firewall ports are opened; the tunnel is the sole ingress path.
 
@@ -159,7 +162,7 @@ On M₁, start both services:
 
 ```bash
 systemctl --user start live.service
-supervisorctl start cloudflared
+supervisorctl start cloudflared  # or the equivalent systemd user unit, see note above
 ```
 
 `live` is managed by systemd (`live.service`, enabled at boot via linger). `cloudflared` would use supervisord if deployed.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,4 +119,4 @@ Logs also written to `~/.local/state/roxabi-live/logs/`:
 
 ### Tailscale Funnel
 
-On M1, the server is exposed publicly via Tailscale Funnel. No additional config is required beyond the standard Tailscale setup.
+On M1, the server is exposed publicly via Tailscale Funnel. Start it once with `tailscale funnel --bg 8000` (no `sudo` — the Tailscale operator is set to the host user); the binding survives `tailscaled` restarts. Verify with `tailscale funnel status`. Disable all bindings with `tailscale funnel --https=443 off`.


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: updated the public ingress bullet — replaces stale OVH/pending-migration note with the confirmed Cloudflare NS migration (2026-06-05); Funnel remains live ingress.
- **docs/cloudflared-setup.md (NOTE block)**: replaces outdated status (OVH blocker) with accurate status: zone is on Cloudflare, tunnel is unblocked but not yet deployed.
- **docs/cloudflared-setup.md (sudo)**: removes `sudo` from `tailscale funnel --bg 8000` — Tailscale operator is set to the host user; appends inline note explaining why.
- **docs/cloudflared-setup.md (IMPORTANT callout)**: adds callout under "Overview (cloudflared — deferred)" flagging the supervisord unit as stale (project is now systemd-only) and directing future deployers to use a systemd user unit; Step 3 of the M₂ → M₁ migration also gets an inline note.
- **docs/getting-started.md (Tailscale Funnel section)**: replaces misleading "no additional config" with actionable start/verify/disable commands, noting no `sudo` needed.

## Test plan

- [ ] Verify `roxabi.dev` NS records still resolve to `donald`/`mia.ns.cloudflare.com`
- [ ] Confirm Funnel still serves `https://roxabituwer.goose-logarithm.ts.net/` on M₁
- [ ] Read through cloudflared-setup.md to confirm no further stale supervisor references were missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)