### PR TITLE
feat(frontend): wire v6 dep-graph assets via Workers-with-assets (#99)

### DIFF
--- a/frontend/app.css
+++ b/frontend/app.css
@@ -1,0 +1,710 @@
+:root, [data-theme="dark"] {
+  --bg:          #0d1117;
+  --bg-panel:    #13191f;
+  --bg-card:     #161b22;
+  --bg-cell:     #0f141a;
+  --border:      #21262d;
+  --border-hi:   #30363d;
+  --text:        #fafafa;
+  --text-muted:  #8b93a1;
+  --text-dim:    #6b7280;
+  --accent:      #e85d04;
+  --accent-dim:  rgba(232,93,4,0.12);
+  --accent-glow: rgba(232,93,4,0.4);
+  --green:       #10b981;
+  --teal:        #14b8a6;
+  --status-open:   #22c55e;
+  --status-closed: #475569;
+  --status-ready:  #22c55e;
+  --status-blocked: #f97316;
+  --status-done:    #475569;
+  --panel-shadow:  0 8px 24px rgba(0,0,0,0.5);
+  --row-header-grad: linear-gradient(180deg, rgba(255,255,255,0.03), transparent);
+  --hl-dim-bg:     rgba(255,255,255,0.04);
+}
+
+[data-theme="light"] {
+  --bg:          #f5f2ec;
+  --bg-panel:    #ede9e0;
+  --bg-card:     #faf8f4;
+  --bg-cell:     #fffdf8;
+  --border:      rgba(0,0,0,0.09);
+  --border-hi:   rgba(0,0,0,0.18);
+  --text:        #1a1d2b;
+  --text-muted:  #5a6070;
+  --text-dim:    #9aa0ae;
+  --accent:      #b8760a;
+  --accent-dim:  rgba(184,118,10,0.12);
+  --accent-glow: rgba(184,118,10,0.35);
+  --green:       #047857;
+  --teal:        #0891b2;
+  --status-open:   #047857;
+  --status-closed: #9ca3af;
+  --status-ready:  #047857;
+  --status-blocked: #ea580c;
+  --status-done:    #9ca3af;
+  --panel-shadow:  0 8px 24px rgba(0,0,0,0.12);
+  --row-header-grad: linear-gradient(180deg, rgba(0,0,0,0.025), transparent);
+  --hl-dim-bg:     rgba(0,0,0,0.04);
+
+  /* Lane tones */
+  --lane-a1: #e85d04; --lane-a2: #f97316; --lane-a3: #fb923c;
+  --lane-b:  #14b8a6;
+  --lane-c1: #8b5cf6; --lane-c2: #a78bfa; --lane-c3: #c4b5fd;
+  --lane-d:  #3b82f6;
+  --lane-e:  #10b981;
+  --lane-f:  #f59e0b;
+  --lane-g:  #ec4899;
+  --lane-h:  #6366f1;
+  --lane-i:  #84cc16;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* Global scrollbars match dark theme */
+html { scrollbar-width: thin; scrollbar-color: var(--border-hi) var(--bg); }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb {
+  background: var(--border-hi); border-radius: 5px;
+  border: 2px solid var(--bg);
+}
+::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+::-webkit-scrollbar-corner { background: var(--bg); }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 24px;
+  min-height: 100vh;
+  transition: background 0.2s, color 0.2s;
+}
+
+/* ─── Theme toggle ───────────────────────────────────────────── */
+.theme-btn {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 5px 10px;
+  line-height: 1;
+  transition: border-color 0.15s, color 0.15s;
+}
+.theme-btn:hover { border-color: var(--accent); color: var(--accent); }
+.theme-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.header-actions { display: inline-flex; align-items: center; gap: 8px; }
+
+/* ─── Sticky header ──────────────────────────────────────────── */
+.sticky-head {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  margin: -24px -24px 0;
+  padding: 16px 24px 12px;
+}
+
+header.page-header {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  gap: 16px; flex-wrap: wrap;
+}
+h1 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 22px; font-weight: 700; letter-spacing: -0.02em;
+}
+h1 .accent { color: var(--accent); }
+.subtitle {
+  color: var(--text-muted); font-size: 12px; margin-top: 6px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ─── Mode toggle ────────────────────────────────────────────── */
+/* ─── Segmented control (forge-style) ─────────────────────────── */
+.segs {
+  display: inline-flex; background: var(--bg-card);
+  border: 1px solid var(--border); border-radius: 6px; overflow: hidden;
+  vertical-align: middle;
+}
+.seg {
+  background: none; border: 0; border-right: 1px solid var(--border);
+  color: var(--text-dim); cursor: pointer;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; font-weight: 500; letter-spacing: 0.02em;
+  padding: 5px 10px; white-space: nowrap;
+  transition: background 0.1s, color 0.1s;
+}
+.seg:last-child { border-right: 0; }
+.seg:hover { background: var(--bg-panel); color: var(--text); }
+.seg.on {
+  background: var(--accent-dim); color: var(--accent); font-weight: 600;
+}
+.seg:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.seg .ico {
+  display: inline-block; margin-right: 4px;
+  font-family: 'JetBrains Mono', monospace;
+}
+.view-segs .seg { padding: 6px 12px; font-size: 11px; }
+
+/* ─── Toolbar ────────────────────────────────────────────────── */
+.toolbar {
+  display: flex; gap: 10px; align-items: center; padding: 10px 0 0; flex-wrap: wrap;
+}
+.toolbar-label {
+  font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-muted);
+}
+select {
+  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  background: var(--bg-card); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: 5px 8px; cursor: pointer;
+}
+select:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+.search-wrap {
+  position: relative; display: inline-flex; align-items: center;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px;
+}
+.search-wrap:focus-within { border-color: var(--accent); }
+#search-input {
+  font-family: 'Inter', sans-serif; font-size: 11px;
+  background: transparent; color: var(--text);
+  border: 0; padding: 5px 28px 5px 8px; width: 160px; outline: none;
+  -webkit-appearance: none; appearance: none;
+}
+#search-input::-webkit-search-cancel-button,
+#search-input::-webkit-search-decoration { display: none; }
+#search-input::placeholder { color: var(--text-dim); }
+.clear-btn {
+  position: absolute; right: 4px;
+  background: none; border: 0; color: var(--text-muted); cursor: pointer;
+  font-size: 14px; line-height: 1; padding: 2px 4px; border-radius: 3px;
+}
+.clear-btn:hover { color: var(--text); }
+
+.pivot-controls { display: inline-flex; gap: 10px; align-items: center; }
+.view-list-active .pivot-controls { display: none; }
+
+/* ─── Views ──────────────────────────────────────────────────── */
+.view { display: none; padding-top: 20px; }
+.view.view-active { display: block; }
+main { padding-bottom: 24px; }
+
+/* ─── Table / Pivot ──────────────────────────────────────────── */
+.pivot-table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+.pivot-table th, .pivot-table td {
+  border: 1px solid var(--border); padding: 6px 8px; vertical-align: top; min-width: 140px;
+}
+.pivot-table th {
+  background: var(--bg-panel); font-family: 'JetBrains Mono', monospace;
+  font-size: 10px; font-weight: 600; color: var(--text-muted);
+  text-align: left; letter-spacing: 0.04em; white-space: nowrap;
+}
+.pivot-table th.row-header-th { width: 150px; min-width: 150px; }
+.pivot-table td { background: var(--bg-cell); }
+.pivot-table td.empty-cell { opacity: 0.4; }
+
+.ms-row-header { display: flex; flex-direction: column; gap: 3px; }
+.ms-row-code {
+  font-family: 'JetBrains Mono', monospace; font-size: 12px;
+  font-weight: 700; color: var(--accent); letter-spacing: 0.04em;
+}
+.ms-row-name { font-size: 10px; color: var(--text-muted); line-height: 1.3; }
+
+.cell-count {
+  font-family: 'JetBrains Mono', monospace; font-size: 9px;
+  color: var(--text-dim); margin-bottom: 4px;
+}
+.cell-issues { display: flex; flex-direction: column; gap: 3px; }
+
+/* ─── Issue cards ────────────────────────────────────────────── */
+.issue-card {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 5px 6px; background: var(--bg-card);
+  border: 1px solid var(--border); border-left: 3px solid var(--accent);
+  border-radius: 4px; font-size: 10.5px; color: var(--text);
+  text-decoration: none; transition: background 0.12s;
+}
+.issue-card:hover { background: var(--bg-panel); }
+.issue-card.state-closed { opacity: 0.45; }
+.issue-card.state-closed .card-title { text-decoration: line-through; color: var(--text-muted); }
+
+.card-head {
+  display: flex; gap: 5px; align-items: center; flex-wrap: wrap;
+}
+.card-dot {
+  width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
+  background: var(--status-closed);
+}
+.state-open .card-dot {
+  background: var(--status-open); box-shadow: 0 0 4px var(--status-open);
+}
+.status-blocked .card-dot {
+  background: var(--status-blocked); box-shadow: 0 0 4px rgba(249,115,22,0.6);
+}
+.card-num {
+  font-family: 'JetBrains Mono', monospace; font-size: 10px;
+  font-weight: 700; color: var(--accent); flex-shrink: 0;
+}
+.card-title { flex: 1; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.card-badges { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; margin-top: 1px; }
+
+.badge {
+  font-family: 'JetBrains Mono', monospace; font-size: 8.5px; font-weight: 600;
+  padding: 1px 4px; border-radius: 3px; border: 1px solid var(--border);
+  background: var(--bg); color: var(--text-muted); letter-spacing: 0.05em;
+}
+.badge-repo { color: var(--text-dim); }
+.badge-ms   { color: var(--accent); border-color: var(--accent-dim); background: var(--accent-dim); }
+.badge-p0   { color: #ef4444; border-color: rgba(239,68,68,0.3); }
+.badge-p1   { color: #f97316; border-color: rgba(249,115,22,0.3); }
+.badge-p2   { color: #eab308; border-color: rgba(234,179,8,0.3); }
+.badge-p3   { color: var(--text-muted); }
+
+.card-deps {
+  display: flex; justify-content: space-between;
+  font-family: 'JetBrains Mono', monospace; font-size: 9px;
+  color: var(--text-dim); margin-top: 2px; line-height: 1.5;
+}
+.dep-label { color: var(--text-muted); }
+.dep-parent { text-align: right; }
+
+/* ─── Multi-select pill dropdown ─────────────────────────────── */
+.ms-wrap { position: relative; }
+
+.ms-trigger {
+  display: inline-flex; align-items: center; flex-wrap: wrap; gap: 3px;
+  min-width: 90px; max-width: 240px;
+  padding: 4px 8px; cursor: pointer;
+  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  background: var(--bg-card); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  text-align: left; transition: border-color 0.12s;
+}
+.ms-trigger:hover { border-color: var(--border-hi); }
+.ms-trigger:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ms-trigger[aria-expanded="true"] { border-color: var(--accent); }
+
+.ms-placeholder { color: var(--text-dim); }
+
+.ms-pill {
+  display: inline-block; padding: 1px 5px; border-radius: 3px;
+  background: var(--accent-dim); color: var(--accent);
+  border: 1px solid rgba(232,93,4,0.3);
+  font-size: 10px; font-weight: 600; white-space: nowrap;
+}
+/* Tone-colored pills (repo filter) — same palette as cards/graph nodes.
+   color-mix keeps the translucent chip look without per-tone background vars. */
+.ms-pill[data-tone="a1"] { color: var(--lane-a1); background: color-mix(in srgb, var(--lane-a1) 15%, transparent); border-color: color-mix(in srgb, var(--lane-a1) 40%, transparent); }
+.ms-pill[data-tone="a2"] { color: var(--lane-a2); background: color-mix(in srgb, var(--lane-a2) 15%, transparent); border-color: color-mix(in srgb, var(--lane-a2) 40%, transparent); }
+.ms-pill[data-tone="b"]  { color: var(--lane-b);  background: color-mix(in srgb, var(--lane-b)  15%, transparent); border-color: color-mix(in srgb, var(--lane-b)  40%, transparent); }
+.ms-pill[data-tone="c1"] { color: var(--lane-c1); background: color-mix(in srgb, var(--lane-c1) 15%, transparent); border-color: color-mix(in srgb, var(--lane-c1) 40%, transparent); }
+.ms-pill[data-tone="d"]  { color: var(--lane-d);  background: color-mix(in srgb, var(--lane-d)  15%, transparent); border-color: color-mix(in srgb, var(--lane-d)  40%, transparent); }
+.ms-pill[data-tone="e"]  { color: var(--lane-e);  background: color-mix(in srgb, var(--lane-e)  15%, transparent); border-color: color-mix(in srgb, var(--lane-e)  40%, transparent); }
+.ms-pill[data-tone="f"]  { color: var(--lane-f);  background: color-mix(in srgb, var(--lane-f)  15%, transparent); border-color: color-mix(in srgb, var(--lane-f)  40%, transparent); }
+.ms-pill[data-tone="g"]  { color: var(--lane-g);  background: color-mix(in srgb, var(--lane-g)  15%, transparent); border-color: color-mix(in srgb, var(--lane-g)  40%, transparent); }
+.ms-pill[data-tone="h"]  { color: var(--lane-h);  background: color-mix(in srgb, var(--lane-h)  15%, transparent); border-color: color-mix(in srgb, var(--lane-h)  40%, transparent); }
+.ms-pill[data-tone="i"]  { color: var(--lane-i);  background: color-mix(in srgb, var(--lane-i)  15%, transparent); border-color: color-mix(in srgb, var(--lane-i)  40%, transparent); }
+.ms-pill[data-tone="teal"]   { color: var(--repo-teal);   background: color-mix(in srgb, var(--repo-teal)   15%, transparent); border-color: color-mix(in srgb, var(--repo-teal)   40%, transparent); }
+.ms-pill[data-tone="blue"]   { color: var(--repo-blue);   background: color-mix(in srgb, var(--repo-blue)   15%, transparent); border-color: color-mix(in srgb, var(--repo-blue)   40%, transparent); }
+.ms-pill[data-tone="pink"]   { color: var(--repo-pink);   background: color-mix(in srgb, var(--repo-pink)   15%, transparent); border-color: color-mix(in srgb, var(--repo-pink)   40%, transparent); }
+.ms-pill[data-tone="plum"]   { color: var(--repo-plum);   background: color-mix(in srgb, var(--repo-plum)   15%, transparent); border-color: color-mix(in srgb, var(--repo-plum)   40%, transparent); }
+.ms-pill[data-tone="orange"] { color: var(--repo-orange); background: color-mix(in srgb, var(--repo-orange) 15%, transparent); border-color: color-mix(in srgb, var(--repo-orange) 40%, transparent); }
+.ms-pill[data-tone="red"]    { color: var(--repo-red);    background: color-mix(in srgb, var(--repo-red)    15%, transparent); border-color: color-mix(in srgb, var(--repo-red)    40%, transparent); }
+.ms-pill[data-tone="lime"]   { color: var(--repo-lime);   background: color-mix(in srgb, var(--repo-lime)   15%, transparent); border-color: color-mix(in srgb, var(--repo-lime)   40%, transparent); }
+.ms-pill[data-tone="amber"]  { color: var(--repo-amber);  background: color-mix(in srgb, var(--repo-amber)  15%, transparent); border-color: color-mix(in srgb, var(--repo-amber)  40%, transparent); }
+.ms-pill[data-tone="green"]  { color: var(--repo-green);  background: color-mix(in srgb, var(--repo-green)  15%, transparent); border-color: color-mix(in srgb, var(--repo-green)  40%, transparent); }
+.ms-pill[data-tone="gray"]   { color: var(--repo-gray);   background: color-mix(in srgb, var(--repo-gray)   15%, transparent); border-color: color-mix(in srgb, var(--repo-gray)   40%, transparent); }
+.ms-pill[data-tone="cyan"]   { color: var(--repo-cyan);   background: color-mix(in srgb, var(--repo-cyan)   15%, transparent); border-color: color-mix(in srgb, var(--repo-cyan)   40%, transparent); }
+.ms-pill[data-tone="indigo"]  { color: var(--repo-indigo);  background: color-mix(in srgb, var(--repo-indigo)  15%, transparent); border-color: color-mix(in srgb, var(--repo-indigo)  40%, transparent); }
+.ms-pill[data-tone="rose"]    { color: var(--repo-rose);    background: color-mix(in srgb, var(--repo-rose)    15%, transparent); border-color: color-mix(in srgb, var(--repo-rose)    40%, transparent); }
+.ms-pill[data-tone="violet"]  { color: var(--repo-violet);  background: color-mix(in srgb, var(--repo-violet)  15%, transparent); border-color: color-mix(in srgb, var(--repo-violet)  40%, transparent); }
+.ms-pill[data-tone="brown"]   { color: var(--repo-brown);   background: color-mix(in srgb, var(--repo-brown)   15%, transparent); border-color: color-mix(in srgb, var(--repo-brown)   40%, transparent); }
+.ms-pill[data-tone="fuchsia"] { color: var(--repo-fuchsia); background: color-mix(in srgb, var(--repo-fuchsia) 15%, transparent); border-color: color-mix(in srgb, var(--repo-fuchsia) 40%, transparent); }
+.ms-pill[data-tone="yellow"]  { color: var(--repo-yellow);  background: color-mix(in srgb, var(--repo-yellow)  15%, transparent); border-color: color-mix(in srgb, var(--repo-yellow)  40%, transparent); }
+
+.ms-panel {
+  position: fixed; z-index: 500;
+  min-width: 180px; max-height: 320px; overflow-y: auto;
+  background: var(--bg-panel); border: 1px solid var(--border-hi);
+  border-radius: 8px; box-shadow: var(--panel-shadow);
+  padding: 6px 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-hi) transparent;
+}
+.ms-panel::-webkit-scrollbar { width: 8px; height: 8px; }
+.ms-panel::-webkit-scrollbar-track { background: transparent; }
+.ms-panel::-webkit-scrollbar-thumb {
+  background: var(--border-hi); border-radius: 4px;
+  border: 2px solid var(--bg-panel);
+}
+.ms-panel::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+
+/* Inline × next to trigger — clears that filter without opening panel */
+.ms-wrap { position: relative; display: inline-flex; align-items: center; gap: 2px; }
+.ms-clear-inline {
+  background: none; border: 0; color: var(--text-dim); cursor: pointer;
+  font-size: 15px; line-height: 1; padding: 2px 5px; border-radius: 4px;
+  transition: color 0.1s, background 0.1s;
+}
+.ms-clear-inline:hover { color: var(--accent); background: var(--bg-panel); }
+.ms-clear-inline:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+.ms-list { list-style: none; }
+.ms-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 5px 12px; cursor: pointer;
+  font-family: 'Inter', sans-serif; font-size: 12px;
+  color: var(--text-muted); transition: background 0.08s;
+}
+.ms-item:hover { background: var(--bg-card); color: var(--text); }
+.ms-item input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
+
+.ms-clear {
+  display: block; width: 100%; margin-top: 4px; padding: 4px 12px;
+  border: 0; border-top: 1px solid var(--border);
+  background: none; color: var(--text-dim); font-size: 11px;
+  font-family: 'JetBrains Mono', monospace; cursor: pointer; text-align: left;
+}
+.ms-clear:hover { color: var(--accent); }
+
+.list-controls { display: inline-flex; gap: 8px; align-items: center; }
+.graph-controls { display: inline-flex; gap: 8px; align-items: center; }
+
+/* ─── List flat-table view ───────────────────────────────────── */
+.list-table {
+  width: 100%; border-collapse: collapse;
+  font-family: 'Inter', sans-serif; font-size: 12px;
+}
+.list-table th {
+  background: var(--bg-panel); color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 600;
+  letter-spacing: 0.04em; text-align: center;
+  padding: 6px 8px; border-bottom: 1px solid var(--border);
+  white-space: nowrap; position: sticky; top: 0; z-index: 10;
+}
+.list-table th.sortable { cursor: pointer; user-select: none; }
+.list-table th.sortable:hover { color: var(--text); }
+.list-table th.sort-asc::after  { content: ' ▲'; font-size: 9px; }
+.list-table th.sort-desc::after { content: ' ▼'; font-size: 9px; }
+
+.list-table td {
+  padding: 5px 8px; border-bottom: 1px solid var(--border);
+  vertical-align: middle; color: var(--text);
+}
+.list-table tr.issue-row:hover td { background: var(--bg-panel); }
+.list-table tr.issue-row.state-closed td { opacity: 0.5; }
+
+.issue-link {
+  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  font-weight: 700; color: var(--accent); text-decoration: none; white-space: nowrap;
+}
+.issue-link:hover { text-decoration: underline; }
+
+.col-dot { width: 24px; text-align: center; }
+.state-dot {
+  display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+  cursor: default;
+}
+.dot-open   { background: var(--status-open);   box-shadow: 0 0 4px var(--status-open); }
+.dot-closed { background: var(--status-closed); }
+.dot-blocked { background: #f97316; box-shadow: 0 0 4px rgba(249,115,22,0.6); }
+
+.col-title { max-width: 48ch; }
+.list-title {
+  display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 48ch;
+}
+
+.text-dim { color: var(--text-dim); }
+
+.col-count { text-align: center; white-space: nowrap; }
+.col-center { text-align: center; }
+.edge-count {
+  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  color: var(--text-muted); cursor: default;
+  border-bottom: 1px dashed var(--border-hi);
+}
+
+/* Group header rows */
+.group-hdr td {
+  background: var(--bg-panel); font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; font-weight: 700; color: var(--accent);
+  padding: 5px 10px; cursor: pointer; user-select: none;
+}
+.group-hdr:hover td { background: var(--bg-card); }
+.group-caret { margin-right: 6px; font-size: 10px; }
+.group-title {
+  margin-left: 6px; font-weight: 400; font-family: 'Inter', sans-serif;
+  color: var(--text-muted); font-size: 11px;
+}
+.group-count {
+  margin-left: 8px; font-size: 10px; font-weight: 400;
+  color: var(--text-muted); font-family: 'JetBrains Mono', monospace;
+}
+
+/* Level-1 vs level-2 group headers */
+.group-hdr.level-1 td {
+  font-size: 12px; padding-left: 10px;
+  border-top: 2px solid var(--border-hi);
+}
+.group-hdr.level-2 td {
+  font-size: 10px; padding-left: 24px;
+  background: var(--bg-card);
+  color: var(--text-muted);
+}
+.group-hdr.level-2:hover td { background: var(--bg-panel); color: var(--accent); }
+
+/* ─── Legacy list-items (kept for compat) ────────────────────── */
+.list-items { display: flex; flex-direction: column; gap: 5px; max-width: 960px; }
+.list-items .issue-card .card-title { white-space: normal; }
+
+/* ─── Footer ─────────────────────────────────────────────────── */
+footer.page-footer {
+  margin-top: 18px; padding-top: 12px; border-top: 1px solid var(--border);
+  color: var(--text-muted); font-size: 11px; font-family: 'JetBrains Mono', monospace;
+}
+footer.page-footer a { color: var(--accent); text-decoration: none; }
+footer.page-footer a:hover { text-decoration: underline; }
+
+.error-msg {
+  margin-top: 16px; padding: 12px 16px;
+  background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.4);
+  border-radius: 6px; color: #ef4444; font-family: 'JetBrains Mono', monospace; font-size: 11px;
+}
+
+/* ─── Lane-swim grid (v5 table view) ─────────────────────────────────────── */
+.lane-swim-grid {
+  --row-header-w: 140px;
+  --col-min-w:    190px;
+  display: grid;
+  grid-template-columns:
+    var(--row-header-w)
+    repeat(var(--cols, 9), minmax(var(--col-min-w), 1fr));
+  gap: 0;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.grid-head { display: contents; }
+.grid-head > .spacer {
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-hi);
+  border-right: 1px dashed var(--border);
+}
+.col-header {
+  padding: 12px 10px;
+  background: var(--row-header-grad);
+  border-bottom: 1px solid var(--border-hi);
+  border-right: 1px dashed var(--border);
+}
+.col-header:last-child { border-right: none; }
+.col-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+.col-label[data-tone="a1"] { color: var(--lane-a1); }
+.col-label[data-tone="a2"] { color: var(--lane-a2); }
+.col-label[data-tone="a3"] { color: var(--lane-a3); }
+.col-label[data-tone="b"]  { color: var(--lane-b); }
+.col-label[data-tone="c1"] { color: var(--lane-c1); }
+.col-label[data-tone="c2"] { color: var(--lane-c2); }
+.col-label[data-tone="c3"] { color: var(--lane-c3); }
+.col-label[data-tone="d"]  { color: var(--lane-d); }
+.col-label[data-tone="e"]  { color: var(--lane-e); }
+.col-label[data-tone="f"]  { color: var(--lane-f); }
+.col-label[data-tone="g"]  { color: var(--lane-g); }
+.col-label[data-tone="h"]  { color: var(--lane-h); }
+.col-label[data-tone="i"]  { color: var(--lane-i); }
+
+.grid-row { display: contents; }
+.row-header {
+  padding: 14px 10px;
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border);
+  border-right: 1px dashed var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.ms-code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+}
+.ms-name {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.3;
+}
+
+.grid-cell {
+  padding: 8px;
+  border-top: 1px solid var(--border);
+  border-right: 1px dashed var(--border);
+  background: var(--bg-cell);
+  min-height: 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.grid-cell:last-child { border-right: none; }
+.cell-empty {
+  color: var(--text-dim);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  text-align: center;
+  opacity: 0.4;
+  padding-top: 18px;
+}
+
+/* ─── Epic grouping within cells ──────────────────────────────────────────── */
+.epic-group { display: flex; flex-direction: column; gap: 4px; }
+.epic-header {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  padding: 3px 4px 4px;
+  border-bottom: 1px dashed var(--border);
+  margin-bottom: 2px;
+  border-radius: 3px;
+  transition: background 0.15s;
+  cursor: pointer;
+}
+.epic-header:hover {
+  background: var(--hl-dim-bg);
+  border-bottom-style: solid;
+}
+.epic-caret {
+  font-size: 8px;
+  color: var(--text-muted);
+  margin-right: 2px;
+}
+.epic-code {
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-hi);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text);
+}
+.epic-code a {
+  color: var(--text);
+  text-decoration: none;
+}
+.epic-code a:hover {
+  color: var(--accent);
+}
+.epic-count { color: var(--text-dim); font-weight: 400; }
+/* Lane tone accent on caret */
+.epic-header[data-tone="a1"] .epic-caret { color: var(--lane-a1); }
+.epic-header[data-tone="a2"] .epic-caret { color: var(--lane-a2); }
+.epic-header[data-tone="a3"] .epic-caret { color: var(--lane-a3); }
+.epic-header[data-tone="b"]  .epic-caret { color: var(--lane-b); }
+.epic-header[data-tone="c1"] .epic-caret { color: var(--lane-c1); }
+.epic-header[data-tone="c2"] .epic-caret { color: var(--lane-c2); }
+.epic-header[data-tone="c3"] .epic-caret { color: var(--lane-c3); }
+.epic-header[data-tone="d"]  .epic-caret { color: var(--lane-d); }
+.epic-header[data-tone="e"]  .epic-caret { color: var(--lane-e); }
+.epic-header[data-tone="f"]  .epic-caret { color: var(--lane-f); }
+.epic-header[data-tone="g"]  .epic-caret { color: var(--lane-g); }
+.epic-header[data-tone="h"]  .epic-caret { color: var(--lane-h); }
+.epic-header[data-tone="i"]  .epic-caret { color: var(--lane-i); }
+
+.epic-cards { display: flex; flex-direction: column; gap: 4px; }
+
+/* ─── Lane tone on cards ──────────────────────────────────────────────────── */
+.issue-card.tone-a1, .issue-card[data-tone="a1"] { border-left-color: var(--lane-a1); }
+.issue-card.tone-a2, .issue-card[data-tone="a2"] { border-left-color: var(--lane-a2); }
+.issue-card.tone-a3, .issue-card[data-tone="a3"] { border-left-color: var(--lane-a3); }
+.issue-card.tone-b,  .issue-card[data-tone="b"]  { border-left-color: var(--lane-b); }
+.issue-card.tone-c1, .issue-card[data-tone="c1"] { border-left-color: var(--lane-c1); }
+.issue-card.tone-c2, .issue-card[data-tone="c2"] { border-left-color: var(--lane-c2); }
+.issue-card.tone-c3, .issue-card[data-tone="c3"] { border-left-color: var(--lane-c3); }
+.issue-card.tone-d,  .issue-card[data-tone="d"]  { border-left-color: var(--lane-d); }
+.issue-card.tone-e,  .issue-card[data-tone="e"]  { border-left-color: var(--lane-e); }
+.issue-card.tone-f,  .issue-card[data-tone="f"]  { border-left-color: var(--lane-f); }
+.issue-card.tone-g,  .issue-card[data-tone="g"]  { border-left-color: var(--lane-g); }
+.issue-card.tone-h,  .issue-card[data-tone="h"]  { border-left-color: var(--lane-h); }
+.issue-card.tone-i,  .issue-card[data-tone="i"]  { border-left-color: var(--lane-i); }
+.issue-card[data-tone="teal"]   { border-left-color: var(--repo-teal); }
+.issue-card[data-tone="blue"]   { border-left-color: var(--repo-blue); }
+.issue-card[data-tone="pink"]   { border-left-color: var(--repo-pink); }
+.issue-card[data-tone="plum"]   { border-left-color: var(--repo-plum); }
+.issue-card[data-tone="orange"] { border-left-color: var(--repo-orange); }
+.issue-card[data-tone="red"]    { border-left-color: var(--repo-red); }
+.issue-card[data-tone="lime"]   { border-left-color: var(--repo-lime); }
+.issue-card[data-tone="amber"]  { border-left-color: var(--repo-amber); }
+.issue-card[data-tone="green"]  { border-left-color: var(--repo-green); }
+.issue-card[data-tone="gray"]   { border-left-color: var(--repo-gray); }
+.issue-card[data-tone="cyan"]   { border-left-color: var(--repo-cyan); }
+
+/* ─── Hover-chain highlight ───────────────────────────────────────────────── */
+.hl-active .issue-card { opacity: 0.18; }
+.hl-active .issue-card.hl-self {
+  opacity: 1;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  z-index: 2;
+}
+.hl-active .issue-card.hl-upstream {
+  opacity: 1;
+  border-left-width: 4px;
+  box-shadow: inset 0 0 0 1px var(--status-blocked);
+}
+.hl-active .issue-card.hl-downstream {
+  opacity: 1;
+  border-left-width: 4px;
+  box-shadow: inset 0 0 0 1px var(--teal);
+}
+
+/* Card animation on hover */
+.issue-card {
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    transform 0.12s,
+    opacity 0.2s,
+    box-shadow 0.15s;
+}
+.issue-card:hover {
+  background: var(--bg-panel);
+  transform: translateX(1px);
+}
+.issue-card.state-closed:hover { opacity: 0.85; }
+
+/* ─── Hover-chain highlight for list rows ─────────────────────────────────── */
+.hl-active .issue-row td { color: var(--text-dim); }
+.hl-active .issue-row .issue-link { color: var(--text-dim); opacity: 0.4; }
+.hl-active .issue-row .state-dot { opacity: 0.3; }
+.hl-active .issue-row .badge { opacity: 0.3; }
+
+.hl-active .issue-row.hl-self td { color: var(--text); background: var(--bg-panel); }
+.hl-active .issue-row.hl-self .issue-link { color: var(--accent); opacity: 1; }
+.hl-active .issue-row.hl-self .state-dot { opacity: 1; }
+.hl-active .issue-row.hl-self .badge { opacity: 1; }
+.hl-active .issue-row.hl-self {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.hl-active .issue-row.hl-upstream td { color: var(--text); background: rgba(249,115,22,0.12); }
+.hl-active .issue-row.hl-upstream .issue-link { color: var(--accent); opacity: 1; }
+.hl-active .issue-row.hl-upstream .state-dot { opacity: 1; }
+
+.hl-active .issue-row.hl-downstream td { color: var(--text); background: rgba(20,184,166,0.12); }
+.hl-active .issue-row.hl-downstream .issue-link { color: var(--accent); opacity: 1; }
+.hl-active .issue-row.hl-downstream .state-dot { opacity: 1; }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,290 @@
+// app.js — bootstrap, controls wiring, render orchestration
+import { state, setState, parseMilestone, annotateNodes } from './state.js';
+import { renderTable } from './pivot.js';
+import { renderList }  from './list.js';
+import { initGraph, clearSearchHighlight }   from './graph.js';
+import { MultiSelect } from './multi_select.js';
+import { clearPinned } from './hover.js';
+import { repoTone } from './tone.js';
+
+const $ = id => document.getElementById(id);
+
+const viewTable     = $('view-table');
+const viewList      = $('view-list');
+const graphPanel    = $('graph-panel');
+const btnTable      = $('btn-table');
+const btnList       = $('btn-list');
+const btnGraph      = $('btn-graph');
+const searchInput   = $('search-input');
+const searchClear   = $('search-clear');
+const pivotControls = $('pivot-controls');
+const listControls  = $('list-controls');
+const graphControls = $('graph-controls');
+const subtitle      = $('subtitle');
+const errorMsg      = $('error-msg');
+
+const PIVOT_DIMS = ['milestone', 'priority', 'repo', 'lane', 'size', 'none'];
+const LIST_DIMS  = ['milestone', 'priority', 'repo', 'lane', 'size', 'status', 'parent', 'none'];
+const TABLE_GROUP_DIMS = ['lane', 'parent', 'none'];
+
+// ─── Seg group builder (click active to deactivate → 'none') ────────────────
+function buildSegs(container, values, current, onPick, opts = {}) {
+  const { allowDeactivate = true, noneValue = 'none' } = opts;
+  container.innerHTML = '';
+  for (const v of values) {
+    const b = document.createElement('button');
+    b.type      = 'button';
+    b.className = 'seg' + (v === current ? ' on' : '');
+    b.dataset.v = v;
+    b.textContent = v;
+    b.addEventListener('click', () => {
+      // Click active → deactivate (set to noneValue)
+      if (allowDeactivate && v === current) {
+        container.querySelectorAll('.seg').forEach(s => s.classList.toggle('on', s.dataset.v === noneValue));
+        onPick(noneValue);
+      } else {
+        container.querySelectorAll('.seg').forEach(s => s.classList.toggle('on', s.dataset.v === v));
+        onPick(v);
+      }
+    });
+    container.appendChild(b);
+  }
+}
+
+// ─── Multi-select instances ───────────────────────────────────────────────
+const msRepo      = new MultiSelect($('ms-repo-btn'),      $('ms-repo-panel'),      { placeholder: 'All repos',      clearBtn: $('ms-repo-clear') });
+const msMilestone = new MultiSelect($('ms-milestone-btn'), $('ms-milestone-panel'), { placeholder: 'All milestones', clearBtn: $('ms-milestone-clear') });
+const msPriority  = new MultiSelect($('ms-priority-btn'),  $('ms-priority-panel'),  { placeholder: 'All priorities', clearBtn: $('ms-priority-clear') });
+const msStatus    = new MultiSelect($('ms-status-btn'),    $('ms-status-panel'),    { placeholder: 'All statuses',   clearBtn: $('ms-status-clear') });
+
+// ─── Render ───────────────────────────────────────────────────────────────
+function render() {
+  const isTable = state.view === 'table';
+  const isList  = state.view === 'list';
+  const isGraph = state.view === 'graph';
+
+  viewTable.classList.toggle('view-active', isTable);
+  viewList.classList.toggle('view-active', isList);
+  if (isGraph) {
+    graphPanel.removeAttribute('hidden');
+    graphPanel.classList.add('view-active');
+  } else {
+    graphPanel.setAttribute('hidden', '');
+    graphPanel.classList.remove('view-active');
+  }
+
+  for (const [btn, match] of [[btnTable, 'table'], [btnList, 'list'], [btnGraph, 'graph']]) {
+    if (!btn) continue;
+    btn.classList.toggle('on', state.view === match);
+    btn.setAttribute('aria-pressed', String(state.view === match));
+  }
+
+  pivotControls.style.display = isTable ? '' : 'none';
+  if (listControls) listControls.style.display = isList ? '' : 'none';
+
+  searchClear.hidden = !state.search;
+  updateSubtitle();
+
+  if (isTable) renderTable(viewTable);
+  else if (isList) renderList(viewList);
+  else if (isGraph) initGraph();
+}
+
+function updateSubtitle() {
+  const total = state.nodes.length;
+  const open  = state.nodes.filter(n => n.state === 'open').length;
+  subtitle.textContent = `${total} issues · ${open} open · ${total - open} closed`;
+}
+
+// ─── View toggle ──────────────────────────────────────────────────────────
+btnTable.addEventListener('click', () => { setState({ view: 'table' }); render(); });
+btnList.addEventListener('click',  () => { setState({ view: 'list'  }); render(); });
+if (btnGraph) btnGraph.addEventListener('click', () => { setState({ view: 'graph' }); render(); });
+
+// ─── Search ───────────────────────────────────────────────────────────────
+searchInput.addEventListener('input', () => {
+  setState({ search: searchInput.value });
+  render();
+});
+searchClear.addEventListener('click', () => {
+  searchInput.value = '';
+  setState({ search: '' });
+  searchInput.focus();
+  clearSearchHighlight();
+  render();
+});
+
+// ESC key clears search + graph highlight
+searchInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    searchInput.value = '';
+    setState({ search: '' });
+    clearSearchHighlight();
+    render();
+  }
+});
+
+// ─── Pivot + List segs ────────────────────────────────────────────────────
+function buildPivotSegs() {
+  buildSegs($('pivot-row-segs'), PIVOT_DIMS, state.pivotRow, v => { setState({ pivotRow: v }); render(); });
+  buildSegs($('pivot-col-segs'), PIVOT_DIMS, state.pivotCol, v => { setState({ pivotCol: v }); render(); });
+  buildSegs($('table-group-segs'), TABLE_GROUP_DIMS, state.tableGroup, v => { setState({ tableGroup: v }); render(); }, { allowDeactivate: true });
+  buildSegs($('list-group-segs'), LIST_DIMS, state.listGroup, v => { setState({ listGroup: v }); render(); }, { allowDeactivate: true });
+  buildSegs($('list-group2-segs'), LIST_DIMS, state.listGroup2, v => { setState({ listGroup2: v }); render(); }, { allowDeactivate: true });
+}
+
+// ─── Graph edge toggle ─────────────────────────────────────────────────────
+function buildGraphSegs() {
+  const container = $('graph-edge-segs');
+  if (!container) return;
+  container.innerHTML = '';
+
+  const parentsSeg = document.createElement('button');
+  parentsSeg.type = 'button';
+  parentsSeg.className = 'seg' + (state.showParents ? ' on' : '');
+  parentsSeg.textContent = 'Parents';
+  parentsSeg.title = 'Show parent (epic) issues';
+  parentsSeg.addEventListener('click', () => {
+    setState({ showParents: !state.showParents });
+    buildGraphSegs();
+    render();
+  });
+  container.appendChild(parentsSeg);
+
+  const closedSeg = document.createElement('button');
+  closedSeg.type = 'button';
+  closedSeg.className = 'seg' + (state.showClosedUnderOpenEpic ? ' on' : '');
+  closedSeg.textContent = 'Closed';
+  closedSeg.title = 'Show closed issues whose parent epic is still open';
+  closedSeg.addEventListener('click', () => {
+    setState({ showClosedUnderOpenEpic: !state.showClosedUnderOpenEpic });
+    buildGraphSegs();
+    render();
+  });
+  container.appendChild(closedSeg);
+}
+
+// ─── Multi-select onChange ────────────────────────────────────────────────
+msRepo.onChange      = vals => { clearPinned(); setState({ repo:      vals }); render(); };
+msMilestone.onChange = vals => { clearPinned(); setState({ milestone: vals }); render(); };
+msPriority.onChange  = vals => { clearPinned(); setState({ priority:  vals }); render(); };
+msStatus.onChange    = vals => { clearPinned(); setState({ status:    vals }); render(); };
+
+// ─── Populate filter options after data load ──────────────────────────────
+function populateFilters(repos) {
+  const nodes = state.nodes;
+
+  const repoItems = repos.map(r => ({ value: r, label: r.split('/')[1] || r, tone: repoTone(r) }));
+  msRepo.setItems(repoItems, state.repo);
+
+  const msMap = new Map();
+  for (const n of nodes) {
+    const ms  = parseMilestone(n);
+    const key = ms.code ?? '(None)';
+    if (!msMap.has(key)) msMap.set(key, ms.sortKey ?? 9999);
+  }
+  const msItems = [...msMap.entries()]
+    .sort((a, b) => a[1] - b[1])
+    .map(([v]) => ({ value: v, label: v }));
+  msMilestone.setItems(msItems, state.milestone);
+
+  msPriority.setItems(
+    ['P0', 'P1', 'P2', 'P3', '(None)'].map(v => ({ value: v, label: v })),
+    state.priority
+  );
+
+  msStatus.setItems(
+    ['ready', 'blocked', 'done'].map(v => ({ value: v, label: v })),
+    state.status
+  );
+}
+
+function restoreControls() {
+  searchInput.value  = state.search;
+  searchClear.hidden = !state.search;
+  buildPivotSegs();
+  buildGraphSegs();
+}
+
+async function loadGraphData() {
+  const resp = await fetch('/api/graph');
+  if (!resp.ok) throw new Error(`/api/graph ${resp.status}`);
+  return resp.json();
+}
+
+async function loadRepos() {
+  try {
+    const resp = await fetch('/api/repos');
+    if (!resp.ok) throw new Error(`/api/repos ${resp.status}`);
+    const j = await resp.json();
+    return (j.repos ?? []).map(r => r.repo);
+  } catch {
+    return [...new Set(state.nodes.map(n => n.repo))].sort();
+  }
+}
+
+// Re-fetch graph data + repos and re-render, preserving view/filters (held in state).
+async function loadAndRender() {
+  const [data, repos] = await Promise.all([loadGraphData(), loadRepos()]);
+  const nodes = data.nodes || [];
+  const edges = data.edges || [];
+  annotateNodes(nodes, edges);
+  setState({ nodes, edges });
+  state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
+  populateFilters(repos);
+  render();
+}
+
+// ─── Live refresh: poll /api/version, reload when corpus.db changes ─────────
+const POLL_MS = 15000;
+let lastVersion = null;
+
+async function fetchVersion() {
+  const resp = await fetch('/api/version');
+  if (!resp.ok) throw new Error(`/api/version ${resp.status}`);
+  return (await resp.json()).version;
+}
+
+function startPolling() {
+  setInterval(async () => {
+    if (document.hidden) return;  // skip while tab is backgrounded
+    try {
+      const v = await fetchVersion();
+      if (lastVersion !== null && v !== lastVersion) await loadAndRender();
+      lastVersion = v;
+    } catch { /* transient — retry next tick */ }
+  }, POLL_MS);
+}
+
+async function init() {
+  restoreControls();
+  try {
+    await loadAndRender();
+    try { lastVersion = await fetchVersion(); } catch { /* poller will retry */ }
+    startPolling();
+  } catch (e) {
+    errorMsg.hidden = false;
+    errorMsg.textContent = `Failed to load graph: ${e.message}`;
+    subtitle.textContent = 'Error';
+  }
+}
+
+// ─── Theme ────────────────────────────────────────────────────────────────
+const themeBtn = $('theme-btn');
+const htmlEl   = document.documentElement;
+let theme = localStorage.getItem('v6:theme')
+  || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+
+function applyTheme(t) {
+  htmlEl.setAttribute('data-theme', t);
+  themeBtn.textContent = t === 'dark' ? '🌙' : '☀️';
+  localStorage.setItem('v6:theme', t);
+}
+themeBtn.addEventListener('click', () => {
+  theme = theme === 'dark' ? 'light' : 'dark';
+  applyTheme(theme);
+});
+applyTheme(theme);
+
+init();

