### PR TITLE
ci(auto-merge): use merge commit instead of squash

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,5 +1,5 @@
 # Auto-merge PRs that have been reviewed and passed all required checks.
-# Adds the PR to GitHub's merge queue (squash) once the "reviewed" label is present.
+# Enables auto-merge (merge commit) once the "reviewed" label is present.
 # GitHub natively waits for all required status checks before merging.
 #
 # Also closes linked issues after merge, because GITHUB_TOKEN-initiated
@@ -31,8 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Enable auto-merge (squash)
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+      - name: Enable auto-merge (merge commit)
+        run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
The auto-merge bot enabled `gh pr merge --auto --squash`, contradicting the Roxabi release convention (**merge-commit only, ¬squash**). Switch to `--merge` so auto-merged PRs preserve per-commit history.

Comment + step-name updated to match.

## Note
Workflow changes take effect once on `staging`; this PR is merged with a **merge commit** manually to bootstrap the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)