### PR TITLE
feat(worker): port corpus sync engine to D1 cron (S4, #96)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,17 +1,16 @@
 import { app } from "./router";
+import { runSync } from "./sync/sync";
 import type { Env } from "./types";
 
 export default {
   fetch: app.fetch,
 
   // Hourly Cron Trigger (wrangler.toml [triggers].crons = "0 * * * *").
-  // The GitHub-sync engine lands in S4 (#96); until then this is an intentional
-  // no-op so scheduled invocations succeed instead of erroring on a missing handler.
   scheduled: async (
     _controller: ScheduledController,
-    _env: Env,
+    env: Env,
     _ctx: ExecutionContext,
   ): Promise<void> => {
-    console.log("[cron] scheduled sync not yet implemented — see #96 (S4)");
+    await runSync(env);
   },
 };

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1,0 +1,911 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BRANCH_ISSUE_RE,
+  batchChunked,
+  canonicalKey,
+  collectEdges,
+  extractFromLabels,
+  flushEdges,
+  acquireSyncLock,
+  isHalted,
+  haltSync,
+  getAuthFailures,
+  incrementAuthFailures,
+  resetAuthFailures,
+  syncRepoIssues,
+  syncBranches,
+  runSync,
+} from "./sync";
+import type { EdgeData } from "./sync";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// FakeD1 mock helpers
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+/** Simple in-memory FakeD1 builder. */
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      // Lazy direct stmt: stmtFactory is only called (and stmt recorded) when
+      // an action method (.first/.run/.all) is actually invoked.  This supports
+      // the D1 pattern `db.prepare(sql).first()` used by helpers that call
+      // prepare() without .bind() and must not pollute capturedStmts eagerly.
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// canonicalKey
+// ---------------------------------------------------------------------------
+
+describe("canonicalKey", () => {
+  it("converts bare number to full key", () => {
+    expect(canonicalKey(42, "Roxabi/lyra")).toBe("Roxabi/lyra#42");
+  });
+
+  it("converts string number to full key", () => {
+    expect(canonicalKey("42", "Roxabi/lyra")).toBe("Roxabi/lyra#42");
+  });
+
+  it("converts short form #N to full key", () => {
+    expect(canonicalKey("#9", "Roxabi/lyra")).toBe("Roxabi/lyra#9");
+  });
+
+  it("passes through full key unchanged regardless of repo arg", () => {
+    expect(canonicalKey("Roxabi/voiceCLI#7", "Roxabi/other")).toBe(
+      "Roxabi/voiceCLI#7",
+    );
+  });
+
+  it("throws on unrecognised ref", () => {
+    expect(() => canonicalKey("not-a-ref", "Roxabi/lyra")).toThrow(
+      /Cannot canonicalise issue ref/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BRANCH_ISSUE_RE
+// ---------------------------------------------------------------------------
+
+describe("BRANCH_ISSUE_RE", () => {
+  it("matches feat/42-some-feature and captures issue number", () => {
+    const m = BRANCH_ISSUE_RE.exec("feat/42-some-feature");
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe("42");
+  });
+
+  it("matches bare 7-fix-thing (no prefix) and captures issue number", () => {
+    const m = BRANCH_ISSUE_RE.exec("7-fix-thing");
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe("7");
+  });
+
+  it("does not match a branch without issue number prefix", () => {
+    expect(BRANCH_ISSUE_RE.exec("main")).toBeNull();
+    expect(BRANCH_ISSUE_RE.exec("staging")).toBeNull();
+    expect(BRANCH_ISSUE_RE.exec("feature/no-issue")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractFromLabels
+// ---------------------------------------------------------------------------
+
+describe("extractFromLabels", () => {
+  it("returns all nulls for empty labels", () => {
+    expect(extractFromLabels([])).toEqual({
+      lane: null,
+      priority: null,
+      size: null,
+    });
+  });
+
+  it("extracts lane from graph:lane/ prefix", () => {
+    const { lane } = extractFromLabels(["graph:lane/backend"]);
+    expect(lane).toBe("backend");
+  });
+
+  it("extracts priority from P1-high", () => {
+    const { priority } = extractFromLabels(["P1-high"]);
+    expect(priority).toBe("P1");
+  });
+
+  it("extracts priority from priority:P2", () => {
+    const { priority } = extractFromLabels(["priority:P2"]);
+    expect(priority).toBe("P2");
+  });
+
+  it("extracts size from size: prefix", () => {
+    const { size } = extractFromLabels(["size:F-lite"]);
+    expect(size).toBe("F-lite");
+  });
+
+  it("maps legacy size:M to F-lite", () => {
+    const { size } = extractFromLabels(["size:M"]);
+    expect(size).toBe("F-lite");
+  });
+
+  it("falls back to bare legacy size label if no size: prefix", () => {
+    const { size } = extractFromLabels(["XS"]);
+    expect(size).toBe("XS");
+  });
+
+  it("first match wins (lane)", () => {
+    const { lane } = extractFromLabels([
+      "graph:lane/frontend",
+      "graph:lane/backend",
+    ]);
+    expect(lane).toBe("frontend");
+  });
+
+  it("extracts all three fields simultaneously", () => {
+    const result = extractFromLabels([
+      "graph:lane/ops",
+      "P0",
+      "size:XL",
+    ]);
+    expect(result).toEqual({ lane: "ops", priority: "P0", size: "XL" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectEdges
+// ---------------------------------------------------------------------------
+
+describe("collectEdges", () => {
+  it("records children from subIssues", () => {
+    const map = new Map<string, EdgeData>();
+    collectEdges(
+      {
+        number: 1,
+        subIssues: {
+          nodes: [{ number: 2, repository: { nameWithOwner: "Roxabi/lyra" } }],
+        },
+      },
+      "Roxabi/lyra",
+      "Roxabi/lyra#1",
+      map,
+    );
+    expect(map.get("Roxabi/lyra#1")?.children).toEqual(["Roxabi/lyra#2"]);
+  });
+
+  it("records parents from parent field", () => {
+    const map = new Map<string, EdgeData>();
+    collectEdges(
+      {
+        number: 2,
+        parent: { number: 1, repository: { nameWithOwner: "Roxabi/lyra" } },
+      },
+      "Roxabi/lyra",
+      "Roxabi/lyra#2",
+      map,
+    );
+    expect(map.get("Roxabi/lyra#2")?.parents).toEqual(["Roxabi/lyra#1"]);
+  });
+
+  it("records blockedBy", () => {
+    const map = new Map<string, EdgeData>();
+    collectEdges(
+      {
+        number: 5,
+        blockedBy: {
+          nodes: [{ number: 3, repository: { nameWithOwner: "Roxabi/lyra" } }],
+        },
+      },
+      "Roxabi/lyra",
+      "Roxabi/lyra#5",
+      map,
+    );
+    expect(map.get("Roxabi/lyra#5")?.blockedBy).toEqual(["Roxabi/lyra#3"]);
+  });
+
+  it("records blocking", () => {
+    const map = new Map<string, EdgeData>();
+    collectEdges(
+      {
+        number: 3,
+        blocking: {
+          nodes: [{ number: 7, repository: { nameWithOwner: "Roxabi/lyra" } }],
+        },
+      },
+      "Roxabi/lyra",
+      "Roxabi/lyra#3",
+      map,
+    );
+    expect(map.get("Roxabi/lyra#3")?.blocking).toEqual(["Roxabi/lyra#7"]);
+  });
+
+  it("sets empty arrays when no edges", () => {
+    const map = new Map<string, EdgeData>();
+    collectEdges({ number: 10 }, "Roxabi/lyra", "Roxabi/lyra#10", map);
+    expect(map.get("Roxabi/lyra#10")).toEqual({
+      parents: [],
+      children: [],
+      blockedBy: [],
+      blocking: [],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// batchChunked
+// ---------------------------------------------------------------------------
+
+describe("batchChunked", () => {
+  it("never calls db.batch with empty array (no stmts)", async () => {
+    const db = makeFakeDb((sql, args) =>
+      makeFakeStmt(sql, args, [], 0),
+    );
+    await batchChunked(db, []);
+    expect((db as unknown as { batch: ReturnType<typeof vi.fn> }).batch).not.toHaveBeenCalled();
+  });
+
+  it("calls db.batch once for fewer than chunk-size statements", async () => {
+    const db = makeFakeDb((sql, args) => makeFakeStmt(sql, args, [], 0));
+    const stmts = Array.from({ length: 3 }, (_, i) =>
+      (db as unknown as { prepare: (sql: string) => { bind: (...a: unknown[]) => FakeStmt } })
+        .prepare(`SELECT ${i}`)
+        .bind(),
+    );
+    await batchChunked(db, stmts as unknown as D1PreparedStatement[]);
+    expect((db as unknown as { batch: ReturnType<typeof vi.fn> }).batch).toHaveBeenCalledTimes(1);
+  });
+
+  it("splits into multiple chunks when exceeding chunk size", async () => {
+    const db = makeFakeDb((sql, args) => makeFakeStmt(sql, args, [], 0));
+    const stmts = Array.from({ length: 5 }, (_, i) =>
+      (db as unknown as { prepare: (sql: string) => { bind: (...a: unknown[]) => FakeStmt } })
+        .prepare(`SELECT ${i}`)
+        .bind(),
+    );
+    await batchChunked(db, stmts as unknown as D1PreparedStatement[], 2);
+    // 5 stmts / chunk-size 2 = 3 batches (2+2+1)
+    expect((db as unknown as { batch: ReturnType<typeof vi.fn> }).batch).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flushEdges — DELETE guard: parent always, blocks only when non-empty
+// ---------------------------------------------------------------------------
+
+describe("flushEdges", () => {
+  it("emits 1 DELETE (parent only) per issue key when no block edges", async () => {
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 0);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    const edges = new Map<string, EdgeData>([
+      ["Roxabi/lyra#1", { parents: [], children: [], blockedBy: [], blocking: [] }],
+    ]);
+
+    await flushEdges(db, edges);
+
+    const deleteStmts = capturedStmts.filter((s) =>
+      s.sql.trimStart().startsWith("DELETE"),
+    );
+    // Only parent DELETE; blocks DELETE is guarded and skipped when both arrays are empty
+    expect(deleteStmts).toHaveLength(1);
+    expect(deleteStmts[0].sql).toContain("kind='parent'");
+  });
+
+  it("emits 2 DELETEs (parent + blocks) when block edges are present", async () => {
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 0);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    const edges = new Map<string, EdgeData>([
+      [
+        "Roxabi/lyra#1",
+        { parents: [], children: [], blockedBy: ["Roxabi/lyra#2"], blocking: [] },
+      ],
+    ]);
+
+    await flushEdges(db, edges);
+
+    const deleteStmts = capturedStmts.filter((s) =>
+      s.sql.trimStart().startsWith("DELETE"),
+    );
+    expect(deleteStmts).toHaveLength(2);
+    expect(deleteStmts[0].sql).toContain("kind='parent'");
+    expect(deleteStmts[1].sql).toContain("kind='blocks'");
+  });
+
+  it("emits 1 DELETE per key with no block edges for multiple keys", async () => {
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 0);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    const edges = new Map<string, EdgeData>([
+      ["Roxabi/lyra#1", { parents: [], children: [], blockedBy: [], blocking: [] }],
+      ["Roxabi/lyra#2", { parents: [], children: [], blockedBy: [], blocking: [] }],
+    ]);
+
+    await flushEdges(db, edges);
+
+    const deleteStmts = capturedStmts.filter((s) =>
+      s.sql.trimStart().startsWith("DELETE"),
+    );
+    // 2 issue keys × 1 kind (parent only, no blocks) = 2 deletes
+    expect(deleteStmts).toHaveLength(2);
+  });
+
+  it("emits INSERT statements for actual edges with correct args", async () => {
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 0);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    const edges = new Map<string, EdgeData>([
+      [
+        "Roxabi/lyra#2",
+        {
+          parents: ["Roxabi/lyra#1"],
+          children: [],
+          blockedBy: ["Roxabi/lyra#3"],
+          blocking: [],
+        },
+      ],
+    ]);
+
+    await flushEdges(db, edges);
+
+    const insertStmts = capturedStmts.filter((s) =>
+      s.sql.trimStart().startsWith("INSERT"),
+    );
+    // 1 parent edge + 1 blockedBy edge = 2 inserts
+    expect(insertStmts).toHaveLength(2);
+    // Parent edge: src=parent, dst=child
+    const parentInsert = insertStmts.find((s) => s.args.includes("Roxabi/lyra#1"));
+    expect(parentInsert).toBeDefined();
+    expect(parentInsert!.args).toEqual(["Roxabi/lyra#1", "Roxabi/lyra#2"]);
+    // Blocks edge: src=blocker, dst=blocked
+    const blocksInsert = insertStmts.find((s) => s.args.includes("Roxabi/lyra#3"));
+    expect(blocksInsert).toBeDefined();
+    expect(blocksInsert!.args).toEqual(["Roxabi/lyra#3", "Roxabi/lyra#2"]);
+  });
+
+  it("is a no-op (no batch call) for empty collectedEdges map", async () => {
+    const db = makeFakeDb((sql, args) => makeFakeStmt(sql, args, [], 0));
+    await flushEdges(db, new Map());
+    expect((db as unknown as { batch: ReturnType<typeof vi.fn> }).batch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// acquireSyncLock
+// ---------------------------------------------------------------------------
+
+describe("acquireSyncLock", () => {
+  it("returns true when UPDATE affects a row (changes=1)", async () => {
+    const db = makeFakeDb((sql, args) =>
+      makeFakeStmt(sql, args, [], 1),
+    );
+    const acquired = await acquireSyncLock(db);
+    expect(acquired).toBe(true);
+  });
+
+  it("returns false when UPDATE affects no rows (changes=0)", async () => {
+    const db = makeFakeDb((sql, args) =>
+      makeFakeStmt(sql, args, [], 0),
+    );
+    const acquired = await acquireSyncLock(db);
+    expect(acquired).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isHalted
+// ---------------------------------------------------------------------------
+
+describe("isHalted", () => {
+  it("returns true when sync_control halted=1", async () => {
+    const db = makeFakeDb((sql, args) =>
+      makeFakeStmt(sql, args, [{ value: "1" }]),
+    );
+    expect(await isHalted(db)).toBe(true);
+  });
+
+  it("returns false when sync_control halted=0", async () => {
+    const db = makeFakeDb((sql, args) =>
+      makeFakeStmt(sql, args, [{ value: "0" }]),
+    );
+    expect(await isHalted(db)).toBe(false);
+  });
+
+  it("returns false when row is missing (null)", async () => {
+    const db = makeFakeDb((sql, args) =>
+      makeFakeStmt(sql, args, []),
+    );
+    expect(await isHalted(db)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// haltSync
+// ---------------------------------------------------------------------------
+
+describe("haltSync", () => {
+  it("executes UPDATE setting halted=1", async () => {
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+    await haltSync(db);
+    expect(capturedStmts).toHaveLength(1);
+    // value='1' is a SQL literal, not a bound param — assert the SQL text
+    expect(capturedStmts[0].sql).toContain("value='1'");
+    expect(capturedStmts[0].sql).toContain("key='halted'");
+    // only the ISO timestamp is bound
+    expect(capturedStmts[0].args).toHaveLength(1);
+    expect(typeof capturedStmts[0].args[0]).toBe("string");
+    expect(String(capturedStmts[0].args[0])).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAuthFailures / incrementAuthFailures / resetAuthFailures
+// ---------------------------------------------------------------------------
+
+describe("auth failure helpers", () => {
+  it("getAuthFailures returns 0 when row missing", async () => {
+    const db = makeFakeDb((sql, args) => makeFakeStmt(sql, args, []));
+    expect(await getAuthFailures(db)).toBe(0);
+  });
+
+  it("getAuthFailures parses integer from value string", async () => {
+    const db = makeFakeDb((sql, args) =>
+      makeFakeStmt(sql, args, [{ value: "2" }]),
+    );
+    expect(await getAuthFailures(db)).toBe(2);
+  });
+
+  it("resetAuthFailures calls UPDATE with value=0", async () => {
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+    await resetAuthFailures(db);
+    // value='0' is a SQL literal, not a bound param — assert the SQL text
+    expect(capturedStmts[0].sql).toContain("value='0'");
+    expect(capturedStmts[0].sql).toContain("key='auth_failures'");
+    // only the ISO timestamp is bound
+    expect(capturedStmts[0].args).toHaveLength(1);
+    expect(String(capturedStmts[0].args[0])).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("incrementAuthFailures increments and returns new count", async () => {
+    // First prepare call (UPDATE) → changes=1; second prepare call (SELECT) → value="3"
+    let callCount = 0;
+    const db = makeFakeDb((sql, args) => {
+      callCount++;
+      if (callCount === 1) return makeFakeStmt(sql, args, [], 1);
+      return makeFakeStmt(sql, args, [{ value: "3" }]);
+    });
+    const result = await incrementAuthFailures(db);
+    expect(result).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractFromLabels — priority alias full coverage
+// ---------------------------------------------------------------------------
+
+describe("extractFromLabels priority aliases", () => {
+  it.each([
+    ["P0", "P0"],
+    ["priority:P0", "P0"],
+    ["P1-high", "P1"],
+    ["priority:high", "P1"],
+    ["priority:P1", "P1"],
+    ["P2-medium", "P2"],
+    ["priority:medium", "P2"],
+    ["priority:P2", "P2"],
+    ["P3-low", "P3"],
+    ["priority:low", "P3"],
+    ["priority: low", "P3"],
+    ["priority:P3", "P3"],
+  ])("label %s → priority %s", (label, expected) => {
+    const { priority } = extractFromLabels([label]);
+    expect(priority).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncRepoIssues — basic coverage
+// ---------------------------------------------------------------------------
+
+vi.mock("./graphql", () => ({
+  ghGraphql: vi.fn(),
+  GraphQLError: class GraphQLError extends Error {
+    isAuth: boolean;
+    constructor(msg: string, isAuth = false) {
+      super(msg);
+      this.isAuth = isAuth;
+    }
+  },
+}));
+
+vi.mock("./queries", () => ({
+  ISSUES_QUERY: "ISSUES_QUERY",
+  PRS_QUERY: "PRS_QUERY",
+  REFS_QUERY: "REFS_QUERY",
+  REPOS_QUERY: "REPOS_QUERY",
+  STUB_ISSUE_QUERY: "STUB_ISSUE_QUERY",
+}));
+
+describe("syncRepoIssues", () => {
+  it("upserts issues, deletes+inserts labels, collects edges, writes sync_state", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // Single page response with one issue
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        rateLimit: { cost: 1, remaining: 4999 },
+        repository: {
+          issues: {
+            nodes: [
+              {
+                number: 42,
+                title: "Test issue",
+                state: "OPEN",
+                url: "https://github.com/Roxabi/lyra/issues/42",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+                closedAt: null,
+                milestone: null,
+                labels: { nodes: [{ name: "P1-high" }, { name: "size:S" }] },
+                subIssues: { nodes: [] },
+                parent: null,
+                blockedBy: { nodes: [] },
+                blocking: { nodes: [] },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    });
+
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      // sync_state SELECT → return null (first run)
+      if (sql.includes("SELECT last_synced_at")) {
+        return makeFakeStmt(sql, args, []);
+      }
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    const edges = new Map<string, EdgeData>();
+    await syncRepoIssues(db, "fake-token", "Roxabi", "lyra", edges);
+
+    // Should have called ghGraphql once
+    expect(mockGhGraphql).toHaveBeenCalledTimes(1);
+    expect(mockGhGraphql).toHaveBeenCalledWith(
+      "ISSUES_QUERY",
+      { owner: "Roxabi", name: "lyra", cursor: null, since: null },
+      "fake-token",
+    );
+
+    // batch() should have been called (pageStmts via batchChunked)
+    const batchMock = (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch;
+    expect(batchMock).toHaveBeenCalled();
+
+    // sync_state INSERT should have been executed
+    const syncStateStmt = capturedStmts.find((s) => s.sql.includes("sync_state"));
+    expect(syncStateStmt).toBeDefined();
+    expect(syncStateStmt!.args[0]).toBe("Roxabi/lyra");
+
+    // Edge collection
+    expect(edges.has("Roxabi/lyra#42")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncBranches — reset-then-set, dedup, atomic batch, D1-safe chunking
+// ---------------------------------------------------------------------------
+
+describe("syncBranches", () => {
+  it("reset-all-to-0 then set matched=1 (deduped) in a single atomic batch", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        rateLimit: { cost: 1, remaining: 4999 },
+        repository: {
+          refs: {
+            nodes: [
+              { name: "feat/42-some-feature" },
+              { name: "7-fix-thing" },
+              { name: "main" },
+              { name: "staging" },
+              { name: "feat/42-duplicate" }, // same issue 42 → must dedup
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    });
+
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    await syncBranches(db, "fake-token", "Roxabi", "lyra");
+
+    expect(mockGhGraphql).toHaveBeenCalledWith(
+      "REFS_QUERY",
+      { owner: "Roxabi", name: "lyra", cursor: null },
+      "fake-token",
+    );
+
+    // One atomic batch ([reset, set]) — no transient all-zero window
+    const batchMock = (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch;
+    expect(batchMock).toHaveBeenCalledTimes(1);
+
+    // reset-to-0 first, scoped to repo only (no `number` clause)
+    const resetStmt = capturedStmts.find(
+      (s) =>
+        s.sql.includes("has_active_branch=0") &&
+        s.sql.includes("WHERE repo=?") &&
+        !s.sql.includes("number"),
+    );
+    expect(resetStmt).toBeDefined();
+    expect(resetStmt!.args).toEqual(["Roxabi/lyra"]);
+
+    // set-to-1 with deduped numbers (42 once, 7 once) → [repo, 42, 7]
+    const setStmt = capturedStmts.find((s) => s.sql.includes("has_active_branch=1"));
+    expect(setStmt).toBeDefined();
+    expect(setStmt!.args).toEqual(["Roxabi/lyra", 42, 7]);
+  });
+
+  it("zeros all issues in repo (no batch) when no branch matches an issue number", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        rateLimit: { cost: 1, remaining: 4999 },
+        repository: {
+          refs: {
+            nodes: [{ name: "main" }, { name: "feature/no-issue" }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    });
+
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    await syncBranches(db, "fake-token", "Roxabi", "lyra");
+
+    // No matched numbers → single reset UPDATE, no batch
+    const batchMock = (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch;
+    expect(batchMock).not.toHaveBeenCalled();
+    const resetStmt = capturedStmts.find((s) => s.sql.includes("has_active_branch=0"));
+    expect(resetStmt).toBeDefined();
+    expect(resetStmt!.args).toEqual(["Roxabi/lyra"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSync — integration branches
+// ---------------------------------------------------------------------------
+
+describe("runSync", () => {
+  function makeEnv(overrides: Record<string, unknown> = {}): Env {
+    return {
+      DB: undefined as unknown as D1Database,
+      GITHUB_TOKEN: "tok",
+      GITHUB_ORG: "Roxabi",
+      ...overrides,
+    } as unknown as Env;
+  }
+
+  it("returns early when isHalted=true", async () => {
+    const db = makeFakeDb((sql, args) => {
+      // All queries return halted=1
+      return makeFakeStmt(sql, args, [{ value: "1" }], 0);
+    });
+    const env = makeEnv({ DB: db });
+
+    // Should not throw; acquireSyncLock must not be called (we return before it)
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // releaseSyncLock is in finally; acquireSyncLock UPDATE → changes=0 → not acquired
+    // The key signal: ghGraphql was never called (mocked, no calls expected)
+    const { ghGraphql } = await import("./graphql");
+    expect(vi.mocked(ghGraphql)).not.toHaveBeenCalled();
+  });
+
+  it("returns early when lock not acquired", async () => {
+    let callIdx = 0;
+    const db = makeFakeDb((sql, args) => {
+      callIdx++;
+      // First call: isHalted SELECT → halted=0
+      if (callIdx === 1) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      // Second call: acquireSyncLock UPDATE → changes=0 (lock not acquired)
+      return makeFakeStmt(sql, args, [], 0);
+    });
+    const env = makeEnv({ DB: db });
+
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    const { ghGraphql } = await import("./graphql");
+    expect(vi.mocked(ghGraphql)).not.toHaveBeenCalled();
+  });
+
+  it("returns early (logs warn) when allowlist is empty", async () => {
+    let callIdx = 0;
+    const db = makeFakeDb((sql, args) => {
+      callIdx++;
+      if (sql.includes("key='halted'") || (callIdx === 1 && sql.includes("sync_control"))) {
+        // isHalted → halted=0
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("UPDATE") && sql.includes("sync_running")) {
+        // acquireSyncLock → acquired (changes=1)
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_started_at")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("repo_allowlist") || sql.includes("SELECT key FROM")) {
+        // getRepoAllowlist → empty
+        return makeFakeStmt(sql, args, []);
+      }
+      // releaseSyncLock
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    // Override batch to work nicely
+    (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch.mockResolvedValue([]);
+
+    const env = makeEnv({ DB: db });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(runSync(env)).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("repo_allowlist empty"));
+    warnSpy.mockRestore();
+  });
+
+  it("halts when auth failures reach threshold (>=2)", async () => {
+    const { ghGraphql, GraphQLError } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // enumerateOrgRepos calls ghGraphql; throw auth error
+    mockGhGraphql.mockRejectedValue(new GraphQLError("auth", true));
+
+    let callIdx = 0;
+    const db = makeFakeDb((sql, args) => {
+      callIdx++;
+      // isHalted → not halted
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      // acquireSyncLock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // sync_started_at update
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      // getRepoAllowlist → one repo so we proceed past the empty check
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "Roxabi/lyra" }]);
+      }
+      // incrementAuthFailures UPDATE → changes=1
+      if (sql.includes("auth_failures") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // incrementAuthFailures SELECT → value=2 (at threshold)
+      if (sql.includes("auth_failures") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "2" }], 0);
+      }
+      // haltSync UPDATE, releaseSyncLock
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const env = makeEnv({ DB: db });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("HALTED"),
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Teardown
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -1,0 +1,917 @@
+/**
+ * Corpus sync engine — TypeScript port of corpus/sync.py for Cloudflare Workers D1.
+ *
+ * Two-pass design:
+ *   Pass 1: syncRepoIssues — upsert issues + labels per repo, collect EdgeData
+ *   Pass 2: flushEdges — write all edges in chunked batches (no cross-page FK hazard)
+ *
+ * Auth-halt circuit breaker in sync_control (auth_failures >= 2 → halted=1).
+ * Advisory distributed lock via sync_control.sync_running (stale after 900 s).
+ */
+
+import { ghGraphql, GraphQLError } from "./graphql";
+import {
+  ISSUES_QUERY,
+  PRS_QUERY,
+  REFS_QUERY,
+  REPOS_QUERY,
+  STUB_ISSUE_QUERY,
+} from "./queries";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const MAX_PAGES = 500;
+
+/** Verbatim port of sync.py UPSERT_ISSUE_SQL — full sync path (sets status=null). */
+export const UPSERT_ISSUE_SQL = `
+  INSERT INTO issues
+      (key, repo, number, title, state, url, created_at, updated_at,
+       closed_at, milestone, is_stub, lane, priority, size, status,
+       has_active_branch)
+  VALUES
+      (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(key) DO UPDATE SET
+      repo              = excluded.repo,
+      number            = excluded.number,
+      title             = excluded.title,
+      state             = excluded.state,
+      url               = excluded.url,
+      created_at        = excluded.created_at,
+      updated_at        = excluded.updated_at,
+      closed_at         = excluded.closed_at,
+      milestone         = excluded.milestone,
+      is_stub           = excluded.is_stub,
+      lane              = excluded.lane,
+      priority          = excluded.priority,
+      size              = excluded.size,
+      status            = excluded.status,
+      has_active_branch = excluded.has_active_branch
+`;
+
+// ---------------------------------------------------------------------------
+// Regex constants (verbatim from sync.py)
+// ---------------------------------------------------------------------------
+
+const _BARE_INT = /^\d+$/;
+const _SHORT_FORM = /^#(\d+)$/;
+const _FULL_KEY = /^[\w.-]+\/[\w.-]+#\d+$/;
+export const BRANCH_ISSUE_RE = /^(?:[a-z]+\/)?(\d+)-/;
+
+// ---------------------------------------------------------------------------
+// Vocab maps (verbatim from sync.py)
+// ---------------------------------------------------------------------------
+
+const _LANE_PREFIX = "graph:lane/";
+const _SIZE_PREFIX = "size:";
+const _LEGACY_SIZE_MAP: Record<string, string> = { M: "F-lite" };
+const _LEGACY_SIZE_RAW = new Set(["XS", "S", "M", "L", "XL"]);
+const _PRIORITY_EXACT: Record<string, string> = {
+  P0: "P0",
+  "priority:P0": "P0",
+  "P1-high": "P1",
+  "priority:high": "P1",
+  "priority:P1": "P1",
+  "P2-medium": "P2",
+  "priority:medium": "P2",
+  "priority:P2": "P2",
+  "P3-low": "P3",
+  "priority:low": "P3",
+  "priority: low": "P3",
+  "priority:P3": "P3",
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Derive lane/priority/size from a label list. First match wins per field. */
+export function extractFromLabels(labels: string[]): {
+  lane: string | null;
+  priority: string | null;
+  size: string | null;
+} {
+  let lane: string | null = null;
+  let priority: string | null = null;
+  let size: string | null = null;
+
+  for (const lbl of labels) {
+    if (lane === null && lbl.startsWith(_LANE_PREFIX)) {
+      lane = lbl.slice(_LANE_PREFIX.length);
+    }
+    if (priority === null && lbl in _PRIORITY_EXACT) {
+      priority = _PRIORITY_EXACT[lbl];
+    }
+    if (size === null && lbl.startsWith(_SIZE_PREFIX)) {
+      const raw = lbl.slice(_SIZE_PREFIX.length);
+      size = _LEGACY_SIZE_MAP[raw] ?? raw;
+    }
+  }
+  // Legacy fallback for bare size labels (only if size: prefix not found)
+  if (size === null) {
+    for (const lbl of labels) {
+      if (_LEGACY_SIZE_RAW.has(lbl)) {
+        size = lbl;
+        break;
+      }
+    }
+  }
+
+  return { lane, priority, size };
+}
+
+/**
+ * Canonicalise an issue reference to 'owner/repo#N' form.
+ *
+ *   42 + 'Roxabi/lyra'          → 'Roxabi/lyra#42'
+ *   '42' + 'Roxabi/lyra'        → 'Roxabi/lyra#42'
+ *   '#9' + 'Roxabi/lyra'        → 'Roxabi/lyra#9'
+ *   'Roxabi/voiceCLI#7' + _any_ → 'Roxabi/voiceCLI#7'
+ */
+export function canonicalKey(ref: number | string, repo: string): string {
+  if (typeof ref === "number") return `${repo}#${ref}`;
+  const s = String(ref);
+  if (_FULL_KEY.test(s)) return s;
+  const mShort = _SHORT_FORM.exec(s);
+  if (mShort) return `${repo}#${mShort[1]}`;
+  if (_BARE_INT.test(s)) return `${repo}#${s}`;
+  throw new Error(`Cannot canonicalise issue ref: ${JSON.stringify(ref)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Edge collection
+// ---------------------------------------------------------------------------
+
+export interface EdgeData {
+  parents: string[];
+  children: string[];
+  blockedBy: string[];
+  blocking: string[];
+}
+
+type IssueNode = {
+  number: number;
+  subIssues?: { nodes: Array<{ number: number; repository: { nameWithOwner: string } }> };
+  parent?: { number: number; repository: { nameWithOwner: string } } | null;
+  blockedBy?: { nodes: Array<{ number: number; repository: { nameWithOwner: string } }> };
+  blocking?: { nodes: Array<{ number: number; repository: { nameWithOwner: string } }> };
+};
+
+/** Collect edge references from a GraphQL issue node into collectedEdges map. */
+export function collectEdges(
+  node: IssueNode,
+  repo: string,
+  key: string,
+  collectedEdges: Map<string, EdgeData>,
+): void {
+  const children = (node.subIssues?.nodes ?? []).map((t) =>
+    canonicalKey(t.number, t.repository.nameWithOwner),
+  );
+  const parentNode = node.parent ?? null;
+  const parents = parentNode
+    ? [canonicalKey(parentNode.number, parentNode.repository.nameWithOwner)]
+    : [];
+  const blockedBy = (node.blockedBy?.nodes ?? []).map((t) =>
+    canonicalKey(t.number, t.repository.nameWithOwner),
+  );
+  const blocking = (node.blocking?.nodes ?? []).map((t) =>
+    canonicalKey(t.number, t.repository.nameWithOwner),
+  );
+
+  collectedEdges.set(key, { parents, children, blockedBy, blocking });
+}
+
+// ---------------------------------------------------------------------------
+// D1 helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute D1 statements in chunks of `size` (default 900).
+ * NEVER calls db.batch([]) — guards against empty array.
+ */
+export async function batchChunked(
+  db: D1Database,
+  stmts: D1PreparedStatement[],
+  size = 900,
+): Promise<void> {
+  for (let i = 0; i < stmts.length; i += size) {
+    const chunk = stmts.slice(i, i + size);
+    if (chunk.length > 0) {
+      await db.batch(chunk);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// sync_control helpers
+// ---------------------------------------------------------------------------
+
+export async function acquireSyncLock(db: D1Database): Promise<boolean> {
+  const result = await db
+    .prepare(
+      `UPDATE sync_control
+       SET value = '1', updated_at = ?
+       WHERE key = 'sync_running'
+         AND (value = '0' OR (CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', updated_at) AS INTEGER)) > 900)`,
+    )
+    .bind(new Date().toISOString())
+    .run();
+  return result.meta.changes > 0;
+}
+
+export async function releaseSyncLock(db: D1Database): Promise<void> {
+  await db
+    .prepare(`UPDATE sync_control SET value='0', updated_at=? WHERE key='sync_running'`)
+    .bind(new Date().toISOString())
+    .run();
+}
+
+export async function isHalted(db: D1Database): Promise<boolean> {
+  const row = await db
+    .prepare(`SELECT value FROM sync_control WHERE key='halted'`)
+    .first<{ value: string }>();
+  return row?.value === "1";
+}
+
+export async function getAuthFailures(db: D1Database): Promise<number> {
+  const row = await db
+    .prepare(`SELECT value FROM sync_control WHERE key='auth_failures'`)
+    .first<{ value: string }>();
+  return parseInt(row?.value ?? "0", 10);
+}
+
+export async function incrementAuthFailures(db: D1Database): Promise<number> {
+  await db
+    .prepare(
+      `UPDATE sync_control SET value=CAST(CAST(value AS INTEGER)+1 AS TEXT), updated_at=?
+       WHERE key='auth_failures'`,
+    )
+    .bind(new Date().toISOString())
+    .run();
+  return getAuthFailures(db);
+}
+
+export async function haltSync(db: D1Database): Promise<void> {
+  await db
+    .prepare(`UPDATE sync_control SET value='1', updated_at=? WHERE key='halted'`)
+    .bind(new Date().toISOString())
+    .run();
+}
+
+export async function resetAuthFailures(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE sync_control SET value='0', updated_at=? WHERE key='auth_failures'`,
+    )
+    .bind(new Date().toISOString())
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Repo allowlist
+// ---------------------------------------------------------------------------
+
+export async function getRepoAllowlist(db: D1Database): Promise<string[]> {
+  const result = await db.prepare(`SELECT repo FROM repo_allowlist`).all<{ repo: string }>();
+  return (result.results ?? []).map((r) => r.repo);
+}
+
+// ---------------------------------------------------------------------------
+// Org repo enumeration
+// ---------------------------------------------------------------------------
+
+interface RepoNode {
+  name: string;
+  owner: { login: string };
+  isArchived: boolean;
+  isPrivate: boolean;
+}
+interface ReposData {
+  organization: {
+    repositories: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: RepoNode[];
+    };
+  };
+  rateLimit: { cost: number; remaining: number; resetAt: string };
+}
+
+export async function enumerateOrgRepos(
+  org: string,
+  token: string,
+): Promise<Array<{ owner: string; name: string }>> {
+  const repos: Array<{ owner: string; name: string }> = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const response: { data: ReposData } & Record<string, unknown> = await ghGraphql<ReposData>(REPOS_QUERY, { org, cursor }, token);
+    const data: ReposData = response.data;
+    const rl = data.rateLimit;
+    console.log(`[sync] repos cost=${rl.cost} remaining=${rl.remaining}`);
+
+    for (const node of data.organization.repositories.nodes) {
+      repos.push({ owner: node.owner.login, name: node.name });
+    }
+
+    const pageInfo: { hasNextPage: boolean; endCursor: string | null } = data.organization.repositories.pageInfo;
+    if (!pageInfo.hasNextPage) break;
+    cursor = pageInfo.endCursor;
+    if (!cursor) break;
+  }
+
+  return repos;
+}
+
+// ---------------------------------------------------------------------------
+// syncRepoIssues
+// ---------------------------------------------------------------------------
+
+interface IssueNodeFull {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  milestone: { title: string } | null;
+  labels: { nodes: Array<{ name: string }> };
+  subIssues: { nodes: Array<{ number: number; repository: { nameWithOwner: string } }> };
+  parent: { number: number; repository: { nameWithOwner: string } } | null;
+  blockedBy: { nodes: Array<{ number: number; repository: { nameWithOwner: string } }> };
+  blocking: { nodes: Array<{ number: number; repository: { nameWithOwner: string } }> };
+}
+interface IssuesData {
+  repository: {
+    issues: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: IssueNodeFull[];
+    };
+  };
+  rateLimit: { cost: number; remaining: number; resetAt: string };
+}
+
+/**
+ * Paginate ISSUES_QUERY for one repo, upsert issues+labels, collect EdgeData.
+ * Writes sync_state ONCE after the full loop (not per-page — prevents partial watermark).
+ */
+export async function syncRepoIssues(
+  db: D1Database,
+  token: string,
+  owner: string,
+  name: string,
+  collectedEdges: Map<string, EdgeData>,
+): Promise<void> {
+  const repo = `${owner}/${name}`;
+  let cursor: string | null = null;
+  let pages = 0;
+
+  // Read watermark from previous sync (null on first run → full fetch)
+  const syncStateRow = await db
+    .prepare("SELECT last_synced_at FROM sync_state WHERE repo=?")
+    .bind(repo)
+    .first<{ last_synced_at: string | null }>();
+  const since: string | null = syncStateRow?.last_synced_at ?? null;
+
+  while (true) {
+    const response: { data: IssuesData } & Record<string, unknown> = await ghGraphql<IssuesData>(
+      ISSUES_QUERY,
+      { owner, name, cursor, since },
+      token,
+    );
+    const data: IssuesData = response.data;
+    const rl = data.rateLimit;
+    console.log(
+      `[sync] ${repo} p${pages + 1} cost=${rl.cost} remaining=${rl.remaining}`,
+    );
+
+    const issuesPage: IssuesData["repository"]["issues"] = data.repository.issues;
+    const nodes = issuesPage.nodes;
+
+    // Collect all D1 statements for this page into one batch
+    const pageStmts: D1PreparedStatement[] = [];
+
+    for (const node of nodes) {
+      const key = canonicalKey(node.number, repo);
+      const labels = node.labels.nodes.map((l: { name: string }) => l.name);
+      const derived = extractFromLabels(labels);
+
+      pageStmts.push(
+        db.prepare(UPSERT_ISSUE_SQL).bind(
+          key,
+          repo,
+          node.number,
+          node.title,
+          node.state.toLowerCase(),
+          node.url,
+          node.createdAt,
+          node.updatedAt,
+          node.closedAt ?? null,
+          node.milestone?.title ?? null,
+          0, // is_stub
+          derived.lane,
+          derived.priority,
+          derived.size,
+          null, // status — managed by Project v2 board
+          0, // has_active_branch — set by branch pass
+        ),
+      );
+
+      // Label wipe + rewrite
+      pageStmts.push(db.prepare("DELETE FROM labels WHERE issue_key=?").bind(key));
+      for (const lbl of labels) {
+        pageStmts.push(
+          db.prepare("INSERT OR IGNORE INTO labels VALUES (?,?)").bind(key, lbl),
+        );
+      }
+
+      // Collect edges (flush in pass 2)
+      collectEdges(node, repo, key, collectedEdges);
+    }
+
+    await batchChunked(db, pageStmts);
+
+    pages++;
+    const pageInfo: { hasNextPage: boolean; endCursor: string | null } = issuesPage.pageInfo;
+
+    if (!pageInfo.hasNextPage || pages >= MAX_PAGES) break;
+    cursor = pageInfo.endCursor;
+    if (!cursor) break;
+  }
+
+  // Write sync_state ONCE after full loop
+  const nowIso = new Date().toISOString();
+  await db
+    .prepare(
+      "INSERT OR REPLACE INTO sync_state(repo,last_cursor,last_synced_at) VALUES(?,NULL,?)",
+    )
+    .bind(repo, nowIso)
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// flushEdges (pass 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write all collected edges to D1 in chunked batches.
+ * Always emits 2 DELETEs per issue key (parent + blocks) even with zero edges.
+ */
+export async function flushEdges(
+  db: D1Database,
+  collectedEdges: Map<string, EdgeData>,
+): Promise<void> {
+  const allStmts: D1PreparedStatement[] = [];
+
+  for (const [issueKey, { parents, children, blockedBy, blocking }] of collectedEdges) {
+    // Always wipe parent edges for this issue
+    allStmts.push(
+      db
+        .prepare("DELETE FROM edges WHERE (src_key=? OR dst_key=?) AND kind='parent'")
+        .bind(issueKey, issueKey),
+    );
+    // Only wipe blocks edges when there is blocks data (matches Python's guard)
+    if (blockedBy.length > 0 || blocking.length > 0) {
+      allStmts.push(
+        db
+          .prepare("DELETE FROM edges WHERE (src_key=? OR dst_key=?) AND kind='blocks'")
+          .bind(issueKey, issueKey),
+      );
+    }
+
+    for (const p of parents) {
+      allStmts.push(
+        db.prepare("INSERT OR IGNORE INTO edges VALUES (?,?,'parent')").bind(p, issueKey),
+      );
+    }
+    for (const c of children) {
+      allStmts.push(
+        db.prepare("INSERT OR IGNORE INTO edges VALUES (?,?,'parent')").bind(issueKey, c),
+      );
+    }
+    for (const b of blockedBy) {
+      allStmts.push(
+        db.prepare("INSERT OR IGNORE INTO edges VALUES (?,?,'blocks')").bind(b, issueKey),
+      );
+    }
+    for (const bl of blocking) {
+      allStmts.push(
+        db.prepare("INSERT OR IGNORE INTO edges VALUES (?,?,'blocks')").bind(issueKey, bl),
+      );
+    }
+  }
+
+  await batchChunked(db, allStmts);
+}
+
+// ---------------------------------------------------------------------------
+// syncBranches
+// ---------------------------------------------------------------------------
+
+interface RefsData {
+  repository: {
+    refs: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: Array<{ name: string }>;
+    };
+  };
+  rateLimit: { cost: number; remaining: number; resetAt: string };
+}
+
+/**
+ * Compute has_active_branch for all issues in repo.
+ * Uses reset-then-set (not NOT IN) chunked at <=90 to stay under D1 param limit.
+ */
+export async function syncBranches(
+  db: D1Database,
+  token: string,
+  owner: string,
+  name: string,
+): Promise<void> {
+  const repo = `${owner}/${name}`;
+  const matchedNumbers: number[] = [];
+  let cursor: string | null = null;
+  let pageCount = 0;
+
+  while (true) {
+    const response: { data: RefsData } & Record<string, unknown> = await ghGraphql<RefsData>(
+      REFS_QUERY,
+      { owner, name, cursor },
+      token,
+    );
+    const data: RefsData = response.data;
+    const rl = data.rateLimit;
+    console.log(`[sync] branches ${repo} cost=${rl.cost} remaining=${rl.remaining}`);
+
+    for (const node of data.repository.refs.nodes) {
+      const m = BRANCH_ISSUE_RE.exec(node.name);
+      if (m) matchedNumbers.push(parseInt(m[1], 10));
+    }
+
+    pageCount++;
+    const pageInfo: { hasNextPage: boolean; endCursor: string | null } = data.repository.refs.pageInfo;
+    if (!pageInfo.hasNextPage || pageCount >= MAX_PAGES) break;
+    cursor = pageInfo.endCursor;
+    if (!cursor) break;
+  }
+
+  if (matchedNumbers.length > 0) {
+    // Reset-all-to-0 then set matched=1, as ONE atomic db.batch (D1 runs a batch
+    // in a single in-order transaction) → same end-state as Python's
+    // set-IN-then-zero-NOT-IN, but with no transient all-zero window AND no
+    // unbounded NOT IN. D1 caps ~100 bound params/stmt, so set is chunked at 90.
+    const matched = [...new Set(matchedNumbers)];
+    const stmts: D1PreparedStatement[] = [
+      db.prepare("UPDATE issues SET has_active_branch=0 WHERE repo=?").bind(repo),
+    ];
+    for (let i = 0; i < matched.length; i += 90) {
+      const chunk = matched.slice(i, i + 90);
+      const ph = chunk.map(() => "?").join(",");
+      stmts.push(
+        db
+          .prepare(`UPDATE issues SET has_active_branch=1 WHERE repo=? AND number IN (${ph})`)
+          .bind(repo, ...chunk),
+      );
+    }
+    await db.batch(stmts);
+  } else {
+    await db.prepare("UPDATE issues SET has_active_branch=0 WHERE repo=?").bind(repo).run();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// syncPRs
+// ---------------------------------------------------------------------------
+
+interface PRNode {
+  number: number;
+  state: string;
+  closingIssuesReferences: {
+    nodes: Array<{ number: number; repository: { nameWithOwner: string } }>;
+  };
+  labels: { nodes: Array<{ name: string }> };
+}
+interface PRsData {
+  repository: {
+    pullRequests: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: PRNode[];
+    };
+  };
+  rateLimit: { cost: number; remaining: number; resetAt: string };
+}
+
+const UPSERT_PR_STATE_SQL = `
+  INSERT INTO pr_state
+      (repo, number, state, has_reviewed_label, closing_issue_keys, updated_at)
+  VALUES
+      (?, ?, ?, ?, ?, ?)
+  ON CONFLICT(repo, number) DO UPDATE SET
+      state               = excluded.state,
+      has_reviewed_label  = excluded.has_reviewed_label,
+      closing_issue_keys  = excluded.closing_issue_keys,
+      updated_at          = excluded.updated_at
+`;
+
+/**
+ * Sync pr_state for open PRs.
+ * Stale detection: diff seen PR numbers in JS, chunk UPDATE <=90.
+ */
+export async function syncPRs(
+  db: D1Database,
+  token: string,
+  owner: string,
+  name: string,
+): Promise<void> {
+  const repo = `${owner}/${name}`;
+  let cursor: string | null = null;
+  const nowIso = new Date().toISOString();
+  const seenPrNumbers: number[] = [];
+  const upsertStmts: D1PreparedStatement[] = [];
+  let pageCount = 0;
+
+  while (true) {
+    const response: { data: PRsData } & Record<string, unknown> = await ghGraphql<PRsData>(
+      PRS_QUERY,
+      { owner, name, cursor },
+      token,
+    );
+    const data: PRsData = response.data;
+    const rl = data.rateLimit;
+    console.log(`[sync] prs ${repo} cost=${rl.cost} remaining=${rl.remaining}`);
+
+    for (const pr of data.repository.pullRequests.nodes) {
+      const labelNames = pr.labels.nodes.map((l: { name: string }) => l.name);
+      const hasReviewedLabel = labelNames.includes("reviewed") ? 1 : 0;
+      const closingRefs = pr.closingIssuesReferences?.nodes ?? [];
+      const closingIssueKeys = closingRefs.map(
+        (ref: { number: number; repository: { nameWithOwner: string } }) => `${ref.repository.nameWithOwner}#${ref.number}`,
+      );
+
+      seenPrNumbers.push(pr.number);
+      upsertStmts.push(
+        db.prepare(UPSERT_PR_STATE_SQL).bind(
+          repo,
+          pr.number,
+          pr.state.toLowerCase(),
+          hasReviewedLabel,
+          JSON.stringify(closingIssueKeys),
+          nowIso,
+        ),
+      );
+    }
+
+    pageCount++;
+    const pageInfo: { hasNextPage: boolean; endCursor: string | null } = data.repository.pullRequests.pageInfo;
+    if (!pageInfo.hasNextPage || pageCount >= MAX_PAGES) break;
+    cursor = pageInfo.endCursor;
+    if (!cursor) break;
+  }
+
+  // Flush upserts
+  await batchChunked(db, upsertStmts);
+
+  // Close stale open PRs (diff in JS, chunk <=90)
+  if (seenPrNumbers.length > 0) {
+    // Get current open PR numbers for this repo
+    const openRows = await db
+      .prepare(`SELECT number FROM pr_state WHERE repo=? AND state='open'`)
+      .bind(repo)
+      .all<{ number: number }>();
+    const openNums = (openRows.results ?? []).map((r) => r.number);
+    const stale = openNums.filter((n) => !seenPrNumbers.includes(n));
+
+    for (let i = 0; i < stale.length; i += 90) {
+      const chunk = stale.slice(i, i + 90);
+      const ph = chunk.map(() => "?").join(",");
+      await db
+        .prepare(
+          `UPDATE pr_state SET state='closed' WHERE repo=? AND state='open' AND number IN (${ph})`,
+        )
+        .bind(repo, ...chunk)
+        .run();
+    }
+  } else {
+    // No open PRs at all — close any orphaned 'open' rows
+    await db
+      .prepare(`UPDATE pr_state SET state='closed' WHERE repo=? AND state='open'`)
+      .bind(repo)
+      .run();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// closedHopPass
+// ---------------------------------------------------------------------------
+
+interface StubIssueData {
+  repository: {
+    issue: {
+      number: number;
+      title: string;
+      state: string;
+      url: string;
+      createdAt: string;
+      updatedAt: string;
+      closedAt: string | null;
+    } | null;
+  };
+  rateLimit: { cost: number; remaining: number; resetAt: string };
+}
+
+/**
+ * Find edge endpoints missing from issues, stub-fetch them.
+ * Catches ANY GraphQLError → log as orphan + continue (matches Python behaviour).
+ */
+export async function closedHopPass(db: D1Database, token: string): Promise<number> {
+  const missingRows = await db
+    .prepare(
+      `SELECT DISTINCT k FROM (
+         SELECT src_key AS k FROM edges
+         UNION SELECT dst_key AS k FROM edges
+       ) WHERE k NOT IN (SELECT key FROM issues)`,
+    )
+    .all<{ k: string }>();
+
+  const keys = (missingRows.results ?? []).map((r) => r.k);
+  let inserted = 0;
+  const stubStmts: D1PreparedStatement[] = [];
+
+  for (const key of keys) {
+    const lastHash = key.lastIndexOf("#");
+    if (lastHash < 0) continue;
+    const ownerRepo = key.slice(0, lastHash);
+    const numberStr = key.slice(lastHash + 1);
+    if (!ownerRepo || !/^\d+$/.test(numberStr)) continue;
+
+    const slashIdx = ownerRepo.indexOf("/");
+    if (slashIdx < 0) continue;
+    const owner = ownerRepo.slice(0, slashIdx);
+    const name = ownerRepo.slice(slashIdx + 1);
+
+    let response: { data: StubIssueData } & Record<string, unknown>;
+    try {
+      response = await ghGraphql<StubIssueData>(
+        STUB_ISSUE_QUERY,
+        { owner, name, number: parseInt(numberStr, 10) },
+        token,
+      );
+    } catch (err) {
+      // ANY GraphQLError = orphan (match Python — do NOT rethrow auth here)
+      if (err instanceof GraphQLError) {
+        console.log(`[sync] orphan reference: ${key}`);
+        continue;
+      }
+      throw err;
+    }
+
+    const rl = response.data.rateLimit;
+    console.log(`[sync] stub ${key} cost=${rl.cost} remaining=${rl.remaining}`);
+
+    const node = response.data.repository.issue;
+    if (node === null) {
+      console.log(`[sync] orphan reference: ${key}`);
+      continue;
+    }
+
+    stubStmts.push(
+      db.prepare(UPSERT_ISSUE_SQL).bind(
+        key,
+        ownerRepo,
+        node.number,
+        node.title,
+        node.state.toLowerCase(),
+        node.url,
+        node.createdAt,
+        node.updatedAt,
+        node.closedAt ?? null,
+        null, // milestone
+        1, // is_stub
+        null, // lane
+        null, // priority
+        null, // size
+        null, // status
+        0, // has_active_branch
+      ),
+    );
+    inserted++;
+  }
+
+  await batchChunked(db, stubStmts);
+  return inserted;
+}
+
+// ---------------------------------------------------------------------------
+// runSync — main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Org-wide sync: check halt → acquire lock → enumerate repos → two-pass issue
+ * sync → branch/PR sync → closed-hop pass → release lock.
+ */
+export async function runSync(env: Env): Promise<void> {
+  const db = env.DB;
+
+  if (await isHalted(db)) {
+    console.log("[sync] halted — skipping");
+    return;
+  }
+
+  if (!(await acquireSyncLock(db))) {
+    console.log("[sync] lock held by another invocation — skipping");
+    return;
+  }
+
+  try {
+    const startedAt = new Date().toISOString();
+    await db
+      .prepare(
+        `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_started_at'`,
+      )
+      .bind(startedAt, startedAt)
+      .run();
+
+    const allowlist = await getRepoAllowlist(db);
+    if (allowlist.length === 0) {
+      console.warn("[sync] repo_allowlist empty — nothing to sync");
+      return;
+    }
+
+    const orgRepos = await enumerateOrgRepos(env.GITHUB_ORG, env.GITHUB_TOKEN);
+    const active = orgRepos.filter((r) => allowlist.includes(`${r.owner}/${r.name}`));
+
+    // Prune stale sync_state rows for repos removed from the allowlist (faithful
+    // to sync.py run_sync: diff sync_state against the active allowlist∩org set).
+    const activeKeys = new Set(active.map((r) => `${r.owner}/${r.name}`));
+    const syncStateRows = await db
+      .prepare("SELECT repo FROM sync_state")
+      .all<{ repo: string }>();
+    const staleRepos = (syncStateRows.results ?? [])
+      .map((r) => r.repo)
+      .filter((repo) => !activeKeys.has(repo));
+    if (staleRepos.length > 0) {
+      await batchChunked(
+        db,
+        staleRepos.map((repo) =>
+          db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo),
+        ),
+      );
+      console.log(`[sync] pruned ${staleRepos.length} stale sync_state row(s)`);
+    }
+
+    // Pass 1: issues + labels (edges collected but not flushed)
+    const collectedEdges = new Map<string, EdgeData>();
+    for (const { owner, name } of active) {
+      try {
+        await syncRepoIssues(db, env.GITHUB_TOKEN, owner, name, collectedEdges);
+      } catch (err) {
+        if (err instanceof GraphQLError && err.isAuth) throw err;
+        console.error(`[sync] skipping ${owner}/${name}:`, err);
+      }
+    }
+
+    // Pass 2: flush all edges
+    await flushEdges(db, collectedEdges);
+
+    // Branch + PR state (per repo)
+    for (const { owner, name } of active) {
+      try {
+        await syncBranches(db, env.GITHUB_TOKEN, owner, name);
+        await syncPRs(db, env.GITHUB_TOKEN, owner, name);
+      } catch (err) {
+        if (err instanceof GraphQLError && err.isAuth) throw err;
+        console.error(`[sync] branch/PR error for ${owner}/${name}:`, err);
+      }
+    }
+
+    // Closed-hop pass
+    const stubs = await closedHopPass(db, env.GITHUB_TOKEN);
+    console.log(`[sync] completed — stubs=${stubs}`);
+
+    await resetAuthFailures(db);
+  } catch (err) {
+    const isAuth = err instanceof GraphQLError && err.isAuth;
+    if (isAuth) {
+      const failures = await incrementAuthFailures(db);
+      console.error(`[sync] auth failure ${failures}/2`);
+      if (failures >= 2) {
+        await haltSync(db);
+        console.error("[sync] HALTED: 2 consecutive auth failures");
+        const notifyUrl = (env as { NOTIFY_URL?: string }).NOTIFY_URL;
+        if (notifyUrl) {
+          await fetch(notifyUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ event: "sync_halted", ts: new Date().toISOString() }),
+          }).catch(() => {});
+        }
+      }
+    } else {
+      console.error("[sync] error:", err);
+    }
+  } finally {
+    await releaseSyncLock(db);
+  }
+}


### PR DESCRIPTION
## S4 — Corpus sync engine (Cloudflare Worker / D1)

Closes #96. Ports `src/roxabi_live/corpus/sync.py` → `worker/src/sync/sync.ts` and wires `runSync` into the hourly `scheduled()` cron handler. Part of epic #92 (serverless migration).

### What
- **Two-pass sync**: `syncRepoIssues` (issues + labels per repo, collect `EdgeData`) → `flushEdges` (all edges, chunked) — avoids cross-page FK hazards.
- **Incremental**: per-repo `since` watermark from `sync_state`; stale `sync_state` rows pruned for de-allowlisted repos (faithful to `run_sync`).
- **Safety**: advisory distributed lock (`sync_running`, 900 s stale reclaim) + auth-halt circuit breaker (2 consecutive auth failures → `halted=1`, optional `NOTIFY_URL` POST), reset on success.
- **Branch state**: atomic reset-then-set in one `db.batch` (D1-safe ≤90-param chunks, no transient all-zero window). **PR state**: upsert open + stale-close diff. **Closed-hop**: stub-fetch missing edge endpoints.
- **Edge fidelity**: `parent` DELETE unconditional; `blocks` DELETE guarded by presence of block data (matches `sync.py` L376-377). All D1 batches chunked ≤900 statements; never `batch([])`.

### Faithfulness deltas resolved during review
3 adversarial review lenses (python-faithfulness, D1-correctness, test-adequacy) + fix pass:
- 🔴 `flushEdges` unconditionally wiped `blocks` edges → **guarded** to match Python.
- 🔴 per-page flush used direct `db.batch` (D1 limit) → **`batchChunked`**.
- 🟠 `since` watermark written but never read (full re-sync each cron) → **wired incremental**.
- 🟠 `sync_state` stale rows never pruned → **prune added**.
- 🟠 `syncBranches` `NOT IN (...all matched...)` exceeded D1 ~100-param cap for repos >100 active branches → **atomic reset + ≤90 chunked set**, deduped.

### Tests
`vitest run` — **71 passing**, `tsc --noEmit` clean. Covers pure helpers, control-flow primitives, `flushEdges` guard+args, `syncRepoIssues`, `syncBranches` (dedup/atomic-batch/no-match), `runSync` guard branches + auth-halt threshold.

### Deferred (sibling follow-up, not blocking)
Direct unit tests for `syncPRs`, `closedHopPass`, `enumerateOrgRepos` (safety-critical paths already covered; these are happy-path I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)