--- a/frontend/graph.css
+++ b/frontend/graph.css
@@ -1,0 +1,438 @@
+/* graph.css — v5.1 graph-view styles, scoped to #graph-panel
+ * Source: lyra-v2-dependency-graph-v5.1.html <style> block
+ * Only rules touching .view-graph / .gg-* / graph chrome.
+ * Toolbar, grid-view, list-view, footer rules omitted.
+ */
+
+/* ── Lane custom properties (used by gg- tone attributes) ──────── */
+/* v4.8 color scheme: lanes map to named palette colors */
+#graph-panel {
+  --status-ready:   #22c55e;
+  --status-blocked: #f97316;
+  --status-done:    #475569;
+  --teal:           #06b6d4;
+  --red:            #ef4444;
+
+  /* v4.8 palette */
+  --plum:  #a855f7;
+  --pink:  #ec4899;
+  --amber: #f59e0b;
+  --cyan:  #22d3ee;
+
+  /* Dev-state animation tokens */
+  --dev-orbit-2nd: #f0abfc;
+
+  /* Lane → color mapping (v4.8 style) */
+  --lane-a1: #22c55e;  /* green - NATS maturity */
+  --lane-a2: #a855f7;  /* plum - roxabi-nats */
+  --lane-a3: #a855f7;  /* plum - roxabi-contracts */
+  --lane-b:  #22d3ee;  /* cyan - Containerize */
+  --lane-c1: #ec4899;  /* pink - LiteLLM */
+  --lane-c2: #ec4899;  /* pink - lyra_harness */
+  --lane-c3: #ec4899;  /* pink - lyra_cli */
+  --lane-d:  #06b6d4;  /* teal - Observability */
+  --lane-e:  #f59e0b;  /* amber - Hub stateless */
+  --lane-f:  #10b981;  /* green - Plugins */
+  --lane-g:  #f59e0b;  /* amber - Voice */
+  --lane-h:  #f59e0b;  /* amber - Deploy ops */
+  --lane-i:  #06b6d4;  /* teal - Vault ingest */
+}
+
+/* Repo palette — 11 distinct hues, decoupled from lanes.
+   Global scope so cards/pills/nodes outside #graph-panel resolve them.
+   Consumed via data-tone="<name>" on repo-colored elements. */
+:root {
+  --repo-teal:   #06b6d4;
+  --repo-blue:   #3b82f6;
+  --repo-pink:   #ec4899;
+  --repo-plum:   #a855f7;
+  --repo-orange: #f97316;
+  --repo-red:    #ef4444;
+  --repo-lime:   #84cc16;
+  --repo-amber:  #f59e0b;
+  --repo-green:  #22c55e;
+  --repo-gray:   #94a3b8;
+  --repo-cyan:   #22d3ee;
+  --repo-indigo:  #6366f1;
+  --repo-rose:    #f43f5e;
+  --repo-violet:  #8b5cf6;
+  --repo-brown:   #b45309;
+  --repo-fuchsia: #d946ef;
+  --repo-yellow:  #eab308;
+}
+
+/* ── Panel chrome ───────────────────────────────────────────────── */
+#graph-panel {
+  padding-top: 20px;
+}
+
+/* ── Graph wrap (outermost container from v5) ───────────────────── */
+#graph-panel .graph-wrap {
+  position: relative;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+#graph-panel .graph-stage {
+  position: absolute;
+  left: 160px;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  overflow: visible;
+}
+
+/* ── Milestone row-headers (left gutter) ────────────────────────── */
+#graph-panel .gg-msrow {
+  position: absolute;
+  left: 12px;
+  width: 136px;
+  padding: 12px 12px 14px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 4;
+}
+#graph-panel .gg-msrow-code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.04em;
+}
+#graph-panel .gg-msrow-name {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.32;
+}
+#graph-panel .gg-msrow-sep {
+  position: absolute;
+  left: 160px;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--border-hi) 20%,
+    var(--border-hi) 80%,
+    transparent
+  );
+  z-index: 1;
+}
+
+/* ── Node dot ────────────────────────────────────────────────────── */
+#graph-panel .gg-node {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: currentColor;
+  box-shadow: 0 0 0 2px var(--bg-panel), 0 0 8px currentColor;
+  z-index: 3;
+  transition: transform 0.12s ease, box-shadow 0.14s ease, opacity 0.18s ease;
+  text-decoration: none;
+}
+#graph-panel .gg-node:hover {
+  transform: translate(-50%, -50%) scale(1.25);
+  z-index: 11;
+}
+/* Parent nodes: rounded square to distinguish epics from leaf issues */
+#graph-panel .gg-node.parent {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+}
+#graph-panel .gg-node.blocked {
+  background: transparent;
+  border: 2px dashed currentColor;
+}
+#graph-panel .gg-node.done {
+  background: var(--status-done);
+  opacity: 0.55;
+  box-shadow: 0 0 0 2px var(--bg-panel);
+}
+
+/* Tone mapping */
+#graph-panel .gg-node[data-tone="a1"]     { color: var(--lane-a1); }
+#graph-panel .gg-node[data-tone="a2"]     { color: var(--lane-a2); }
+#graph-panel .gg-node[data-tone="a3"]     { color: var(--lane-a3); }
+#graph-panel .gg-node[data-tone="b"]      { color: var(--lane-b); }
+#graph-panel .gg-node[data-tone="c1"]     { color: var(--lane-c1); }
+#graph-panel .gg-node[data-tone="c2"]     { color: var(--lane-c2); }
+#graph-panel .gg-node[data-tone="c3"]     { color: var(--lane-c3); }
+#graph-panel .gg-node[data-tone="d"]      { color: var(--lane-d); }
+#graph-panel .gg-node[data-tone="e"]      { color: var(--lane-e); }
+#graph-panel .gg-node[data-tone="f"]      { color: var(--lane-f); }
+#graph-panel .gg-node[data-tone="g"]      { color: var(--lane-g); }
+#graph-panel .gg-node[data-tone="h"]      { color: var(--lane-h); }
+#graph-panel .gg-node[data-tone="i"]      { color: var(--lane-i); }
+#graph-panel .gg-node[data-tone="teal"]   { color: var(--repo-teal); }
+#graph-panel .gg-node[data-tone="blue"]   { color: var(--repo-blue); }
+#graph-panel .gg-node[data-tone="pink"]   { color: var(--repo-pink); }
+#graph-panel .gg-node[data-tone="plum"]   { color: var(--repo-plum); }
+#graph-panel .gg-node[data-tone="orange"] { color: var(--repo-orange); }
+#graph-panel .gg-node[data-tone="red"]    { color: var(--repo-red); }
+#graph-panel .gg-node[data-tone="lime"]   { color: var(--repo-lime); }
+#graph-panel .gg-node[data-tone="amber"]  { color: var(--repo-amber); }
+#graph-panel .gg-node[data-tone="green"]  { color: var(--repo-green); }
+#graph-panel .gg-node[data-tone="gray"]   { color: var(--repo-gray); }
+#graph-panel .gg-node[data-tone="cyan"]   { color: var(--repo-cyan); }
+#graph-panel .gg-node[data-tone="indigo"]  { color: var(--repo-indigo); }
+#graph-panel .gg-node[data-tone="rose"]    { color: var(--repo-rose); }
+#graph-panel .gg-node[data-tone="violet"]  { color: var(--repo-violet); }
+#graph-panel .gg-node[data-tone="brown"]   { color: var(--repo-brown); }
+#graph-panel .gg-node[data-tone="fuchsia"] { color: var(--repo-fuchsia); }
+#graph-panel .gg-node[data-tone="yellow"]  { color: var(--repo-yellow); }
+#graph-panel .gg-node[data-tone="accent"]  { color: var(--accent); }
+
+/* ── Inline pill label ───────────────────────────────────────────── */
+#graph-panel .gg-ilabel {
+  position: absolute;
+  transform: translate(-50%, 14px);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  min-width: 46px;
+  max-width: 104px;
+  border-radius: 99px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-hi);
+  color: var(--text);
+  font-family: 'Inter', sans-serif;
+  font-size: 10.5px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-decoration: none;
+  white-space: nowrap;
+  z-index: 2;
+  cursor: pointer;
+  transition:
+    transform 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.14s ease,
+    max-width 0.18s ease,
+    opacity 0.18s ease;
+}
+#graph-panel .gg-ilabel:hover {
+  transform: translate(-50%, 14px) scale(1.04);
+  max-width: 280px;
+  border-color: currentColor;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.45), 0 0 0 1px currentColor;
+  z-index: 12;
+}
+#graph-panel .gg-ilabel-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 10px;
+  color: currentColor;
+  flex-shrink: 0;
+}
+#graph-panel .gg-ilabel-size {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+#graph-panel .gg-ilabel-title {
+  color: var(--text);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#graph-panel .gg-ilabel:hover .gg-ilabel-title {
+  white-space: normal;
+  overflow: visible;
+}
+#graph-panel .gg-ilabel.done { opacity: 0.45; }
+#graph-panel .gg-ilabel.done .gg-ilabel-title {
+  text-decoration: line-through;
+  text-decoration-color: var(--status-done);
+  color: var(--text-muted);
+}
+#graph-panel .gg-ilabel.blocked { border-style: dashed; }
+
+/* Tone mapping */
+#graph-panel .gg-ilabel[data-tone="a1"]     { color: var(--lane-a1); }
+#graph-panel .gg-ilabel[data-tone="a2"]     { color: var(--lane-a2); }
+#graph-panel .gg-ilabel[data-tone="a3"]     { color: var(--lane-a3); }
+#graph-panel .gg-ilabel[data-tone="b"]      { color: var(--lane-b); }
+#graph-panel .gg-ilabel[data-tone="c1"]     { color: var(--lane-c1); }
+#graph-panel .gg-ilabel[data-tone="c2"]     { color: var(--lane-c2); }
+#graph-panel .gg-ilabel[data-tone="c3"]     { color: var(--lane-c3); }
+#graph-panel .gg-ilabel[data-tone="d"]      { color: var(--lane-d); }
+#graph-panel .gg-ilabel[data-tone="e"]      { color: var(--lane-e); }
+#graph-panel .gg-ilabel[data-tone="f"]      { color: var(--lane-f); }
+#graph-panel .gg-ilabel[data-tone="g"]      { color: var(--lane-g); }
+#graph-panel .gg-ilabel[data-tone="h"]      { color: var(--lane-h); }
+#graph-panel .gg-ilabel[data-tone="i"]      { color: var(--lane-i); }
+#graph-panel .gg-ilabel[data-tone="teal"]   { color: var(--repo-teal); }
+#graph-panel .gg-ilabel[data-tone="blue"]   { color: var(--repo-blue); }
+#graph-panel .gg-ilabel[data-tone="pink"]   { color: var(--repo-pink); }
+#graph-panel .gg-ilabel[data-tone="plum"]   { color: var(--repo-plum); }
+#graph-panel .gg-ilabel[data-tone="orange"] { color: var(--repo-orange); }
+#graph-panel .gg-ilabel[data-tone="red"]    { color: var(--repo-red); }
+#graph-panel .gg-ilabel[data-tone="lime"]   { color: var(--repo-lime); }
+#graph-panel .gg-ilabel[data-tone="amber"]  { color: var(--repo-amber); }
+#graph-panel .gg-ilabel[data-tone="green"]  { color: var(--repo-green); }
+#graph-panel .gg-ilabel[data-tone="gray"]   { color: var(--repo-gray); }
+#graph-panel .gg-ilabel[data-tone="cyan"]   { color: var(--repo-cyan); }
+#graph-panel .gg-ilabel[data-tone="indigo"]  { color: var(--repo-indigo); }
+#graph-panel .gg-ilabel[data-tone="rose"]    { color: var(--repo-rose); }
+#graph-panel .gg-ilabel[data-tone="violet"]  { color: var(--repo-violet); }
+#graph-panel .gg-ilabel[data-tone="brown"]   { color: var(--repo-brown); }
+#graph-panel .gg-ilabel[data-tone="fuchsia"] { color: var(--repo-fuchsia); }
+#graph-panel .gg-ilabel[data-tone="yellow"]  { color: var(--repo-yellow); }
+#graph-panel .gg-ilabel[data-tone="accent"]  { color: var(--accent); }
+
+/* ── SVG edges ───────────────────────────────────────────────────── */
+#graph-panel .graph-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+}
+#graph-panel .gg-edge {
+  fill: none;
+  stroke: var(--text-dim);
+  stroke-width: 1.2;
+  opacity: 0.45;
+  transition: opacity 0.18s, stroke-width 0.18s, stroke 0.18s;
+}
+/* blocks edges stay solid; active blockers (dst still open) get an opacity
+   boost so the live blocking link reads stronger than the historic one. */
+#graph-panel .gg-edge.blocked { opacity: 0.9; }
+#graph-panel .gg-edge.parent-edge {
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+  opacity: 0.3;
+}
+#graph-panel .gg-edge[data-tone="a1"]     { stroke: var(--lane-a1); }
+#graph-panel .gg-edge[data-tone="a2"]     { stroke: var(--lane-a2); }
+#graph-panel .gg-edge[data-tone="a3"]     { stroke: var(--lane-a3); }
+#graph-panel .gg-edge[data-tone="b"]      { stroke: var(--lane-b); }
+#graph-panel .gg-edge[data-tone="c1"]     { stroke: var(--lane-c1); }
+#graph-panel .gg-edge[data-tone="c2"]     { stroke: var(--lane-c2); }
+#graph-panel .gg-edge[data-tone="c3"]     { stroke: var(--lane-c3); }
+#graph-panel .gg-edge[data-tone="d"]      { stroke: var(--lane-d); }
+#graph-panel .gg-edge[data-tone="e"]      { stroke: var(--lane-e); }
+#graph-panel .gg-edge[data-tone="f"]      { stroke: var(--lane-f); }
+#graph-panel .gg-edge[data-tone="g"]      { stroke: var(--lane-g); }
+#graph-panel .gg-edge[data-tone="h"]      { stroke: var(--lane-h); }
+#graph-panel .gg-edge[data-tone="i"]      { stroke: var(--lane-i); }
+#graph-panel .gg-edge[data-tone="teal"]   { stroke: var(--repo-teal); }
+#graph-panel .gg-edge[data-tone="blue"]   { stroke: var(--repo-blue); }
+#graph-panel .gg-edge[data-tone="pink"]   { stroke: var(--repo-pink); }
+#graph-panel .gg-edge[data-tone="plum"]   { stroke: var(--repo-plum); }
+#graph-panel .gg-edge[data-tone="orange"] { stroke: var(--repo-orange); }
+#graph-panel .gg-edge[data-tone="red"]    { stroke: var(--repo-red); }
+#graph-panel .gg-edge[data-tone="lime"]   { stroke: var(--repo-lime); }
+#graph-panel .gg-edge[data-tone="amber"]  { stroke: var(--repo-amber); }
+#graph-panel .gg-edge[data-tone="green"]  { stroke: var(--repo-green); }
+#graph-panel .gg-edge[data-tone="gray"]   { stroke: var(--repo-gray); }
+#graph-panel .gg-edge[data-tone="cyan"]   { stroke: var(--repo-cyan); }
+#graph-panel .gg-edge[data-tone="accent"] { stroke: var(--accent); }
+
+/* ── Hover-chain highlight ───────────────────────────────────────── */
+#graph-panel.hl-active .gg-node,
+#graph-panel.hl-active .gg-ilabel { opacity: 0.15; }
+#graph-panel.hl-active .gg-edge   { opacity: 0.08; }
+
+#graph-panel.hl-active .gg-node.hl-self,
+#graph-panel.hl-active .gg-ilabel.hl-self {
+  opacity: 1;
+  z-index: 15;
+  box-shadow: 0 0 0 2px var(--accent), 0 0 14px rgba(232,93,4,0.55);
+}
+#graph-panel.hl-active .gg-node.hl-upstream,
+#graph-panel.hl-active .gg-ilabel.hl-upstream {
+  opacity: 1;
+  box-shadow: 0 0 0 1px var(--red), 0 0 6px rgba(248,113,113,0.35);
+}
+#graph-panel.hl-active .gg-node.hl-downstream,
+#graph-panel.hl-active .gg-ilabel.hl-downstream {
+  opacity: 1;
+  box-shadow: 0 0 0 1px var(--teal), 0 0 6px rgba(6,182,212,0.35);
+}
+#graph-panel.hl-active .gg-edge.hl-edge {
+  opacity: 0.95;
+  stroke-width: 2.2;
+}
+
+/* ── Dim overlay for filter integration (stretch goal) ──────────── */
+#graph-panel .gg-node.dim  { opacity: 0.12; }
+#graph-panel .gg-ilabel.dim { opacity: 0.12; }
+#graph-panel .gg-edge.dim  { opacity: 0.06; }
+
+/* ── Dev-state animations (issue #82) ───────────────────────────── */
+/* Halo pulse (::before) — dev / pr_open / pr_reviewed */
+#graph-panel .gg-node.pulse::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  animation: gg-pulse 1.6s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
+  pointer-events: none;
+}
+#graph-panel .gg-node.parent.pulse::before {
+  border-radius: 5px;
+}
+@keyframes gg-pulse {
+  0%   { transform: scale(0.85); opacity: 0.9; }
+  80%  { opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+
+/* First orbit dot (::after) — pr_open (orbit-1) or pr_reviewed (orbit-2) */
+#graph-panel .gg-node.orbit-1::after,
+#graph-panel .gg-node.orbit-2::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 0%, currentColor 0 2.2px, transparent 2.6px);
+  animation: gg-orbit 1.8s linear infinite;
+  pointer-events: none;
+}
+
+/* Second orbit dot (child element) — pr_reviewed only */
+#graph-panel .gg-node.orbit-2 .gg-orbit-2nd {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  pointer-events: none;
+}
+#graph-panel .gg-node.orbit-2 .gg-orbit-2nd::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 0%, var(--dev-orbit-2nd) 0 2.2px, transparent 2.6px);
+  animation: gg-orbit 1.8s linear infinite;
+  animation-delay: -0.9s;
+  pointer-events: none;
+}
+
+@keyframes gg-orbit { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  #graph-panel .gg-node.pulse::before,
+  #graph-panel .gg-node.orbit-1::after,
+  #graph-panel .gg-node.orbit-2::after,
+  #graph-panel .gg-node.orbit-2 .gg-orbit-2nd::before {
+    animation: none;
+  }
+}

