### PR TITLE
feat(worker): per-run R2 audit summary — Free-plan Logpush alternative (#120)

### DIFF
--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -17,6 +17,7 @@ import {
   syncPRs,
   syncRepoBundle,
   runSync,
+  writeRunAudit,
 } from "./sync";
 import type { EdgeData } from "./sync";
 import type { Env } from "../types";
@@ -1046,6 +1047,91 @@ describe("runSync", () => {
     await expect(runSync(env)).resolves.toBeUndefined();
 
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  // R2 run-audit (#120) -----------------------------------------------------
+
+  it("writes a run-audit object to R2 (outcome=halted) on the halt path", async () => {
+    const { ghGraphql, GraphQLError } = await import("./graphql");
+    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const put = vi.fn().mockResolvedValue(undefined);
+
+    const env = makeEnv({ DB: makeHaltDb(), LOGS: { put } as unknown as R2Bucket });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    expect(put).toHaveBeenCalledTimes(1);
+    const [key, body] = put.mock.calls[0];
+    expect(key).toMatch(/^runs\/\d{4}-\d{2}-\d{2}\/.+\.json$/);
+    expect(JSON.parse(body as string).outcome).toBe("halted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeRunAudit (#120)
+// ---------------------------------------------------------------------------
+
+describe("writeRunAudit", () => {
+  function auditDb() {
+    return makeFakeDb((sql, args) => {
+      if (sql.includes("FROM issues")) return makeFakeStmt(sql, args, [{ c: 2650 }]);
+      if (sql.includes("FROM edges")) return makeFakeStmt(sql, args, [{ c: 2432 }]);
+      if (sql.includes("FROM pr_state")) return makeFakeStmt(sql, args, [{ c: 373 }]);
+      if (sql.includes("MAX(last_synced_at)"))
+        return makeFakeStmt(sql, args, [{ w: "2026-06-08T09:00:00Z" }]);
+      if (sql.includes("sync_control"))
+        return makeFakeStmt(sql, args, [
+          { key: "halted", value: "0" },
+          { key: "auth_failures", value: "0" },
+        ]);
+      return makeFakeStmt(sql, args, []);
+    });
+  }
+
+  it("no-ops when LOGS is unbound (never throws)", async () => {
+    const env = { DB: auditDb() } as unknown as Env;
+    await expect(
+      writeRunAudit(env, env.DB, { outcome: "success", stubs: 0, durationMs: 1 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("puts a JSON snapshot with counts + watermark when LOGS is bound", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const put = vi.fn().mockResolvedValue(undefined);
+    const db = auditDb();
+    const env = { DB: db, LOGS: { put } } as unknown as Env;
+
+    await writeRunAudit(env, db, { outcome: "success", stubs: 4, durationMs: 1234 });
+
+    expect(put).toHaveBeenCalledTimes(1);
+    const [key, body, opts] = put.mock.calls[0];
+    expect(key).toMatch(/^runs\/\d{4}-\d{2}-\d{2}\/.+\.json$/);
+    expect(opts).toMatchObject({ httpMetadata: { contentType: "application/json" } });
+    const snap = JSON.parse(body as string);
+    expect(snap).toMatchObject({
+      outcome: "success",
+      stubs: 4,
+      durationMs: 1234,
+      issues: 2650,
+      edges: 2432,
+      prs: 373,
+      watermark: "2026-06-08T09:00:00Z",
+      halted: false,
+      authFailures: 0,
+    });
+  });
+
+  it("swallows R2 put failures (audit must not fail the sync)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const put = vi.fn().mockRejectedValue(new Error("R2 down"));
+    const db = auditDb();
+    const env = { DB: db, LOGS: { put } } as unknown as Env;
+
+    await expect(
+      writeRunAudit(env, db, { outcome: "error", stubs: 0, durationMs: 5 }),
+    ).resolves.toBeUndefined();
+    expect(put).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -1030,6 +1030,61 @@ export async function closedHopPass(db: D1Database, token: string): Promise<numb
  * Org-wide sync: check halt → acquire lock → enumerate repos → two-pass issue
  * sync → branch/PR sync → closed-hop pass → release lock.
  */
+/** Outcome of a single runSync invocation, recorded in the R2 audit summary. */
+export type RunOutcome = "success" | "empty" | "halted" | "auth_error" | "error";
+
+/**
+ * Write a compact per-run audit summary to the R2 `LOGS` bucket (#120).
+ * Best-effort: no-op when LOGS is unbound, and never throws into runSync — a
+ * failed audit must not fail the sync. Free-plan alternative to Logpush→R2.
+ */
+export async function writeRunAudit(
+  env: Env,
+  db: D1Database,
+  info: { outcome: RunOutcome; stubs: number; durationMs: number },
+): Promise<void> {
+  const bucket = env.LOGS;
+  if (!bucket) return;
+  try {
+    const [issues, edges, prs, wm, ctrl] = await Promise.all([
+      db.prepare("SELECT COUNT(*) AS c FROM issues").first<{ c: number }>(),
+      db.prepare("SELECT COUNT(*) AS c FROM edges").first<{ c: number }>(),
+      db.prepare("SELECT COUNT(*) AS c FROM pr_state").first<{ c: number }>(),
+      db
+        .prepare("SELECT MAX(last_synced_at) AS w FROM sync_state")
+        .first<{ w: string | null }>(),
+      db
+        .prepare(
+          "SELECT key, value FROM sync_control WHERE key IN ('halted','auth_failures')",
+        )
+        .all<{ key: string; value: string }>(),
+    ]);
+    const ctrlMap = new Map(
+      (ctrl.results ?? []).map((r) => [r.key, r.value] as const),
+    );
+    const ts = new Date().toISOString();
+    const summary = {
+      ts,
+      outcome: info.outcome,
+      durationMs: info.durationMs,
+      stubs: info.stubs,
+      issues: issues?.c ?? 0,
+      edges: edges?.c ?? 0,
+      prs: prs?.c ?? 0,
+      watermark: wm?.w ?? null,
+      halted: ctrlMap.get("halted") === "1",
+      authFailures: Number(ctrlMap.get("auth_failures") ?? 0),
+    };
+    const key = `runs/${ts.slice(0, 10)}/${ts}.json`;
+    await bucket.put(key, JSON.stringify(summary), {
+      httpMetadata: { contentType: "application/json" },
+    });
+    console.log(`[sync] audit written → ${key} (${info.outcome})`);
+  } catch (err) {
+    console.error("[sync] audit write failed (non-fatal):", err);
+  }
+}
+
 export async function runSync(env: Env): Promise<void> {
   const db = env.DB;
 
@@ -1043,6 +1098,11 @@ export async function runSync(env: Env): Promise<void> {
     return;
   }
 
+  // Audit tracking (#120) — recorded to R2 in the finally block.
+  const t0 = Date.now();
+  let outcome: RunOutcome = "error";
+  let stubsCount = 0;
+
   try {
     const startedAt = new Date().toISOString();
     await db
@@ -1055,6 +1115,7 @@ export async function runSync(env: Env): Promise<void> {
     const allowlist = await getRepoAllowlist(db);
     if (allowlist.length === 0) {
       console.warn("[sync] repo_allowlist empty — nothing to sync");
+      outcome = "empty";
       return;
     }
 
@@ -1095,15 +1156,17 @@ export async function runSync(env: Env): Promise<void> {
     await flushEdges(db, collectedEdges);
 
     // Closed-hop pass
-    const stubs = await closedHopPass(db, env.GITHUB_TOKEN);
-    console.log(`[sync] completed — stubs=${stubs}`);
+    stubsCount = await closedHopPass(db, env.GITHUB_TOKEN);
+    console.log(`[sync] completed — stubs=${stubsCount}`);
 
     await resetAuthFailures(db);
+    outcome = "success";
   } catch (err) {
     const isAuth = err instanceof GraphQLError && err.isAuth;
     if (isAuth) {
       const failures = await incrementAuthFailures(db);
       console.error(`[sync] auth failure ${failures}/2`);
+      outcome = failures >= 2 ? "halted" : "auth_error";
       if (failures >= 2) {
         await haltSync(db);
         console.error("[sync] HALTED: 2 consecutive auth failures");
@@ -1117,9 +1180,15 @@ export async function runSync(env: Env): Promise<void> {
         }
       }
     } else {
+      outcome = "error";
       console.error("[sync] error:", err);
     }
   } finally {
     await releaseSyncLock(db);
+    await writeRunAudit(env, db, {
+      outcome,
+      stubs: stubsCount,
+      durationMs: Date.now() - t0,
+    });
   }
 }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -18,4 +18,11 @@ export interface Env {
    * Set via `wrangler secret put NOTIFY_URL`; unset = alerts disabled.
    */
   NOTIFY_URL?: string;
+  /**
+   * R2 audit bucket (#120) — optional. After each sync run, runSync writes a
+   * compact JSON summary (counts, watermark, outcome) to `roxabi-live-logs` as a
+   * persistent audit trail. Free-plan alternative to Logpush (which needs Workers
+   * Paid). Unset = audit disabled (no-op); never blocks the sync.
+   */
+  LOGS?: R2Bucket;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,10 +10,10 @@ binding   = "ASSETS"
 [triggers]
 crons = ["0 * * * *"]
 
-# Workers Logs (S8, #100) — emits invocation logs that Logpush ships to the
-# roxabi-live-logs R2 bucket for a persistent audit trail (go/no-go gate for S9
-# cutover, since M₁'s local logs disappear at decommission). head_sampling_rate=1
-# keeps every cron invocation (1/hour — volume is trivial).
+# Workers Logs (S8, #100) — in-dashboard invocation logs (~3-day retention on the
+# Free plan). NOTE: persistent export via Logpush→R2 needs Workers Paid; on Free the
+# persistent audit trail is instead written by the Worker itself (#120, see [[r2_buckets]]
+# below). head_sampling_rate=1 keeps every cron invocation (1/hour — volume is trivial).
 [observability]
 enabled = true
 head_sampling_rate = 1
@@ -23,6 +23,12 @@ binding        = "DB"
 database_name  = "roxabi-live-production"
 database_id    = "c3951107-146c-4a7d-a8a5-86d09e4570e9"
 migrations_dir = "worker/migrations"
+
+# R2 audit bucket (#120) — runSync writes a per-run JSON summary here (Free-plan
+# alternative to Logpush). Bucket created via `wrangler r2 bucket create roxabi-live-logs`.
+[[r2_buckets]]
+binding     = "LOGS"
+bucket_name = "roxabi-live-logs"
 
 # ── Staging environment ──────────────────────────────────────────────────────
 
@@ -42,3 +48,8 @@ crons = ["0 * * * *"]
 [env.staging.observability]
 enabled = true
 head_sampling_rate = 1
+
+# Named envs don't inherit top-level [[r2_buckets]] either — repeat for staging.
+[[env.staging.r2_buckets]]
+binding     = "LOGS"
+bucket_name = "roxabi-live-logs"


### PR DESCRIPTION
## Summary

Logpush→R2 (the audit mechanism planned in S8 #100) requires the **Workers Paid** plan; the account is on **Free**. Mickael chose to stay Free, so the **Worker writes its own audit trail** instead — a persistent, queryable per-run snapshot in the existing `roxabi-live-logs` R2 bucket. Satisfies the **persistent-prod-audit go/no-go gate** for S9 cutover with **no plan upgrade**.

- **types.ts** — optional `LOGS?: R2Bucket` binding.
- **sync.ts** — `writeRunAudit()` at the end of `runSync` (`finally`) writes `runs/{date}/{ts}.json` = `{ts, outcome, durationMs, stubs, issues, edges, prs, watermark, halted, authFailures}`. Tracks `outcome` across success/empty/halted/auth_error/error. **Best-effort**: no-op when `LOGS` unbound, swallows R2 errors — never fails the sync.
- **wrangler.toml** — `[[r2_buckets]]` `LOGS` for prod + `[env.staging]` (named envs don't inherit). Corrected the #100 observability comment (Logpush=Paid → Worker self-writes).
- **tests** — `writeRunAudit` no-op / put-snapshot / error-swallow + `runSync` halt-path audit.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #120 (sibling of #100, deferred from S8) | OPEN |
| Implementation | 1 commit on `feat/120-cf-audit-summary-r2` (tier S) | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new) — worker 225/225, wrangler dry-run binds `LOGS` ✅ | Passed |

## Test Plan

- [ ] CI green
- [ ] Post-deploy (staging): trigger a sync → `wrangler r2 object get roxabi-live-logs --prefix runs/` lists a summary
- [ ] Sync still completes if R2 put fails (covered by unit test)

Fixes #120
Closes #120

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`