### PR TITLE
feat(worker): provision staging+prod D1, wire IDs, apply 0001 schema (#94)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,7 +13,7 @@ crons = ["0 * * * *"]
 [[d1_databases]]
 binding        = "DB"
 database_name  = "roxabi-live-production"
-database_id    = "<PROD_D1_ID>"     # fill after: wrangler d1 create roxabi-live-production
+database_id    = "c3951107-146c-4a7d-a8a5-86d09e4570e9"
 migrations_dir = "worker/migrations"
 
 # ── Staging environment ──────────────────────────────────────────────────────
@@ -24,7 +24,7 @@ name = "roxabi-live-staging"
 [[env.staging.d1_databases]]
 binding        = "DB"
 database_name  = "roxabi-live-staging"
-database_id    = "<STAGING_D1_ID>"  # fill after: wrangler d1 create roxabi-live-staging
+database_id    = "dd96d8cd-db6b-49ed-8218-53c88773aff4"
 migrations_dir = "worker/migrations"
 
 [env.staging.triggers]


### PR DESCRIPTION
## What

S2 (#94) **D1 bootstrap** — provisions the Cloudflare D1 backend and activates the deploy pipeline, reusing the existing bouly.io Cloudflare account (shared with `roxabi-1page`).

- `wrangler.toml`: fill real `database_id` for both envs
  - staging  `roxabi-live-staging`  → `dd96d8cd-db6b-49ed-8218-53c88773aff4`
  - prod     `roxabi-live-production` → `c3951107-146c-4a7d-a8a5-86d09e4570e9`
- Applied `0001_initial.sql` to **both** remote D1 (17 statements each ✅) — end-to-end validation of the `journal_mode=WAL` blocker fix (#103 review finding); without that fix this step hard-fails.
- Repo secrets set: `CF_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` → CI `deploy` job no longer a green no-op.

## Effect on merge

Push to `staging` triggers `deploy` → `wrangler deploy --env staging` → Worker live on `*.workers.dev`, `/api/version` returns 200 (empty DB until import). Closes #93's deferred deploy acceptance.

## Remaining for #94 (follow-up)

- corpus.db WAL-checkpoint → `wrangler d1 import` (staging + prod)
- row-count parity check (issues / edges / labels / sync_state)

Refs #94