### PR TITLE
feat(worker): GitHub GraphQL transport via fetch() + query ports (#95)

### DIFF
--- a/worker/src/sync/graphql.test.ts
+++ b/worker/src/sync/graphql.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GraphQLError, fetchIssueDeps, ghGraphql } from "./graphql";
+
+// ---------------------------------------------------------------------------
+// fetch mock helpers
+// ---------------------------------------------------------------------------
+
+function makeFetchMock(response: {
+  ok: boolean;
+  status: number;
+  json?: () => Promise<unknown>;
+  text?: () => Promise<string>;
+}) {
+  return vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status,
+    json: response.json ?? (() => Promise.resolve({})),
+    text: response.text ?? (() => Promise.resolve("")),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// ghGraphql — Authorization + User-Agent headers
+// ---------------------------------------------------------------------------
+
+describe("ghGraphql — request headers", () => {
+  it("sends Authorization: Bearer <token>", async () => {
+    const mockFetch = makeFetchMock({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: { result: 1 } }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await ghGraphql("query { viewer { login } }", {}, "gh-token-abc");
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer gh-token-abc");
+  });
+
+  it("sends User-Agent: roxabi-live-worker", async () => {
+    const mockFetch = makeFetchMock({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: {} }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await ghGraphql("query { viewer { login } }", {}, "any-token");
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe("roxabi-live-worker");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ghGraphql — GraphQL-level errors
+// ---------------------------------------------------------------------------
+
+describe("ghGraphql — GraphQL errors", () => {
+  it("throws GraphQLError when body contains an errors key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ errors: [{ message: "boom" }] }),
+      }),
+    );
+
+    await expect(
+      ghGraphql("query { viewer { login } }", {}, "token"),
+    ).rejects.toThrow(GraphQLError);
+
+    await expect(
+      ghGraphql("query { viewer { login } }", {}, "token"),
+    ).rejects.toThrow(/GraphQL errors/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ghGraphql — auth errors → isAuth = true
+// ---------------------------------------------------------------------------
+
+describe("ghGraphql — auth errors", () => {
+  it("throws GraphQLError with isAuth=true on HTTP 401", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({ ok: false, status: 401 }),
+    );
+
+    let caught: unknown;
+    try {
+      await ghGraphql("query { viewer { login } }", {}, "bad-token");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(GraphQLError);
+    expect((caught as GraphQLError).isAuth).toBe(true);
+  });
+
+  it("throws GraphQLError with isAuth=true on HTTP 403", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({ ok: false, status: 403 }),
+    );
+
+    let caught: unknown;
+    try {
+      await ghGraphql("query { viewer { login } }", {}, "bad-token");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(GraphQLError);
+    expect((caught as GraphQLError).isAuth).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ghGraphql — happy path
+// ---------------------------------------------------------------------------
+
+describe("ghGraphql — happy path", () => {
+  it("returns the parsed body on a successful 200 response", async () => {
+    const payload = { data: { viewer: { login: "roxabi" } }, rateLimit: { cost: 1 } };
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(payload),
+      }),
+    );
+
+    const result = await ghGraphql("query { viewer { login } }", {}, "token");
+    expect(result).toEqual(payload);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchIssueDeps — mapping
+// ---------------------------------------------------------------------------
+
+describe("fetchIssueDeps — mapping", () => {
+  it("maps blockedBy and blocking nodes to owner/repo#N keys", async () => {
+    const issuePayload = {
+      data: {
+        repository: {
+          issue: {
+            number: 10,
+            blockedBy: {
+              nodes: [
+                { number: 5, repository: { nameWithOwner: "Roxabi/roxabi-live" } },
+              ],
+            },
+            blocking: {
+              nodes: [
+                { number: 20, repository: { nameWithOwner: "Roxabi/other-repo" } },
+                { number: 21, repository: { nameWithOwner: "Roxabi/other-repo" } },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(issuePayload),
+      }),
+    );
+
+    const result = await fetchIssueDeps("Roxabi", "roxabi-live", 10, "token");
+    expect(result).toEqual({
+      blocked_by: ["Roxabi/roxabi-live#5"],
+      blocking: ["Roxabi/other-repo#20", "Roxabi/other-repo#21"],
+    });
+  });
+
+  it("returns empty arrays when the issue node is null", async () => {
+    const nullPayload = {
+      data: {
+        repository: {
+          issue: null,
+        },
+      },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(nullPayload),
+      }),
+    );
+
+    const result = await fetchIssueDeps("Roxabi", "roxabi-live", 999, "token");
+    expect(result).toEqual({ blocked_by: [], blocking: [] });
+  });
+});

--- a/worker/src/sync/graphql.ts
+++ b/worker/src/sync/graphql.ts
@@ -1,0 +1,137 @@
+/**
+ * GitHub GraphQL transport — fetch()-based port of corpus/graphql.py (#95).
+ *
+ * Replaces the `gh api graphql` subprocess with a direct fetch() call so the
+ * transport runs inside the Cloudflare Worker runtime. The token is an explicit
+ * parameter (comes from env.GITHUB_TOKEN) rather than being ambient.
+ */
+
+import { SINGLE_ISSUE_DEPS_QUERY } from "./queries";
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/** Raised on HTTP errors, auth failures, or GraphQL-level error responses. */
+export class GraphQLError extends Error {
+  /** True when the failure is an authentication/authorization error (401/403). */
+  public isAuth: boolean;
+
+  constructor(message: string, isAuth = false) {
+    super(message);
+    this.name = "GraphQLError";
+    this.isAuth = isAuth;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core transport
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a GraphQL query against the GitHub API using fetch().
+ *
+ * Ports `gh_graphql` from corpus/graphql.py (#95), replacing the subprocess
+ * with a direct HTTP call. The `User-Agent` header is required — GitHub rejects
+ * requests that omit it (the Python path received it for free from the gh CLI).
+ *
+ * @param query     GraphQL query string (one of the constants from queries.ts).
+ * @param variables Variable map matching the query's parameter declarations.
+ * @param token     GitHub PAT (env.GITHUB_TOKEN in Worker context).
+ * @returns         Parsed response body; always contains a `data` key on success.
+ * @throws          GraphQLError on HTTP errors or GraphQL-level `errors` in body.
+ */
+export async function ghGraphql<T = unknown>(
+  query: string,
+  variables: Record<string, unknown>,
+  token: string,
+): Promise<{ data: T } & Record<string, unknown>> {
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "roxabi-live-worker",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new GraphQLError(
+      `GitHub GraphQL auth error: HTTP ${res.status}`,
+      true,
+    );
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new GraphQLError(
+      `GitHub GraphQL request failed: HTTP ${res.status} — ${text}`,
+    );
+  }
+
+  const body = (await res.json()) as Record<string, unknown>;
+
+  if ("errors" in body) {
+    throw new GraphQLError(`GraphQL errors: ${JSON.stringify(body.errors)}`);
+  }
+
+  return body as { data: T } & Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+interface DepNode {
+  number: number;
+  repository: { nameWithOwner: string };
+}
+
+interface IssueDepsData {
+  repository: {
+    issue: {
+      number: number;
+      blockedBy: { nodes: DepNode[] };
+      blocking: { nodes: DepNode[] };
+    } | null;
+  };
+}
+
+/**
+ * Fetch blockedBy + blocking lists for a single issue via GraphQL.
+ *
+ * Ports `fetch_issue_deps` from corpus/graphql.py (#95). Returns snake_case
+ * keys (`blocked_by` / `blocking`) to match the Python/D1 sync contract.
+ *
+ * @param owner   Repository owner (org or user login).
+ * @param name    Repository name.
+ * @param number  Issue number.
+ * @param token   GitHub PAT (env.GITHUB_TOKEN in Worker context).
+ * @returns       `{ blocked_by, blocking }` — each a list of `"owner/repo#N"` keys.
+ */
+export async function fetchIssueDeps(
+  owner: string,
+  name: string,
+  number: number,
+  token: string,
+): Promise<{ blocked_by: string[]; blocking: string[] }> {
+  const body = await ghGraphql<IssueDepsData>(
+    SINGLE_ISSUE_DEPS_QUERY,
+    { owner, name, number },
+    token,
+  );
+
+  const issue = body.data.repository.issue;
+  if (issue === null) {
+    return { blocked_by: [], blocking: [] };
+  }
+
+  const toKeys = (nodes: DepNode[]): string[] =>
+    nodes.map((n) => `${n.repository.nameWithOwner}#${n.number}`);
+
+  return {
+    blocked_by: toKeys(issue.blockedBy.nodes),
+    blocking: toKeys(issue.blocking.nodes),
+  };
+}

--- a/worker/src/sync/queries.ts
+++ b/worker/src/sync/queries.ts
@@ -1,0 +1,111 @@
+/**
+ * GraphQL query string constants — verbatim ports of corpus/graphql.py (#95).
+ *
+ * These are the six query templates used by the GitHub GraphQL transport.
+ * No logic lives here; callers import the constants they need.
+ */
+
+export const ISSUES_QUERY = `
+query($owner: String!, $name: String!, $cursor: String, $since: DateTime) {
+  repository(owner: $owner, name: $name) {
+    issues(
+      first: 100
+      after: $cursor
+      filterBy: { since: $since }
+      orderBy: { field: UPDATED_AT, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        state
+        url
+        createdAt
+        updatedAt
+        closedAt
+        milestone { title }
+        labels(first: 30) { nodes { name } }
+        subIssues(first: 50) { nodes { number repository { nameWithOwner } } }
+        parent { number repository { nameWithOwner } }
+        blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
+        blocking(first: 50) { nodes { number repository { nameWithOwner } } }
+      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export const REPOS_QUERY = `
+query($org: String!, $cursor: String) {
+  organization(login: $org) {
+    repositories(
+      first: 100
+      after: $cursor
+      isArchived: false
+      orderBy: { field: NAME, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes { name owner { login } isArchived isPrivate }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export const REFS_QUERY = `
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    refs(refPrefix: "refs/heads/", first: 100, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes { name }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export const PRS_QUERY = `
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN, first: 50, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        state
+        # first: 25 — PRs closing more issues are out of scope for this tool
+        # (Roxabi convention: 1 PR ≈ 1 epic)
+        closingIssuesReferences(first: 25) {
+          nodes { number repository { nameWithOwner } }
+        }
+        labels(first: 20) { nodes { name } }
+      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export const STUB_ISSUE_QUERY = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number title state url createdAt updatedAt closedAt
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export const SINGLE_ISSUE_DEPS_QUERY = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number
+      blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
+      blocking(first: 50) { nodes { number repository { nameWithOwner } } }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;


### PR DESCRIPTION
## S3 (#95) — GitHub GraphQL transport via `fetch()` + query ports

Slice S3 of epic #92 (roxabi-live → Cloudflare serverless). Pure-TS port of `src/roxabi_live/corpus/graphql.py`; no CF binding required (token is an explicit param), so fully unit-testable now.

### Files (3, +472)
- `worker/src/sync/queries.ts` — the 6 query strings **verbatim** (`ISSUES/REPOS/REFS/PRS/STUB_ISSUE/SINGLE_ISSUE_DEPS`); PRS inline comments preserved.
- `worker/src/sync/graphql.ts` — `GraphQLError` (with `isAuth`), `ghGraphql<T>(query, variables, token)`, `fetchIssueDeps(owner, name, number, token)`.
- `worker/src/sync/graphql.test.ts` — 8 vitest tests (mock `fetch`).

### Transport contract (ports `gh_graphql`)
- `POST https://api.github.com/graphql`, `Authorization: Bearer <token>`, `Content-Type: application/json`, **`User-Agent: roxabi-live-worker`** (GitHub rejects requests without a UA — the `gh` CLI supplied it implicitly).
- `401|403` → `GraphQLError` with `isAuth=true`; other non-2xx → `GraphQLError`; `errors` key in body → `GraphQLError`.
- `fetchIssueDeps` keeps snake_case keys (`blocked_by`/`blocking`) to match the Python/D1 sync contract; null issue → empty lists.

### Verification (also enforced by CI `worker` job)
- `tsc --noEmit`: clean
- `vitest run`: 12 passed (8 new + 4 existing)
- All 6 queries confirmed **verbatim-equivalent** to the Python source (normalized diff).

### Out of scope
Runtime use needs the dedicated Roxabi service PAT (#92 Q4/Q5) — wired when the S4 sync engine (#96) calls these. This slice is transport + queries + tests only.

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)