### PR TITLE
docs: reflect CF cutover — prod on Worker, M₁ decommissioned (#92)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@ Let:
 
 ## Project
 
-**Roxabi Live** — operations cockpit (FastAPI + aiosqlite + Tailscale Funnel)
-- Exposes `~/.roxabi/corpus.db` via live HTTP API (`GET /api/*`)
-- Receives GitHub org webhooks at `POST /webhook/github` (HMAC-gated)
-- Frontend: static HTML/JS (dep-graph tab first, see spec #866)
-- Public via Tailscale Funnel on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (`roxabi.dev` zone migrated to Cloudflare as of 2026-06-05 → Cloudflare Tunnel now unblocked but not yet deployed; Funnel remains the live ingress)
+**Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
+- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev** behind Cloudflare Access (Email-OTP, mickael@bouly.io)
+- Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
+- Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 * * * *` + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
+- Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)
+- `/admin/*` gated by `ADMIN_TOKEN` secret (defense-in-depth, #123) in addition to edge Access
+- M₁ (roxabituwer) **decommissioned 2026-06-08**: `live.service` stopped+disabled, Tailscale Funnel retired, `~/.roxabi/corpus.db` archived
 
 → `docs/ARCHITECTURE.md` (to be created)
 
@@ -24,31 +26,72 @@ Let:
 
 ## Key files
 
+**Worker (prod — primary)**
+
 | File | Role |
 |---|---|
-| `src/roxabi_live/app.py` | FastAPI application factory |
-| `src/roxabi_live/__main__.py` | uvicorn entry point |
-| `src/roxabi_live/corpus/` | Issue sync GraphQL → `~/.roxabi/corpus.db` (migrated from lyra) |
-| `src/roxabi_live/dep_graph/v1/` | Legacy CLI renderer (frozen) |
-| `src/roxabi_live/dep_graph/v5/` | Matrix + graph HTML renderer (frozen) |
-| `src/roxabi_live/dep_graph/v6/` | API-first renderer → `GET /api/graph` |
-| `src/roxabi_live/reconciler.py` | Hourly corpus sync heal loop + startup one-shot |
-| `src/roxabi_live/api/issues.py` | `GET /api/issues`, `GET /api/issues/:key` |
-| `src/roxabi_live/webhook/` | GitHub webhook handlers (HMAC verify + issues/deps/sub_issues dispatch) |
-| `deploy/systemd/live.service` | systemd user unit (M₁ boot) |
-| `frontend/` | Static HTML/JS/CSS (dep-graph tab + future tabs) |
+| `worker/src/index.ts` | Worker entry point (`fetch` + `scheduled` handlers) |
+| `worker/src/router.ts` | Request routing |
+| `worker/src/types.ts` | `Env` interface + shared types |
+| `worker/src/api/issues.ts` | `GET /api/issues`, `GET /api/issues/:key` |
+| `worker/src/api/graph.ts` | `GET /api/graph` |
+| `worker/src/api/admin.ts` | `POST /admin/sync` (ADMIN_TOKEN-gated) |
+| `worker/src/api/version.ts` | `GET /api/version` |
+| `worker/src/sync/sync.ts` | Hourly sync orchestrator + R2 audit write |
+| `worker/src/sync/graphql.ts` | GitHub GraphQL client (`fetch()`) |
+| `worker/src/sync/queries.ts` | GraphQL query strings |
+| `worker/src/sync/parse.ts` | Issue/edge parsing |
+| `worker/src/webhook/handlers.ts` | Webhook dispatch (issues/deps/sub_issues) |
+| `worker/src/webhook/hmac.ts` | HMAC verification |
+| `worker/src/webhook/mutations.ts` | D1 write helpers |
+| `worker/migrations/` | D1 schema migrations |
+| `wrangler.toml` | Worker config (bindings, Cron, routes, environments) |
+| `frontend/` | Static HTML/JS/CSS served via ASSETS binding |
 | `artifacts/` | Frames, specs, plans (dev-core) |
-| `.env.example` | Env var reference (CORPUS_DB_PATH, GITHUB_WEBHOOK_SECRET, …) |
+
+**Legacy Python app (pre-CF, M₁-era — decommissioned 2026-06-08, code kept for reference)**
+
+| File | Role |
+|---|---|
+| `src/roxabi_live/app.py` | ~~FastAPI application factory~~ |
+| `src/roxabi_live/__main__.py` | ~~uvicorn entry point~~ |
+| `src/roxabi_live/corpus/` | ~~Issue sync GraphQL → `~/.roxabi/corpus.db`~~ |
+| `src/roxabi_live/dep_graph/v1/` | ~~Legacy CLI renderer (frozen)~~ |
+| `src/roxabi_live/dep_graph/v5/` | ~~Matrix + graph HTML renderer (frozen)~~ |
+| `src/roxabi_live/dep_graph/v6/` | ~~API-first renderer~~ |
+| `src/roxabi_live/reconciler.py` | ~~Hourly corpus sync heal loop~~ |
+| `src/roxabi_live/api/issues.py` | ~~`GET /api/issues`~~ |
+| `src/roxabi_live/webhook/` | ~~GitHub webhook handlers~~ |
+| `deploy/systemd/live.service` | ~~systemd user unit (M₁ boot)~~ |
+| `.env.example` | Env var reference (legacy Python env; CF secrets via `wrangler secret put`) |
 
 ## Dep-graph versions
 
 | Version | Status | Entry |
 |---|---|---|
-| v1 | frozen (legacy CLI) | `dep-graph` script |
-| v5 | frozen (static HTML build) | `dep-graph-v5` script · `GET /dep-graph/` (auto-rebuild when corpus.db newer) |
-| v6 | **primary** — API-first | `GET /api/graph` · `dep-graph-v6` CLI (debug) |
+| v1 | frozen (legacy CLI — decommissioned) | `dep-graph` script |
+| v5 | frozen (static HTML build — decommissioned) | `dep-graph-v5` script |
+| v6 | **primary** — served by CF Worker ASSETS | `GET /api/graph` · Worker ASSETS binding |
 
 ## Package layout
+
+**Worker (active)**
+
+```
+worker/
+  src/
+    index.ts        # fetch + scheduled entry
+    router.ts
+    types.ts
+    api/            # issues, graph, admin, version
+    sync/           # sync, graphql, queries, parse
+    webhook/        # handlers, hmac, mutations
+  migrations/
+wrangler.toml       # repo root — binds both envs
+frontend/           # served via ASSETS binding
+```
+
+**Legacy Python app (decommissioned 2026-06-08)**
 
 ```
 src/roxabi_live/
@@ -59,11 +102,11 @@ tests/
   test_health.py
 ```
 
-Module name: `roxabi_live` (underscore). CLI: `roxabi-live` (hyphen).
+Module name: `roxabi_live` (underscore). CLI: `roxabi-live` (hyphen). ¬running in prod.
 
 ## Corpus sync — edge algorithm
 
-GitHub issue relationships map to `corpus.db` edges table with specific `kind` values:
+GitHub issue relationships map to D1 `edges` table with specific `kind` values (algorithm identical to pre-CF; implementation moved to `worker/src/sync/sync.ts` + `worker/src/sync/parse.ts`):
 
 | Relationship | GraphQL field | Edge direction | `kind` |
 |--------------|---------------|----------------|--------|
@@ -75,14 +118,12 @@ GitHub issue relationships map to `corpus.db` edges table with specific `kind` v
 - `parent`: `src` is the parent issue, `dst` is a sub-issue. Parent must complete before children can proceed.
 - `blocks`: `src` blocks `dst`. If `src` is open, `dst` is "blocked"; if `src` is closed, `dst` is "ready".
 
-**Sync flow** (`src/roxabi_live/corpus/sync.py`):
+**Sync flow** (`worker/src/sync/sync.ts`):
 1. Fetch issues via GraphQL with `subIssues`, `parent`, `blockedBy`, `blocking` fields
-2. For each issue:
-   - `upsert_edges(conn, key, parents, children, kind="parent")` — parents point to this issue, this issue points to children
-   - `upsert_edges(conn, key, blocked_by, blocking, kind="blocks")` — blockers point to this issue, this issue points to blockees
-3. `upsert_edges` deletes only edges of the same `kind` for the issue, allowing multiple edge types per issue
+2. For each issue: upsert parent edges + blocks edges (deletes only edges of same `kind`)
+3. Write per-run audit to R2 bucket `roxabi-live-logs`
 
-**Frontend status computation** (`src/roxabi_live/dep_graph/v6/frontend/state.js`):
+**Frontend status computation** (`frontend/` → `state.js`, served via ASSETS binding):
 ```js
 // Any edge where this node is dst → src blocks it
 if (node.state === 'closed') return 'done';
@@ -104,11 +145,29 @@ File/rename → update P immediately
 |---|---|
 | `CLAUDE.md` | project root |
 
-Rules: add/delete/move → update P | new `src/roxabi_live/` subdir → nearest P (¬nested)
+Rules: add/delete/move → update P | new `worker/src/` subdir → update Key files table
 
 ## Deploy pattern
 
-M₁ (prod): `deploy/systemd/live.service` — systemd user unit, installed to `~/.config/systemd/user/live.service`, enabled via linger.
-Service control on M₁: `systemctl --user {start,stop,status,restart} live.service` (no `make live` wrapper — supervisor no longer manages this service).
-M₂ (dev): start manually with `uv run roxabi-live`.
-Log dir: `~/.local/state/roxabi-live/logs/`
+**Prod (Cloudflare — CI-driven)**
+
+Push to `main` → CI `deploy` job → `wrangler deploy` (binds `live.roxabi.dev` via top-level `routes` in `wrangler.toml`).
+Push to `staging` → `wrangler deploy --env staging`.
+
+Secrets (set once; `CLOUDFLARE_ACCOUNT_ID` required — token sees 2 accounts):
+```bash
+# prod
+printf %s '<value>' | wrangler secret put SECRET_NAME
+# staging
+printf %s '<value>' | wrangler secret put SECRET_NAME --env staging
+```
+
+Local worker dev:
+```bash
+cd worker && npm ci && npx wrangler dev
+```
+
+**M₁ / systemd — decommissioned 2026-06-08**
+
+`live.service` stopped+disabled. `uv run roxabi-live` (M₂ dev server) no longer reflects prod.
+Legacy log dir: `~/.local/state/roxabi-live/logs/` (archived on M₁).

--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -3,8 +3,20 @@ title: Cloudflared Tunnel Setup
 description: One-time provisioning of the Cloudflare Tunnel that exposes dashboard.roxabi.dev, and migration from M₂ to M₁.
 ---
 
+> [!WARNING]
+> **ARCHIVED — historical reference only (as of 2026-06-08)**
+>
+> This document describes infrastructure that was **never deployed** and is now superseded.
+> The production ingress is **Cloudflare Access + Worker** at `https://live.roxabi.dev`.
+> Tailscale Funnel on M₁ has been **retired** (`tailscale funnel --https=443 off`).
+> M₁ `live.service` is **stopped and disabled**. The `cloudflared` Tunnel approach
+> described below was deferred and ultimately skipped — the S9 cutover went directly
+> to the CF Worker + Access model (Email-OTP, no `cloudflared` daemon needed).
+>
+> See `docs/s9-cutover.md` for the completed cutover runbook.
+
 > [!NOTE]
-> **Status (updated 2026-06-05):** the `roxabi.dev` zone has **migrated to Cloudflare** (NS: `donald`/`mia.ns.cloudflare.com`), so the previous blocker is gone — Cloudflare Tunnel + Access **can** now front it. This setup is, however, **still not deployed**: production ingress remains **Tailscale Funnel** on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (see "Current deployment" below). This document is the runbook for the eventual migration to Cloudflare Tunnel.
+> **Status (updated 2026-06-05, superseded 2026-06-08):** the `roxabi.dev` zone has **migrated to Cloudflare** (NS: `donald`/`mia.ns.cloudflare.com`), so the previous blocker is gone — Cloudflare Tunnel + Access **can** now front it. This setup is, however, **still not deployed**: production ingress remains **Tailscale Funnel** on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (see "Current deployment" below). This document is the runbook for the eventual migration to Cloudflare Tunnel.
 
 ## Current deployment (Tailscale Funnel)
 
@@ -263,3 +275,5 @@ Webhook delivery:
 - Rotate the service token: Zero Trust → Service Tokens → `github-webhook` → **Refresh**. Update the worker secret. Redeliver a test webhook to confirm.
 - Rotate the identity-provider allowlist: edit the `Allow owner` policy (Step A.5).
 - After a `_halted` reconciler event (CRITICAL log emitted due to repeated auth failures): rotate the GitHub token, then restart the live service to clear the sticky halt state: `systemctl --user restart live.service`. The reconciler will resume on the next hourly tick.
+
+> **Note (2026-06-08 — decommissioned):** `live.service` no longer runs on M₁. The CF Worker handles sync via `ADMIN_TOKEN`-gated `/admin/sync` (manual) or hourly Cron Trigger. To clear a halted sync on the Worker: rotate `GITHUB_TOKEN` via `wrangler secret put`, then trigger `POST /admin/sync` with `Authorization: Bearer <ADMIN_TOKEN>`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,18 @@
 # Getting Started
 
+> [!NOTE]
+> **Production (2026-06-08+):** Roxabi Live runs as a **Cloudflare Worker** at
+> `https://live.roxabi.dev` (CF Access Email-OTP). Python/systemd/M₁ is decommissioned.
+> For Worker local dev: `cd worker && npm ci && npx wrangler dev`.
+> The Python setup below applies to the legacy app only.
+
 ## Prerequisites
 
+**Worker dev (active):**
+- Node.js (for `wrangler`) — `npx wrangler dev` works without a global install
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) — `npm ci` in `worker/`
+
+**Legacy Python app (decommissioned — reference only):**
 - Python 3.12 (managed via `.python-version` — `pyenv` or system install)
 - [uv](https://docs.astral.sh/uv/) — package manager
 - [GitHub CLI](https://cli.github.com/) (`gh`) — authenticated via `gh auth login` (needs `read:org`, `repo` scopes)
@@ -86,13 +97,42 @@ For local dev, use a tunnel (e.g. `ngrok http 8000`) to expose the local server.
 
 See [GitHub docs — Creating webhooks](https://docs.github.com/en/webhooks/using-webhooks/creating-webhooks) for details.
 
-## Production Deployment (systemd)
+## Production Deployment (Cloudflare Worker — CI-driven)
 
-Roxabi Live is deployed as a systemd user service on M1 (`roxabituwer`). The unit is at `deploy/systemd/live.service`.
+> **Decommissioned (2026-06-08):** The Python/systemd/M₁ deployment described below has been retired. See the archived sections.
 
-### Install
+Production is a Cloudflare Worker deployed via CI. Push to `main` → `wrangler deploy` (prod, `live.roxabi.dev`). Push to `staging` → `wrangler deploy --env staging`.
 
-Run once on the target machine:
+### Local Worker dev
+
+```bash
+cd worker && npm ci && npx wrangler dev
+```
+
+Worker binds a local D1 preview. No Python/uvicorn needed.
+
+### Secrets (set once per environment)
+
+```bash
+printf %s '<value>' | wrangler secret put SECRET_NAME           # prod
+printf %s '<value>' | wrangler secret put SECRET_NAME --env staging
+```
+
+Required secrets: `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET`, `ADMIN_TOKEN`.
+
+---
+
+## Legacy: Production Deployment via systemd (decommissioned 2026-06-08)
+
+> [!WARNING]
+> M₁ (`roxabituwer`) `live.service` was stopped and disabled on 2026-06-08. The
+> Python FastAPI app (`src/roxabi_live/`) is kept in the repo as a historical reference
+> but is no longer deployed. `~/.roxabi/corpus.db` was archived as `.bak` on M₁.
+> The sections below are preserved for reference only.
+
+Roxabi Live was deployed as a systemd user service on M1 (`roxabituwer`). The unit is at `deploy/systemd/live.service`.
+
+### Install (historical)
 
 ```bash
 cp deploy/systemd/live.service ~/.config/systemd/user/live.service
@@ -101,22 +141,17 @@ systemctl --user enable live.service
 systemctl --user start live.service
 ```
 
-Requires `loginctl enable-linger $USER` (already set on M1).
-
-### Service control
+### Service control (historical)
 
 ```bash
 systemctl --user status live.service
-systemctl --user start live.service
-systemctl --user stop live.service
-systemctl --user restart live.service
 journalctl --user -u live.service -f   # follow logs
 ```
 
-Logs also written to `~/.local/state/roxabi-live/logs/`:
-- `live.log` — stdout
-- `live_error.log` — stderr
+Logs were written to `~/.local/state/roxabi-live/logs/` (archived on M₁).
 
-### Tailscale Funnel
+### Tailscale Funnel (retired)
 
-On M1, the server is exposed publicly via Tailscale Funnel. Start it once with `tailscale funnel --bg 8000` (no `sudo` — the Tailscale operator is set to the host user); the binding survives `tailscaled` restarts. Verify with `tailscale funnel status`. Disable all bindings with `tailscale funnel --https=443 off`.
+The Tailscale Funnel (`tailscale funnel --bg 8000`) that fronted M₁ has been retired
+(`tailscale funnel --https=443 off`). Ingress is now `https://live.roxabi.dev` via
+Cloudflare Access (Email-OTP).

--- a/docs/s8-cron-observability.md
+++ b/docs/s8-cron-observability.md
@@ -7,8 +7,11 @@ handler, and the auth-halt → `NOTIFY_URL` alert all exist. This slice adds the
 **observability config** and the **operational steps** that can't live in the repo, plus
 two code hardening changes (typed `Env.NOTIFY_URL`, halt-alert test).
 
-This is the **hard go/no-go gate** before S9 cutover (#101): do **not** decommission M₁
+This was the **hard go/no-go gate** before S9 cutover (#101): do **not** decommission M₁
 until a **persistent prod audit trail** exists, because M₁'s local logs vanish with it.
+
+> **Update (2026-06-08):** S9 cutover is **DONE**. The gate passed — prod R2 audit confirmed
+> before M₁ decommission. See `docs/s9-cutover.md` for the completed cutover record.
 
 > **Update (#120):** Logpush was abandoned — it requires the Workers **Paid** plan and
 > this account is on **Free**. The persistent audit is instead written by the Worker

--- a/docs/s9-cutover.md
+++ b/docs/s9-cutover.md
@@ -2,6 +2,27 @@
 
 Issue [#101](https://github.com/Roxabi/roxabi-live/issues/101) · epic [#92](https://github.com/Roxabi/roxabi-live/issues/92).
 
+## Status: DONE (2026-06-08)
+
+All go/no-go items confirmed green. Cutover and decommission completed.
+
+| Item | Result |
+|---|---|
+| CF Access Email-OTP app live (`live.roxabi.dev`) | ✅ confirmed |
+| Bypass policy on `/webhook/*` | ✅ confirmed — no OTP challenge |
+| `live.roxabi.dev` bound to prod Worker | ✅ DNS + TLS live, CF-Ray present |
+| GitHub org webhook repointed → `https://live.roxabi.dev/webhook/github` | ✅ 200 OK on redeliver |
+| R2 audit object present (prod cron confirmed via `wrangler tail`) | ✅ confirmed |
+| `ADMIN_TOKEN` set on prod + staging (PR #124) | ✅ set |
+| M₁ `live.service` stopped + disabled | ✅ done |
+| Tailscale Funnel retired (`tailscale funnel --https=443 off`) | ✅ done |
+| `~/.roxabi/corpus.db` archived as `.bak` on M₁ | ✅ done |
+| `~/projects/CLAUDE.md` updated (M₁ roles) | handled separately |
+
+The runbook below is preserved as historical reference.
+
+---
+
 Final slice of the Cloudflare serverless migration. Goes live on `live.roxabi.dev`
 and retires M₁. **No bridge** — the Tailscale Funnel
 (`https://roxabituwer.goose-logarithm.ts.net`) served as the interim public ingress


### PR DESCRIPTION
Updates project docs to reflect that the Cloudflare serverless migration (#92) is done and M₁ is decommissioned (2026-06-08).

- `CLAUDE.md` — Project / Key files / Package layout / Deploy now describe the CF Worker (`worker/src/**`, D1, cron, `live.roxabi.dev` behind Access); Python `src/roxabi_live/**` marked legacy/decommissioned.
- `docs/s9-cutover.md` — "Status: DONE" note (Phases 4–5 executed).
- `docs/{cloudflared-setup,getting-started,s8-cron-observability}.md` — corrected stale "Funnel is the live ingress" / FastAPI-prod statements.

Docs-only (typecheck/trufflehog green). Refs #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)