--- a/frontend/graph.js
+++ b/frontend/graph.js
@@ -1,0 +1,160 @@
+// graph.js — v6 graph view with v5 layout
+// Uses layout.js for positioning and render_graph.js for DOM rendering
+
+import { state, filteredNodesForGraph } from './state.js';
+import { runLayout } from './layout.js';
+import { renderGraph, getEdgeElements, getLabelElements } from './render_graph.js';
+
+let loaded = false;
+
+// ── Shared highlight helpers ────────────────────────────────────────────────
+function getReachableKeys(edges, startKey, dir) {
+  const visited = new Set();
+  const queue = [startKey];
+  while (queue.length) {
+    const k = queue.shift();
+    if (visited.has(k)) continue;
+    visited.add(k);
+    for (const e of edges) {
+      const next = dir === 'up' ? e.dataset.src : e.dataset.dst;
+      const cur = dir === 'up' ? e.dataset.dst : e.dataset.src;
+      if (cur === k && next) queue.push(next);
+    }
+  }
+  visited.delete(startKey);
+  return visited;
+}
+
+function applyHighlight(panel, edges, key) {
+  const labels = getLabelElements(panel);
+  const byKey = new Map();
+  for (const el of labels) {
+    const k = el.dataset.iss;
+    if (!k) continue;
+    if (!byKey.has(k)) byKey.set(k, []);
+    byKey.get(k).push(el);
+  }
+
+  panel.classList.add('hl-active');
+  (byKey.get(key) || []).forEach(n => n.classList.add('hl-self'));
+
+  for (const k of getReachableKeys(edges, key, 'up')) {
+    (byKey.get(k) || []).forEach(n => n.classList.add('hl-upstream'));
+  }
+  for (const k of getReachableKeys(edges, key, 'down')) {
+    (byKey.get(k) || []).forEach(n => n.classList.add('hl-downstream'));
+  }
+
+  for (const e of edges) {
+    const src = e.dataset.src;
+    const dst = e.dataset.dst;
+    if (src && dst) {
+      const srcIsHl = (byKey.get(src) || []).some(n =>
+        n.classList.contains('hl-self') || n.classList.contains('hl-upstream') ||
+        n.classList.contains('hl-downstream')
+      );
+      const dstIsHl = (byKey.get(dst) || []).some(n =>
+        n.classList.contains('hl-self') || n.classList.contains('hl-upstream') ||
+        n.classList.contains('hl-downstream')
+      );
+      if (srcIsHl && dstIsHl) e.classList.add('hl-edge');
+    }
+  }
+}
+
+function clearHighlight(panel, edges) {
+  panel.classList.remove('hl-active');
+  panel.querySelectorAll('.hl-self, .hl-upstream, .hl-downstream')
+    .forEach(el => el.classList.remove('hl-self', 'hl-upstream', 'hl-downstream'));
+  edges.forEach(e => e.classList.remove('hl-edge'));
+}
+
+// ── Hover-chain highlight ─────────────────────────────────────────────────
+function wireHoverChain(panel, edges) {
+  const labels = getLabelElements(panel);
+  const allItems = labels;
+
+  for (const el of allItems) {
+    el.addEventListener('mouseenter', () => {
+      clearHighlight(panel, edges);
+      applyHighlight(panel, edges, el.dataset.iss);
+    });
+    el.addEventListener('mouseleave', () => clearHighlight(panel, edges));
+  }
+}
+
+// ── Search highlight (tree-based, no filtering) ─────────────────────────────
+function applySearchHighlight(panel, nodes, edges) {
+  const search = (state.search ?? '').trim().toLowerCase();
+  if (!search) return;
+
+  // Find matching nodes
+  const matches = nodes.filter(n => {
+    const hay = `${n.key} ${n.title ?? ''} ${(n.labels ?? []).join(' ')}`.toLowerCase();
+    return hay.includes(search);
+  });
+
+  if (matches.length === 0) return;
+
+  // Apply highlight to first match and its tree
+  const key = matches[0].key;
+  applyHighlight(panel, edges, key);
+}
+
+// Store current edges for clearSearchHighlight
+let currentEdges = [];
+
+// ── Main graph initialization ────────────────────────────────────────────
+export async function initGraph() {
+  const panel = document.getElementById('graph-panel');
+  if (!panel) return;
+
+  // Graph filters by repo/milestone/priority/status, but search uses highlight.
+  // Parent-node filtering (showParents=false) is applied inside applyFilters.
+  const nodes = filteredNodesForGraph();
+
+  const nodeKeys = new Set(nodes.map(n => n.key));
+
+  // Filter edges: only blocks edges, optionally include parent
+  const edges = state.edges.filter(e =>
+    nodeKeys.has(e.src) && nodeKeys.has(e.dst) &&
+    (e.kind === 'blocks' || state.showParents)
+  );
+  currentEdges = [];
+
+  if (nodes.length === 0) {
+    panel.innerHTML = '<div class="error-msg">No issues match the current filters.</div>';
+    return;
+  }
+
+  panel.innerHTML = '<div style="padding:20px;color:var(--text-muted)">Calculating layout…</div>';
+
+  try {
+    const layoutResult = await runLayout(nodes, edges);
+    renderGraph(panel, nodes, edges, layoutResult);
+
+    // Get DOM edge elements for highlight
+    currentEdges = getEdgeElements(panel);
+
+    wireHoverChain(panel, currentEdges);
+    applySearchHighlight(panel, nodes, currentEdges);
+    loaded = true;
+  } catch (e) {
+    panel.innerHTML = `<div class="error-msg">Graph layout failed: ${e.message}</div>`;
+    console.error('Graph layout error:', e);
+  }
+}
+
+// ── Clear search highlight (for ESC key) ───────────────────────────────────
+export function clearSearchHighlight() {
+  const panel = document.getElementById('graph-panel');
+  if (panel && currentEdges.length) {
+    clearHighlight(panel, currentEdges);
+  }
+}
+
+// ── Force reload (for external use) ───────────────────────────────────────
+export async function reloadGraph() {
+  loaded = false;
+  await initGraph();
+}

