### PR TITLE
feat(worker): CF S8 cron + observability — Logpush→R2, halt alerts (#100)

### DIFF
--- a/artifacts/frames/100-cf-s8-cron-observability-frame.mdx
+++ b/artifacts/frames/100-cf-s8-cron-observability-frame.mdx
@@ -1,0 +1,87 @@
+---
+title: CF S8 — Cron trigger + observability (Logpush→R2, halt alerts)
+issue: 100
+status: approved
+tier: S
+date: 2026-06-08
+---
+
+## Problem
+
+S8 is the **observability + go/no-go gate** before the S9 cutover (`live.roxabi.dev`,
+M₁ decommission). On investigation, the *code* for S8 was already shipped in S4 (#96):
+
+- Cron `0 * * * *` is configured for both prod (`wrangler.toml:11`) and staging
+  (`wrangler.toml:31`), and `scheduled()` calls `runSync(env)` (`index.ts:14`).
+- The auth-halt circuit breaker already POSTs to `NOTIFY_URL` on 2 consecutive auth
+  failures (`sync.ts:1110-1116`).
+
+What is genuinely missing is **operational**, not architectural:
+
+1. **No audit trail** — Logpush → R2 is not configured. The #92 spec flags this as a
+   **hard go/no-go gate**: M₁ must not be decommissioned (S9) before prod logs persist
+   to R2, else the prod sync runs blind with no forensic trail.
+2. **No prod Cron proof** — the hourly trigger has never been confirmed firing in
+   production (staging was verified live via `--test-scheduled`).
+3. **`NOTIFY_URL` unset** — the halt-alert code is dead until the secret holds a real
+   webhook/ntfy URL.
+
+Two thin code gaps remain: `NOTIFY_URL` is read via an inline `(env as …)` cast rather
+than a typed `Env` binding, and the halt-alert POST path has no test.
+
+## Who
+
+- **Primary:** Mickael (ops) — needs a persistent audit trail and a halt alarm before
+  trusting prod sync unattended post-cutover.
+- **Secondary:** future-self debugging a silent prod sync stall — Logpush→R2 is the only
+  forensic record once M₁ (and its local logs) are gone.
+
+## Constraints
+
+- Logpush job creation has **no `wrangler` subcommand** — it is a Cloudflare API / dashboard
+  operation (account-level Logpush + R2 bucket). Partly outside the repo.
+- `NOTIFY_URL` requires a real endpoint value from Mickael (ntfy topic / webhook).
+- Prod Cron verification requires the prod Worker deployed + waiting for ≥1 real hourly tick
+  (cannot be fully forced in CI).
+- Workers Free plan: confirm Logpush is available (Logpush to R2 is supported on Free for
+  Workers Trace Events / Workers logs — verify at config time).
+- Shared personal CF token (bouly.io account) — same as prior slices.
+
+## Out of Scope
+
+- S9 cutover (CF Access apps, DNS `live.roxabi.dev`, M₁ stop) — issue #101.
+- Re-architecting halt logic or the breaker threshold (S4 design is frozen).
+- Structured/JSON log reformatting — current `console.log/error` lines are captured by
+  Logpush as-is; reformat only if a later need surfaces (deferred).
+
+## Premise Validity
+
+**Success in 6 months:** Prod Worker syncs hourly unattended; every invocation's logs land
+in the `roxabi-live-logs` R2 bucket (queryable audit trail); a forced auth-halt fires a
+`sync_halted` POST to `NOTIFY_URL` that Mickael actually receives. `/api/version` timestamp
+is always ≤65 min old.
+
+**Failure in 6 months:** Prod sync silently stalls (watermark frozen >2h) and there is **no
+log in R2** to diagnose it, OR a halt fires with no alert delivered. Falsifiable: after 1
+prod hour, R2 object count for the Logpush dataset == 0, or `/api/version` age >65 min.
+
+**Simplest alternative:** Skip Logpush; rely on `wrangler tail` live logs + the existing
+`/api/version` endpoint for liveness.
+**Why not simplest:** `wrangler tail` is ephemeral (no retention) and requires an attended
+terminal — useless for a post-mortem of an overnight stall after M₁ is gone. The #92 spec
+makes persistent logs a hard gate precisely because the cutover removes the local fallback.
+
+## Complexity
+
+**Tier: S** — ≤2 files of code (`types.ts` typed `NOTIFY_URL` binding + a halt-alert vitest);
+the remaining work is Cloudflare ops (R2 bucket, Logpush job, `wrangler secret put`) captured
+as a runbook, plus a prod-Cron verification step. No new architecture — S4 already shipped the
+cron handler and the halt-alert path.
+
+Signals observed:
+- Code footprint ≤3 files, single domain (worker), no new pattern → S.
+- Bulk of effort is dashboard/API ops + verification, not implementation.
+- Original /dev tier guess (F-lite) predated reading the code; the halt-alert + cron already
+  existing collapses the code scope → downgrade recommended.
+- Go/no-go risk is real, but the #92 umbrella spec already documents the gate, so a fresh
+  S8 spec would largely duplicate it.

--- a/docs/s8-cron-observability.md
+++ b/docs/s8-cron-observability.md
@@ -1,0 +1,128 @@
+# S8 — Cron trigger + observability (runbook)
+
+Issue [#100](https://github.com/Roxabi/roxabi-live/issues/100) · epic [#92](https://github.com/Roxabi/roxabi-live/issues/92).
+
+The **code** for S8 shipped in S4 (#96): the hourly Cron trigger, the `scheduled()`
+handler, and the auth-halt → `NOTIFY_URL` alert all exist. This slice adds the
+**observability config** and the **operational steps** that can't live in the repo, plus
+two code hardening changes (typed `Env.NOTIFY_URL`, halt-alert test).
+
+This is the **hard go/no-go gate** before S9 cutover (#101): do **not** decommission M₁
+until Logpush → R2 is delivering prod logs, because M₁'s local logs vanish with it.
+
+---
+
+## What's in the repo (this PR)
+
+| Change | File | Effect |
+|---|---|---|
+| Workers Logs enabled | `wrangler.toml` `[observability]` + `[env.staging.observability]` | emits invocation logs for Logpush to ship |
+| Typed halt-alert binding | `worker/src/types.ts` (`Env.NOTIFY_URL?`) | replaces inline `(env as …)` cast |
+| Halt-alert tests | `worker/src/sync/sync.test.ts` | POST fires with `sync_halted` body / no-op when unset |
+
+`[observability] enabled = true` must be live (deployed) **before** a Logpush job can
+select the Workers Logs dataset.
+
+---
+
+## Ops steps (Cloudflare side — run once per environment)
+
+Account: `b5e90be971920ce406f7b679c4f1cd33` (mickael@bouly.io). `CLOUDFLARE_API_TOKEN` is
+already in the shell env (see provisioning memory). Run from repo root.
+
+### 1. Create the R2 audit bucket
+
+```bash
+wrangler r2 bucket create roxabi-live-logs
+# (optional) staging isolation:
+# wrangler r2 bucket create roxabi-live-logs-staging
+```
+
+### 2. Create the Logpush job → R2 (Workers Logs dataset)
+
+Logpush has **no `wrangler` subcommand** — use the API. `workers_trace_events` is the
+dataset backing Workers Logs.
+
+```bash
+ACCOUNT=b5e90be971920ce406f7b679c4f1cd33
+curl -sS -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/logpush/jobs" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "roxabi-live-logs",
+    "dataset": "workers_trace_events",
+    "destination_conf": "r2://roxabi-live-logs/{DATE}?account-id='"${ACCOUNT}"'&access-key-id=<R2_ACCESS_KEY_ID>&secret-access-key=<R2_SECRET>",
+    "enabled": true,
+    "output_options": {
+      "field_names": ["EventTimestampMs","Outcome","ScriptName","Logs","Exceptions"],
+      "timestamp_format": "rfc3339"
+    }
+  }'
+```
+
+R2 S3 credentials: **R2 → Manage R2 API Tokens** in the dashboard (Object Read & Write,
+scoped to `roxabi-live-logs`). The token used here needs the **Logpush** account permission.
+
+Verify the job:
+
+```bash
+curl -sS "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/logpush/jobs" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq '.result[] | {name,dataset,enabled,last_complete,last_error}'
+```
+
+### 3. Set the halt-alert secret
+
+`NOTIFY_URL` = an ntfy topic or webhook that reaches you (the breaker POSTs
+`{"event":"sync_halted","ts":…}` on 2 consecutive auth failures).
+
+```bash
+# prod
+printf %s 'https://ntfy.sh/<your-topic>' | wrangler secret put NOTIFY_URL
+# staging
+printf %s 'https://ntfy.sh/<your-topic>' | wrangler secret put NOTIFY_URL --env staging
+```
+
+Unset = alerts disabled (the code no-ops; the breaker still halts the sync).
+
+---
+
+## Acceptance verification (Accept criteria, #100)
+
+1. **≥1 successful Cron execution in prod.** After deploy, wait for the top of an hour, then:
+
+   ```bash
+   # CF dashboard → Workers & Pages → roxabi-live → Cron → invocation log shows success
+   # OR via D1 (watermark advanced within the last ~65 min):
+   wrangler d1 execute roxabi-live-production --remote \
+     --command "SELECT key, value, datetime(updated_at) FROM sync_control WHERE key IN ('halted','auth_failures'); SELECT MAX(last_synced_at) AS watermark FROM sync_state;"
+   ```
+
+2. **R2 receives logs.** Logpush flushes every ~5 min / 100k lines:
+
+   ```bash
+   wrangler r2 object get roxabi-live-logs --prefix "$(date -u +%Y%m%d)" 2>/dev/null || \
+   curl -sS "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/logpush/jobs" \
+     -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq '.result[] | select(.name=="roxabi-live-logs") | {last_complete,last_error}'
+   ```
+
+3. **`/api/version` timestamp ≤ 65 min old** after one prod hour:
+
+   ```bash
+   curl -sS https://<prod-host>/api/version | jq '.'
+   ```
+
+All three green → S8 done → S9 (#101) cutover unblocked.
+
+---
+
+## Halt-alert manual smoke test (optional)
+
+Force the breaker on staging without a real GitHub outage:
+
+```bash
+wrangler d1 execute roxabi-live-staging --remote \
+  --command "UPDATE sync_control SET value='1' WHERE key='auth_failures'"
+# rotate GITHUB_TOKEN to an invalid value, trigger /admin/sync, confirm the NOTIFY_URL POST,
+# then restore the token and: UPDATE sync_control SET value='0' WHERE key IN ('auth_failures','halted')
+```

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -998,6 +998,55 @@ describe("runSync", () => {
     );
     errorSpy.mockRestore();
   });
+
+  // Halt-alert POST path (S8, #100) ----------------------------------------
+
+  // Builds a FakeD1 that drives runSync straight to the auth-halt branch
+  // (isHalted=0 → lock acquired → one allowlist repo → ghGraphql throws auth →
+  // auth_failures=2 → haltSync). Shared by the two NOTIFY_URL tests below.
+  function makeHaltDb() {
+    return makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "Roxabi/lyra" }]);
+      }
+      if (sql.includes("auth_failures") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("auth_failures") && sql.includes("SELECT")) return makeFakeStmt(sql, args, [{ value: "2" }], 0);
+      return makeFakeStmt(sql, args, [], 1);
+    });
+  }
+
+  it("POSTs a sync_halted alert to NOTIFY_URL when the breaker trips", async () => {
+    const { ghGraphql, GraphQLError } = await import("./graphql");
+    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const env = makeEnv({ DB: makeHaltDb(), NOTIFY_URL: "https://ntfy.example/roxabi" });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://ntfy.example/roxabi");
+    expect(init).toMatchObject({ method: "POST" });
+    expect(String((init as RequestInit).body)).toContain("sync_halted");
+  });
+
+  it("does not POST when NOTIFY_URL is unset", async () => {
+    const { ghGraphql, GraphQLError } = await import("./graphql");
+    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const env = makeEnv({ DB: makeHaltDb() }); // no NOTIFY_URL
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -1107,7 +1107,7 @@ export async function runSync(env: Env): Promise<void> {
       if (failures >= 2) {
         await haltSync(db);
         console.error("[sync] HALTED: 2 consecutive auth failures");
-        const notifyUrl = (env as { NOTIFY_URL?: string }).NOTIFY_URL;
+        const notifyUrl = env.NOTIFY_URL;
         if (notifyUrl) {
           await fetch(notifyUrl, {
             method: "POST",

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -12,4 +12,10 @@ export interface Env {
   GITHUB_ORG: string;
   /** HMAC secret for webhook verification (S5, #97) — differs per env. */
   GITHUB_WEBHOOK_SECRET: string;
+  /**
+   * Halt-alert webhook (S8, #100) — optional. When the auth-halt breaker trips
+   * (2 consecutive auth failures), runSync POSTs a `sync_halted` event here.
+   * Set via `wrangler secret put NOTIFY_URL`; unset = alerts disabled.
+   */
+  NOTIFY_URL?: string;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,6 +10,14 @@ binding   = "ASSETS"
 [triggers]
 crons = ["0 * * * *"]
 
+# Workers Logs (S8, #100) — emits invocation logs that Logpush ships to the
+# roxabi-live-logs R2 bucket for a persistent audit trail (go/no-go gate for S9
+# cutover, since M₁'s local logs disappear at decommission). head_sampling_rate=1
+# keeps every cron invocation (1/hour — volume is trivial).
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [[d1_databases]]
 binding        = "DB"
 database_name  = "roxabi-live-production"
@@ -29,3 +37,8 @@ migrations_dir = "worker/migrations"
 
 [env.staging.triggers]
 crons = ["0 * * * *"]
+
+# Named environments do not inherit top-level [observability] — repeat per env.
+[env.staging.observability]
+enabled = true
+head_sampling_rate = 1


### PR DESCRIPTION
## Summary

S8 = the **observability go/no-go gate** before S9 cutover (#101). The cron trigger,
`scheduled()` handler, and auth-halt → `NOTIFY_URL` alert all shipped in S4 (#96) — this
slice wires the missing observability config + hardens the alert path. Bulk of S8 is
Cloudflare **ops** (R2 bucket, Logpush job, secret), captured as a runbook rather than code.

- **wrangler.toml** — enable `[observability]` (prod + staging) so Workers Logs exist for
  Logpush → R2 export (the hard audit gate: M₁'s local logs vanish at decommission).
- **types.ts** — type `NOTIFY_URL?: string` on `Env`; drop the inline `(env as {…})` cast
  in the `sync.ts` halt-alert.
- **sync.test.ts** — cover the halt-alert POST path (fires `sync_halted` body when set;
  no-op when unset).
- **docs/s8-cron-observability.md** — runbook for the CF-side ops + acceptance queries.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #100: CF S8 — Cron + observability | OPEN |
| Frame | [frame](artifacts/frames/100-cf-s8-cron-observability-frame.mdx) (tier S) | Present |
| Implementation | 1 impl commit on `feat/100-cf-s8-cron-observability` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2 new) — worker 221/221, tsc clean, wrangler dry-run ✅ | Passed |

## Test Plan

- [ ] CI green (Python + worker jobs)
- [ ] **Ops (post-merge, per runbook):** create `roxabi-live-logs` R2 bucket + Logpush job → confirm R2 receives logs
- [ ] **Ops:** `wrangler secret put NOTIFY_URL` (prod + staging) → force breaker → confirm `sync_halted` POST received
- [ ] **Ops:** ≥1 prod Cron execution; `/api/version` timestamp ≤65 min old

> ⚠️ The 3 ops checkboxes require Cloudflare dashboard/API + a real `NOTIFY_URL` value and
> are the **acceptance criteria for #100** — they complete after merge+deploy, not in CI.

Fixes #100

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`