### PR TITLE
chore(dev-core): drop ProjectV2 board config — issues-only

### DIFF
--- a/.claude/dev-core.yml
+++ b/.claude/dev-core.yml
@@ -1,10 +1,12 @@
-# Roxabi Hub project board (PVT_kwDOB8J6DM4BVWlE)
-gh_project_id: 'PVT_kwDOB8J6DM4BVWlE'
-status_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy83E'
-size_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy838'
-priority_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy834'
-lane_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy830'
-status_options_json: '{"Todo":"fb4666b4","Ready":"9a1e7011","In Progress":"f972685d","Blocked":"93ed3508","Done":"833e5ce2","Backlog":"fb4666b4","Analysis":"fb4666b4","Specs":"fb4666b4","Review":"f972685d"}'
-size_options_json: '{"S":"0e7a5f75","F-lite":"33ba8e50","F-full":"c67a71e0","XS":"0e7a5f75","M":"33ba8e50","L":"c67a71e0","XL":"c67a71e0"}'
-priority_options_json: '{"P0 - Urgent":"1869a39d","P1 - High":"8ce35f78","P2 - Medium":"c54358fe","P3 - Low":"f5160185"}'
-lane_options_json: '{"a1":"37e922a5","a2":"4adaf605","a3":"439b1e49","b":"405ef672","c1":"2dc55a75","c2":"7cadbf6e","c3":"13dc3bfb","d":"53688630","e":"3b91e2a2","f":"47d23510","g":"da0857d9","h":"cf0e69b7","i":"44b4f2c8","j":"290d193f","k":"369edbea","l":"10431d4a","m":"6e85f6b8","n":"acb15dcd","o":"3fa48df2","standalone":"f8fcc5f9"}'
+# .claude/dev-core.yml — roxabi-live is ISSUES-ONLY (no GitHub Project V2 board).
+#
+# The Roxabi Hub board config (gh_project_id / *_field_id / *_options_json) was
+# removed on 2026-06-08 so dev-core stops writing the board:
+#   - status / size / priority live as labels on the issue (issue-triage still syncs labels)
+#   - dependencies + parent/child use native GitHub sub-issues (GraphQL, board-free)
+#   - issue listing -> `gh issue list` or the roxabi-live dep-graph cockpit (corpus.db)
+#
+# `issue-triage list` / `/issues` dashboard stay board-native until the plugin work lands:
+#   Roxabi/roxabi-plugins#253 (repo-centric CLI) + Roxabi/roxabi-plugins#252 (dashboard ProjectV2 drop).
+#
+# Keep this file board-free. Do NOT re-add board IDs here (a stray `/init` may try to).


### PR DESCRIPTION
## What

Neutralises `.claude/dev-core.yml` — removes the Roxabi Hub board config (`gh_project_id` / `*_field_id` / `*_options_json`). roxabi-live goes **issues-only**.

## Why

The board↔dev-core coupling lived entirely in this one file. Removing it means `issue-triage` stops writing the GitHub Project V2 board; size/priority/status are carried by **labels** on the issue, dependencies + parent/child use **native GitHub sub-issues** (GraphQL, board-free), and the `/dev` pipeline is unaffected (it never read the board).

## Effect

| Surface | After |
|---|---|
| `/dev` pipeline, deps, parent/child | unchanged (board-free) |
| `set --status/size/priority` | board write **skipped** → labels only (verified: _"GitHub Project V2 not configured — skipping project field updates"_) |
| `issue-triage list` / `/issues` dashboard | board-native → use `gh issue list` or the dep-graph cockpit until the plugin work lands |

## Related

Plugin-side counterpart (makes listing repo-centric so nothing is lost):
- Roxabi/roxabi-plugins#253 — switch CLI issues to `repository.issues`
- Roxabi/roxabi-plugins#252 — drop ProjectV2 dashboard dependency

## Note

`status:*` labels don't exist in this repo yet → `issue-triage` emits a harmless warning when syncing a status label. Create them only if we want status-by-label; otherwise status = open/closed + dep-graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)