--- a/frontend/hover.js
+++ b/frontend/hover.js
@@ -1,0 +1,173 @@
+// hover.js — hover-chain highlight for table and list views
+// Lifted from v5 hover.js, adapted for v6 module system
+
+import { state } from './state.js';
+
+// ── Build adjacency maps from edges ───────────────────────────────────────────
+function buildAdjacency() {
+  const blockers = new Map(); // key → keys that block it
+  const unblocks = new Map(); // key → keys it unblocks
+
+  for (const e of state.edges) {
+    if (e.kind === 'blocks' || !e.kind) {
+      if (!blockers.has(e.dst)) blockers.set(e.dst, []);
+      blockers.get(e.dst).push(e.src);
+      if (!unblocks.has(e.src)) unblocks.set(e.src, []);
+      unblocks.get(e.src).push(e.dst);
+    }
+  }
+  return { blockers, unblocks };
+}
+
+// ── Traverse graph to find upstream/downstream ────────────────────────────────
+function traverse(start, adj) {
+  const seen = new Set();
+  const stack = [start];
+  while (stack.length) {
+    const k = stack.pop();
+    for (const n of adj.get(k) || []) {
+      if (!seen.has(n)) { seen.add(n); stack.push(n); }
+    }
+  }
+  return seen;
+}
+
+// ── Highlight logic ────────────────────────────────────────────────────────────
+let panelEl = null;
+let targetsFn = null;
+let edgesFn = null;
+let pinnedKey = null;
+
+function highlightKey(k, byKey, edges) {
+  const { blockers, unblocks } = buildAdjacency();
+  const up = traverse(k, blockers);
+  const down = traverse(k, unblocks);
+
+  panelEl.classList.add('hl-active');
+  (byKey.get(k) || []).forEach(n => n.classList.add('hl-self'));
+  up.forEach(key => (byKey.get(key) || []).forEach(n => n.classList.add('hl-upstream')));
+  down.forEach(key => (byKey.get(key) || []).forEach(n => n.classList.add('hl-downstream')));
+
+  const chain = new Set([k, ...up, ...down]);
+  edges.forEach(e => {
+    if (chain.has(e.dataset.src) && chain.has(e.dataset.tgt)) {
+      e.classList.add('hl-edge');
+    }
+  });
+}
+
+function clearHighlight() {
+  if (!panelEl) return;
+  panelEl.classList.remove('hl-active');
+  panelEl.querySelectorAll('.hl-self, .hl-upstream, .hl-downstream')
+    .forEach(el => el.classList.remove('hl-self', 'hl-upstream', 'hl-downstream'));
+  (edgesFn ? edgesFn() : []).forEach(e => e.classList.remove('hl-edge'));
+}
+
+function restorePinned(byKey, edges) {
+  clearHighlight();
+  if (pinnedKey) highlightKey(pinnedKey, byKey, edges);
+}
+
+// ── Wire hover events on all targets ───────────────────────────────────────────
+function wireTargets(targets, byKey, edges) {
+  targets.forEach(el => {
+    el.addEventListener('mouseenter', () => {
+      clearHighlight();
+      highlightKey(el.dataset.iss, byKey, edges);
+    });
+    el.addEventListener('mouseleave', () => restorePinned(byKey, edges));
+  });
+}
+
+// ── Wire search input for pinned highlight ─────────────────────────────────────
+let searchWired = false;
+
+function wireSearch(input) {
+  if (!input || searchWired) return;
+  searchWired = true;
+
+  function applySearch() {
+    const raw = input.value.trim().replace(/^#/, '');
+    if (!raw) {
+      pinnedKey = null;
+      clearHighlight();
+      return;
+    }
+    // Rebuild byNum from current view panel DOM on each search (handles filtered nodes)
+    const byNum = new Map();
+    const currentByKey = new Map();
+    const panel = panelEl || document.querySelector('.view-active');
+    if (!panel) return;
+    panel.querySelectorAll('[data-iss]').forEach(el => {
+      const k = el.dataset.iss;
+      if (!k) return;
+      if (!currentByKey.has(k)) currentByKey.set(k, []);
+      currentByKey.get(k).push(el);
+      const m = /#(\d+)$/.exec(k);
+      if (!m) return;
+      const num = m[1];
+      if (!byNum.has(num)) byNum.set(num, []);
+      byNum.get(num).push(k);
+    });
+    const keys = byNum.get(raw);
+    if (!keys || keys.length === 0) {
+      pinnedKey = null;
+      clearHighlight();
+      return;
+    }
+    pinnedKey = keys[0];
+    clearHighlight();
+    // Get current edge elements from graph if visible
+    const edges = Array.from(panel.querySelectorAll('.gg-edge[data-src]'));
+    highlightKey(pinnedKey, currentByKey, edges);
+  }
+
+  input.addEventListener('input', applySearch);
+
+  // Esc clears search
+  document.addEventListener('keydown', e => {
+    if (e.key !== 'Escape') return;
+    if (!input.value && !pinnedKey) return;
+    input.value = '';
+    applySearch();
+    if (document.activeElement === input) input.blur();
+  });
+}
+
+// ── Public: initialize hover for a view container ──────────────────────────────
+export function initHover(panel, viewName) {
+  panelEl = panel;
+
+  // Get all elements with data-iss (issue cards, list rows, etc.)
+  const targets = Array.from(panel.querySelectorAll('[data-iss]'));
+  if (targets.length === 0) return;
+
+  // Bucket elements by issue key
+  const byKey = new Map();
+  targets.forEach(el => {
+    const k = el.dataset.iss;
+    if (!byKey.has(k)) byKey.set(k, []);
+    byKey.get(k).push(el);
+  });
+
+  // Get edge elements if any (for graph view)
+  const edges = viewName === 'graph'
+    ? Array.from(panel.querySelectorAll('.gg-edge[data-src]'))
+    : [];
+
+  edgesFn = () => edges;
+
+  wireTargets(targets, byKey, edges);
+
+  // Wire search once (guarded by searchWired flag)
+  const searchInput = document.getElementById('search-input');
+  if (searchInput) {
+    wireSearch(searchInput);
+  }
+}
+
+// ── Clear pinned key when filters change ───────────────────────────────────────
+export function clearPinned() {
+  pinnedKey = null;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dep-Graph v6 · Roxabi Live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@500;600;700&display=swap">
+<link rel="stylesheet" href="app.css">
+<link rel="stylesheet" href="graph.css">
+</head>
+<body>
+<div class="sticky-head">
+  <header class="page-header">
+    <div>
+      <h1>Dep-Graph <span class="accent">v6</span> · Roxabi Live</h1>
+      <div class="subtitle" id="subtitle">Loading…</div>
+    </div>
+    <div class="header-actions">
+      <div class="segs view-segs" role="group" aria-label="View">
+        <button id="btn-table" class="seg on" data-v="table" aria-pressed="true"  title="Table"><span class="ico">⊞</span> Table</button>
+        <button id="btn-list"  class="seg"    data-v="list"  aria-pressed="false" title="List"><span class="ico">≡</span> List</button>
+        <button id="btn-graph" class="seg"    data-v="graph" aria-pressed="false" title="Graph"><span class="ico">⋈</span> Graph</button>
+      </div>
+      <button id="theme-btn" class="theme-btn" type="button" title="Toggle theme" aria-label="Toggle theme">🌙</button>
+    </div>
+  </header>
+
+  <div class="toolbar">
+    <div class="ms-wrap">
+      <button id="ms-repo-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by repo">
+        <span class="ms-placeholder">All repos</span>
+      </button>
+      <button id="ms-repo-clear" class="ms-clear-inline" aria-label="Clear repo filter" hidden>×</button>
+      <div id="ms-repo-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
+      <button id="ms-milestone-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by milestone">
+        <span class="ms-placeholder">All milestones</span>
+      </button>
+      <button id="ms-milestone-clear" class="ms-clear-inline" aria-label="Clear milestone filter" hidden>×</button>
+      <div id="ms-milestone-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
+      <button id="ms-priority-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by priority">
+        <span class="ms-placeholder">All priorities</span>
+      </button>
+      <button id="ms-priority-clear" class="ms-clear-inline" aria-label="Clear priority filter" hidden>×</button>
+      <div id="ms-priority-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
+      <button id="ms-status-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by status">
+        <span class="ms-placeholder">All statuses</span>
+      </button>
+      <button id="ms-status-clear" class="ms-clear-inline" aria-label="Clear status filter" hidden>×</button>
+      <div id="ms-status-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="search-wrap">
+      <input type="search" id="search-input" placeholder="Search issues…" autocomplete="off" aria-label="Search issues">
+      <button id="search-clear" class="clear-btn" aria-label="Clear search" hidden>×</button>
+    </div>
+
+    <!-- Table-only: Pivot seg controls -->
+    <span class="pivot-controls" id="pivot-controls">
+      <span class="toolbar-label">Row</span>
+      <div class="segs" id="pivot-row-segs" role="group" aria-label="Pivot row dimension"></div>
+      <span class="toolbar-label">Col</span>
+      <div class="segs" id="pivot-col-segs" role="group" aria-label="Pivot column dimension"></div>
+      <span class="toolbar-label">Group</span>
+      <div class="segs" id="table-group-segs" role="group" aria-label="Group cells by"></div>
+    </span>
+
+    <!-- List-only: Group-by segs (2 levels) -->
+    <span class="list-controls" id="list-controls" style="display:none">
+      <span class="toolbar-label">Group</span>
+      <div class="segs" id="list-group-segs" role="group" aria-label="Primary grouping"></div>
+      <span class="toolbar-label">Then</span>
+      <div class="segs" id="list-group2-segs" role="group" aria-label="Secondary grouping"></div>
+    </span>
+
+    <!-- Shared: hide parent issues in all views (+ parent edges in graph) -->
+    <span class="graph-controls" id="graph-controls">
+      <div class="segs" id="graph-edge-segs" role="group" aria-label="Parent visibility"></div>
+    </span>
+  </div>
+</div>
+
+<main>
+  <div id="view-table" class="view view-active" role="region" aria-label="Table view"></div>
+  <div id="view-list"  class="view"             role="region" aria-label="List view"></div>
+  <section id="graph-panel" class="view"        role="region" aria-label="Graph view" hidden></section>
+  <div id="error-msg" class="error-msg" hidden></div>
+</main>
+
+<footer class="page-footer">
+  <span>v6</span>
+</footer>
+
+<script type="module" src="state.js"></script>
+<script type="module" src="pivot.js"></script>
+<script type="module" src="app.js"></script>
+<script type="module" src="graph.js"></script>
+</body>
+</html>

--- a/frontend/layout.js
+++ b/frontend/layout.js
@@ -1,0 +1,280 @@
+// layout.js — Graph layout for v6 dep-graph
+// v5 engine: percentage coords, depth-based bands, parent-child alignment
+
+// ── v5 positioning constants (match Python layout_graph.py) ──────────────────
+const LANE_X_START = 4.0;
+const LANE_X_END = 96.0;
+const Y_TOP = 2.5;
+const Y_BOT = 88.0;
+const MIN_CELL_GAP = 2;
+const MAX_CELL_WIDTH_PCT = 4.0;
+const MAX_BAND_GAP_PX = 80;
+const MIN_CONTAINER_H = 320;
+
+function msIdx(ms, msCodes) {
+  if (!ms || ms === '(None)') return -1;
+  const idx = msCodes.indexOf(ms);
+  return idx >= 0 ? idx : 99;
+}
+
+function laneIdx(lane, laneOrder) {
+  const idx = laneOrder.indexOf(lane);
+  return idx >= 0 ? idx : laneOrder.length;
+}
+
+export function edgePath(x1, y1, x2, y2) {
+  if (Math.abs(x1 - x2) < 0.1) {
+    return `M ${x1.toFixed(2)},${y1.toFixed(2)} L ${x2.toFixed(2)},${y2.toFixed(2)}`;
+  }
+  const ymid = (y1 + y2) / 2;
+  return `M ${x1.toFixed(2)},${y1.toFixed(2)} C ${x1.toFixed(2)},${ymid.toFixed(2)} ${x2.toFixed(2)},${ymid.toFixed(2)} ${x2.toFixed(2)},${y2.toFixed(2)}`;
+}
+
+function msBounds(gridSize) {
+  const pageSpan = LANE_X_END - LANE_X_START;
+  const pageCenter = (LANE_X_START + LANE_X_END) / 2;
+  if (gridSize <= 1) return { xStart: pageCenter, xEnd: pageCenter, step: 0 };
+  const natural = pageSpan / (gridSize - 1);
+  if (natural <= MAX_CELL_WIDTH_PCT) {
+    return { xStart: LANE_X_START, xEnd: LANE_X_END, step: natural };
+  }
+  const step = MAX_CELL_WIDTH_PCT;
+  const span = step * (gridSize - 1);
+  const xStart = pageCenter - span / 2;
+  return { xStart, xEnd: xStart + span, step };
+}
+
+function xFromCell(cell, gridSize) {
+  const { xStart, step } = msBounds(gridSize);
+  return xStart + cell * step;
+}
+
+function cellFromX(x, gridSize) {
+  const { xStart, step } = msBounds(gridSize);
+  if (step === 0) return 0;
+  const raw = Math.round((x - xStart) / step);
+  return Math.max(0, Math.min(gridSize - 1, raw));
+}
+
+function resolveCells(desired, gridSize) {
+  const n = desired.length;
+  const order = [...Array(n).keys()].sort((a, b) => desired[a] - desired[b] || a - b);
+  const final = new Array(n);
+
+  for (let k = 0; k < n; k++) {
+    const idx = order[k];
+    let c = Math.max(desired[idx], 0);
+    if (k > 0) {
+      c = Math.max(c, final[order[k - 1]] + MIN_CELL_GAP);
+    }
+    final[idx] = c;
+  }
+
+  for (let k = n - 1; k >= 0; k--) {
+    const idx = order[k];
+    let c = Math.min(final[idx], gridSize - 1);
+    if (k < n - 1) {
+      c = Math.min(c, final[order[k + 1]] - MIN_CELL_GAP);
+    }
+    final[idx] = c;
+  }
+
+  return final;
+}
+
+function uniformCells(n, gridSize) {
+  if (n <= 0) return [];
+  if (n === 1) return [Math.floor(gridSize / 2)];
+  const step = (gridSize - 1) / (n - 1);
+  return [...Array(n).keys()].map(i => Math.round(i * step));
+}
+
+function getParentCells(task, allTasks, ms, cellOf, xOf, gridSize) {
+  const cells = [];
+  for (const parent of allTasks) {
+    if (parent.key === task.key) continue;
+    const edges = task._blockers || [];
+    const isParent = edges.some(e => e.src === parent.key);
+    if (!isParent) continue;
+
+    const pNum = parent.key;
+    if (parent.milestone_code === ms && cellOf.has(pNum)) {
+      cells.push(cellOf.get(pNum));
+    } else if (xOf.has(pNum)) {
+      cells.push(cellFromX(xOf.get(pNum), gridSize));
+    }
+  }
+  return cells;
+}
+
+export function layoutV5(nodes, edges) {
+  const laneSet = new Set(nodes.map(n => n.lane).filter(Boolean));
+  const laneOrder = [...laneSet].sort();
+
+  const msMap = new Map();
+  for (const n of nodes) {
+    const code = n.milestone_code ?? '-';
+    const sortKey = n.milestone_sort_key ?? 9999;
+    if (!msMap.has(code)) msMap.set(code, sortKey);
+  }
+  const msCodes = [...msMap.entries()]
+    .sort((a, b) => a[1] - b[1])
+    .map(([code]) => code);
+
+  const blockersByDst = new Map();
+  for (const e of edges) {
+    if (!blockersByDst.has(e.dst)) blockersByDst.set(e.dst, []);
+    blockersByDst.get(e.dst).push(e);
+  }
+  for (const n of nodes) {
+    n._blockers = blockersByDst.get(n.key) || [];
+  }
+
+  const byMsDepth = new Map();
+  for (const n of nodes) {
+    const ms = n.milestone_code ?? '-';
+    const depth = n._depth ?? 0;
+    if (!byMsDepth.has(ms)) byMsDepth.set(ms, new Map());
+    if (!byMsDepth.get(ms).has(depth)) byMsDepth.get(ms).set(depth, []);
+    byMsDepth.get(ms).get(depth).push(n);
+  }
+
+  // Depth = longest chain of blockers (blocks-edges) AND parents (parent-edges)
+  // ending at this node.  Both kinds contribute; we take the max so a node sits
+  // strictly below both its deepest blocker and its parent.
+  //
+  // Memoize across calls (DAG traversal must not collapse to 0 when reached via
+  // a second path) and use an in-flight `stack` set strictly for cycle break
+  // (returns 0 on detected cycle, mirroring the previous behaviour).
+  const nodesByKey = new Map(nodes.map(n => [n.key, n]));
+  const depthCache = new Map();
+  function computeDepth(node, stack = new Set()) {
+    const cached = depthCache.get(node.key);
+    if (cached !== undefined) return cached;
+    if (stack.has(node.key)) return 0;  // cycle break
+    stack.add(node.key);
+    let maxDepth = 0;
+    for (const e of node._blockers || []) {
+      const blocker = nodesByKey.get(e.src);
+      if (blocker) {
+        maxDepth = Math.max(maxDepth, computeDepth(blocker, stack) + 1);
+      }
+    }
+    stack.delete(node.key);
+    depthCache.set(node.key, maxDepth);
+    return maxDepth;
+  }
+  for (const n of nodes) {
+    n._depth = computeDepth(n);
+  }
+
+  byMsDepth.clear();
+  for (const n of nodes) {
+    const ms = n.milestone_code ?? '(None)';
+    const depth = n._depth;
+    if (!byMsDepth.has(ms)) byMsDepth.set(ms, new Map());
+    if (!byMsDepth.get(ms).has(depth)) byMsDepth.get(ms).set(depth, []);
+    byMsDepth.get(ms).get(depth).push(n);
+  }
+
+  const gridSizePerMs = new Map();
+  for (const [ms, depths] of byMsDepth) {
+    let maxBand = 1;
+    for (const [, bandNodes] of depths) {
+      maxBand = Math.max(maxBand, bandNodes.length);
+    }
+    gridSizePerMs.set(ms, Math.max(MIN_CELL_GAP * maxBand - 1, 1));
+  }
+
+  const cellOf = new Map();
+  const xOf = new Map();
+
+  for (const ms of [...byMsDepth.keys()].sort((a, b) => msIdx(a, msCodes) - msIdx(b, msCodes))) {
+    const depths = byMsDepth.get(ms);
+    const gridSize = gridSizePerMs.get(ms);
+
+    for (const depth of [...depths.keys()].sort((a, b) => a - b)) {
+      const bandNodes = depths.get(depth);
+      bandNodes.sort((a, b) => laneIdx(a.lane, laneOrder) - laneIdx(b.lane, laneOrder) || a.key.localeCompare(b.key));
+
+      const desired = bandNodes.map(n => {
+        const pc = getParentCells(n, nodes, ms, cellOf, xOf, gridSize);
+        if (pc.length > 0) return Math.round(pc.reduce((a, b) => a + b, 0) / pc.length);
+        const uniform = uniformCells(bandNodes.length, gridSize);
+        return uniform[bandNodes.indexOf(n)];
+      });
+
+      const final = resolveCells(desired, gridSize);
+      for (let i = 0; i < bandNodes.length; i++) {
+        const n = bandNodes[i];
+        cellOf.set(n.key, final[i]);
+        xOf.set(n.key, xFromCell(final[i], gridSize));
+      }
+    }
+  }
+
+  const sortedBandKeys = [];
+  for (const [ms, depths] of byMsDepth) {
+    for (const depth of depths.keys()) {
+      sortedBandKeys.push([ms, depth]);
+    }
+  }
+  sortedBandKeys.sort((a, b) => msIdx(a[0], msCodes) - msIdx(b[0], msCodes) || a[1] - b[1]);
+
+  const nBands = sortedBandKeys.length;
+  const stepY = nBands > 1 ? (Y_BOT - Y_TOP) / (nBands - 1) : 0;
+
+  const positions = new Map();
+  const bandRecords = [];
+
+  for (let i = 0; i < sortedBandKeys.length; i++) {
+    const [ms, depth] = sortedBandKeys[i];
+    const bandY = Y_TOP + i * stepY;
+    const bandNodes = byMsDepth.get(ms).get(depth) || [];
+    bandNodes.sort((a, b) => (cellOf.get(a.key) || 0) - (cellOf.get(b.key) || 0));
+
+    for (const n of bandNodes) {
+      positions.set(n.key, { x: xOf.get(n.key) || 50, y: bandY });
+    }
+
+    bandRecords.push({ ms, depth, y: bandY, count: bandNodes.length });
+  }
+
+  const ysByMs = new Map();
+  for (const b of bandRecords) {
+    if (!ysByMs.has(b.ms)) ysByMs.set(b.ms, []);
+    ysByMs.get(b.ms).push(b.y);
+  }
+
+  const milestoneInfo = [];
+  for (const [ms, ys] of ysByMs) {
+    const top = Math.min(...ys) - stepY / 2;
+    const bot = Math.max(...ys) + stepY / 2;
+    const msNode = nodes.find(n => (n.milestone_code ?? '(None)') === ms);
+    milestoneInfo.push({
+      code: ms,
+      name: msNode?.milestone_name || null,
+      y: Math.max(top, 1.0),
+      height: Math.min(bot, 99.0) - Math.max(top, 1.0)
+    });
+  }
+  milestoneInfo.sort((a, b) => msIdx(a.code, msCodes) - msIdx(b.code, msCodes));
+
+  const bandSpanPct = (Y_BOT - Y_TOP) / 100;
+  const containerH = nBands > 1
+    ? Math.max(MIN_CONTAINER_H, (MAX_BAND_GAP_PX * (nBands - 1)) / bandSpanPct + 80)
+    : MIN_CONTAINER_H;
+
+  return {
+    positions,
+    milestoneInfo,
+    lanes: laneOrder,
+    width: 100,
+    height: containerH,
+    usePercentage: true
+  };
+}
+
+export function runLayout(nodes, edges) {
+  return layoutV5(nodes, edges);
+}

--- a/frontend/list.js
+++ b/frontend/list.js
@@ -1,0 +1,389 @@
+// list.js — flat-table list renderer with group-by and sort
+import { state, filteredNodes, parseMilestone, prioritySortKey, dimValue } from './state.js';
+import { initHover } from './hover.js';
+
+const PRIORITY_COLOR = { P0: 'p0', P1: 'p1', P2: 'p2', P3: 'p3' };
+const STATUS_DOT     = { open: 'dot-open', closed: 'dot-closed' };
+
+// ─── Edge helpers ─────────────────────────────────────────────────────────
+function edgeFilter(edges, key, dir, kind) {
+  // dir='src': edges where src===key; dir='dst': edges where dst===key
+  return edges.filter(e => e.kind === kind && e[dir] === key);
+}
+
+function shortKey(k) {
+  // "Roxabi/lyra#42" -> "#42"
+  const m = k.match(/#(\d+)$/);
+  return m ? `#${m[1]}` : k;
+}
+
+// ─── Group title helper ───────────────────────────────────────────────────
+function groupTitle(dim, gVal, nodes) {
+  if (dim === 'parent' && gVal && gVal !== '—') {
+    // Find parent node to get its title
+    const parent = nodes.find(n => n.key === gVal);
+    if (parent) {
+      const title = parent.title || '';
+      return title.length > 50 ? title.slice(0, 47) + '…' : title;
+    }
+  }
+  // For other dims, no extra title
+  return null;
+}
+
+// ─── Sort state ───────────────────────────────────────────────────────────
+let sortCol = null;    // column id or null (default)
+let sortDir = 'asc';  // 'asc' | 'desc'
+
+function defaultSort(a, b) {
+  const msa = parseMilestone(a).sortKey - parseMilestone(b).sortKey;
+  if (msa !== 0) return msa;
+  const pa = prioritySortKey(a.priority) - prioritySortKey(b.priority);
+  if (pa !== 0) return pa;
+  return a.number - b.number;
+}
+
+function colSortKey(n, col) {
+  switch (col) {
+    case 'ref':      return `${n.repo}#${String(n.number).padStart(8, '0')}`;
+    case 'status':   return n._status ?? '';
+    case 'title':    return (n.title ?? '').toLowerCase();
+    case 'milestone':return String(parseMilestone(n).sortKey).padStart(8, '0');
+    case 'priority': return String(prioritySortKey(n.priority)).padStart(3, '0');
+    case 'lane':     return n.lane ?? '~';
+    case 'size':     return n.size ?? '~';
+    case 'blocks':   return 0;  // sorted by count — filled at render time
+    case 'blockedby':return 0;
+    case 'parentof': return 0;
+    default:         return '';
+  }
+}
+
+function sortNodes(nodes, edges) {
+  if (!sortCol) return [...nodes].sort(defaultSort);
+
+  // For edge-count cols we need to compute per-node
+  if (['blocks', 'blockedby', 'parentof'].includes(sortCol)) {
+    const counted = nodes.map(n => {
+      let cnt;
+      if (sortCol === 'blocks')    cnt = edgeFilter(edges, n.key, 'src', 'blocks').length;
+      if (sortCol === 'blockedby') cnt = edgeFilter(edges, n.key, 'dst', 'blocks').length;
+      if (sortCol === 'parentof')  cnt = edgeFilter(edges, n.key, 'src', 'parent').length;
+      return { n, cnt };
+    });
+    counted.sort((a, b) => sortDir === 'asc' ? a.cnt - b.cnt : b.cnt - a.cnt);
+    return counted.map(x => x.n);
+  }
+
+  return [...nodes].sort((a, b) => {
+    const ka = colSortKey(a, sortCol);
+    const kb = colSortKey(b, sortCol);
+    const cmp = ka < kb ? -1 : ka > kb ? 1 : 0;
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+}
+
+// ─── Group ordering ───────────────────────────────────────────────────────
+function groupSortKey(dim, val, nodes) {
+  if (dim === 'milestone') {
+    const n = nodes.find(x => dimValue(x, 'milestone') === val);
+    return n ? parseMilestone(n).sortKey : 9999;
+  }
+  if (dim === 'priority') {
+    const order = { P0: 0, P1: 1, P2: 2, P3: 3, None: 4, '—': 5 };
+    return order[val] ?? 99;
+  }
+  if (dim === 'status') {
+    return { ready: 0, blocked: 1, done: 2 }[val] ?? 99;
+  }
+  return val === '—' ? '￿' : val;
+}
+
+// ─── Row builder ──────────────────────────────────────────────────────────
+function buildRow(n, edges) {
+  const tr  = document.createElement('tr');
+  tr.className = `issue-row state-${n.state}`;
+  tr.dataset.iss = n.key;
+
+  // Hover-chain attrs
+  const blockers = edges.filter(e => e.kind === 'blocks' && e.dst === n.key).map(e => e.src);
+  const blocking = edges.filter(e => (e.kind === 'blocks' || !e.kind) && e.src === n.key).map(e => e.dst);
+  if (blockers.length) tr.dataset.blockedby = blockers.join(',');
+  if (blocking.length) tr.dataset.blocking = blocking.join(',');
+
+  const repoShort = n.repo ? n.repo.split('/')[1] : n.repo;
+
+  // # ref
+  const tdRef = document.createElement('td');
+  const a = document.createElement('a');
+  a.href   = n.url || '#';
+  a.target = '_blank';
+  a.rel    = 'noopener noreferrer';
+  a.className = 'issue-link';
+  a.textContent = `${repoShort}#${n.number}`;
+  tdRef.appendChild(a);
+
+  // ● state dot + status tooltip
+  const tdDot = document.createElement('td');
+  tdDot.className = 'col-dot';
+  const dot = document.createElement('span');
+  dot.className = `state-dot ${STATUS_DOT[n.state] || 'dot-closed'}`;
+  dot.setAttribute('title', `${n.state} · ${n._status ?? ''}`);
+  dot.setAttribute('aria-label', `${n.state}, ${n._status ?? ''}`);
+  if (n._status === 'blocked') dot.classList.add('dot-blocked');
+  tdDot.appendChild(dot);
+
+  // Title
+  const tdTitle = document.createElement('td');
+  tdTitle.className = 'col-title';
+  const titleSpan = document.createElement('span');
+  titleSpan.className  = 'list-title';
+  titleSpan.textContent = n.title || `Issue #${n.number}`;
+  titleSpan.setAttribute('title', n.title || '');
+  tdTitle.appendChild(titleSpan);
+
+  // Milestone (centered)
+  const tdMs = document.createElement('td');
+  tdMs.className = 'col-center';
+  const ms = parseMilestone(n);
+  if (ms.code) {
+    const badge = document.createElement('span');
+    badge.className  = 'badge badge-ms';
+    badge.textContent = ms.code;
+    tdMs.appendChild(badge);
+  }
+
+  // Priority (centered)
+  const tdPri = document.createElement('td');
+  tdPri.className = 'col-center';
+  if (n.priority) {
+    const badge = document.createElement('span');
+    badge.className  = `badge badge-${PRIORITY_COLOR[n.priority] || ''}`;
+    badge.textContent = n.priority;
+    tdPri.appendChild(badge);
+  }
+
+  // Lane (centered)
+  const tdLane = document.createElement('td');
+  tdLane.className = 'col-center';
+  tdLane.textContent = n.lane ?? '';
+
+  // Size (centered)
+  const tdSize = document.createElement('td');
+  tdSize.className = 'col-center';
+  tdSize.textContent = n.size ?? '';
+
+  // Edge counts helper
+  function makeCountCell(edgeList) {
+    const td   = document.createElement('td');
+    td.className = 'col-count col-center';  // center edge counts
+    if (!edgeList.length) { return td; }  // blank for empty
+    const sp = document.createElement('span');
+    sp.className = 'edge-count';
+    sp.textContent = edgeList.length;
+    sp.setAttribute('title', edgeList.map(e => shortKey(e.src === n.key ? e.dst : e.src)).join(', '));
+    td.appendChild(sp);
+    return td;
+  }
+
+  const blocksEdges    = edgeFilter(edges, n.key, 'src', 'blocks');
+  const blockedByEdges = edgeFilter(edges, n.key, 'dst', 'blocks');
+  const parentOfEdges  = edgeFilter(edges, n.key, 'src', 'parent');
+
+  tr.append(tdRef, tdDot, tdTitle, tdMs, tdPri, tdLane, tdSize,
+    makeCountCell(blocksEdges),
+    makeCountCell(blockedByEdges),
+    makeCountCell(parentOfEdges));
+
+  return tr;
+}
+
+// ─── Table shell ──────────────────────────────────────────────────────────
+const COLS = [
+  { id: 'ref',      label: '#'          },
+  { id: 'status',   label: '●'          },
+  { id: 'title',    label: 'Title'      },
+  { id: 'milestone',label: 'Milestone'  },
+  { id: 'priority', label: 'Priority'   },
+  { id: 'lane',     label: 'Lane'       },
+  { id: 'size',     label: 'Size'       },
+  { id: 'blocks',   label: 'Blocks'     },
+  { id: 'blockedby',label: 'Blocked by' },
+  { id: 'parentof', label: 'Parent of'  },
+];
+
+function buildThead(onSort) {
+  const thead = document.createElement('thead');
+  const tr    = document.createElement('tr');
+  for (const col of COLS) {
+    const th = document.createElement('th');
+    th.textContent = col.label;
+    th.dataset.col = col.id;
+    // Center all columns except ref, status, title
+    const centerCols = ['milestone', 'priority', 'lane', 'size', 'blocks', 'blockedby', 'parentof'];
+    th.className = 'sortable' + (centerCols.includes(col.id) ? ' col-center' : '');
+    if (sortCol === col.id) th.classList.add(sortDir === 'asc' ? 'sort-asc' : 'sort-desc');
+    th.setAttribute('aria-sort', sortCol === col.id ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none');
+    th.addEventListener('click', () => onSort(col.id));
+    tr.appendChild(th);
+  }
+  thead.appendChild(tr);
+  return thead;
+}
+
+// ─── Collapse tracking ────────────────────────────────────────────────────
+const collapsed = new Set();   // group values that are folded
+
+// ─── Main renderer ────────────────────────────────────────────────────────
+export function renderList(container) {
+  const nodes = filteredNodes();
+  const edges = state.edges;
+  const group  = state.listGroup;
+  const group2 = state.listGroup2;
+
+  container.innerHTML = '';
+
+  if (!nodes.length) {
+    container.textContent = 'No issues match the current filter.';
+    return;
+  }
+
+  const sorted = sortNodes(nodes, edges);
+
+  const table = document.createElement('table');
+  table.className = 'list-table';
+
+  function rebuild() {
+    table.innerHTML = '';
+    const onSort = (colId) => {
+      if (sortCol === colId) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+      else { sortCol = colId; sortDir = 'asc'; }
+      rebuild();
+    };
+    table.appendChild(buildThead(onSort));
+
+    const tbody = document.createElement('tbody');
+    const reSorted = sortNodes(nodes, edges);
+
+    if ((!group || group === 'none') && (!group2 || group2 === 'none')) {
+      // No grouping
+      for (const n of reSorted) tbody.appendChild(buildRow(n, edges));
+    } else if (!group2 || group2 === 'none' || group2 === group) {
+      // Single-level grouping
+      renderGroups(tbody, reSorted, edges, group, 1);
+    } else {
+      // Two-level grouping
+      const groups1 = new Map();
+      for (const n of reSorted) {
+        const gv = dimValue(n, group);
+        if (!groups1.has(gv)) groups1.set(gv, []);
+        groups1.get(gv).push(n);
+      }
+
+      const gKeys = [...groups1.keys()].sort((a, b) => {
+        const ka = groupSortKey(group, a, nodes);
+        const kb = groupSortKey(group, b, nodes);
+        if (typeof ka === 'number' && typeof kb === 'number') return ka - kb;
+        return String(ka).localeCompare(String(kb));
+      });
+
+      for (const gVal of gKeys) {
+        const groupNodes = groups1.get(gVal);
+        const collapseKey = `${group}:${gVal}`;
+        const isCollapsed = collapsed.has(collapseKey);
+
+        // Level-1 header
+        const hdr = document.createElement('tr');
+        hdr.className = 'group-hdr level-1';
+        const hdrTd = document.createElement('td');
+        hdrTd.colSpan = COLS.length;
+        const caret = document.createElement('span');
+        caret.className = 'group-caret';
+        caret.textContent = isCollapsed ? '▸' : '▾';
+        caret.setAttribute('aria-hidden', 'true');
+        const gTitle = groupTitle(group, gVal, nodes);
+        const titleSpan = gTitle ? Object.assign(document.createElement('span'), {
+          className: 'group-title', textContent: gTitle,
+        }) : null;
+        hdrTd.append(caret, ` ${gVal} `, titleSpan || '', '  ', Object.assign(document.createElement('span'), {
+          className: 'group-count', textContent: `${groupNodes.length}`,
+        }));
+        hdr.appendChild(hdrTd);
+        hdr.addEventListener('click', () => {
+          if (collapsed.has(collapseKey)) collapsed.delete(collapseKey);
+          else collapsed.add(collapseKey);
+          rebuild();
+        });
+        tbody.appendChild(hdr);
+
+        if (!isCollapsed) {
+          // Level-2 groups within this level-1 group
+          renderGroups(tbody, groupNodes, edges, group2, 2);
+        }
+      }
+    }
+
+    table.appendChild(tbody);
+  }
+
+  // Helper: render single-level groups at a given nesting level
+  function renderGroups(tbody, nodeList, edges, dim, level) {
+    if (!dim || dim === 'none') {
+      for (const n of nodeList) tbody.appendChild(buildRow(n, edges));
+      return;
+    }
+
+    const groups = new Map();
+    for (const n of nodeList) {
+      const gv = dimValue(n, dim);
+      if (!groups.has(gv)) groups.set(gv, []);
+      groups.get(gv).push(n);
+    }
+
+    const gKeys = [...groups.keys()].sort((a, b) => {
+      const ka = groupSortKey(dim, a, nodes);
+      const kb = groupSortKey(dim, b, nodes);
+      if (typeof ka === 'number' && typeof kb === 'number') return ka - kb;
+      return String(ka).localeCompare(String(kb));
+    });
+
+    for (const gVal of gKeys) {
+      const groupNodes = groups.get(gVal);
+      const collapseKey = `${dim}:${gVal}`;
+      const isCollapsed = collapsed.has(collapseKey);
+
+      const hdr = document.createElement('tr');
+      hdr.className = `group-hdr level-${level}`;
+      const hdrTd = document.createElement('td');
+      hdrTd.colSpan = COLS.length;
+      const caret = document.createElement('span');
+      caret.className = 'group-caret';
+      caret.textContent = isCollapsed ? '▸' : '▾';
+      caret.setAttribute('aria-hidden', 'true');
+      const gTitle = groupTitle(dim, gVal, nodeList);
+      const titleSpan = gTitle ? Object.assign(document.createElement('span'), {
+        className: 'group-title', textContent: gTitle,
+      }) : null;
+      hdrTd.append(caret, ` ${gVal} `, titleSpan || '', '  ', Object.assign(document.createElement('span'), {
+        className: 'group-count', textContent: `${groupNodes.length}`,
+      }));
+      hdr.appendChild(hdrTd);
+      hdr.addEventListener('click', () => {
+        if (collapsed.has(collapseKey)) collapsed.delete(collapseKey);
+        else collapsed.add(collapseKey);
+        rebuild();
+      });
+      tbody.appendChild(hdr);
+
+      if (!isCollapsed) {
+        for (const n of groupNodes) tbody.appendChild(buildRow(n, edges));
+      }
+    }
+  }
+
+  rebuild();
+  container.appendChild(table);
+
+  // Wire hover-chain highlighting
+  initHover(container, 'list');
+}

--- a/frontend/multi_select.js
+++ b/frontend/multi_select.js
@@ -1,0 +1,155 @@
+// multi_select.js — pill multi-select dropdown component
+// Usage: new MultiSelect(triggerEl, panelEl, { placeholder, onChange, clearBtn })
+
+const INSTANCES = new Set();
+
+document.addEventListener('click', e => {
+  for (const inst of INSTANCES) {
+    if (!inst.open) continue;
+    if (inst.trigger.contains(e.target)) continue;
+    if (inst.panel.contains(e.target)) continue;
+    if (inst.clearBtn && inst.clearBtn.contains(e.target)) continue;
+    inst.close();
+  }
+});
+document.addEventListener('keydown', e => {
+  if (e.key !== 'Escape') return;
+  for (const inst of INSTANCES) inst.close();
+});
+
+export class MultiSelect {
+  constructor(trigger, panel, opts = {}) {
+    this.trigger     = trigger;
+    this.panel       = panel;
+    this.clearBtn    = opts.clearBtn ?? null; // optional inline × next to trigger
+    this.placeholder = opts.placeholder ?? 'All';
+    this.onChange    = opts.onChange ?? (() => {});
+    this.selected    = new Set();
+    this.items       = [];
+    this.open        = false;
+
+    this.trigger.addEventListener('click', () => {
+      // Close siblings first
+      for (const inst of INSTANCES) if (inst !== this) inst.close();
+      this.toggle();
+    });
+
+    if (this.clearBtn) {
+      this.clearBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        this.clear();
+      });
+    }
+
+    INSTANCES.add(this);
+  }
+
+  setItems(items, selected = []) {
+    this.items    = items;
+    this.selected = new Set(selected);
+    this._buildPanel();
+    this._updateTrigger();
+  }
+
+  setSelected(values) {
+    this.selected = new Set(values);
+    this._syncCheckboxes();
+    this._updateTrigger();
+  }
+
+  getSelected() { return [...this.selected]; }
+
+  clear() {
+    this.selected.clear();
+    this._syncCheckboxes();
+    this._updateTrigger();
+    this.onChange([]);
+  }
+
+  toggle() { this.open ? this.close() : this._open(); }
+
+  _open() {
+    this.open = true;
+    this.panel.hidden = false;
+    this.trigger.setAttribute('aria-expanded', 'true');
+    const rect = this.trigger.getBoundingClientRect();
+    this.panel.style.top  = `${rect.bottom + window.scrollY + 4}px`;
+    this.panel.style.left = `${rect.left   + window.scrollX}px`;
+  }
+
+  close() {
+    if (!this.open) return;
+    this.open = false;
+    this.panel.hidden = true;
+    this.trigger.setAttribute('aria-expanded', 'false');
+  }
+
+  _buildPanel() {
+    this.panel.innerHTML = '';
+    const ul = document.createElement('ul');
+    ul.className = 'ms-list';
+    ul.setAttribute('role', 'listbox');
+    ul.setAttribute('aria-multiselectable', 'true');
+
+    for (const item of this.items) {
+      const li = document.createElement('li');
+      li.setAttribute('role', 'option');
+      li.setAttribute('aria-selected', this.selected.has(item.value) ? 'true' : 'false');
+
+      const lbl = document.createElement('label');
+      lbl.className = 'ms-item';
+
+      const cb = document.createElement('input');
+      cb.type    = 'checkbox';
+      cb.value   = item.value;
+      cb.checked = this.selected.has(item.value);
+      cb.addEventListener('change', () => {
+        if (cb.checked) this.selected.add(item.value);
+        else            this.selected.delete(item.value);
+        li.setAttribute('aria-selected', cb.checked ? 'true' : 'false');
+        this._updateTrigger();
+        this.onChange([...this.selected]);
+      });
+
+      const span = document.createElement('span');
+      span.textContent = item.label;
+
+      lbl.append(cb, span);
+      li.appendChild(lbl);
+      ul.appendChild(li);
+    }
+
+    const clear = document.createElement('button');
+    clear.type      = 'button';
+    clear.className = 'ms-clear';
+    clear.textContent = 'Clear all';
+    clear.addEventListener('click', () => this.clear());
+
+    this.panel.appendChild(ul);
+    this.panel.appendChild(clear);
+  }
+
+  _syncCheckboxes() {
+    if (!this.panel) return;
+    for (const cb of this.panel.querySelectorAll('input[type=checkbox]')) {
+      cb.checked = this.selected.has(cb.value);
+      const li = cb.closest('li');
+      if (li) li.setAttribute('aria-selected', cb.checked ? 'true' : 'false');
+    }
+  }
+
+  _updateTrigger() {
+    const sel = [...this.selected];
+    if (this.clearBtn) this.clearBtn.hidden = sel.length === 0;
+    if (!sel.length) {
+      this.trigger.innerHTML = `<span class="ms-placeholder">${this.placeholder}</span>`;
+    } else {
+      const pills = sel.map(v => {
+        const item = this.items.find(i => i.value === v);
+        const toneAttr = item && item.tone ? ` data-tone="${item.tone}"` : '';
+        return `<span class="ms-pill"${toneAttr}>${item ? item.label : v}</span>`;
+      }).join('');
+      this.trigger.innerHTML = pills;
+    }
+  }
+}

--- a/frontend/pivot.js
+++ b/frontend/pivot.js
@@ -1,0 +1,430 @@
+// pivot.js — pivot-matrix (Table view) renderer with hover-chain + epic grouping
+import { state, filteredNodes, dimValue, parseMilestone,
+         prioritySortKey, buildEdgeLookup } from './state.js';
+import { initHover, clearPinned } from './hover.js';
+import { repoTone } from './tone.js';
+
+// ─── Lane tone mapping (kept for lane column/group headers) ──────────────────
+const LANE_TONES = {
+  'a1': 'a1', 'a2': 'a2', 'a3': 'a3',
+  'b': 'b',
+  'c1': 'c1', 'c2': 'c2', 'c3': 'c3',
+  'd': 'd', 'e': 'e', 'f': 'f', 'g': 'g', 'h': 'h', 'i': 'i'
+};
+
+function getTone(node) {
+  return repoTone(node.repo);
+}
+
+// ─── Collapse tracking for epic groups ───────────────────────────────────────
+const epicCollapsed = new Set();
+
+// ─── Card builder with hover attrs ───────────────────────────────────────────
+function buildCard(node, edgeLookup, opts = {}) {
+  const a = document.createElement('a');
+  const tone = getTone(node);
+  const statusCls = node._status === 'blocked' ? ' status-blocked' : '';
+  a.className = `issue-card state-${node.state}${statusCls}${tone ? ` tone-${tone}` : ''}`;
+  if (tone) a.dataset.tone = tone;
+
+  // Hover-chain attrs
+  a.dataset.iss = node.key;
+  const blockers = edgeLookup.blocks[node.key] || [];
+  const blocking = (state.edges.filter(e => e.src === node.key && (e.kind === 'blocks' || !e.kind))
+    .map(e => e.dst).join(',')) || '';
+  if (blockers.length) a.dataset.blockedby = blockers.join(',');
+  if (blocking) a.dataset.blocking = blocking;
+
+  a.href = node.url || '#';
+  if (node.url) a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+
+  const head = document.createElement('div');
+  head.className = 'card-head';
+
+  const dot = document.createElement('span');
+  dot.className = 'card-dot';
+  dot.setAttribute('aria-hidden', 'true');
+
+  const num = document.createElement('span');
+  num.className = 'card-num';
+  num.textContent = `#${node.number}`;
+
+  const title = document.createElement('span');
+  title.className = 'card-title';
+  title.textContent = node.title || `Issue #${node.number}`;
+
+  head.append(dot, num, title);
+  a.appendChild(head);
+
+  const badges = document.createElement('div');
+  badges.className = 'card-badges';
+  if (opts.showRepo) {
+    const rb = document.createElement('span');
+    rb.className = 'badge badge-repo';
+    rb.textContent = node.repo.split('/')[1] || node.repo;
+    badges.appendChild(rb);
+  }
+  if (node.priority) {
+    const pb = document.createElement('span');
+    pb.className = `badge badge-${node.priority.toLowerCase()}`;
+    pb.textContent = node.priority;
+    badges.appendChild(pb);
+  }
+  if (node.size) {
+    const sb = document.createElement('span');
+    sb.className = 'badge';
+    sb.textContent = node.size;
+    badges.appendChild(sb);
+  }
+  if (opts.showMs) {
+    const ms = parseMilestone(node);
+    if (ms.code) {
+      const mb = document.createElement('span');
+      mb.className = 'badge badge-ms';
+      mb.textContent = ms.code;
+      badges.appendChild(mb);
+    }
+  }
+  if (badges.children.length) a.appendChild(badges);
+
+  if (edgeLookup) {
+    const blockedBy = blockers;
+    const parentOf  = edgeLookup.parent[node.key]  || [];
+    if (blockedBy.length || parentOf.length) {
+      const deps = document.createElement('div');
+      deps.className = 'card-deps';
+      if (blockedBy.length) {
+        const sp = document.createElement('span');
+        sp.className = 'dep-label dep-blocked';
+        sp.textContent = `blocked by: ${blockedBy.map(k => '#' + k.split('#')[1]).join(', ')}`;
+        deps.appendChild(sp);
+      }
+      if (parentOf.length) {
+        const sp = document.createElement('span');
+        sp.className = 'dep-label dep-parent';
+        sp.textContent = `parent: ${parentOf.map(k => '#' + k.split('#')[1]).join(', ')}`;
+        deps.appendChild(sp);
+      }
+      a.appendChild(deps);
+    }
+  }
+  return a;
+}
+
+// ─── Epic group header (for lane grouping within cells) ───────────────────────
+function buildEpicHeader(lane, nodesWithLane, parentKey, onToggle) {
+  const collapseKey = `${lane}:${parentKey || ''}`;
+  const isCollapsed = epicCollapsed.has(collapseKey);
+
+  const header = document.createElement('div');
+  header.className = 'epic-header' + (isCollapsed ? ' collapsed' : '');
+  const tone = lane ? (LANE_TONES[lane.toLowerCase()] || '') : '';
+  if (tone) header.dataset.tone = tone;
+
+  // Caret for collapse
+  const caret = document.createElement('span');
+  caret.className = 'epic-caret';
+  caret.textContent = isCollapsed ? '▸' : '▾';
+  caret.setAttribute('aria-hidden', 'true');
+  header.appendChild(caret);
+
+  // Code element - link if parent URL exists
+  const codeEl = document.createElement('span');
+  codeEl.className = 'epic-code';
+  const parentNode = parentKey ? state.nodes.find(n => n.key === parentKey) : null;
+  if (parentNode?.url) {
+    const link = document.createElement('a');
+    link.href = parentNode.url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = lane || '—';
+    link.addEventListener('click', e => e.stopPropagation());  // prevent collapse toggle
+    codeEl.appendChild(link);
+  } else {
+    codeEl.textContent = lane || '—';
+  }
+  header.appendChild(codeEl);
+
+  // Count
+  if (nodesWithLane.length > 0) {
+    const countEl = document.createElement('span');
+    countEl.className = 'epic-count';
+    countEl.textContent = `(${nodesWithLane.length})`;
+    header.appendChild(countEl);
+  }
+
+  // Click to collapse/expand
+  header.addEventListener('click', () => {
+    if (epicCollapsed.has(collapseKey)) epicCollapsed.delete(collapseKey);
+    else epicCollapsed.add(collapseKey);
+    onToggle?.();
+  });
+
+  return { header, isCollapsed };
+}
+
+// ─── Cell renderer with epic grouping ────────────────────────────────────────
+function buildCell(cellNodes, edgeLookup, opts) {
+  if (!cellNodes.length) {
+    const td = document.createElement('td');
+    td.className = 'empty-cell';
+    td.textContent = '·';
+    return td;
+  }
+
+  const td = document.createElement('td');
+
+  const cnt = document.createElement('div');
+  cnt.className = 'cell-count';
+  cnt.textContent = `${cellNodes.length}`;
+  td.appendChild(cnt);
+
+  // Group by lane if showing parent grouping
+  if (opts.groupByParent || opts.groupByLane) {
+    const byLane = new Map();
+    for (const n of cellNodes) {
+      const lane = n.lane || '—';
+      if (!byLane.has(lane)) byLane.set(lane, []);
+      byLane.get(lane).push(n);
+    }
+
+    const issues = document.createElement('div');
+    issues.className = 'cell-issues';
+
+    for (const [lane, laneNodes] of byLane) {
+      const group = document.createElement('div');
+      group.className = 'epic-group';
+
+      const header = buildEpicHeader(lane, laneNodes, null);
+      group.appendChild(header);
+
+      const cards = document.createElement('div');
+      cards.className = 'epic-cards';
+      for (const n of laneNodes) {
+        cards.appendChild(buildCard(n, edgeLookup, opts));
+      }
+      group.appendChild(cards);
+      issues.appendChild(group);
+    }
+    td.appendChild(issues);
+  } else {
+    const issues = document.createElement('div');
+    issues.className = 'cell-issues';
+    for (const n of cellNodes) {
+      issues.appendChild(buildCard(n, edgeLookup, opts));
+    }
+    td.appendChild(issues);
+  }
+
+  return td;
+}
+
+// ─── Pivot sort helpers ───────────────────────────────────────────────────────
+function sortRowValues(values, dim) {
+  if (dim === 'milestone') {
+    return values.sort((a, b) => {
+      const ka = state.nodes.find(n => dimValue(n, 'milestone') === a);
+      const kb = state.nodes.find(n => dimValue(n, 'milestone') === b);
+      const sa = ka ? parseMilestone(ka).sortKey : 9999;
+      const sb = kb ? parseMilestone(kb).sortKey : 9999;
+      if (a === '—') return 1; if (b === '—') return -1;
+      return sa - sb;
+    });
+  }
+  if (dim === 'priority') {
+    const order = { P0: 0, P1: 1, P2: 2, P3: 3, None: 4 };
+    return values.sort((a, b) => (order[a] ?? 99) - (order[b] ?? 99));
+  }
+  return values.sort((a, b) => {
+    if (a === '—' || a === 'All') return 1;
+    if (b === '—' || b === 'All') return -1;
+    return a.localeCompare(b);
+  });
+}
+
+function msHeaderHTML(code) {
+  const node = state.nodes.find(n => dimValue(n, 'milestone') === code);
+  const ms = node ? parseMilestone(node) : { code, name: null };
+  const div = document.createElement('div');
+  div.className = 'ms-row-header';
+  const codeEl = document.createElement('div');
+  codeEl.className = 'ms-row-code';
+  codeEl.textContent = ms.code || '—';
+  div.appendChild(codeEl);
+  if (ms.name) {
+    const nameEl = document.createElement('div');
+    nameEl.className = 'ms-row-name';
+    nameEl.textContent = ms.name;
+    div.appendChild(nameEl);
+  }
+  return div;
+}
+
+// ─── Table renderer ───────────────────────────────────────────────────────────
+export function renderTable(container) {
+  const { pivotRow, pivotCol, tableGroup } = state;
+  const nodes = filteredNodes();
+  const edgeLookup = buildEdgeLookup(state.edges);
+
+  const rowVals = [...new Set(nodes.map(n => dimValue(n, pivotRow)))];
+  const colVals = [...new Set(nodes.map(n => dimValue(n, pivotCol)))];
+  sortRowValues(rowVals, pivotRow);
+  sortRowValues(colVals, pivotCol);
+
+  const matrix = {};
+  for (const n of nodes) {
+    const r = dimValue(n, pivotRow);
+    const c = dimValue(n, pivotCol);
+    (matrix[r] = matrix[r] || {})[c] = matrix[r]?.[c] || [];
+    matrix[r][c].push(n);
+  }
+
+  container.innerHTML = '';
+  if (!nodes.length) {
+    container.textContent = 'No issues match the current filter.';
+    return;
+  }
+
+  // Build parent lookup for parent grouping
+  // Edge direction: src=parent, dst=child
+  // We want: given child, find parent → child → [parents]
+  const parentOf = {};
+  for (const e of state.edges) {
+    if (e.kind === 'parent') {
+      parentOf[e.dst] = parentOf[e.dst] || [];
+      parentOf[e.dst].push(e.src);
+    }
+  }
+
+  // Helper: get grouping key for a node based on tableGroup
+  function getGroupKey(n) {
+    if (tableGroup === 'lane') return n.lane || '—';
+    if (tableGroup === 'parent') {
+      const parents = parentOf[n.key] || [];
+      return parents.length ? parents[0] : '—';
+    }
+    return '—'; // none
+  }
+
+  // Rebuild function for collapse/expand
+  function rebuild() {
+    renderTable(container);
+  }
+
+  // Use grid layout for lane-swim matrix style
+  const grid = document.createElement('div');
+  grid.className = 'lane-swim-grid';
+  grid.style.setProperty('--cols', colVals.length);
+  grid.style.setProperty('--row-header-w', '140px');
+  grid.style.setProperty('--col-min-w', '190px');
+
+  // Header row
+  const gridHead = document.createElement('div');
+  gridHead.className = 'grid-head';
+
+  const spacer = document.createElement('div');
+  spacer.className = 'spacer';
+  gridHead.appendChild(spacer);
+
+  for (const cv of colVals) {
+    const colHeader = document.createElement('div');
+    colHeader.className = 'col-header';
+    const tone = LANE_TONES[cv?.toLowerCase()] || '';
+    if (tone) colHeader.dataset.tone = tone;
+
+    const label = document.createElement('div');
+    label.className = 'col-label';
+    if (tone) label.dataset.tone = tone;
+    label.textContent = cv;
+    colHeader.appendChild(label);
+    gridHead.appendChild(colHeader);
+  }
+  grid.appendChild(gridHead);
+
+  // Data rows
+  for (const rv of rowVals) {
+    const gridRow = document.createElement('div');
+    gridRow.className = 'grid-row';
+
+    const rowHeader = document.createElement('div');
+    rowHeader.className = 'row-header';
+    if (pivotRow === 'milestone') {
+      rowHeader.appendChild(msHeaderHTML(rv));
+    } else {
+      const codeEl = document.createElement('div');
+      codeEl.className = 'ms-code';
+      codeEl.textContent = rv;
+      rowHeader.appendChild(codeEl);
+    }
+    gridRow.appendChild(rowHeader);
+
+    for (const cv of colVals) {
+      const cellNodes = (matrix[rv] || {})[cv] || [];
+      const cell = document.createElement('div');
+      cell.className = 'grid-cell';
+      cell.dataset.col = cv;
+      cell.dataset.row = rv;
+
+      if (!cellNodes.length) {
+        const empty = document.createElement('div');
+        empty.className = 'cell-empty';
+        empty.textContent = '·';
+        cell.appendChild(empty);
+      } else {
+        const cnt = document.createElement('div');
+        cnt.className = 'cell-count';
+        cnt.textContent = `${cellNodes.length}`;
+        cell.appendChild(cnt);
+
+        const issues = document.createElement('div');
+        issues.className = 'cell-issues';
+
+        if (tableGroup === 'none') {
+          // No grouping: flat list
+          for (const n of cellNodes) {
+            issues.appendChild(buildCard(n, edgeLookup, {
+              showRepo: pivotRow !== 'repo' && pivotCol !== 'repo',
+            }));
+          }
+        } else {
+          // Group by lane or parent
+          const groups = new Map();
+          for (const n of cellNodes) {
+            const gk = getGroupKey(n);
+            if (!groups.has(gk)) groups.set(gk, []);
+            groups.get(gk).push(n);
+          }
+
+          for (const [gk, groupNodes] of groups) {
+            const group = document.createElement('div');
+            group.className = 'epic-group';
+
+            const { header, isCollapsed } = buildEpicHeader(gk, groupNodes, tableGroup === 'parent' ? gk : null, rebuild);
+            group.appendChild(header);
+
+            const cards = document.createElement('div');
+            cards.className = 'epic-cards';
+            if (!isCollapsed) {
+              for (const n of groupNodes) {
+                cards.appendChild(buildCard(n, edgeLookup, {
+                  showRepo: pivotRow !== 'repo' && pivotCol !== 'repo',
+                }));
+              }
+            }
+            group.appendChild(cards);
+            issues.appendChild(group);
+          }
+        }
+        cell.appendChild(issues);
+      }
+      gridRow.appendChild(cell);
+    }
+    grid.appendChild(gridRow);
+  }
+
+  container.appendChild(grid);
+
+  // Wire hover-chain highlighting
+  initHover(container, 'table');
+}

--- a/frontend/render_graph.js
+++ b/frontend/render_graph.js
@@ -1,0 +1,242 @@
+// render_graph.js — DOM renderer for graph layouts
+// Matches v5 HTML structure: percentage coords, SVG with viewBox="0 0 100 100"
+
+import { edgePath } from './layout.js';
+import { repoTone } from './tone.js';
+import { mapDevStateToClass } from './state.js';
+
+function getTone(node) {
+  return repoTone(node.repo) || 'accent';
+}
+
+// ── Render nodes as .gg-node dots + .gg-ilabel labels (v4.8 style) ───────────
+function renderNodes(container, nodes, positions, usePercentage) {
+  const byKey = new Map();
+  for (const n of nodes) byKey.set(n.key, n);
+
+  for (const [key, pos] of positions) {
+    const node = byKey.get(key);
+    if (!node) continue;
+
+    const tone = getTone(node);
+    const isDone = node.state === 'closed';
+    const isBlocked = node._status === 'blocked';
+    const isParent = node._isParent === true;
+
+    // Determine blockers/unblockers for data attrs
+    const blockers = (node._blockers || []).map(e => e.src).join(',');
+    const unblocks = nodes
+      .filter(n => (n._blockers || []).some(e => e.src === key))
+      .map(n => n.key)
+      .join(',');
+
+    const style = usePercentage
+      ? `left:${pos.x.toFixed(2)}%; top:${pos.y.toFixed(2)}%;`
+      : `left:${pos.x}px; top:${pos.y}px;`;
+
+    // ── Dot (.gg-node) ──────────────────────────────────────────────────────
+    const dot = document.createElement('a');
+    dot.className = 'gg-node' + (isParent ? ' parent' : '') + (isDone ? ' done' : '') + (isBlocked ? ' blocked' : '');
+    dot.dataset.tone = tone;
+    dot.dataset.iss = key;
+    dot.dataset.blockedby = blockers;
+    dot.dataset.blocking = unblocks;
+    dot.href = node.url || '#';
+    dot.target = '_blank';
+    dot.rel = 'noopener';
+    dot.style.cssText = style;
+    dot.title = `#${node.number} — ${node.title || ''}`;
+
+    // Dev-state animation classes — skip for closed nodes (done wins)
+    if (!isDone) {
+      const devClass = mapDevStateToClass(node.dev_state);
+      if (devClass) {
+        dot.className += ' ' + devClass;
+        // Inject second orbit dot host element for pr_reviewed (orbit-2)
+        if (devClass.includes('orbit-2')) {
+          const orbitChild = document.createElement('span');
+          orbitChild.className = 'gg-orbit-2nd';
+          orbitChild.setAttribute('aria-hidden', 'true');
+          dot.appendChild(orbitChild);
+        }
+      }
+    }
+
+    container.appendChild(dot);
+
+    // ── Label (.gg-ilabel) ──────────────────────────────────────────────────
+    const label = document.createElement('a');
+    label.className = 'gg-ilabel' + (isParent ? ' parent' : '') + (isDone ? ' done' : '') + (isBlocked ? ' blocked' : '');
+    label.dataset.tone = tone;
+    label.dataset.iss = key;
+    label.dataset.blockedby = blockers;
+    label.dataset.blocking = unblocks;
+    label.href = node.url || '#';
+    label.target = '_blank';
+    label.rel = 'noopener';
+    label.style.cssText = style;
+    label.title = `#${node.number} — ${node.title || ''}`;
+
+    // Issue number
+    const num = document.createElement('span');
+    num.className = 'gg-ilabel-num';
+    num.textContent = `#${node.number}`;
+    label.appendChild(num);
+
+    // Size
+    if (node.size) {
+      const size = document.createElement('span');
+      size.className = 'gg-ilabel-size';
+      size.textContent = node.size;
+      label.appendChild(size);
+    }
+
+    // Title (truncated)
+    const title = document.createElement('span');
+    title.className = 'gg-ilabel-title';
+    const fullTitle = node.title || '';
+    title.textContent = fullTitle.length > 28 ? fullTitle.slice(0, 27) + '…' : fullTitle;
+    label.appendChild(title);
+
+    container.appendChild(label);
+  }
+}
+
+// ── Render milestone row headers (v5 layout only) ─────────────────────────────
+function renderMilestoneHeaders(container, milestoneInfo, usePercentage) {
+  for (const ms of milestoneInfo) {
+    if (!ms.code) continue;
+
+    const row = document.createElement('div');
+    row.className = 'gg-msrow';
+    row.style.top = usePercentage
+      ? `${ms.y.toFixed(2)}%`
+      : `${ms.y}px`;
+    row.style.height = usePercentage
+      ? `${(ms.height || 5).toFixed(2)}%`
+      : `${ms.height || 40}px`;
+
+    // Hide code for "no milestone" rows
+    const isNoMs = ms.code === '-' || ms.code === '(None)';
+    if (!isNoMs) {
+      const code = document.createElement('div');
+      code.className = 'gg-msrow-code';
+      code.textContent = ms.code;
+      row.appendChild(code);
+    }
+
+    // Show name, or "No milestone" for rows without milestone
+    const displayName = ms.name || (isNoMs ? 'No milestone' : null);
+    if (displayName) {
+      const name = document.createElement('div');
+      name.className = 'gg-msrow-name';
+      name.textContent = displayName;
+      row.appendChild(name);
+    }
+
+    container.appendChild(row);
+  }
+}
+
+// ── Render SVG edges ─────────────────────────────────────────────────────────
+function renderEdges(svgContainer, nodes, edges, positions, usePercentage) {
+  const byKey = new Map();
+  for (const n of nodes) byKey.set(n.key, n);
+
+  for (const edge of edges) {
+    const srcPos = positions.get(edge.src);
+    const dstPos = positions.get(edge.dst);
+    if (!srcPos || !dstPos) continue;
+
+    const srcNode = byKey.get(edge.src);
+    const dstNode = byKey.get(edge.dst);
+    const tone = getTone(srcNode || {});
+    const isBlocked = dstNode?._status === 'blocked';
+    const kind = edge.kind || 'blocks';
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.classList.add('gg-edge');
+    if (isBlocked) path.classList.add('blocked');
+    if (kind === 'parent') path.classList.add('parent-edge');
+    path.dataset.tone = tone;
+    path.dataset.kind = kind;
+    path.dataset.src = edge.src;
+    path.dataset.dst = edge.dst;
+
+    // Use percentage-based path for v5, pixel-based for others
+    const d = usePercentage
+      ? edgePath(srcPos.x, srcPos.y, dstPos.x, dstPos.y)
+      : `M ${srcPos.x} ${srcPos.y} C ${srcPos.x} ${(srcPos.y + dstPos.y) / 2}, ${dstPos.x} ${(srcPos.y + dstPos.y) / 2}, ${dstPos.x} ${dstPos.y}`;
+
+    path.setAttribute('d', d);
+    if (usePercentage) {
+      path.setAttribute('vector-effect', 'non-scaling-stroke');
+    }
+
+    svgContainer.appendChild(path);
+  }
+}
+
+// ── Main render function ──────────────────────────────────────────────────────
+export function renderGraph(container, nodes, edges, layoutResult) {
+  const { positions, milestoneInfo, width, height, usePercentage } = layoutResult;
+
+  container.innerHTML = '';
+
+  // Create graph wrapper
+  const wrap = document.createElement('div');
+  wrap.className = 'graph-wrap';
+  wrap.style.height = usePercentage ? `${height}px` : `${Math.max(height, 400)}px`;
+  wrap.style.position = 'relative';
+  wrap.setAttribute('role', 'img');
+  wrap.setAttribute('aria-label', 'Dependency graph');
+
+  // Render milestone headers OUTSIDE stage (they need left:12px from wrap edge)
+  if (milestoneInfo && milestoneInfo.length > 0) {
+    renderMilestoneHeaders(wrap, milestoneInfo, usePercentage);
+  }
+
+  // Create stage container (holds both SVG and nodes, same coordinate system)
+  const stage = document.createElement('div');
+  stage.className = 'graph-stage';
+
+  // Create SVG layer for edges (inside stage so coords match nodes)
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.classList.add('graph-svg');
+
+  if (usePercentage) {
+    // v5 style: percentage-based positioning with viewBox
+    svg.setAttribute('viewBox', '0 0 100 100');
+    svg.setAttribute('preserveAspectRatio', 'none');
+  } else {
+    // Pixel-based: full size
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', '100%');
+  }
+  svg.setAttribute('aria-hidden', 'true');
+
+  // Render edges first (behind nodes)
+  renderEdges(svg, nodes, edges, positions, usePercentage);
+
+  // Render nodes
+  renderNodes(stage, nodes, positions, usePercentage);
+
+  // SVG and nodes share the same stage (same coordinate space)
+  stage.appendChild(svg);
+  // Nodes already appended to stage in renderNodes
+
+  wrap.appendChild(stage);
+  container.appendChild(wrap);
+
+  return wrap;
+}
+
+// ── Exports for hover-chain wiring ────────────────────────────────────────────
+export function getEdgeElements(container) {
+  return Array.from(container.querySelectorAll('.gg-edge[data-src]'));
+}
+
+export function getLabelElements(container) {
+  // Include both .gg-node dots and .gg-ilabel labels for hover-chain
+  return Array.from(container.querySelectorAll('.gg-node[data-iss], .gg-ilabel[data-iss]'));
+}

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -1,0 +1,297 @@
+// state.js — shared app state + sessionStorage persistence (per-tab)
+export const SS = {
+  get(key, def) {
+    try { const v = sessionStorage.getItem(key); return v === null ? def : v; } catch { return def; }
+  },
+  getJSON(key, def) {
+    try { const v = sessionStorage.getItem(key); return v === null ? def : JSON.parse(v); } catch { return def; }
+  },
+  set(key, val) {
+    try { sessionStorage.setItem(key, val); } catch {}
+  },
+  setJSON(key, val) {
+    try { sessionStorage.setItem(key, JSON.stringify(val)); } catch {}
+  },
+};
+
+// Migration: old repo was a string. Convert to array.
+function migrateRepo() {
+  const raw = sessionStorage.getItem('v6:repo');
+  if (raw === null) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+    // was a string (old format)
+    return parsed === 'all' ? [] : [parsed];
+  } catch {
+    // raw was plain string, not JSON
+    return raw === 'all' ? [] : [raw];
+  }
+}
+
+export const state = {
+  view:      SS.get('v6:view', 'table'),
+  // multi-select arrays (empty = all)
+  repo:      migrateRepo(),
+  milestone: SS.getJSON('v6:milestone', []),
+  priority:  SS.getJSON('v6:priority', []),
+  status:    SS.getJSON('v6:status', ['ready', 'blocked']),
+  search:    SS.get('v6:search', ''),
+  pivotRow:  SS.get('v6:pivotRow', 'milestone'),
+  pivotCol:  SS.get('v6:pivotCol', 'lane'),
+  listGroup: SS.get('v6:listGroup', 'milestone'),
+  listGroup2: SS.get('v6:listGroup2', 'none'),
+  tableGroup: SS.get('v6:tableGroup', 'parent'),
+  // graph options
+  showParents: SS.get('v6:showParents', 'false') === 'true',
+  showClosedUnderOpenEpic: SS.get('v6:showClosedUnderOpenEpic', 'false') === 'true',
+  nodes:     [],
+  edges:     [],
+  // built once after load
+  edgesBySrc: new Map(),
+  edgesByDst: new Map(),
+  nodesByKey: new Map(),
+};
+
+const SS_KEYS = {
+  view:        { key: 'v6:view',        json: false },
+  repo:        { key: 'v6:repo',        json: true  },
+  milestone:   { key: 'v6:milestone',   json: true  },
+  priority:    { key: 'v6:priority',    json: true  },
+  status:      { key: 'v6:status',      json: true  },
+  search:      { key: 'v6:search',      json: false },
+  pivotRow:    { key: 'v6:pivotRow',    json: false },
+  pivotCol:    { key: 'v6:pivotCol',    json: false },
+  listGroup:   { key: 'v6:listGroup',   json: false },
+  listGroup2:  { key: 'v6:listGroup2',  json: false },
+  tableGroup:  { key: 'v6:tableGroup',  json: false },
+  showParents: { key: 'v6:showParents', json: false },
+  showClosedUnderOpenEpic: { key: 'v6:showClosedUnderOpenEpic', json: false },
+};
+
+export function setState(patch) {
+  Object.assign(state, patch);
+  for (const [k, v] of Object.entries(patch)) {
+    const meta = SS_KEYS[k];
+    if (!meta) continue;
+    meta.json ? SS.setJSON(meta.key, v) : SS.set(meta.key, v);
+  }
+}
+
+// ─── Edge index ───────────────────────────────────────────────────────────
+export function buildEdgeIndex(edges) {
+  const bySrc = new Map();
+  const byDst = new Map();
+  for (const e of edges) {
+    if (!bySrc.has(e.src)) bySrc.set(e.src, []);
+    bySrc.get(e.src).push(e);
+    if (!byDst.has(e.dst)) byDst.set(e.dst, []);
+    byDst.get(e.dst).push(e);
+  }
+  return { bySrc, byDst };
+}
+
+// ─── Status computation ───────────────────────────────────────────────────
+// Only 'blocks' edges affect status; 'parent' edges are for layout only
+export function computeStatus(node, blockingEdgesByDst, nodesByKey) {
+  if (node.state === 'closed') return 'done';
+  const blockers = blockingEdgesByDst.get(node.key) ?? [];
+  const openBlocker = blockers.some(e => {
+    const srcNode = nodesByKey.get(e.src);
+    return srcNode?.state === 'open';
+  });
+  return openBlocker ? 'blocked' : 'ready';
+}
+
+// Attach _status, _blockers, _parent to every node after payload load
+// _blockers: all edges where this node is dst (for layout positioning)
+// _status: computed from 'blocks' kind edges, then propagated through 'parent'
+//          edges so any descendant of a blocked node is also rendered blocked
+//          (unless the descendant itself is already closed → kept as 'done').
+// _parent: parent issue key (from 'parent' edges where dst=this, src=parent)
+export function annotateNodes(nodes, edges) {
+  const blockingByDst = new Map();  // kind='blocks' only, for status
+  const allByDst = new Map();       // all edges, for _blockers
+  const parentByDst = new Map();    // kind='parent', dst=child → src=parent
+  const childrenBySrc = new Map();  // kind='parent', src=parent → [child nodes]
+  const byKey = new Map();
+
+  for (const n of nodes) byKey.set(n.key, n);
+  for (const e of edges) {
+    if (!allByDst.has(e.dst)) allByDst.set(e.dst, []);
+    allByDst.get(e.dst).push(e);
+
+    if (e.kind === 'blocks') {
+      if (!blockingByDst.has(e.dst)) blockingByDst.set(e.dst, []);
+      blockingByDst.get(e.dst).push(e);
+    }
+
+    if (e.kind === 'parent') {
+      if (!parentByDst.has(e.dst)) parentByDst.set(e.dst, []);
+      parentByDst.get(e.dst).push(e.src);  // src is the parent
+      if (!childrenBySrc.has(e.src)) childrenBySrc.set(e.src, []);
+      childrenBySrc.get(e.src).push(e.dst);  // dst is the child
+    }
+  }
+
+  // Pass 1: direct status from blocks-edges + closed-state
+  for (const n of nodes) {
+    n._blockers = allByDst.get(n.key) || [];
+    n._status = computeStatus(n, blockingByDst, byKey);
+    const parents = parentByDst.get(n.key);
+    n._parent = parents?.length ? parents[0] : null;
+  }
+
+  // Stamp _isParent on nodes that have at least one child edge
+  for (const n of nodes) {
+    n._isParent = childrenBySrc.has(n.key);
+  }
+
+  // Pass 2: propagate 'blocked' through parent → child edges (BFS).
+  // A descendant of a blocked parent is itself rendered blocked, unless it
+  // is already 'done' (closed) — closed always wins.  Visited guard handles
+  // any pathological parent cycles.
+  const queue = nodes.filter(n => n._status === 'blocked').map(n => n.key);
+  const visited = new Set(queue);
+  while (queue.length) {
+    const parentKey = queue.shift();
+    const childKeys = childrenBySrc.get(parentKey) || [];
+    for (const childKey of childKeys) {
+      if (visited.has(childKey)) continue;
+      visited.add(childKey);
+      const child = byKey.get(childKey);
+      if (!child || child._status === 'done') continue;
+      child._status = 'blocked';
+      queue.push(childKey);
+    }
+  }
+}
+
+// ─── Milestone parsing (client-side fallback) ──────────────────────────────
+const MS_RE = /^(M\d+|Ph\d+|FIN|Phase\s*\d+)/i;
+
+export function parseMilestone(node) {
+  if (node.milestone_code !== undefined) {
+    return {
+      code:    node.milestone_code ?? null,
+      name:    node.milestone_name ?? null,
+      sortKey: node.milestone_sort_key ?? 9999,
+    };
+  }
+  const raw = node.milestone ?? '';
+  if (!raw) return { code: null, name: null, sortKey: 9999 };
+  const m = raw.match(MS_RE);
+  if (m) {
+    const code = m[1].replace(/Phase\s*/i, 'Ph');
+    const name = raw.slice(m[0].length).replace(/^\s*[—–-]\s*/, '').trim() || null;
+    return { code, name, sortKey: codeToSortKey(code) };
+  }
+  return { code: raw.slice(0, 8), name: null, sortKey: 9999 };
+}
+
+function codeToSortKey(code) {
+  if (!code) return 9999;
+  const u = code.toUpperCase();
+  if (u === 'FIN') return 8888;
+  const mNum = u.match(/^M(\d+)$/);   if (mNum)  return parseInt(mNum[1], 10);
+  const phNum = u.match(/^PH(\d+)$/); if (phNum) return 1000 + parseInt(phNum[1], 10);
+  return 9999;
+}
+
+// ─── Priority sort order ───────────────────────────────────────────────────
+const PRIORITY_ORDER = { P0: 0, P1: 1, P2: 2, P3: 3 };
+export function prioritySortKey(p) {
+  return p ? (PRIORITY_ORDER[p] ?? 99) : 99;
+}
+
+// ─── Dim-value extraction ──────────────────────────────────────────────────
+export function dimValue(node, dim) {
+  if (dim === 'none')      return 'All';
+  if (dim === 'milestone') { const ms = parseMilestone(node); return ms.code ?? '—'; }
+  if (dim === 'priority')  return node.priority ?? 'None';
+  if (dim === 'repo')      return node.repo ?? '—';
+  if (dim === 'lane')      return node.lane ?? '—';
+  if (dim === 'size')      return node.size ?? '—';
+  if (dim === 'status')    return node._status ?? '—';
+  if (dim === 'parent')    return node._parent ?? '—';
+  return '—';
+}
+
+// ─── Filter application ───────────────────────────────────────────────────
+export function applyFilters(nodes, filters) {
+  const q = (filters.search ?? '').trim().toLowerCase();
+  const parentKeys = state.showParents
+    ? null
+    : new Set(state.edges.filter(e => e.kind === 'parent').map(e => e.src));
+  return nodes.filter(n => {
+    if (parentKeys && parentKeys.has(n.key)) return false;
+    if (filters.repo.length && !filters.repo.includes(n.repo)) return false;
+    const msCode = n.milestone_code ?? '(None)';
+    if (filters.milestone.length && !filters.milestone.includes(msCode)) return false;
+    const pri = n.priority ?? '(None)';
+    if (filters.priority.length && !filters.priority.includes(pri)) return false;
+    if (filters.status.length && !filters.status.includes(n._status)) return false;
+    if (q) {
+      const hay = `${n.key} ${n.title ?? ''} ${(n.labels ?? []).join(' ')}`.toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+// Convenience: apply current state filters to state.nodes
+export function filteredNodes() {
+  return applyFilters(state.nodes, {
+    repo:      state.repo,
+    milestone: state.milestone,
+    priority:  state.priority,
+    status:    state.status,
+    search:    state.search,
+  });
+}
+
+// For graph view: filter by all except search (search uses highlight).
+// When `showClosedUnderOpenEpic` is enabled, a closed (`done`) issue whose
+// parent epic is still open is kept visible even when the status filter
+// excludes `done`. The node keeps its `_status='done'` so the rest of the
+// rendering logic is unchanged.
+export function filteredNodesForGraph() {
+  const base = applyFilters(state.nodes, {
+    repo:      state.repo,
+    milestone: state.milestone,
+    priority:  state.priority,
+    status:    [],   // bypass status here, re-apply with override below
+    search:    '',
+  });
+  if (state.status.length === 0) return base;
+  return base.filter(n => {
+    if (state.status.includes(n._status)) return true;
+    if (state.showClosedUnderOpenEpic && n._status === 'done' && n._parent) {
+      const parent = state.nodesByKey.get(n._parent);
+      if (parent && parent.state === 'open') return true;
+    }
+    return false;
+  });
+}
+
+// ─── Dev-state → animation class mapping (issue #82) ─────────────────────
+export function mapDevStateToClass(devState) {
+  if (devState === 'pr_reviewed') return 'pulse orbit-2';
+  if (devState === 'pr_open')     return 'pulse orbit-1';
+  if (devState === 'dev')         return 'pulse';
+  return '';
+}
+
+// ─── Build edge lookup (legacy helper, kept for pivot.js) ─────────────────
+export function buildEdgeLookup(edges) {
+  const blocks = {};
+  const parent = {};
+  for (const e of edges) {
+    if (e.kind === 'blocks' || !e.kind) {
+      (blocks[e.dst] = blocks[e.dst] || []).push(e.src);
+    } else if (e.kind === 'parent') {
+      (parent[e.dst] = parent[e.dst] || []).push(e.src);
+    }
+  }
+  return { blocks, parent };
+}

--- a/frontend/tone.js
+++ b/frontend/tone.js
@@ -1,0 +1,40 @@
+// tone.js — stable repo → color mapping
+// Consumed as data-tone="<name>" on graph nodes, cards, and filter pills.
+// CSS defines --repo-<name> in graph.css; selectors live in graph.css + app.css.
+
+const REPO_TONE_MAP = {
+  'Roxabi/lyra':               'teal',
+  'Roxabi/voiceCLI':           'blue',
+  'Roxabi/imageCLI':           'pink',
+  'Roxabi/llmCLI':             'plum',
+  'Roxabi/roxabi-forge':       'orange',
+  'Roxabi/roxabi-live':        'red',
+  'Roxabi/roxabi-plugins':     'lime',
+  'Roxabi/roxabi-vault':       'amber',
+  'Roxabi/roxabi-production':  'green',
+  'Roxabi/roxabi-boilerplate': 'gray',
+  'Roxabi/projects-meta':      'cyan',
+};
+
+// Full palette — must match --repo-<name> vars in graph.css and selectors in
+// graph.css (.gg-node, .gg-ilabel) + app.css (.ms-pill).
+const FULL_PALETTE = [
+  'teal', 'blue', 'pink', 'plum', 'orange',
+  'red', 'lime', 'amber', 'green', 'gray', 'cyan',
+  'indigo', 'rose', 'violet', 'brown', 'fuchsia', 'yellow',
+];
+
+// Fallback excludes tones already claimed by REPO_TONE_MAP so unlisted repos
+// never collide with explicit assignments.  Without this filter, the hash
+// can land on a slot already used (e.g. roxabi-cortex → teal == lyra).
+const _EXPLICIT_TONES = new Set(Object.values(REPO_TONE_MAP));
+const FALLBACK_PALETTE = FULL_PALETTE.filter(t => !_EXPLICIT_TONES.has(t));
+
+export function repoTone(repo) {
+  if (!repo) return '';
+  if (REPO_TONE_MAP[repo]) return REPO_TONE_MAP[repo];
+  if (FALLBACK_PALETTE.length === 0) return 'accent';
+  let h = 0;
+  for (let i = 0; i < repo.length; i++) h = (h * 31 + repo.charCodeAt(i)) | 0;
+  return FALLBACK_PALETTE[Math.abs(h) % FALLBACK_PALETTE.length];
+}


### PR DESCRIPTION
## Summary
- Populate `frontend/` with the 13 v6 dep-graph static assets (index.html, app/graph CSS, 10 ES-module JS) ported from `src/roxabi_live/dep_graph/v6/frontend/`.
- The Worker ASSETS binding (`wrangler.toml [assets] directory=./frontend`) + router `*` fallback (`router.ts:48`) serve them at `/`; relative `/api/*` calls resolve same-origin.
- Drop the dead `/dep-graph/` v5.1 reference link — the v5 static renderer is not ported to the CF Worker (v1/v5 orphaned per #92).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #99: CF S7 — Frontend wiring via Workers-with-assets | Slice of epic #92 |
| Spec | [92-cloudflare-serverless-migration.md](artifacts/specs/92-cloudflare-serverless-migration.md) | Present |
| Implementation | 1 commit on `feat/99-cf-s7-frontend-wiring` | Complete |
| Verification | Lint ✅ Typecheck ✅ (no TS touched — static assets only) | Passed |

## Test Plan (post-deploy on staging Worker)
- [ ] `GET /` returns the dep-graph HTML (ASSETS serves `index.html`)
- [ ] dep-graph renders from `GET /api/graph` (same-origin)
- [ ] filter tabs persist across reload via `sessionStorage`

## Notes
- `/api/repos` is **not** implemented in the worker; `app.js::loadRepos()` falls back to deriving the repo list from graph nodes (graceful `catch`). Parity follow-up can be filed if needed.

Closes #99

---
Generated with [Claude Code](https://claude.com/claude-code)