### PR TITLE
feat(webhook): handle milestone renamed event to update corpus.db

### DIFF
--- a/src/roxabi_live/corpus/mutations.py
+++ b/src/roxabi_live/corpus/mutations.py
@@ -40,6 +40,9 @@ SET_ACTIVE_BRANCH_ON_SQL = (
 SET_ACTIVE_BRANCH_OFF_SQL = (
     "UPDATE issues SET has_active_branch=0 WHERE repo=? AND number=?"
 )
+RENAME_MILESTONE_SQL = (
+    "UPDATE issues SET milestone = ? WHERE repo = ? AND milestone = ?"
+)
 
 
 async def upsert_issue_async(
@@ -186,3 +189,13 @@ async def upsert_pr_state_async(  # noqa: PLR0913
         UPSERT_PR_STATE_SQL,
         (repo, number, state, has_reviewed_label, closing_issue_keys_json, updated_at),
     )
+
+
+async def rename_milestone_async(
+    conn: aiosqlite.Connection, repo: str, old_title: str, new_title: str
+) -> None:
+    """Rename a milestone across all issues in a repo.
+
+    Runs inside the caller's transaction — no commit() here.
+    """
+    await conn.execute(RENAME_MILESTONE_SQL, (new_title, repo, old_title))

--- a/src/roxabi_live/webhook/handlers.py
+++ b/src/roxabi_live/webhook/handlers.py
@@ -19,6 +19,7 @@ from roxabi_live.corpus.mutations import (
     add_edge_async,
     delete_issue_async,
     remove_edge_async,
+    rename_milestone_async,
     replace_labels_async,
     set_active_branch_async,
     upsert_edges_async,
@@ -162,9 +163,7 @@ async def _point_fetch_and_upsert_deps(
         return 0
 
 
-async def handle_deps(
-    payload: dict[str, Any], conn: aiosqlite.Connection
-) -> int:
+async def handle_deps(payload: dict[str, Any], conn: aiosqlite.Connection) -> int:
     """Process a GitHub `issue_dependencies` webhook event.
 
     Acted upon: blocked_by_added, blocked_by_removed.
@@ -227,9 +226,7 @@ async def handle_deps(
     return 0
 
 
-async def handle_sub_issues(
-    payload: dict[str, Any], conn: aiosqlite.Connection
-) -> int:
+async def handle_sub_issues(payload: dict[str, Any], conn: aiosqlite.Connection) -> int:
     """Process a GitHub `sub_issues` webhook event.
 
     Acted upon: sub_issue_added, sub_issue_removed.
@@ -419,3 +416,25 @@ async def handle_pull_request(
     except Exception:
         await conn.rollback()
         raise
+
+
+async def handle_milestone(payload: dict[str, Any], conn: aiosqlite.Connection) -> None:
+    """Process a GitHub `milestone` webhook event.
+
+    Only `edited` + title change is handled — renames the milestone in-place
+    without re-fetching all issues from GitHub.
+    """
+    action = payload.get("action")
+    if action != "edited":
+        return
+    changes: dict[str, Any] = cast(dict[str, Any], payload.get("changes") or {})
+    title_change: dict[str, Any] | None = cast(
+        "dict[str, Any] | None", changes.get("title")
+    )
+    if not title_change:
+        return
+    old_title: str = str(title_change["from"])
+    new_title: str = str(payload["milestone"]["title"])  # type: ignore[index]
+    repo: str = str(payload["repository"]["full_name"])  # type: ignore[index]
+    await rename_milestone_async(conn, repo, old_title, new_title)
+    await conn.commit()

--- a/src/roxabi_live/webhook/router.py
+++ b/src/roxabi_live/webhook/router.py
@@ -16,6 +16,7 @@ from roxabi_live.webhook import hmac_auth
 from roxabi_live.webhook.handlers import (
     handle_deps,
     handle_issues,
+    handle_milestone,
     handle_pull_request,
     handle_ref_create,
     handle_ref_delete,
@@ -125,6 +126,8 @@ async def github_webhook(  # noqa: PLR0913 C901 — FastAPI deps + branching dis
             await handle_ref_delete(payload, conn, db_path=db_path)
         elif x_github_event == "pull_request":
             await handle_pull_request(payload, conn)
+        elif x_github_event == "milestone":
+            await handle_milestone(payload, conn)
         else:
             return {"ok": True, "ignored": x_github_event}
 

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -7,4 +7,4 @@ src/roxabi_live/dep_graph/v1/audit.py  # 419 lines — legacy v1, frozen for v6 
 src/roxabi_live/dep_graph/v1/derive.py  # 308 lines — legacy v1, frozen for v6 migration
 src/roxabi_live/corpus/sync.py  # 746 lines — #75 adds run_single_repo_sync; #872 adds _parse_project_fields + upsert 11->15; #82 adds sync_branches + sync_prs
 src/roxabi_live/reconciler.py  # 335 lines — #82 adds heal_pr_branch_state + run_repo_once sync_branches/sync_prs restore
-src/roxabi_live/webhook/handlers.py  # 408 lines — #82 adds handle_ref_create/delete + handle_pull_request
+src/roxabi_live/webhook/handlers.py  # 436 lines — #82 adds handle_ref_create/delete + handle_pull_request; handle_milestone


### PR DESCRIPTION
## Summary
- Adds `milestone` webhook event to the router (`x-github-event: milestone`)
- On `action: edited` + title change, renames the milestone across all matching issues in corpus.db via a direct SQL UPDATE — no GraphQL re-fetch needed, the payload's `changes.title.from` provides the old name
- Other milestone actions (created, deleted, closed, etc.) are silently ignored

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #104: feat(webhook): handle milestone renamed event | Open |
| Implementation | 1 commit on `feat/104-milestone-webhook-renamed` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (658 passed) | Passed |

## Test Plan
- [ ] Rename a milestone on GitHub → verify corpus.db issues update immediately (no hourly reconciler wait)
- [ ] Other milestone actions (e.g. `closed`) → verify 200 OK with no DB mutation
- [ ] Milestone rename with no title change (e.g. description edit) → verify no-op

Fixes #104

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`