### PR TITLE
feat(worker): webhook handlers + HMAC-SHA256 via Web Crypto (#97)

### DIFF
--- a/artifacts/plans/97-cf-s5-webhook-handlers-plan.mdx
+++ b/artifacts/plans/97-cf-s5-webhook-handlers-plan.mdx
@@ -1,0 +1,323 @@
+---
+title: "Plan: CF S5 — Webhook handlers + HMAC-SHA256 (Web Crypto)"
+issue: 97
+spec: artifacts/specs/92-cloudflare-serverless-migration.md  # §4.8, §4.9, §6, §7 + issue #97 body (per-slice SSoT)
+complexity: 5/10
+tier: F-lite
+generated: 2026-06-06
+---
+
+## Summary
+
+Port `POST /webhook/github` (HMAC-gated, real-time corpus updates) from the FastAPI app to the
+Cloudflare Worker. Add 9 per-row D1 write helpers + 2 SQL constants (`mutations.ts`), Web-Crypto HMAC
+verify (`hmac.ts`), 7 event handlers + a dispatch entry (`handlers.ts`), and wire the route into
+`router.ts` before the `ASSETS` fallback. Port verbatim from the Python SSoT — the only redesigns are
+forced by the runtime: D1 has no interactive transactions (use `db.batch`), and there is no in-process
+reconciler (drop `trigger_heal`).
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph router["worker/src/router.ts"]
+    POST["app.post(/webhook/github)"]
+    ASSETS["app.all(*) → ASSETS.fetch"]
+  end
+  subgraph wh["worker/src/webhook/"]
+    DISP["handlers.ts :: webhookRoute<br/>(body cap 25MB → HMAC gate → event switch)"]
+    HMAC["hmac.ts :: verifyHmac(ArrayBuffer)"]
+    H["handlers.ts :: handleIssues / handleDeps / handleSubIssues /<br/>handleRefCreate / handleRefDelete / handlePullRequest / handleMilestone"]
+    MUT["mutations.ts :: 9 stmt-builders + 2 SQL consts"]
+  end
+  subgraph reuse["reused (S3/S4)"]
+    GQL["sync/graphql.ts :: fetchIssueDeps, GraphQLError"]
+    SYNC["sync/sync.ts :: canonicalKey, extractFromLabels,<br/>BRANCH_ISSUE_RE, syncBranches"]
+  end
+  D1[("env.DB (D1)")]
+
+  POST --> DISP
+  DISP --> HMAC
+  DISP --> H
+  H --> MUT
+  H -->|cross-repo deps| GQL
+  H -->|ref delete| SYNC
+  H -->|labels/derive| SYNC
+  MUT -->|prepared stmts| D1
+  POST -.before.-> ASSETS
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph hmacf["hmac.ts"]
+    vh["verifyHmac(body, header, secret)"]
+  end
+  subgraph mutf["mutations.ts"]
+    sql1["UPSERT_ISSUE_FROM_WEBHOOK_SQL"]
+    sql2["UPSERT_PR_STATE_SQL"]
+    m1["upsertIssueFromWebhook"]
+    m2["replaceLabels"]
+    m3["addEdge / removeEdge"]
+    m4["upsertEdges"]
+    m5["deleteIssue"]
+    m6["setActiveBranch"]
+    m7["upsertPrState"]
+    m8["renameMilestone"]
+  end
+  subgraph hf["handlers.ts"]
+    wr["webhookRoute (dispatch)"]
+    hi["handleIssues"]
+    hd["handleDeps"]
+    hs["handleSubIssues"]
+    hrc["handleRefCreate"]
+    hrd["handleRefDelete"]
+    hpr["handlePullRequest"]
+    hm["handleMilestone"]
+  end
+  subgraph rf["router.ts"]
+    reg["app.post(/webhook/github, webhookRoute)"]
+  end
+  subgraph tests["*.test.ts (vitest, FakeD1)"]
+    t1["hmac.test.ts"]
+    t2["mutations.test.ts"]
+    t3["handlers.test.ts"]
+  end
+
+  wr --> vh
+  wr --> hi & hd & hs & hrc & hrd & hpr & hm
+  hi --> m1 & m2 & m5
+  hd --> m3 & m4
+  hs --> m3
+  hrc --> m6
+  hpr --> m7
+  hm --> m8
+  reg --> wr
+  t1 --> vh
+  t2 --> m1 & m2 & m3 & m4 & m5 & m6 & m7 & m8
+  t3 --> wr
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1, T2 | `webhook/mutations.ts`, `webhook/hmac.ts` |
+| backend-dev-B | T3, T4 | `webhook/handlers.ts`, `router.ts` |
+| tester-A | T5, T6, T7 | `webhook/hmac.test.ts`, `webhook/mutations.test.ts`, `webhook/handlers.test.ts` |
+
+Split A/B respects the per-instance ≤2-subject cap: A owns the leaf primitives (sql, crypto), B owns
+dispatch + wiring. B reads A's committed `mutations.ts`/`hmac.ts` exports from disk → import coherence
+preserved via the filesystem, not shared context.
+
+## Wave Structure
+
+3 waves, max 2 parallel agents. Elapsed ~3 units vs ~7 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | backend-dev-A: T1, T2 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-B: T3→T4 · tester-A: T5, T6 |
+| 3 | T3 done | 1 | tester-A: T7 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 mutations.ts | 9 helpers + 2 SQL | judgmental | 8 | — |
+| T2 hmac.ts | 1 fn (spec §4.9 verbatim) | bounded | 3 | — |
+| T3 handlers.ts | 7 handlers + dispatch | judgmental | 12 | — |
+| T4 router.ts wiring | 1 edit | bounded | 3 | — |
+| T5 hmac.test.ts | ~6 cases | bounded | 4 | — |
+| T6 mutations.test.ts | 9 helper asserts | judgmental | 8 | — |
+| T7 handlers.test.ts | 7 handlers + dispatch | judgmental | 12 | — |
+
+**Total estimated ops: ~50**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2 | 11 | sql, crypto | — |
+| backend-dev-B | T3, T4 | 15 | dispatch, wiring | — |
+| tester-A | T5, T6, T7 | 24 | tests | — |
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | mutations (sql) |
+| T2 | backend-dev-A | — | hmac (crypto) |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-B | T1, T2 | handlers (dispatch) |
+| T4 | backend-dev-B | T3 | router (wiring) |
+| T5 | tester-A | T2 | tests (hmac) |
+| T6 | tester-A | T1 | tests (mutations) |
+
+### Wave 3 — after T3, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | tester-A | T3 | tests (handlers) |
+
+---
+
+## Micro-Tasks
+
+### T1 — `webhook/mutations.ts` — SQL constants + 9 stmt-builders  [backend-dev-A · subject: mutations · diff 3]
+
+**Port source:** `src/roxabi_live/corpus/mutations.py`. **Spec:** §4.8 (`UPSERT_ISSUE_FROM_WEBHOOK_SQL`).
+**Contract:** every helper *returns* `D1PreparedStatement` (or `D1PreparedStatement[]`); the caller
+(handler) runs/batches them. No `.run()` inside helpers — the handler owns the transaction boundary
+(mirrors the Python "no commit() in helpers" contract; D1's batch is the tx).
+
+Column names (confirmed from `sync/sync.ts` inline SQL): `labels(issue_key, name)`,
+`edges(src_key, dst_key, kind)`, `pr_state(repo, number, state, has_reviewed_label, closing_issue_keys, updated_at)` PK `(repo, number)`, `issues(... key, repo, number, title, state, url, created_at, updated_at, closed_at, milestone, is_stub, lane, priority, size, status, has_active_branch)`.
+
+```typescript
+// SQL constants
+export const UPSERT_ISSUE_FROM_WEBHOOK_SQL = `…`;  // spec §4.8 — preserves status, no has_active_branch in SET
+export const UPSERT_PR_STATE_SQL = `…`;            // identical to sync.ts module-local const (not exported there)
+
+export interface WebhookIssue {  // 13 bound fields
+  key: string; repo: string; number: number; title: string; state: string;
+  url: string | null; created_at: string | null; updated_at: string | null;
+  closed_at: string | null; milestone: string | null;
+  lane: string | null; priority: string | null; size: string | null;
+}
+
+export function upsertIssueFromWebhook(db: D1Database, i: WebhookIssue): D1PreparedStatement;
+export function replaceLabels(db: D1Database, key: string, names: string[]): D1PreparedStatement[]; // [DELETE, ...INSERT OR IGNORE]
+export function addEdge(db: D1Database, src: string, dst: string, kind: string): D1PreparedStatement;       // INSERT OR IGNORE INTO edges VALUES(?,?,?)
+export function removeEdge(db: D1Database, src: string, dst: string, kind: string): D1PreparedStatement;    // DELETE … WHERE src_key=? AND dst_key=? AND kind=?
+export function upsertEdges(db: D1Database, key: string, blockedBy: string[], blocking: string[], kind: string): D1PreparedStatement[]; // [DELETE (src=? OR dst=?) AND kind=?, ...INSERTs]
+export function deleteIssue(db: D1Database, key: string): D1PreparedStatement;            // DELETE FROM issues WHERE key=?
+export function setActiveBranch(db: D1Database, repo: string, number: number, value: 0 | 1): D1PreparedStatement;
+export function upsertPrState(db: D1Database, repo: string, number: number, state: string, hasReviewed: 0 | 1, closingKeysJson: string, updatedAt: string): D1PreparedStatement;
+export function renameMilestone(db: D1Database, repo: string, oldTitle: string, newTitle: string): D1PreparedStatement; // UPDATE issues SET milestone=? WHERE repo=? AND milestone=?
+```
+
+**`upsertEdges` direction (port from `upsert_edges_async`):** for each `b` in `blockedBy` → `(src=b, dst=key)`; for each `b` in `blocking` → `(src=key, dst=b)`. Always emit the DELETE-by-kind first.
+**Verify:** `cd worker && npx tsc --noEmit` (clean). **Spec trace:** issue §helpers, §4.8. **Slice:** V1. **Phase:** GREEN.
+
+### T2 — `webhook/hmac.ts` — `verifyHmac`  [backend-dev-A · subject: hmac · diff 2]
+
+Port spec §4.9 verbatim. `verifyHmac(body: ArrayBuffer, header: string | null, secret: string): Promise<boolean>`.
+Null-safe (`!header?.startsWith("sha256=")` → false), exactly-32-byte hex (`hexBytes.length !== 32` → false),
+`crypto.subtle.importKey`/`verify` (constant-time). **Verify:** `npx tsc --noEmit`. **Spec trace:** §4.9. **Slice:** V1. **Phase:** GREEN.
+
+### T3 — `webhook/handlers.ts` — 7 handlers + `webhookRoute` dispatch  [backend-dev-B · subject: dispatch · diff 4]
+
+**Port source:** `src/roxabi_live/webhook/handlers.py` + `router.py`. Reads T1 (`mutations.ts`) + T2 (`hmac.ts`) from disk.
+
+**`webhookRoute(c: Context<{ Bindings: Env }>)`** (Hono handler — the `router.py` dispatch):
+1. `const body = await c.req.arrayBuffer()`; if `body.byteLength > 25*1024*1024` → `c.json(…, 413)`.
+2. `const secret = c.env.GITHUB_WEBHOOK_SECRET`; if `!secret` → **503**.
+3. `if (!(await verifyHmac(body, c.req.header("x-hub-signature-256") ?? null, secret)))` → **401**.
+4. `try { payload = JSON.parse(new TextDecoder().decode(body)) } catch → 400`.
+5. switch `c.req.header("x-github-event")`:
+   `issues`→handleIssues · `issue_dependencies`→handleDeps(…,env) · `sub_issues`→handleSubIssues ·
+   `create`→handleRefCreate · `delete`→handleRefDelete(…,env) · `pull_request`→handlePullRequest ·
+   `milestone`→handleMilestone · default → `c.json({ ok: true, ignored: event })`.
+6. handled → `c.json({ ok: true })`.
+
+**Handler ports (signatures take `db: D1Database`, deps/ref-delete also `env`/`token`):**
+- `handleIssues(payload, db)`: `deleted`/`transferred` → `await deleteIssue(db,key).run()`. Else build
+  `issue_partial` (milestone title, `extractFromLabels(names)` → lane/priority/size) →
+  **atomic** `await db.batch([upsertIssueFromWebhook(db,i), ...replaceLabels(db,key,names)])` (SC9).
+- `handleDeps(payload, db, env)`: ignore `blocking_*`; act on `blocked_by_added/removed`. `blocking_issue`
+  present (same-repo) → `addEdge`/`removeEdge` kind=`blocks` (`.run()`). Absent (cross-repo) → point-fetch
+  `fetchIssueDeps(owner,name,number, env.GITHUB_TOKEN)` → `db.batch(upsertEdges(db,key,blocked_by,blocking,"blocks"))`.
+  Wrap point-fetch in try/catch(GraphQLError) → log + no-op (webhooks always 200).
+- `handleSubIssues(payload, db)`: act on `sub_issue_added/removed` (ignore `parent_*`); top-level
+  `parent_issue`/`parent_issue_repo`/`sub_issue`/`sub_issue_repo` keys → `addEdge`/`removeEdge` kind=`parent`.
+  Malformed → log + return (no throw).
+- `handleRefCreate(payload, db)`: `ref_type==="branch"` ∧ `BRANCH_ISSUE_RE.exec(ref)` → `setActiveBranch(db,repo,number,1).run()`.
+- `handleRefDelete(payload, db, env)`: `ref_type==="branch"` ∧ regex match → split `repo` "owner/name" →
+  `await syncBranches(db, env.GITHUB_TOKEN, owner, name)` (re-query — deletion event not trusted alone).
+  **Delta vs Python:** no fresh sqlite3 conn — use `env.DB` directly.
+- `handlePullRequest(payload, db)`: state `closed` if `state==="closed"` OR `merged`; `has_reviewed_label`
+  = `labels` includes `"reviewed"`; `closing_issue_keys` = `_CLOSING_KEYWORD_RE` matches in body →
+  `[{repo}#{n}]` JSON; `updated_at` = `new Date().toISOString()` → `upsertPrState(…).run()`.
+  Port regex: `/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi`.
+- `handleMilestone(payload, db)`: `action==="edited"` ∧ `changes.title` present → `renameMilestone(db, repo,
+  changes.title.from, payload.milestone.title).run()`. Else no-op.
+
+**DROP:** all `trigger_heal()` calls. **Verify:** `npx tsc --noEmit`. **Spec trace:** issue events table. **Slice:** V1. **Phase:** GREEN.
+
+### T4 — `router.ts` wiring  [backend-dev-B · subject: wiring · diff 2]
+
+Import `webhookRoute` from `./webhook/handlers`; register `app.post("/webhook/github", webhookRoute)`
+**before** `app.all("*", …ASSETS…)`. Update the S1 scaffold comment (S5 done). **Verify:** `npx tsc --noEmit`. **Slice:** V1. **Phase:** GREEN.
+
+### RED-GATE V1 — `cd worker && npx tsc --noEmit && npx vitest run` green before tests count as done.
+
+### T5 — `webhook/hmac.test.ts`  [tester-A · subject: tests · diff 2]
+
+Cases: null header → false; wrong prefix → false; <32-byte hex → false; valid sig (compute expected via
+`crypto.subtle` in-test) → true; tampered body → false; tampered sig → false. **Verify:** `npx vitest run hmac`. **Phase:** RED→GREEN.
+
+### T6 — `webhook/mutations.test.ts`  [tester-A · subject: tests · diff 3]
+
+FakeD1 (clone pattern from `sync/sync.test.ts`). Assert each builder produces the expected SQL + bind
+order: `upsertIssueFromWebhook` (13 binds, status NOT in SET), `replaceLabels` (DELETE + N INSERTs),
+`addEdge`/`removeEdge` (kind passthrough), `upsertEdges` direction (blocker→key, key→blockee; DELETE-by-kind first),
+`deleteIssue`, `setActiveBranch` (1/0), `upsertPrState` (6 binds), `renameMilestone`. **Verify:** `npx vitest run mutations`. **Phase:** RED→GREEN.
+
+### T7 — `webhook/handlers.test.ts`  [tester-A · subject: tests · diff 4]
+
+FakeD1 + mock `fetchIssueDeps`/`syncBranches`. Per handler: issues opened (atomic batch upsert+labels),
+issues deleted (deleteIssue), deps same-repo add/remove, deps cross-repo point-fetch path, sub_issues
+add/remove (kind=parent), ref create (setActiveBranch=1), ref delete (syncBranches called), pull_request
+(merged→closed, reviewed label, body close-keyword parse), milestone edited+title (rename) vs non-title (no-op).
+Dispatch: missing secret→503, bad sig→401, bad JSON→400, unknown event→`{ok:true,ignored}`, body>25MB→413.
+**Verify:** `npx vitest run handlers`. **Phase:** RED→GREEN.
+
+---
+
+## Consistency Report
+
+| Spec/issue element | Covered by | Status |
+|---|---|---|
+| 7 events (issues, deps, sub_issues, create, delete, pull_request, milestone) | T3 | ✓ |
+| 9 write helpers | T1 | ✓ |
+| 2 SQL constants (§4.8) | T1 | ✓ |
+| HMAC §4.9 (null-safe, 32-byte, constant-time) | T2 | ✓ |
+| Router wiring before ASSETS fallback | T4 | ✓ |
+| Status codes (200/401/503/400/413, ignored:true) | T3 + T7 | ✓ |
+| Atomic issue upsert+labels (SC9) | T3 (db.batch) + T7 | ✓ |
+| Cross-repo deps point-fetch | T3 (fetchIssueDeps) + T7 | ✓ |
+| DROP trigger_heal | T3 | ✓ |
+| handle_ref_delete uses env.DB (no fresh conn) | T3 | ✓ |
+| vitest per handler + HMAC | T5, T6, T7 | ✓ |
+| tsc clean | RED-GATE V1 | ✓ |
+
+**Out of code scope (post-merge ops — manual, NOT a CI gate):** `wrangler secret put GITHUB_WEBHOOK_SECRET --env staging`
+(value ≠ prod); CF Access **App 2** `/webhook/*` → **Bypass**; register GitHub **org** webhook → staging
+Worker URL (events: issues, issue_dependencies, sub_issues, create, delete, pull_request, milestone);
+live test delivery → **200**. These are tracked under #92 deploy and verified at cutover, not in this PR.
+
+**Untraced tasks:** none. **Exemptions:** worker TS is outside `file_length`/`folder_size` gates (glob `src/**/*.py` / `src/**`).
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 9 — mutations (backend-dev-A, wave 1)
+- T2: 10 — hmac (backend-dev-A, wave 1)
+- T3: 11 — dispatch (backend-dev-B, wave 2, blockedBy T1,T2)
+- T4: 12 — wiring (backend-dev-B, wave 2, blockedBy T3)
+- T5: 13 — tests/hmac (tester-A, wave 2, blockedBy T2)
+- T6: 14 — tests/mutations (tester-A, wave 2, blockedBy T1)
+- T7: 15 — tests/handlers (tester-A, wave 3, blockedBy T3)

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -1,13 +1,17 @@
 import { Hono } from "hono";
 import type { Env } from "./types";
 import { versionRoute } from "./api/version";
+import { webhookRoute } from "./webhook/handlers";
 
 const app = new Hono<{ Bindings: Env }>();
 
 // ── API routes — evaluated BEFORE the ASSETS fallback ───────────────────────
-// S1 scaffold wires only /health + /api/version. The issues / graph / webhook /
-// admin routes are added in their slices: S6 (#98), S5 (#97), S8 (#100).
+// S1 scaffold wires /health + /api/version. S5 (#97) adds POST /webhook/github.
+// Remaining slices: S6 (#98) issues/graph, S8 (#100) admin.
 app.get("/api/version", versionRoute);
+
+// POST /webhook/github — HMAC-verified GitHub org webhooks (S5, #97).
+app.post("/webhook/github", webhookRoute);
 
 // GET /health — db reachability + issue count (mirrors Python app.py::health).
 app.get("/health", async (c) => {

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -1,0 +1,981 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleDeps,
+  handleIssues,
+  handleMilestone,
+  handlePullRequest,
+  handleRefCreate,
+  handleRefDelete,
+  handleSubIssues,
+  webhookRoute,
+} from "./handlers";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be at top level before imports resolve
+// ---------------------------------------------------------------------------
+
+vi.mock("../sync/graphql", () => ({
+  fetchIssueDeps: vi.fn(),
+  GraphQLError: class GraphQLError extends Error {
+    isAuth: boolean;
+    constructor(msg: string, isAuth = false) {
+      super(msg);
+      this.name = "GraphQLError";
+      this.isAuth = isAuth;
+    }
+  },
+}));
+
+vi.mock("../sync/sync", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../sync/sync")>();
+  return {
+    ...actual,
+    syncBranches: vi.fn(),
+  };
+});
+
+import { fetchIssueDeps } from "../sync/graphql";
+import { syncBranches } from "../sync/sync";
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from mutations.test.ts / sync.test.ts pattern
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database & { _recorded: FakeStmt[] } {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 1 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements produced via bind() calls on the FakeDb. */
+function captureDb(): {
+  db: D1Database & { _recorded: FakeStmt[] };
+  stmts: () => FakeStmt[];
+} {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 1);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — HMAC for dispatch tests
+// ---------------------------------------------------------------------------
+
+async function computeHmac(body: ArrayBuffer, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, body);
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256=${hex}`;
+}
+
+function makeRequest(
+  body: string,
+  sig: string,
+  event: string,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  return new Request("https://example.com/webhook/github", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-hub-signature-256": sig,
+      "x-github-event": event,
+      ...extraHeaders,
+    },
+    body,
+  });
+}
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    DB: captureDb().db,
+    GITHUB_TOKEN: "ghp_test",
+    GITHUB_ORG: "Roxabi",
+    GITHUB_WEBHOOK_SECRET: "test-secret",
+    ASSETS: {} as Fetcher,
+    ...overrides,
+  };
+}
+
+/** Build a minimal Hono-like Context for webhookRoute tests. */
+function makeContext(
+  req: Request,
+  env: Env,
+): { c: Parameters<typeof webhookRoute>[0]; db: D1Database & { _recorded: FakeStmt[] } } {
+  const { db, stmts: _stmts } = captureDb();
+  const envWithDb: Env = { ...env, DB: db };
+
+  const headers: Record<string, string> = {};
+  req.headers.forEach((v, k) => {
+    headers[k.toLowerCase()] = v;
+  });
+
+  const c = {
+    env: envWithDb,
+    req: {
+      header: (name: string) => headers[name.toLowerCase()] ?? undefined,
+      arrayBuffer: () => req.arrayBuffer(),
+    },
+    json: (data: unknown, status?: number) =>
+      new Response(JSON.stringify(data), {
+        status: status ?? 200,
+        headers: { "content-type": "application/json" },
+      }),
+  } as unknown as Parameters<typeof webhookRoute>[0];
+
+  return { c, db };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const REPO = "Roxabi/lyra";
+
+function makeIssuePayload(action: string, issueOverrides: Record<string, unknown> = {}) {
+  return {
+    action,
+    issue: {
+      number: 42,
+      title: "Test issue",
+      state: "open",
+      html_url: "https://github.com/Roxabi/lyra/issues/42",
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-02T00:00:00Z",
+      closed_at: null,
+      milestone: null,
+      labels: [{ name: "bug" }, { name: "P1-high" }],
+      ...issueOverrides,
+    },
+    repository: { full_name: REPO },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleIssues
+// ---------------------------------------------------------------------------
+
+describe("handleIssues", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe("opened / edited (upsert path)", () => {
+    it("calls db.batch (not loose .run) with issue upsert + label statements", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const payload = makeIssuePayload("opened");
+
+      // Act
+      await handleIssues(payload, db);
+
+      // Assert — batch was called (SC9 atomic requirement)
+      expect(vi.mocked(db.batch)).toHaveBeenCalledOnce();
+      const batchArgs = vi.mocked(db.batch).mock.calls[0][0] as unknown as FakeStmt[];
+      // First stmt = issue upsert (INSERT INTO issues)
+      expect(batchArgs[0].sql).toContain("INSERT INTO issues");
+      // Remaining stmts = label ops (DELETE + INSERT per label)
+      expect(batchArgs.length).toBeGreaterThan(1);
+      const labelSqls = batchArgs.slice(1).map((s) => s.sql);
+      expect(labelSqls.some((s) => s.includes("DELETE FROM labels"))).toBe(true);
+    });
+
+    it("batch contains label INSERT stmts for each label name", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const payload = makeIssuePayload("edited", {
+        labels: [{ name: "enhancement" }, { name: "F-lite" }],
+      });
+
+      // Act
+      await handleIssues(payload, db);
+
+      // Assert
+      const batchArgs = vi.mocked(db.batch).mock.calls[0][0] as unknown as FakeStmt[];
+      const labelInserts = batchArgs.filter((s) => s.sql.includes("INSERT OR IGNORE INTO labels"));
+      expect(labelInserts).toHaveLength(2);
+      const names = labelInserts.map((s) => s.args[1]);
+      expect(names).toContain("enhancement");
+      expect(names).toContain("F-lite");
+    });
+
+    it("does NOT call db.batch when action=deleted", async () => {
+      // Arrange — guard: deleted path must NOT run upsert batch
+      const { db } = captureDb();
+      const payload = makeIssuePayload("deleted");
+
+      // Act
+      await handleIssues(payload, db);
+
+      // Assert
+      expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleted / transferred (delete path)", () => {
+    it("runs DELETE FROM issues for action=deleted", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const payload = makeIssuePayload("deleted");
+
+      // Act
+      await handleIssues(payload, db);
+
+      // Assert — a stmt with DELETE FROM issues was run
+      const deletedStmt = stmts().find((s) => s.sql.includes("DELETE FROM issues"));
+      expect(deletedStmt).toBeDefined();
+      expect(vi.mocked(deletedStmt!.run)).toHaveBeenCalled();
+      expect(deletedStmt!.args).toContain(`${REPO}#42`);
+    });
+
+    it("runs DELETE FROM issues for action=transferred", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const payload = makeIssuePayload("transferred");
+
+      // Act
+      await handleIssues(payload, db);
+
+      // Assert
+      const deletedStmt = stmts().find((s) => s.sql.includes("DELETE FROM issues"));
+      expect(deletedStmt).toBeDefined();
+      expect(vi.mocked(deletedStmt!.run)).toHaveBeenCalled();
+    });
+
+    it("guard: deleting the deleted/transferred check would break test — no batch called", async () => {
+      // Negative: batch must NOT be called on deleted action
+      const { db } = captureDb();
+      await handleIssues(makeIssuePayload("deleted"), db);
+      expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDeps
+// ---------------------------------------------------------------------------
+
+describe("handleDeps", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const baseEnv: Env = makeEnv();
+
+  describe("same-repo blocked_by_added", () => {
+    it("calls addEdge with kind=blocks and runs it (src=blocker, dst=blocked)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const payload = {
+        action: "blocked_by_added",
+        blocking_issue: { number: 10 },
+        blocked_issue: { number: 42 },
+        blocking_issue_repo: { full_name: REPO },
+        repository: { full_name: REPO },
+      };
+
+      // Act
+      await handleDeps(payload, db, baseEnv);
+
+      // Assert — INSERT OR IGNORE INTO edges with kind=blocks
+      const edgeStmt = stmts().find((s) => s.sql.includes("INSERT OR IGNORE INTO edges"));
+      expect(edgeStmt).toBeDefined();
+      expect(edgeStmt!.args).toEqual([`${REPO}#10`, `${REPO}#42`, "blocks"]);
+      expect(vi.mocked(edgeStmt!.run)).toHaveBeenCalled();
+    });
+  });
+
+  describe("same-repo blocked_by_removed", () => {
+    it("calls removeEdge with kind=blocks (DELETE FROM edges)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const payload = {
+        action: "blocked_by_removed",
+        blocking_issue: { number: 10 },
+        blocked_issue: { number: 42 },
+        blocking_issue_repo: { full_name: REPO },
+        repository: { full_name: REPO },
+      };
+
+      // Act
+      await handleDeps(payload, db, baseEnv);
+
+      // Assert
+      const edgeStmt = stmts().find((s) => s.sql.includes("DELETE FROM edges"));
+      expect(edgeStmt).toBeDefined();
+      expect(edgeStmt!.args).toEqual([`${REPO}#10`, `${REPO}#42`, "blocks"]);
+      expect(vi.mocked(edgeStmt!.run)).toHaveBeenCalled();
+    });
+  });
+
+  describe("blocking_* actions (ignored)", () => {
+    it.each(["blocking_added", "blocking_removed"])(
+      "returns 0 and touches no DB for action=%s",
+      async (action) => {
+        // Arrange
+        const { db, stmts } = captureDb();
+        const payload = { action, blocking_issue: { number: 5 }, repository: { full_name: REPO } };
+
+        // Act
+        const result = await handleDeps(payload, db, baseEnv);
+
+        // Assert — no-op
+        expect(result).toBe(0);
+        expect(stmts()).toHaveLength(0);
+        expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe("cross-repo (blocking_issue absent)", () => {
+    it("calls fetchIssueDeps then db.batch with upsertEdges stmts", async () => {
+      // Arrange
+      const { db } = captureDb();
+      vi.mocked(fetchIssueDeps).mockResolvedValue({
+        blocked_by: [`${REPO}#7`],
+        blocking: [],
+      });
+      const payload = {
+        action: "blocked_by_added",
+        blocked_issue: { number: 42 },
+        repository: { full_name: REPO },
+        // no blocking_issue key → cross-repo path
+      };
+
+      // Act
+      await handleDeps(payload, db, { ...baseEnv, DB: db });
+
+      // Assert — fetchIssueDeps was called
+      expect(vi.mocked(fetchIssueDeps)).toHaveBeenCalled();
+      // db.batch was called with the upsertEdges stmts
+      expect(vi.mocked(db.batch)).toHaveBeenCalled();
+    });
+
+    it("swallows GraphQLError — handler resolves without throwing", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { GraphQLError } = await import("../sync/graphql");
+      vi.mocked(fetchIssueDeps).mockRejectedValue(new GraphQLError("rate limited"));
+      const payload = {
+        action: "blocked_by_added",
+        blocked_issue: { number: 42 },
+        repository: { full_name: REPO },
+      };
+
+      // Act — must NOT throw
+      const result = await handleDeps(payload, db, { ...baseEnv, DB: db });
+
+      // Assert — returns 0, does not propagate error
+      expect(result).toBe(0);
+    });
+
+    it("guard: GraphQLError swallow — if catch is removed, this test would fail (evidence)", async () => {
+      // This tests the same path as above but verifies the negative:
+      // if the catch were bypassed, the promise would reject.
+      const { db } = captureDb();
+      const { GraphQLError } = await import("../sync/graphql");
+      vi.mocked(fetchIssueDeps).mockRejectedValue(new GraphQLError("auth failure", true));
+      const payload = {
+        action: "blocked_by_added",
+        blocked_issue: { number: 42 },
+        repository: { full_name: REPO },
+      };
+      // Must resolve (not throw) — proves catch is active
+      await expect(handleDeps(payload, db, { ...baseEnv, DB: db })).resolves.toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSubIssues
+// ---------------------------------------------------------------------------
+
+describe("handleSubIssues", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe("sub_issue_added", () => {
+    it("calls addEdge with kind=parent (src=parent, dst=child)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const payload = {
+        action: "sub_issue_added",
+        parent_issue: { number: 10 },
+        parent_issue_repo: { full_name: REPO },
+        sub_issue: { number: 42 },
+        sub_issue_repo: { full_name: REPO },
+        repository: { full_name: REPO },
+      };
+
+      // Act
+      await handleSubIssues(payload, db);
+
+      // Assert — INSERT OR IGNORE INTO edges with kind=parent
+      const edgeStmt = stmts().find((s) => s.sql.includes("INSERT OR IGNORE INTO edges"));
+      expect(edgeStmt).toBeDefined();
+      expect(edgeStmt!.args).toEqual([`${REPO}#10`, `${REPO}#42`, "parent"]);
+      expect(vi.mocked(edgeStmt!.run)).toHaveBeenCalled();
+    });
+  });
+
+  describe("sub_issue_removed", () => {
+    it("calls removeEdge with kind=parent (DELETE FROM edges)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const payload = {
+        action: "sub_issue_removed",
+        parent_issue: { number: 10 },
+        parent_issue_repo: { full_name: REPO },
+        sub_issue: { number: 42 },
+        sub_issue_repo: { full_name: REPO },
+        repository: { full_name: REPO },
+      };
+
+      // Act
+      await handleSubIssues(payload, db);
+
+      // Assert
+      const edgeStmt = stmts().find((s) => s.sql.includes("DELETE FROM edges"));
+      expect(edgeStmt).toBeDefined();
+      expect(edgeStmt!.args).toEqual([`${REPO}#10`, `${REPO}#42`, "parent"]);
+      expect(vi.mocked(edgeStmt!.run)).toHaveBeenCalled();
+    });
+  });
+
+  describe("parent_* actions (ignored)", () => {
+    it.each(["parent_issue_added", "parent_issue_removed"])(
+      "returns 0 and touches no DB for action=%s",
+      async (action) => {
+        // Arrange
+        const { db, stmts } = captureDb();
+        const payload = { action, repository: { full_name: REPO } };
+
+        // Act
+        const result = await handleSubIssues(payload, db);
+
+        // Assert — no-op
+        expect(result).toBe(0);
+        expect(stmts()).toHaveLength(0);
+      },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleRefCreate
+// ---------------------------------------------------------------------------
+
+describe("handleRefCreate", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls setActiveBranch(db, repo, issueNumber, 1) for matching branch", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = {
+      ref_type: "branch",
+      ref: "42-some-feature",
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleRefCreate(payload, db);
+
+    // Assert — UPDATE issues SET has_active_branch=1
+    const branchStmt = stmts().find((s) => s.sql.includes("has_active_branch=1"));
+    expect(branchStmt).toBeDefined();
+    expect(branchStmt!.args).toEqual([REPO, 42]);
+    expect(vi.mocked(branchStmt!.run)).toHaveBeenCalled();
+  });
+
+  it("no-op for non-matching branch name", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = {
+      ref_type: "branch",
+      ref: "dependabot/npm/lodash-4.17.21",
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleRefCreate(payload, db);
+
+    // Assert — no DB statements
+    expect(stmts()).toHaveLength(0);
+  });
+
+  it("no-op for tag ref_type", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = {
+      ref_type: "tag",
+      ref: "42-tagged",
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleRefCreate(payload, db);
+
+    // Assert
+    expect(stmts()).toHaveLength(0);
+  });
+
+  it("guard: setActiveBranch is called — if guard removed, matching branch still calls it", async () => {
+    // Negative: if BRANCH_ISSUE_RE guard is removed, a non-matching ref would still hit setActiveBranch
+    // Verify matching ref hits it
+    const { db, stmts } = captureDb();
+    await handleRefCreate(
+      { ref_type: "branch", ref: "97-cf-webhook", repository: { full_name: REPO } },
+      db,
+    );
+    expect(stmts().some((s) => s.sql.includes("has_active_branch=1"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleRefDelete
+// ---------------------------------------------------------------------------
+
+describe("handleRefDelete", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const baseEnv: Env = makeEnv();
+
+  it("calls syncBranches(db, token, owner, name) for matching branch", async () => {
+    // Arrange
+    const { db } = captureDb();
+    vi.mocked(syncBranches).mockResolvedValue(undefined);
+    const payload = {
+      ref_type: "branch",
+      ref: "42-done",
+      repository: { full_name: "Roxabi/lyra" },
+    };
+
+    // Act
+    await handleRefDelete(payload, db, { ...baseEnv, DB: db });
+
+    // Assert — syncBranches called with correct owner/name split
+    expect(vi.mocked(syncBranches)).toHaveBeenCalledWith(db, baseEnv.GITHUB_TOKEN, "Roxabi", "lyra");
+  });
+
+  it("no-op for non-matching branch name", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const payload = {
+      ref_type: "branch",
+      ref: "release-please/branches/main",
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleRefDelete(payload, db, { ...baseEnv, DB: db });
+
+    // Assert — syncBranches not called
+    expect(vi.mocked(syncBranches)).not.toHaveBeenCalled();
+  });
+
+  it("no-op for tag ref_type", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const payload = {
+      ref_type: "tag",
+      ref: "97-tagged",
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleRefDelete(payload, db, { ...baseEnv, DB: db });
+
+    // Assert
+    expect(vi.mocked(syncBranches)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handlePullRequest
+// ---------------------------------------------------------------------------
+
+describe("handlePullRequest", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function makePrPayload(prOverrides: Record<string, unknown> = {}) {
+    return {
+      action: "closed",
+      pull_request: {
+        number: 5,
+        state: "closed",
+        merged: false,
+        labels: [],
+        body: "",
+        ...prOverrides,
+      },
+      repository: { full_name: REPO },
+    };
+  }
+
+  it("upserts pr_state with state=closed when merged=true", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = makePrPayload({ state: "open", merged: true });
+
+    // Act
+    await handlePullRequest(payload, db);
+
+    // Assert — upsertPrState ran with state=closed
+    const prStmt = stmts().find((s) => s.sql.includes("INSERT INTO pr_state"));
+    expect(prStmt).toBeDefined();
+    expect(prStmt!.args[2]).toBe("closed"); // state
+    expect(vi.mocked(prStmt!.run)).toHaveBeenCalled();
+  });
+
+  it("upserts pr_state with has_reviewed_label=1 when reviewed label present", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = makePrPayload({
+      state: "open",
+      merged: false,
+      labels: [{ name: "reviewed" }, { name: "bug" }],
+    });
+
+    // Act
+    await handlePullRequest(payload, db);
+
+    // Assert
+    const prStmt = stmts().find((s) => s.sql.includes("INSERT INTO pr_state"));
+    expect(prStmt).toBeDefined();
+    expect(prStmt!.args[3]).toBe(1); // has_reviewed_label
+  });
+
+  it("upserts pr_state with has_reviewed_label=0 when reviewed label absent", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = makePrPayload({ labels: [{ name: "bug" }] });
+
+    // Act
+    await handlePullRequest(payload, db);
+
+    // Assert
+    const prStmt = stmts().find((s) => s.sql.includes("INSERT INTO pr_state"));
+    expect(prStmt!.args[3]).toBe(0); // has_reviewed_label
+  });
+
+  it("extracts closing issue keys from body 'fixes #12' keyword", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = makePrPayload({
+      body: "This PR fixes #12 and closes #34.",
+      state: "open",
+    });
+
+    // Act
+    await handlePullRequest(payload, db);
+
+    // Assert — closing_issue_keys JSON contains repo#12 and repo#34
+    const prStmt = stmts().find((s) => s.sql.includes("INSERT INTO pr_state"));
+    expect(prStmt).toBeDefined();
+    const closingJson = prStmt!.args[4] as string;
+    const closing = JSON.parse(closingJson) as string[];
+    expect(closing).toContain(`${REPO}#12`);
+    expect(closing).toContain(`${REPO}#34`);
+  });
+
+  it("upserts pr_state with empty closing_issue_keys when no keywords in body", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = makePrPayload({ body: "No closing keywords here." });
+
+    // Act
+    await handlePullRequest(payload, db);
+
+    // Assert
+    const prStmt = stmts().find((s) => s.sql.includes("INSERT INTO pr_state"));
+    const closingJson = prStmt!.args[4] as string;
+    expect(JSON.parse(closingJson)).toEqual([]);
+  });
+
+  it("guard: upsertPrState is always called — if guard removed, no DB write would occur", async () => {
+    // Negative: calling with a valid PR must always run the INSERT INTO pr_state
+    const { db, stmts } = captureDb();
+    await handlePullRequest(makePrPayload(), db);
+    expect(stmts().some((s) => s.sql.includes("INSERT INTO pr_state"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleMilestone
+// ---------------------------------------------------------------------------
+
+describe("handleMilestone", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls renameMilestone when action=edited with changes.title", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = {
+      action: "edited",
+      changes: { title: { from: "Sprint 1" } },
+      milestone: { title: "Sprint 2" },
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleMilestone(payload, db);
+
+    // Assert — UPDATE issues SET milestone
+    const renameStmt = stmts().find((s) => s.sql.includes("UPDATE issues") && s.sql.includes("milestone"));
+    expect(renameStmt).toBeDefined();
+    // binds (newTitle, repo, oldTitle)
+    expect(renameStmt!.args).toEqual(["Sprint 2", REPO, "Sprint 1"]);
+    expect(vi.mocked(renameStmt!.run)).toHaveBeenCalled();
+  });
+
+  it("no-op when action=edited but no changes.title (description-only edit)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = {
+      action: "edited",
+      changes: { description: { from: "old desc" } },
+      milestone: { title: "Sprint 1" },
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleMilestone(payload, db);
+
+    // Assert
+    expect(stmts()).toHaveLength(0);
+  });
+
+  it("no-op for non-edited actions (created, closed, deleted)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const payload = {
+      action: "created",
+      milestone: { title: "Sprint 3" },
+      repository: { full_name: REPO },
+    };
+
+    // Act
+    await handleMilestone(payload, db);
+
+    // Assert
+    expect(stmts()).toHaveLength(0);
+  });
+
+  it("guard: no-op on edited without title change — if guard removed, renameMilestone would run erroneously", async () => {
+    // Negative: ensures the titleChange guard is active
+    const { db, stmts } = captureDb();
+    await handleMilestone(
+      {
+        action: "edited",
+        changes: {},
+        milestone: { title: "Sprint 1" },
+        repository: { full_name: REPO },
+      },
+      db,
+    );
+    expect(stmts()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// webhookRoute (dispatch)
+// ---------------------------------------------------------------------------
+
+describe("webhookRoute", () => {
+  const SECRET = "test-secret";
+
+  afterEach(() => vi.restoreAllMocks());
+
+  async function dispatchRequest(
+    body: string,
+    event: string,
+    envOverrides: Partial<Env> = {},
+    extraHeaders: Record<string, string> = {},
+  ): Promise<Response> {
+    const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
+    const sig = await computeHmac(bodyBytes, SECRET);
+    const req = makeRequest(body, sig, event, extraHeaders);
+    const env = makeEnv({ ...envOverrides });
+    const { c } = makeContext(req, env);
+    return webhookRoute(c);
+  }
+
+  describe("missing GITHUB_WEBHOOK_SECRET", () => {
+    it("returns 503", async () => {
+      // Arrange
+      const body = JSON.stringify({ action: "opened" });
+      const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
+      const sig = await computeHmac(bodyBytes, SECRET);
+      const req = makeRequest(body, sig, "issues");
+      const env = makeEnv({ GITHUB_WEBHOOK_SECRET: "" });
+      const { c } = makeContext(req, env);
+
+      // Act
+      const res = await webhookRoute(c);
+
+      // Assert
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe("bad signature", () => {
+    it("returns 401 when signature does not match", async () => {
+      // Arrange
+      const body = JSON.stringify({ action: "opened" });
+      const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
+      // Compute sig with WRONG secret
+      const wrongSig = await computeHmac(bodyBytes, "wrong-secret");
+      const req = makeRequest(body, wrongSig, "issues");
+      const env = makeEnv();
+      const { c } = makeContext(req, env);
+
+      // Act
+      const res = await webhookRoute(c);
+
+      // Assert
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("malformed JSON body", () => {
+    it("returns 400 when body is not valid JSON", async () => {
+      // Arrange
+      const body = "not-json{{";
+      const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
+      const sig = await computeHmac(bodyBytes, SECRET);
+      const req = makeRequest(body, sig, "issues");
+      const env = makeEnv();
+      const { c } = makeContext(req, env);
+
+      // Act
+      const res = await webhookRoute(c);
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("unknown x-github-event", () => {
+    it("returns 200 with { ok: true, ignored: <event> } for unknown event", async () => {
+      // Arrange
+      const body = JSON.stringify({ action: "foobar" });
+      const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
+      const sig = await computeHmac(bodyBytes, SECRET);
+      const req = makeRequest(body, sig, "unknown_event_xyz");
+      const env = makeEnv();
+      const { c } = makeContext(req, env);
+
+      // Act
+      const res = await webhookRoute(c);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(json["ok"]).toBe(true);
+      expect(json["ignored"]).toBe("unknown_event_xyz");
+    });
+  });
+
+  describe("body exceeding 25 MB cap", () => {
+    it("returns 413 via Content-Length header guard", async () => {
+      // Arrange — declare large Content-Length without sending that many bytes
+      const body = JSON.stringify({ action: "opened" });
+      const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
+      const sig = await computeHmac(bodyBytes, SECRET);
+      const req = makeRequest(body, sig, "issues", {
+        "content-length": String(26 * 1024 * 1024), // 26 MB declared
+      });
+      const env = makeEnv();
+      const { c } = makeContext(req, env);
+
+      // Act
+      const res = await webhookRoute(c);
+
+      // Assert
+      expect(res.status).toBe(413);
+    });
+  });
+
+  describe("known event dispatched successfully", () => {
+    it("returns 200 { ok: true } for a valid issues opened event", async () => {
+      // Arrange
+      const payload = makeIssuePayload("opened");
+      const res = await dispatchRequest(JSON.stringify(payload), "issues");
+
+      // Assert
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as Record<string, unknown>;
+      expect(json["ok"]).toBe(true);
+    });
+  });
+});

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -231,7 +231,7 @@ function makeIssuePayload(action: string, issueOverrides: Record<string, unknown
 // ---------------------------------------------------------------------------
 
 describe("handleIssues", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   describe("opened / edited (upsert path)", () => {
     it("calls db.batch (not loose .run) with issue upsert + label statements", async () => {
@@ -329,7 +329,7 @@ describe("handleIssues", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleDeps", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   const baseEnv: Env = makeEnv();
 
@@ -440,19 +440,22 @@ describe("handleDeps", () => {
       expect(result).toBe(0);
     });
 
-    it("guard: GraphQLError swallow — if catch is removed, this test would fail (evidence)", async () => {
-      // This tests the same path as above but verifies the negative:
-      // if the catch were bypassed, the promise would reject.
+    it("swallows non-GraphQLError — catch-all returns 0 for any error type", async () => {
+      // Arrange — generic Error (not GraphQLError); source catch returns 0 for all errors,
+      // only the log level differs (warn for GraphQLError, error for everything else).
       const { db } = captureDb();
-      const { GraphQLError } = await import("../sync/graphql");
-      vi.mocked(fetchIssueDeps).mockRejectedValue(new GraphQLError("auth failure", true));
+      vi.mocked(fetchIssueDeps).mockRejectedValue(new Error("boom"));
       const payload = {
         action: "blocked_by_added",
         blocked_issue: { number: 42 },
         repository: { full_name: REPO },
       };
-      // Must resolve (not throw) — proves catch is active
-      await expect(handleDeps(payload, db, { ...baseEnv, DB: db })).resolves.toBe(0);
+
+      // Act — must NOT throw
+      const result = await handleDeps(payload, db, { ...baseEnv, DB: db });
+
+      // Assert — catch swallows all errors, not just GraphQLError
+      expect(result).toBe(0);
     });
   });
 });
@@ -462,7 +465,7 @@ describe("handleDeps", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleSubIssues", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   describe("sub_issue_added", () => {
     it("calls addEdge with kind=parent (src=parent, dst=child)", async () => {
@@ -536,7 +539,7 @@ describe("handleSubIssues", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleRefCreate", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   it("calls setActiveBranch(db, repo, issueNumber, 1) for matching branch", async () => {
     // Arrange
@@ -606,7 +609,7 @@ describe("handleRefCreate", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleRefDelete", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   const baseEnv: Env = makeEnv();
 
@@ -665,7 +668,7 @@ describe("handleRefDelete", () => {
 // ---------------------------------------------------------------------------
 
 describe("handlePullRequest", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   function makePrPayload(prOverrides: Record<string, unknown> = {}) {
     return {
@@ -775,7 +778,7 @@ describe("handlePullRequest", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleMilestone", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   it("calls renameMilestone when action=edited with changes.title", async () => {
     // Arrange
@@ -854,7 +857,7 @@ describe("handleMilestone", () => {
 describe("webhookRoute", () => {
   const SECRET = "test-secret";
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.clearAllMocks());
 
   async function dispatchRequest(
     body: string,
@@ -947,21 +950,32 @@ describe("webhookRoute", () => {
   });
 
   describe("body exceeding 25 MB cap", () => {
-    it("returns 413 via Content-Length header guard", async () => {
-      // Arrange — declare large Content-Length without sending that many bytes
-      const body = JSON.stringify({ action: "opened" });
-      const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
-      const sig = await computeHmac(bodyBytes, SECRET);
-      const req = makeRequest(body, sig, "issues", {
-        "content-length": String(26 * 1024 * 1024), // 26 MB declared
-      });
-      const env = makeEnv();
-      const { c } = makeContext(req, env);
+    it("returns 413 when actual body byteLength exceeds 25 MB", async () => {
+      // Arrange — build a real oversized body (26 MB + 1 byte)
+      const huge = new Uint8Array(26 * 1024 * 1024 + 1);
+      const bodyBuffer = huge.buffer as ArrayBuffer;
+      // Valid secret in env so the 503 gate passes; no valid signature needed —
+      // the byteLength guard fires before HMAC verification.
+      const env = makeEnv({ GITHUB_WEBHOOK_SECRET: SECRET });
+
+      const headers: Record<string, string> = {};
+      const c = {
+        env: { ...env, DB: captureDb().db },
+        req: {
+          header: (name: string) => headers[name.toLowerCase()] ?? undefined,
+          arrayBuffer: () => Promise.resolve(bodyBuffer),
+        },
+        json: (data: unknown, status?: number) =>
+          new Response(JSON.stringify(data), {
+            status: status ?? 200,
+            headers: { "content-type": "application/json" },
+          }),
+      } as unknown as Parameters<typeof webhookRoute>[0];
 
       // Act
       const res = await webhookRoute(c);
 
-      // Assert
+      // Assert — byteLength guard fires, no Content-Length header needed
       expect(res.status).toBe(413);
     });
   });

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -6,8 +6,8 @@
  *   - D1 db.batch([...stmts]) replaces aiosqlite interactive transactions.
  *   - trigger_heal() calls are DROPPED (no in-process reconciler in CF Worker).
  *   - handleRefDelete uses env.DB directly (no fresh sqlite3.connect).
- *   - MAX_WEBHOOK_BODY_BYTES enforced via Content-Length header only (CF Workers
- *     buffer the body before the handler runs; streaming guard not needed).
+ *   - MAX_WEBHOOK_BODY_BYTES enforced via bodyBuffer.byteLength after arrayBuffer()
+ *     (authoritative check; Content-Length is spoofable and saves nothing).
  */
 
 import type { Context } from "hono";
@@ -33,10 +33,6 @@ import { fetchIssueDeps, GraphQLError } from "../sync/graphql";
 // ---------------------------------------------------------------------------
 
 const MAX_WEBHOOK_BODY_BYTES = 25 * 1024 * 1024; // 25 MB
-
-// Regex ported from .github/workflows/auto-merge.yml close-linked-issues job:
-// /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi
-const _CLOSING_KEYWORD_RE = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
 
 // ---------------------------------------------------------------------------
 // Local helpers
@@ -69,7 +65,7 @@ function issueKey(
 export async function handleIssues(payload: Record<string, unknown>, db: D1Database): Promise<void> {
   const action = payload["action"] as string | undefined;
   const issue = payload["issue"] as Record<string, unknown>;
-  const repo = (payload["repository"] as Record<string, unknown>)["full_name"] as string;
+  const repo = ((payload["repository"] as Record<string, unknown> | undefined) ?? {})["full_name"] as string | undefined ?? "";
   const key = `${repo}#${issue["number"]}`;
 
   if (action === "deleted" || action === "transferred") {
@@ -100,7 +96,7 @@ export async function handleIssues(payload: Record<string, unknown>, db: D1Datab
     number: issue["number"] as number,
     title: issue["title"] as string,
     state: issue["state"] as string,
-    url: (issue["html_url"] as string | undefined) ?? "",
+    url: (issue["html_url"] as string | undefined) ?? null,
     created_at: (issue["created_at"] as string | null | undefined) ?? null,
     updated_at: (issue["updated_at"] as string | null | undefined) ?? null,
     closed_at: (issue["closed_at"] as string | null | undefined) ?? null,
@@ -419,10 +415,8 @@ export async function handlePullRequest(
 
   const body = String(pr["body"] ?? "");
   const issueNumbers: string[] = [];
-  // Reset lastIndex since the regex has the `g` flag — always start from 0.
-  _CLOSING_KEYWORD_RE.lastIndex = 0;
-  for (const match of body.matchAll(_CLOSING_KEYWORD_RE)) {
-    issueNumbers.push(match[1]);
+  for (const m of body.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi)) {
+    issueNumbers.push(m[1]);
   }
   const closingIssueKeys: string[] = issueNumbers.map((n) => `${repoStr}#${n}`);
   const closingIssueKeysJson = JSON.stringify(closingIssueKeys);
@@ -453,10 +447,10 @@ export async function handleMilestone(
   }
   const oldTitle = String(titleChange["from"]);
   const newTitle = String(
-    ((payload["milestone"] as Record<string, unknown>)["title"] as string | undefined) ?? "",
+    ((payload["milestone"] as Record<string, unknown> | undefined ?? {})["title"] as string | undefined) ?? "",
   );
   const repo = String(
-    ((payload["repository"] as Record<string, unknown>)["full_name"] as string | undefined) ?? "",
+    ((payload["repository"] as Record<string, unknown> | undefined ?? {})["full_name"] as string | undefined) ?? "",
   );
   await renameMilestone(db, repo, oldTitle, newTitle).run();
 }
@@ -477,16 +471,6 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
   const secret = c.env.GITHUB_WEBHOOK_SECRET;
   if (!secret) {
     return c.json({ error: "webhook not configured" }, 503);
-  }
-
-  // Enforce body size cap via Content-Length header (CF Workers buffer the
-  // full body before the handler runs, so streaming guard is not needed).
-  const declaredLength = c.req.header("content-length");
-  if (declaredLength != null) {
-    const len = parseInt(declaredLength, 10);
-    if (!isNaN(len) && len > MAX_WEBHOOK_BODY_BYTES) {
-      return c.json({ error: "payload too large" }, 413);
-    }
   }
 
   const bodyBuffer = await c.req.arrayBuffer();
@@ -510,22 +494,27 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
   const event = c.req.header("x-github-event") ?? null;
   const db = c.env.DB;
 
-  if (event === "issues") {
-    await handleIssues(payload, db);
-  } else if (event === "issue_dependencies") {
-    await handleDeps(payload, db, c.env);
-  } else if (event === "sub_issues") {
-    await handleSubIssues(payload, db);
-  } else if (event === "create") {
-    await handleRefCreate(payload, db);
-  } else if (event === "delete") {
-    await handleRefDelete(payload, db, c.env);
-  } else if (event === "pull_request") {
-    await handlePullRequest(payload, db);
-  } else if (event === "milestone") {
-    await handleMilestone(payload, db);
-  } else {
-    return c.json({ ok: true, ignored: event });
+  try {
+    if (event === "issues") {
+      await handleIssues(payload, db);
+    } else if (event === "issue_dependencies") {
+      await handleDeps(payload, db, c.env);
+    } else if (event === "sub_issues") {
+      await handleSubIssues(payload, db);
+    } else if (event === "create") {
+      await handleRefCreate(payload, db);
+    } else if (event === "delete") {
+      await handleRefDelete(payload, db, c.env);
+    } else if (event === "pull_request") {
+      await handlePullRequest(payload, db);
+    } else if (event === "milestone") {
+      await handleMilestone(payload, db);
+    } else {
+      return c.json({ ok: true, ignored: event });
+    }
+  } catch (err) {
+    console.error("[webhook] unhandled handler error", err);
+    return c.json({ ok: true, error: "internal" });
   }
 
   return c.json({ ok: true });

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -1,0 +1,532 @@
+/**
+ * GitHub webhook handlers — verbatim port of src/roxabi_live/webhook/handlers.py
+ * and src/roxabi_live/webhook/router.py for the Cloudflare Worker runtime.
+ *
+ * Runtime-forced deltas vs. the Python original:
+ *   - D1 db.batch([...stmts]) replaces aiosqlite interactive transactions.
+ *   - trigger_heal() calls are DROPPED (no in-process reconciler in CF Worker).
+ *   - handleRefDelete uses env.DB directly (no fresh sqlite3.connect).
+ *   - MAX_WEBHOOK_BODY_BYTES enforced via Content-Length header only (CF Workers
+ *     buffer the body before the handler runs; streaming guard not needed).
+ */
+
+import type { Context } from "hono";
+import type { Env } from "../types";
+import { verifyHmac } from "./hmac";
+import {
+  upsertIssueFromWebhook,
+  replaceLabels,
+  addEdge,
+  removeEdge,
+  upsertEdges,
+  deleteIssue,
+  setActiveBranch,
+  upsertPrState,
+  renameMilestone,
+  type WebhookIssue,
+} from "./mutations";
+import { BRANCH_ISSUE_RE, canonicalKey, extractFromLabels, syncBranches } from "../sync/sync";
+import { fetchIssueDeps, GraphQLError } from "../sync/graphql";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_WEBHOOK_BODY_BYTES = 25 * 1024 * 1024; // 25 MB
+
+// Regex ported from .github/workflows/auto-merge.yml close-linked-issues job:
+// /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi
+const _CLOSING_KEYWORD_RE = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive an issue key from a partial issue object plus an optional repo override.
+ * Verbatim port of _issue_key() from handlers.py.
+ */
+function issueKey(
+  issue: Record<string, unknown>,
+  repoOverride?: Record<string, unknown> | null,
+): string {
+  const repo = repoOverride ?? (issue["repository"] as Record<string, unknown> | undefined) ?? {};
+  const fullName = (repo["full_name"] as string | undefined) ?? "";
+  return `${fullName}#${issue["number"]}`;
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a GitHub `issues` webhook event.
+ *
+ * Supported actions: opened, edited, reopened, labeled, unlabeled, closed,
+ * deleted, transferred.
+ * Issue upsert + label replacement are committed atomically via db.batch (SC9).
+ */
+export async function handleIssues(payload: Record<string, unknown>, db: D1Database): Promise<void> {
+  const action = payload["action"] as string | undefined;
+  const issue = payload["issue"] as Record<string, unknown>;
+  const repo = (payload["repository"] as Record<string, unknown>)["full_name"] as string;
+  const key = `${repo}#${issue["number"]}`;
+
+  if (action === "deleted" || action === "transferred") {
+    await deleteIssue(db, key).run();
+    return;
+  }
+
+  const rawLabels: unknown[] = (issue["labels"] as unknown[] | undefined) ?? [];
+  const names: string[] = rawLabels.map((lbl) => {
+    if (lbl && typeof lbl === "object") {
+      return String((lbl as Record<string, unknown>)["name"] ?? "");
+    }
+    return String(lbl);
+  });
+
+  const milestoneObj = issue["milestone"];
+  let milestoneTitle: string | null = null;
+  if (milestoneObj && typeof milestoneObj === "object") {
+    const titleVal = (milestoneObj as Record<string, unknown>)["title"];
+    milestoneTitle = titleVal != null ? String(titleVal) : null;
+  }
+
+  const derived = extractFromLabels(names);
+
+  const issuePartial: WebhookIssue = {
+    key,
+    repo,
+    number: issue["number"] as number,
+    title: issue["title"] as string,
+    state: issue["state"] as string,
+    url: (issue["html_url"] as string | undefined) ?? "",
+    created_at: (issue["created_at"] as string | null | undefined) ?? null,
+    updated_at: (issue["updated_at"] as string | null | undefined) ?? null,
+    closed_at: (issue["closed_at"] as string | null | undefined) ?? null,
+    milestone: milestoneTitle,
+    lane: derived.lane,
+    priority: derived.priority,
+    size: derived.size,
+  };
+
+  // Atomic upsert + label replacement via db.batch (SC9).
+  await db.batch([upsertIssueFromWebhook(db, issuePartial), ...replaceLabels(db, key, names)]);
+}
+
+/**
+ * Point-fetch the current blockedBy/blocking state for a single issue and
+ * upsert edges into D1.
+ *
+ * Used when GitHub omits `blocking_issue` from cross-repo dependency payloads.
+ * Returns the number of rows changed (0 on error or no-change).
+ */
+async function pointFetchAndUpsertDeps(
+  db: D1Database,
+  token: string,
+  blockedIssue: Record<string, unknown>,
+  repo: Record<string, unknown>,
+): Promise<number> {
+  const number = blockedIssue["number"] as number | undefined;
+  if (number == null) {
+    console.warn(
+      `[webhook] handle_deps: missing number in blocked_issue — keys=${Object.keys(blockedIssue).join(",")}`,
+    );
+    return 0;
+  }
+  const fullName = (repo["full_name"] as string | undefined) ?? "";
+  const slashIdx = fullName.indexOf("/");
+  if (slashIdx < 0 || slashIdx === fullName.length - 1) {
+    console.warn(
+      `[webhook] handle_deps: cannot point-fetch — malformed repository.full_name=${JSON.stringify(fullName)}`,
+    );
+    return 0;
+  }
+  const owner = fullName.slice(0, slashIdx);
+  const name = fullName.slice(slashIdx + 1);
+  const key = canonicalKey(number, fullName);
+
+  try {
+    const deps = await fetchIssueDeps(owner, name, number, token);
+    const stmts = upsertEdges(db, key, deps.blocked_by, deps.blocking, "blocks");
+    if (stmts.length > 0) {
+      const results = await db.batch(stmts);
+      return results.reduce((acc, r) => acc + (r.meta.changes ?? 0), 0);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof GraphQLError) {
+      console.warn(`[webhook] handle_deps: point-fetch failed for ${key} — ${err.message}`);
+      return 0;
+    }
+    console.error(`[webhook] handle_deps: unexpected error for ${key}`, err);
+    return 0;
+  }
+}
+
+/**
+ * Process a GitHub `issue_dependencies` webhook event.
+ *
+ * Acted upon: blocked_by_added, blocked_by_removed.
+ * Ignored (duplicate-direction): blocking_added, blocking_removed.
+ *
+ * Cross-repo case: GitHub omits `blocking_issue` from payloads when the
+ * blocker is in a different repo.  When that field is absent we fall back to a
+ * point-fetch of the affected issue's current dependency lists and rewrite all
+ * its `blocks` edges via upsertEdges.
+ *
+ * Returns the number of rows changed (0 for ignored events or no-ops).
+ */
+export async function handleDeps(
+  payload: Record<string, unknown>,
+  db: D1Database,
+  env: Env,
+): Promise<number> {
+  const action = payload["action"] as string | undefined;
+
+  if (action === "blocking_added" || action === "blocking_removed") {
+    return 0;
+  }
+
+  if (action !== "blocked_by_added" && action !== "blocked_by_removed") {
+    return 0;
+  }
+
+  const blockingIssue = (payload["blocking_issue"] as Record<string, unknown> | undefined) ?? null;
+  const blockedIssue =
+    ((payload["blocked_issue"] ?? payload["issue"]) as Record<string, unknown> | undefined) ?? null;
+  const blockingRepo =
+    (payload["blocking_issue_repo"] as Record<string, unknown> | undefined) ?? null;
+
+  if (blockedIssue == null) {
+    console.warn(
+      `[webhook] handle_deps: unexpected payload shape for ${action} — keys=${Object.keys(payload).join(",")}`,
+    );
+    return 0;
+  }
+
+  // Cross-repo case: blocking_issue absent — point-fetch the downstream issue's
+  // current dep graph and derive edges from the authoritative GitHub state.
+  if (blockingIssue == null) {
+    const repoObj = (payload["repository"] as Record<string, unknown> | undefined) ?? {};
+    return await pointFetchAndUpsertDeps(db, env.GITHUB_TOKEN, blockedIssue, repoObj);
+  }
+
+  // Same-repo fast path: both sides are in the payload — use them directly.
+  const blockerKey = issueKey(
+    blockingIssue,
+    blockingRepo,
+  );
+  const blockedKey = issueKey(
+    blockedIssue,
+    (payload["repository"] as Record<string, unknown> | undefined) ?? null,
+  );
+
+  if (action === "blocked_by_added") {
+    const result = await addEdge(db, blockerKey, blockedKey, "blocks").run();
+    return result.meta.changes ?? 0;
+  }
+
+  if (action === "blocked_by_removed") {
+    const result = await removeEdge(db, blockerKey, blockedKey, "blocks").run();
+    return result.meta.changes ?? 0;
+  }
+
+  return 0;
+}
+
+/**
+ * Process a GitHub `sub_issues` webhook event.
+ *
+ * Acted upon: sub_issue_added, sub_issue_removed.
+ * Ignored (duplicate-direction): parent_issue_added, parent_issue_removed.
+ *
+ * Returns the number of rows changed (0 for ignored events or no-ops).
+ */
+export async function handleSubIssues(
+  payload: Record<string, unknown>,
+  db: D1Database,
+): Promise<number> {
+  const action = payload["action"] as string | undefined;
+
+  if (action === "parent_issue_added" || action === "parent_issue_removed") {
+    return 0;
+  }
+
+  if (action !== "sub_issue_added" && action !== "sub_issue_removed") {
+    return 0;
+  }
+
+  const parentIssue = payload["parent_issue"] as Record<string, unknown> | undefined;
+  const parentRepo =
+    ((payload["parent_issue_repo"] ?? payload["repository"]) as
+      | Record<string, unknown>
+      | undefined) ?? null;
+  const subIssue = payload["sub_issue"] as Record<string, unknown> | undefined;
+  const subRepo =
+    ((payload["sub_issue_repo"] ?? payload["repository"]) as
+      | Record<string, unknown>
+      | undefined) ?? null;
+
+  if (!parentIssue || !parentRepo || !subIssue || !subRepo) {
+    console.warn(
+      `[webhook] handle_sub_issues: unexpected payload shape for ${action} — keys=${Object.keys(payload).sort().join(",")}`,
+    );
+    return 0;
+  }
+
+  let parentKey: string;
+  let childKey: string;
+  try {
+    parentKey = `${(parentRepo as Record<string, unknown>)["full_name"]}#${parentIssue["number"]}`;
+    childKey = `${(subRepo as Record<string, unknown>)["full_name"]}#${subIssue["number"]}`;
+  } catch {
+    console.warn(
+      `[webhook] handle_sub_issues: malformed payload for ${action} — keys=${Object.keys(payload).sort().join(",")}`,
+    );
+    return 0;
+  }
+
+  if (action === "sub_issue_added") {
+    const result = await addEdge(db, parentKey, childKey, "parent").run();
+    return result.meta.changes ?? 0;
+  } else {
+    // sub_issue_removed
+    const result = await removeEdge(db, parentKey, childKey, "parent").run();
+    return result.meta.changes ?? 0;
+  }
+}
+
+/**
+ * Handle GitHub `create` event for branch refs.
+ *
+ * Applies BRANCH_ISSUE_RE to the ref name. If the branch name encodes an
+ * issue number, sets has_active_branch=1 for that issue in D1.
+ * Non-matching refs (dependabot, release-please, tags, etc.) are no-ops.
+ */
+export async function handleRefCreate(
+  payload: Record<string, unknown>,
+  db: D1Database,
+): Promise<void> {
+  if (payload["ref_type"] !== "branch") {
+    return;
+  }
+  const ref = (payload["ref"] as string | undefined) ?? "";
+  const repo =
+    ((payload["repository"] as Record<string, unknown> | undefined) ?? {})["full_name"] as
+      | string
+      | undefined;
+  const repoStr = repo ?? "";
+  const m = BRANCH_ISSUE_RE.exec(ref);
+  if (!m) {
+    return;
+  }
+  const number = parseInt(m[1], 10);
+  await setActiveBranch(db, repoStr, number, 1).run();
+}
+
+/**
+ * Handle GitHub `delete` event for branch refs.
+ *
+ * On a matching branch deletion, re-queries GitHub via syncBranches (race
+ * rule: do not trust the branch-removal event alone).
+ * syncBranches uses env.DB directly (no fresh sqlite3 connection needed in
+ * the Worker runtime).
+ */
+export async function handleRefDelete(
+  payload: Record<string, unknown>,
+  db: D1Database,
+  env: Env,
+): Promise<void> {
+  if (payload["ref_type"] !== "branch") {
+    return;
+  }
+  const ref = (payload["ref"] as string | undefined) ?? "";
+  const repoFull =
+    ((payload["repository"] as Record<string, unknown> | undefined) ?? {})["full_name"] as
+      | string
+      | undefined;
+  const repo = repoFull ?? "";
+
+  const m = BRANCH_ISSUE_RE.exec(ref);
+  if (!m) {
+    return;
+  }
+
+  const slashIdx = repo.indexOf("/");
+  if (slashIdx < 0 || slashIdx === repo.length - 1) {
+    console.warn(
+      `[webhook] handle_ref_delete: malformed repo=${JSON.stringify(repo)} ref=${ref} — skipping syncBranches`,
+    );
+    return;
+  }
+  const owner = repo.slice(0, slashIdx);
+  const name = repo.slice(slashIdx + 1);
+
+  try {
+    await syncBranches(db, env.GITHUB_TOKEN, owner, name);
+  } catch (err) {
+    console.error(
+      `[webhook] handle_ref_delete: syncBranches failed for repo=${repo} ref=${ref}`,
+      err,
+    );
+  }
+}
+
+/**
+ * Handle GitHub `pull_request` events.
+ *
+ * Supported actions: opened, labeled, unlabeled, closed, reopened, edited,
+ * synchronize.
+ *
+ * Upserts a pr_state row:
+ * - state: 'open' or 'closed' (merged PRs count as closed)
+ * - has_reviewed_label: 1 if any label name == 'reviewed', else 0
+ * - closing_issue_keys: JSON array of 'owner/repo#N' for bare #N keyword
+ *   refs in the PR body (same regex as auto-merge.yml)
+ * - updated_at: current UTC ISO timestamp
+ */
+export async function handlePullRequest(
+  payload: Record<string, unknown>,
+  db: D1Database,
+): Promise<void> {
+  const pr = (payload["pull_request"] as Record<string, unknown> | undefined) ?? {};
+  const repo =
+    ((payload["repository"] as Record<string, unknown> | undefined) ?? {})["full_name"] as
+      | string
+      | undefined;
+  const repoStr = repo ?? "";
+  const number = parseInt(String(pr["number"] ?? "0"), 10);
+  if (!number) {
+    console.warn(
+      `[webhook] pull_request webhook missing PR number; payload keys: ${Object.keys(pr).join(",")}`,
+    );
+    return;
+  }
+
+  const rawState = String(pr["state"] ?? "open");
+  const merged = Boolean(pr["merged"]);
+  const state = rawState === "closed" || merged ? "closed" : "open";
+
+  const rawLabels: unknown[] = (pr["labels"] as unknown[] | undefined) ?? [];
+  const labelNames: string[] = rawLabels.map((lbl) => {
+    if (lbl && typeof lbl === "object") {
+      return String((lbl as Record<string, unknown>)["name"] ?? "");
+    }
+    return String(lbl);
+  });
+  const hasReviewedLabel: 0 | 1 = labelNames.includes("reviewed") ? 1 : 0;
+
+  const body = String(pr["body"] ?? "");
+  const issueNumbers: string[] = [];
+  // Reset lastIndex since the regex has the `g` flag — always start from 0.
+  _CLOSING_KEYWORD_RE.lastIndex = 0;
+  for (const match of body.matchAll(_CLOSING_KEYWORD_RE)) {
+    issueNumbers.push(match[1]);
+  }
+  const closingIssueKeys: string[] = issueNumbers.map((n) => `${repoStr}#${n}`);
+  const closingIssueKeysJson = JSON.stringify(closingIssueKeys);
+
+  const updatedAt = new Date().toISOString();
+
+  await upsertPrState(db, repoStr, number, state, hasReviewedLabel, closingIssueKeysJson, updatedAt).run();
+}
+
+/**
+ * Process a GitHub `milestone` webhook event.
+ *
+ * Only `edited` + title change is handled — renames the milestone in-place
+ * without re-fetching all issues from GitHub.
+ */
+export async function handleMilestone(
+  payload: Record<string, unknown>,
+  db: D1Database,
+): Promise<void> {
+  const action = payload["action"] as string | undefined;
+  if (action !== "edited") {
+    return;
+  }
+  const changes = (payload["changes"] as Record<string, unknown> | undefined) ?? {};
+  const titleChange = changes["title"] as Record<string, unknown> | undefined;
+  if (!titleChange) {
+    return;
+  }
+  const oldTitle = String(titleChange["from"]);
+  const newTitle = String(
+    ((payload["milestone"] as Record<string, unknown>)["title"] as string | undefined) ?? "",
+  );
+  const repo = String(
+    ((payload["repository"] as Record<string, unknown>)["full_name"] as string | undefined) ?? "",
+  );
+  await renameMilestone(db, repo, oldTitle, newTitle).run();
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher — POST /webhook/github
+// ---------------------------------------------------------------------------
+
+/**
+ * Hono route handler for POST /webhook/github.
+ *
+ * Verbatim port of router.py::github_webhook with runtime-forced deltas:
+ * - HMAC verification via Web Crypto (verifyHmac)
+ * - D1 via c.env.DB (no aiosqlite)
+ * - trigger_heal() calls DROPPED
+ */
+export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Response> {
+  const secret = c.env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) {
+    return c.json({ error: "webhook not configured" }, 503);
+  }
+
+  // Enforce body size cap via Content-Length header (CF Workers buffer the
+  // full body before the handler runs, so streaming guard is not needed).
+  const declaredLength = c.req.header("content-length");
+  if (declaredLength != null) {
+    const len = parseInt(declaredLength, 10);
+    if (!isNaN(len) && len > MAX_WEBHOOK_BODY_BYTES) {
+      return c.json({ error: "payload too large" }, 413);
+    }
+  }
+
+  const bodyBuffer = await c.req.arrayBuffer();
+  if (bodyBuffer.byteLength > MAX_WEBHOOK_BODY_BYTES) {
+    return c.json({ error: "payload too large" }, 413);
+  }
+
+  const sigHeader = c.req.header("x-hub-signature-256") ?? null;
+  const valid = await verifyHmac(bodyBuffer, sigHeader, secret);
+  if (!valid) {
+    return c.json({ error: "invalid signature" }, 401);
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(bodyBuffer));
+  } catch {
+    return c.json({ error: "invalid JSON payload" }, 400);
+  }
+
+  const event = c.req.header("x-github-event") ?? null;
+  const db = c.env.DB;
+
+  if (event === "issues") {
+    await handleIssues(payload, db);
+  } else if (event === "issue_dependencies") {
+    await handleDeps(payload, db, c.env);
+  } else if (event === "sub_issues") {
+    await handleSubIssues(payload, db);
+  } else if (event === "create") {
+    await handleRefCreate(payload, db);
+  } else if (event === "delete") {
+    await handleRefDelete(payload, db, c.env);
+  } else if (event === "pull_request") {
+    await handlePullRequest(payload, db);
+  } else if (event === "milestone") {
+    await handleMilestone(payload, db);
+  } else {
+    return c.json({ ok: true, ignored: event });
+  }
+
+  return c.json({ ok: true });
+}

--- a/worker/src/webhook/hmac.test.ts
+++ b/worker/src/webhook/hmac.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { verifyHmac } from "./hmac";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Compute a valid HMAC-SHA256 signature for the given body + secret. */
+async function computeHmac(body: ArrayBuffer, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, body);
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256=${hex}`;
+}
+
+const BODY_A = new TextEncoder().encode("hello body A").buffer as ArrayBuffer;
+const BODY_B = new TextEncoder().encode("tampered body B").buffer as ArrayBuffer;
+const SECRET = "test-webhook-secret";
+
+// ---------------------------------------------------------------------------
+// verifyHmac
+// ---------------------------------------------------------------------------
+
+describe("verifyHmac", () => {
+  it("returns false when header is null", async () => {
+    // Arrange
+    const header = null;
+    // Act
+    const result = await verifyHmac(BODY_A, header, SECRET);
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns false when header has wrong prefix (sha1=…)", async () => {
+    // Arrange
+    const validHex = "a".repeat(64); // 32 bytes hex
+    const header = `sha1=${validHex}`;
+    // Act
+    const result = await verifyHmac(BODY_A, header, SECRET);
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns false when header has no prefix at all", async () => {
+    // Arrange
+    const validHex = "a".repeat(64);
+    const header = validHex;
+    // Act
+    const result = await verifyHmac(BODY_A, header, SECRET);
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns false when hex decodes to fewer than 32 bytes (truncated)", async () => {
+    // Arrange — 31 bytes = 62 hex chars
+    const header = `sha256=${"ab".repeat(31)}`;
+    // Act
+    const result = await verifyHmac(BODY_A, header, SECRET);
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns false when hex decodes to more than 32 bytes", async () => {
+    // Arrange — 33 bytes = 66 hex chars
+    const header = `sha256=${"ab".repeat(33)}`;
+    // Act
+    const result = await verifyHmac(BODY_A, header, SECRET);
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns true for a valid signature computed over the same body + secret", async () => {
+    // Arrange
+    const header = await computeHmac(BODY_A, SECRET);
+    // Act
+    const result = await verifyHmac(BODY_A, header, SECRET);
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false when body is tampered (valid sig for body A, verified against body B)", async () => {
+    // Arrange — signature is correct for BODY_A but body passed is BODY_B
+    const header = await computeHmac(BODY_A, SECRET);
+    // Act
+    const result = await verifyHmac(BODY_B, header, SECRET);
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns false when signature is tampered (one byte flipped)", async () => {
+    // Arrange — compute valid sig then flip first byte
+    const validHeader = await computeHmac(BODY_A, SECRET);
+    const hexPart = validHeader.slice(7); // strip "sha256="
+    // Flip first two hex chars (first byte)
+    const firstByte = parseInt(hexPart.slice(0, 2), 16);
+    const flipped = ((firstByte + 1) & 0xff).toString(16).padStart(2, "0");
+    const tamperedHeader = `sha256=${flipped}${hexPart.slice(2)}`;
+    // Act
+    const result = await verifyHmac(BODY_A, tamperedHeader, SECRET);
+    // Assert
+    expect(result).toBe(false);
+  });
+});

--- a/worker/src/webhook/hmac.ts
+++ b/worker/src/webhook/hmac.ts
@@ -1,0 +1,34 @@
+/**
+ * HMAC-SHA256 webhook verification — verbatim port of §4.9 of the CF migration spec.
+ *
+ * Uses Web Crypto (native in the Workers runtime); no Node.js compat needed.
+ * Constant-time comparison via crypto.subtle.verify.
+ */
+
+/**
+ * Verify a GitHub webhook HMAC-SHA256 signature header.
+ *
+ * @param body   - Raw request body as ArrayBuffer.
+ * @param header - Value of the `X-Hub-Signature-256` header (e.g. "sha256=<hex>").
+ * @param secret - HMAC secret configured on the GitHub webhook.
+ * @returns true if the signature is valid, false otherwise.
+ */
+export async function verifyHmac(
+  body: ArrayBuffer,
+  header: string | null,
+  secret: string,
+): Promise<boolean> {
+  if (!header?.startsWith("sha256=")) return false;
+  const hexPart = header.slice(7);
+  const hexBytes = hexPart.match(/.{2}/g) ?? [];
+  if (hexBytes.length !== 32) return false;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+  const sig = Uint8Array.from(hexBytes.map((b) => parseInt(b, 16)));
+  return crypto.subtle.verify("HMAC", key, sig, body);
+}

--- a/worker/src/webhook/mutations.test.ts
+++ b/worker/src/webhook/mutations.test.ts
@@ -1,0 +1,504 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  UPSERT_ISSUE_FROM_WEBHOOK_SQL,
+  UPSERT_PR_STATE_SQL,
+  addEdge,
+  deleteIssue,
+  removeEdge,
+  renameMilestone,
+  replaceLabels,
+  setActiveBranch,
+  upsertEdges,
+  upsertIssueFromWebhook,
+  upsertPrState,
+} from "./mutations";
+import type { WebhookIssue } from "./mutations";
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from src/sync/sync.test.ts
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements produced via bind() calls on the FakeDb. */
+function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// upsertIssueFromWebhook
+// ---------------------------------------------------------------------------
+
+describe("upsertIssueFromWebhook", () => {
+  const baseIssue: WebhookIssue = {
+    key: "Roxabi/lyra#42",
+    repo: "Roxabi/lyra",
+    number: 42,
+    title: "Test issue",
+    state: "open",
+    url: "https://github.com/Roxabi/lyra/issues/42",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+    closed_at: null,
+    milestone: "Sprint 1",
+    lane: "backend",
+    priority: "P1",
+    size: "F-lite",
+  };
+
+  it("uses UPSERT_ISSUE_FROM_WEBHOOK_SQL constant", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertIssueFromWebhook(db, baseIssue);
+    // Assert
+    expect(stmts()[0].sql).toBe(UPSERT_ISSUE_FROM_WEBHOOK_SQL);
+  });
+
+  it("binds 13 args in the correct order matching WebhookIssue field layout", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertIssueFromWebhook(db, baseIssue);
+    // Assert — order: key, repo, number, title, state, url, created_at, updated_at, closed_at, milestone, lane, priority, size
+    expect(stmts()[0].args).toEqual([
+      "Roxabi/lyra#42",
+      "Roxabi/lyra",
+      42,
+      "Test issue",
+      "open",
+      "https://github.com/Roxabi/lyra/issues/42",
+      "2024-01-01T00:00:00Z",
+      "2024-01-02T00:00:00Z",
+      null,
+      "Sprint 1",
+      "backend",
+      "P1",
+      "F-lite",
+    ]);
+  });
+
+  it("coerces undefined optional fields to null", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const minimalIssue: WebhookIssue = {
+      key: "Roxabi/lyra#1",
+      repo: "Roxabi/lyra",
+      number: 1,
+      title: "Minimal",
+      state: "open",
+      url: "https://github.com/Roxabi/lyra/issues/1",
+    };
+    // Act
+    upsertIssueFromWebhook(db, minimalIssue);
+    // Assert — all optional fields become null
+    const args = stmts()[0].args;
+    expect(args).toHaveLength(13);
+    expect(args[6]).toBeNull(); // created_at
+    expect(args[7]).toBeNull(); // updated_at
+    expect(args[8]).toBeNull(); // closed_at
+    expect(args[9]).toBeNull(); // milestone
+    expect(args[10]).toBeNull(); // lane
+    expect(args[11]).toBeNull(); // priority
+    expect(args[12]).toBeNull(); // size
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replaceLabels
+// ---------------------------------------------------------------------------
+
+describe("replaceLabels", () => {
+  it("returns [DELETE stmt, ...INSERT stmts] — DELETE is first", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    const result = replaceLabels(db, "Roxabi/lyra#42", ["bug", "P1-high"]);
+    // Assert — 1 DELETE + 2 INSERTs = 3 stmts
+    expect(result).toHaveLength(3);
+    expect(stmts()[0].sql).toContain("DELETE FROM labels");
+    expect(stmts()[1].sql).toContain("INSERT OR IGNORE INTO labels");
+    expect(stmts()[2].sql).toContain("INSERT OR IGNORE INTO labels");
+  });
+
+  it("DELETE binds only issue_key", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    replaceLabels(db, "Roxabi/lyra#42", ["bug"]);
+    // Assert
+    expect(stmts()[0].args).toEqual(["Roxabi/lyra#42"]);
+  });
+
+  it("each INSERT binds (issue_key, name) in that order", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    replaceLabels(db, "Roxabi/lyra#42", ["bug", "P1-high"]);
+    // Assert
+    expect(stmts()[1].args).toEqual(["Roxabi/lyra#42", "bug"]);
+    expect(stmts()[2].args).toEqual(["Roxabi/lyra#42", "P1-high"]);
+  });
+
+  it("returns only DELETE stmt for empty names array", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    const result = replaceLabels(db, "Roxabi/lyra#42", []);
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(stmts()[0].sql).toContain("DELETE FROM labels");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addEdge
+// ---------------------------------------------------------------------------
+
+describe("addEdge", () => {
+  it("uses INSERT OR IGNORE SQL", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    addEdge(db, "Roxabi/lyra#1", "Roxabi/lyra#2", "parent");
+    // Assert
+    expect(stmts()[0].sql).toContain("INSERT OR IGNORE INTO edges");
+  });
+
+  it("binds (src, dst, kind) in that order", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    addEdge(db, "Roxabi/lyra#1", "Roxabi/lyra#2", "parent");
+    // Assert
+    expect(stmts()[0].args).toEqual(["Roxabi/lyra#1", "Roxabi/lyra#2", "parent"]);
+  });
+
+  it("passes kind=blocks through to bind list", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    addEdge(db, "Roxabi/lyra#3", "Roxabi/lyra#5", "blocks");
+    // Assert
+    expect(stmts()[0].args[2]).toBe("blocks");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeEdge
+// ---------------------------------------------------------------------------
+
+describe("removeEdge", () => {
+  it("uses DELETE SQL (not INSERT)", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    removeEdge(db, "Roxabi/lyra#1", "Roxabi/lyra#2", "parent");
+    // Assert
+    expect(stmts()[0].sql).toContain("DELETE FROM edges");
+    expect(stmts()[0].sql).not.toContain("INSERT");
+  });
+
+  it("binds (src, dst, kind) in that order", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    removeEdge(db, "Roxabi/lyra#1", "Roxabi/lyra#2", "parent");
+    // Assert
+    expect(stmts()[0].args).toEqual(["Roxabi/lyra#1", "Roxabi/lyra#2", "parent"]);
+  });
+
+  it("passes kind=blocks through to bind list with AND kind=? clause", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    removeEdge(db, "Roxabi/lyra#3", "Roxabi/lyra#5", "blocks");
+    // Assert
+    expect(stmts()[0].sql).toContain("AND kind");
+    expect(stmts()[0].args[2]).toBe("blocks");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertEdges
+// ---------------------------------------------------------------------------
+
+describe("upsertEdges", () => {
+  it("first stmt is DELETE-by-kind with issueKey bound twice + kind", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertEdges(db, "Roxabi/lyra#5", [], [], "parent");
+    // Assert
+    const del = stmts()[0];
+    expect(del.sql).toContain("DELETE FROM edges");
+    expect(del.sql).toContain("src_key = ?");
+    expect(del.sql).toContain("dst_key = ?");
+    expect(del.args).toEqual(["Roxabi/lyra#5", "Roxabi/lyra#5", "parent"]);
+  });
+
+  it("each blockedBy entry produces (src=blocker, dst=issueKey) INSERT", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertEdges(db, "Roxabi/lyra#5", ["Roxabi/lyra#3", "Roxabi/lyra#4"], [], "parent");
+    // Assert — stmts: [DELETE, INSERT for #3, INSERT for #4]
+    expect(stmts()).toHaveLength(3);
+    expect(stmts()[1].args).toEqual(["Roxabi/lyra#3", "Roxabi/lyra#5", "parent"]);
+    expect(stmts()[2].args).toEqual(["Roxabi/lyra#4", "Roxabi/lyra#5", "parent"]);
+  });
+
+  it("each blocking entry produces (src=issueKey, dst=blockee) INSERT", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertEdges(db, "Roxabi/lyra#5", [], ["Roxabi/lyra#7", "Roxabi/lyra#8"], "blocks");
+    // Assert — stmts: [DELETE, INSERT for #7, INSERT for #8]
+    expect(stmts()).toHaveLength(3);
+    expect(stmts()[1].args).toEqual(["Roxabi/lyra#5", "Roxabi/lyra#7", "blocks"]);
+    expect(stmts()[2].args).toEqual(["Roxabi/lyra#5", "Roxabi/lyra#8", "blocks"]);
+  });
+
+  it("combines blockedBy and blocking — blockedBy first, blocking after", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertEdges(db, "Roxabi/lyra#5", ["Roxabi/lyra#3"], ["Roxabi/lyra#7"], "parent");
+    // Assert — [DELETE, blockedBy INSERT, blocking INSERT]
+    expect(stmts()).toHaveLength(3);
+    expect(stmts()[1].args).toEqual(["Roxabi/lyra#3", "Roxabi/lyra#5", "parent"]);
+    expect(stmts()[2].args).toEqual(["Roxabi/lyra#5", "Roxabi/lyra#7", "parent"]);
+  });
+
+  it("defaults kind to 'parent' when omitted", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertEdges(db, "Roxabi/lyra#5", [], []);
+    // Assert
+    expect(stmts()[0].args[2]).toBe("parent");
+  });
+
+  it("returns only DELETE stmt when both arrays are empty", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    const result = upsertEdges(db, "Roxabi/lyra#5", [], [], "blocks");
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(stmts()[0].sql).toContain("DELETE FROM edges");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteIssue
+// ---------------------------------------------------------------------------
+
+describe("deleteIssue", () => {
+  it("uses DELETE FROM issues WHERE key=? SQL", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    deleteIssue(db, "Roxabi/lyra#42");
+    // Assert
+    expect(stmts()[0].sql).toContain("DELETE FROM issues");
+    expect(stmts()[0].sql).toContain("key");
+  });
+
+  it("binds the issue key", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    deleteIssue(db, "Roxabi/lyra#42");
+    // Assert
+    expect(stmts()[0].args).toEqual(["Roxabi/lyra#42"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setActiveBranch
+// ---------------------------------------------------------------------------
+
+describe("setActiveBranch", () => {
+  it("uses SET has_active_branch=1 SQL when value=1", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    setActiveBranch(db, "Roxabi/lyra", 42, 1);
+    // Assert
+    expect(stmts()[0].sql).toContain("has_active_branch=1");
+  });
+
+  it("binds (repo, number) for value=1", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    setActiveBranch(db, "Roxabi/lyra", 42, 1);
+    // Assert
+    expect(stmts()[0].args).toEqual(["Roxabi/lyra", 42]);
+  });
+
+  it("uses SET has_active_branch=0 SQL when value=0", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    setActiveBranch(db, "Roxabi/lyra", 7, 0);
+    // Assert
+    expect(stmts()[0].sql).toContain("has_active_branch=0");
+  });
+
+  it("binds (repo, number) for value=0", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    setActiveBranch(db, "Roxabi/lyra", 7, 0);
+    // Assert
+    expect(stmts()[0].args).toEqual(["Roxabi/lyra", 7]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertPrState
+// ---------------------------------------------------------------------------
+
+describe("upsertPrState", () => {
+  it("uses UPSERT_PR_STATE_SQL constant", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertPrState(db, "Roxabi/lyra", 5, "open", 0, "[]", "2024-01-01T00:00:00Z");
+    // Assert
+    expect(stmts()[0].sql).toBe(UPSERT_PR_STATE_SQL);
+  });
+
+  it("binds 6 args in order: repo, number, state, hasReviewedLabel, closingIssueKeysJson, updatedAt", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertPrState(
+      db,
+      "Roxabi/lyra",
+      5,
+      "open",
+      1,
+      '["Roxabi/lyra#42"]',
+      "2024-06-01T12:00:00Z",
+    );
+    // Assert
+    expect(stmts()[0].args).toEqual([
+      "Roxabi/lyra",
+      5,
+      "open",
+      1,
+      '["Roxabi/lyra#42"]',
+      "2024-06-01T12:00:00Z",
+    ]);
+  });
+
+  it("accepts hasReviewedLabel=0 correctly", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    upsertPrState(db, "Roxabi/lyra", 5, "closed", 0, "[]", "2024-06-01T00:00:00Z");
+    // Assert
+    expect(stmts()[0].args[3]).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renameMilestone
+// ---------------------------------------------------------------------------
+
+describe("renameMilestone", () => {
+  it("uses UPDATE issues SET milestone=? WHERE repo=? AND milestone=? SQL", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    renameMilestone(db, "Roxabi/lyra", "Sprint 1", "Sprint 2");
+    // Assert
+    expect(stmts()[0].sql).toContain("UPDATE issues");
+    expect(stmts()[0].sql).toContain("milestone");
+    expect(stmts()[0].sql).toContain("repo");
+  });
+
+  it("binds (newTitle, repo, oldTitle) — newTitle first, oldTitle last", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    renameMilestone(db, "Roxabi/lyra", "Sprint 1", "Sprint 2");
+    // Assert
+    expect(stmts()[0].args).toEqual(["Sprint 2", "Roxabi/lyra", "Sprint 1"]);
+  });
+});

--- a/worker/src/webhook/mutations.ts
+++ b/worker/src/webhook/mutations.ts
@@ -78,7 +78,7 @@ export interface WebhookIssue {
   number: number;
   title: string;
   state: string;
-  url: string;
+  url: string | null;
   created_at?: string | null;
   updated_at?: string | null;
   closed_at?: string | null;

--- a/worker/src/webhook/mutations.ts
+++ b/worker/src/webhook/mutations.ts
@@ -1,0 +1,239 @@
+/**
+ * D1 mutation helpers for the webhook layer.
+ *
+ * Verbatim port of src/roxabi_live/corpus/mutations.py to the Cloudflare
+ * Workers / D1 runtime.
+ *
+ * Design contract (mirrors the Python original):
+ * - NEVER call .run() inside a helper — the caller owns the transaction
+ *   boundary via db.batch([...stmts]).
+ * - Single-statement helpers return D1PreparedStatement.
+ * - Multi-statement helpers (upsertEdges, replaceLabels) return
+ *   D1PreparedStatement[] so the caller can fold them into one batch.
+ * - SQL constants are exported so callers can inspect or test them.
+ */
+
+// ---------------------------------------------------------------------------
+// SQL constants (verbatim from corpus/sync.py — SSoT for both paths)
+// ---------------------------------------------------------------------------
+
+/** Webhook upsert — preserves status (Project v2) and has_active_branch. */
+export const UPSERT_ISSUE_FROM_WEBHOOK_SQL = `
+  INSERT INTO issues
+      (key, repo, number, title, state, url, created_at, updated_at, closed_at,
+       milestone, is_stub, lane, priority, size, status, has_active_branch)
+  VALUES
+      (?, ?, ?, ?, ?, ?, ?, ?, ?,
+       ?, 0, ?, ?, ?, NULL, 0)
+  ON CONFLICT(key) DO UPDATE SET
+      repo       = excluded.repo,
+      number     = excluded.number,
+      title      = excluded.title,
+      state      = excluded.state,
+      url        = excluded.url,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at,
+      closed_at  = excluded.closed_at,
+      milestone  = excluded.milestone,
+      is_stub    = excluded.is_stub,
+      lane       = excluded.lane,
+      priority   = excluded.priority,
+      size       = excluded.size
+`;
+
+/** PR state upsert — shared with sync path (byte-identical SQL on both paths). */
+export const UPSERT_PR_STATE_SQL = `
+  INSERT INTO pr_state
+      (repo, number, state, has_reviewed_label, closing_issue_keys, updated_at)
+  VALUES
+      (?, ?, ?, ?, ?, ?)
+  ON CONFLICT(repo, number) DO UPDATE SET
+      state               = excluded.state,
+      has_reviewed_label  = excluded.has_reviewed_label,
+      closing_issue_keys  = excluded.closing_issue_keys,
+      updated_at          = excluded.updated_at
+`;
+
+const DELETE_LABELS_SQL = "DELETE FROM labels WHERE issue_key = ?";
+const INSERT_LABEL_SQL = "INSERT OR IGNORE INTO labels (issue_key, name) VALUES (?, ?)";
+const DELETE_EDGES_BY_KIND_SQL =
+  "DELETE FROM edges WHERE (src_key = ? OR dst_key = ?) AND kind = ?";
+const INSERT_EDGE_SQL = "INSERT OR IGNORE INTO edges (src_key, dst_key, kind) VALUES (?, ?, ?)";
+const DELETE_EDGE_SQL =
+  "DELETE FROM edges WHERE src_key = ? AND dst_key = ? AND kind = ?";
+const SET_ACTIVE_BRANCH_ON_SQL =
+  "UPDATE issues SET has_active_branch=1 WHERE repo=? AND number=?";
+const SET_ACTIVE_BRANCH_OFF_SQL =
+  "UPDATE issues SET has_active_branch=0 WHERE repo=? AND number=?";
+const RENAME_MILESTONE_SQL =
+  "UPDATE issues SET milestone = ? WHERE repo = ? AND milestone = ?";
+
+// ---------------------------------------------------------------------------
+// WebhookIssue — partial issue shape expected by upsertIssue
+// ---------------------------------------------------------------------------
+
+export interface WebhookIssue {
+  key: string;
+  repo: string;
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  closed_at?: string | null;
+  milestone?: string | null;
+  lane?: string | null;
+  priority?: string | null;
+  size?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — each returns D1PreparedStatement (or array); never calls .run()
+// ---------------------------------------------------------------------------
+
+/**
+ * Prepare an upsert statement for an issue from a webhook payload.
+ * Uses UPSERT_ISSUE_FROM_WEBHOOK_SQL — preserves status and has_active_branch.
+ */
+export function upsertIssueFromWebhook(db: D1Database, issue: WebhookIssue): D1PreparedStatement {
+  return db.prepare(UPSERT_ISSUE_FROM_WEBHOOK_SQL).bind(
+    issue.key,
+    issue.repo,
+    issue.number,
+    issue.title,
+    issue.state,
+    issue.url,
+    issue.created_at ?? null,
+    issue.updated_at ?? null,
+    issue.closed_at ?? null,
+    issue.milestone ?? null,
+    issue.lane ?? null,
+    issue.priority ?? null,
+    issue.size ?? null,
+  );
+}
+
+/**
+ * Prepare statements to wipe all labels for an issue key and rewrite them.
+ * Returns [DELETE stmt, ...INSERT stmts].
+ */
+export function replaceLabels(
+  db: D1Database,
+  key: string,
+  names: string[],
+): D1PreparedStatement[] {
+  const stmts: D1PreparedStatement[] = [db.prepare(DELETE_LABELS_SQL).bind(key)];
+  for (const name of names) {
+    stmts.push(db.prepare(INSERT_LABEL_SQL).bind(key, name));
+  }
+  return stmts;
+}
+
+/**
+ * Prepare a single INSERT OR IGNORE edge statement.
+ */
+export function addEdge(
+  db: D1Database,
+  src: string,
+  dst: string,
+  kind: string,
+): D1PreparedStatement {
+  return db.prepare(INSERT_EDGE_SQL).bind(src, dst, kind);
+}
+
+/**
+ * Prepare a single DELETE edge statement.
+ */
+export function removeEdge(
+  db: D1Database,
+  src: string,
+  dst: string,
+  kind: string,
+): D1PreparedStatement {
+  return db.prepare(DELETE_EDGE_SQL).bind(src, dst, kind);
+}
+
+/**
+ * Prepare a DELETE issue statement.
+ */
+export function deleteIssue(db: D1Database, key: string): D1PreparedStatement {
+  return db.prepare("DELETE FROM issues WHERE key = ?").bind(key);
+}
+
+/**
+ * Prepare statements to wipe all edges touching issueKey (as src OR dst) of
+ * the given kind, then rewrite from blockedBy + blocking.
+ *
+ * Canonical direction (mirrors corpus/mutations.py):
+ *   blockedBy: every b → row (src=b, dst=issueKey)
+ *   blocking:  every b → row (src=issueKey, dst=b)
+ *
+ * Returns [DELETE stmt, ...INSERT stmts].
+ */
+export function upsertEdges(
+  db: D1Database,
+  issueKey: string,
+  blockedBy: string[],
+  blocking: string[],
+  kind: string = "parent",
+): D1PreparedStatement[] {
+  const stmts: D1PreparedStatement[] = [
+    db.prepare(DELETE_EDGES_BY_KIND_SQL).bind(issueKey, issueKey, kind),
+  ];
+  for (const blocker of blockedBy) {
+    stmts.push(db.prepare(INSERT_EDGE_SQL).bind(blocker, issueKey, kind));
+  }
+  for (const blockee of blocking) {
+    stmts.push(db.prepare(INSERT_EDGE_SQL).bind(issueKey, blockee, kind));
+  }
+  return stmts;
+}
+
+/**
+ * Prepare a statement to set or clear has_active_branch for an issue.
+ * value: 1 = active, 0 = clear.
+ */
+export function setActiveBranch(
+  db: D1Database,
+  repo: string,
+  number: number,
+  value: 0 | 1,
+): D1PreparedStatement {
+  const sql = value ? SET_ACTIVE_BRANCH_ON_SQL : SET_ACTIVE_BRANCH_OFF_SQL;
+  return db.prepare(sql).bind(repo, number);
+}
+
+/**
+ * Prepare a statement to upsert a pr_state row.
+ */
+export function upsertPrState(
+  db: D1Database,
+  repo: string,
+  number: number,
+  state: string,
+  hasReviewedLabel: 0 | 1,
+  closingIssueKeysJson: string,
+  updatedAt: string,
+): D1PreparedStatement {
+  return db.prepare(UPSERT_PR_STATE_SQL).bind(
+    repo,
+    number,
+    state,
+    hasReviewedLabel,
+    closingIssueKeysJson,
+    updatedAt,
+  );
+}
+
+/**
+ * Prepare a statement to rename a milestone across all issues in a repo.
+ */
+export function renameMilestone(
+  db: D1Database,
+  repo: string,
+  oldTitle: string,
+  newTitle: string,
+): D1PreparedStatement {
+  return db.prepare(RENAME_MILESTONE_SQL).bind(newTitle, repo, oldTitle);
+}


### PR DESCRIPTION
## Summary
- Port `POST /webhook/github` (HMAC-gated, real-time corpus updates) from the Python FastAPI app to the Cloudflare Worker — **verbatim port**, S5 of the CF serverless migration (#92).
- Adds `worker/src/webhook/`: `mutations.ts` (9 D1 statement-builders + 2 SQL consts), `hmac.ts` (Web Crypto HMAC-SHA256 verify), `handlers.ts` (7 event handlers + `webhookRoute` dispatch), wired into `router.ts` before the `ASSETS` fallback.
- Runtime-forced deltas only: D1 has no interactive transactions → atomic multi-statement writes use `db.batch([...])`; no in-process reconciler → all `trigger_heal()` calls dropped; `handleRefDelete` uses `env.DB` (no fresh connection).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #97: CF S5 — Webhook handlers + HMAC-SHA256 (Web Crypto) | OPEN (P1-high) |
| Spec | #92 epic spec §4.8/§4.9 (`artifacts/specs/92-cloudflare-serverless-migration.md`) | Present (shared) |
| Plan | [97-cf-s5-webhook-handlers-plan.mdx](artifacts/plans/97-cf-s5-webhook-handlers-plan.mdx) | Present |
| Implementation | 3 commits on `feat/97-cf-s5-webhook-handlers` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (worker 150 pass · 3 new test files · repo 659 pytest pass) | Passed |

## Test Plan
- [ ] `cd worker && npx tsc --noEmit && npx vitest run` → 150 green
- [ ] HMAC: valid sig → 200, tampered body/sig → 401, missing secret → 503, bad JSON → 400, body > 25 MB → 413, unknown event → `{ok:true,ignored}`
- [ ] Handlers: issue upsert+labels atomic (`db.batch`), deps same-repo edge add/remove + cross-repo point-fetch, sub-issues `kind=parent`, ref create → `has_active_branch=1`, ref delete → `syncBranches` re-query, PR merged→closed + reviewed-label + closing-keyword parse, milestone rename
- [ ] Post-merge (tracked under #92, not this PR): `wrangler secret put GITHUB_WEBHOOK_SECRET --env staging`; CF Access App-2 `/webhook/*` → Bypass; register GitHub org webhook → staging Worker; live 200 test delivery

Fixes #97

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
