### PR TITLE
feat(frontend): dep-graph toolbar — fix repo filter, add label filter, show milestone/priority names

### DIFF
--- a/frontend/app.css
+++ b/frontend/app.css
@@ -360,6 +360,11 @@ main { padding-bottom: 24px; }
   font-family: 'Inter', sans-serif; font-size: 12px;
   color: var(--text-muted); transition: background 0.08s;
 }
+.ms-sub {
+  color: var(--text-dim);
+  font-size: 10px;
+  margin-left: 6px;
+}
 .ms-item:hover { background: var(--bg-card); color: var(--text); }
 .ms-item input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -56,6 +56,7 @@ const msRepo      = new MultiSelect($('ms-repo-btn'),      $('ms-repo-panel'),  
 const msMilestone = new MultiSelect($('ms-milestone-btn'), $('ms-milestone-panel'), { placeholder: 'All milestones', clearBtn: $('ms-milestone-clear') });
 const msPriority  = new MultiSelect($('ms-priority-btn'),  $('ms-priority-panel'),  { placeholder: 'All priorities', clearBtn: $('ms-priority-clear') });
 const msStatus    = new MultiSelect($('ms-status-btn'),    $('ms-status-panel'),    { placeholder: 'All statuses',   clearBtn: $('ms-status-clear') });
+const msLabel     = new MultiSelect($('ms-label-btn'),     $('ms-label-panel'),     { placeholder: 'All labels',     clearBtn: $('ms-label-clear') });
 
 // ─── Render ───────────────────────────────────────────────────────────────
 function render() {
@@ -170,8 +171,24 @@ msRepo.onChange      = vals => { clearPinned(); setState({ repo:      vals }); r
 msMilestone.onChange = vals => { clearPinned(); setState({ milestone: vals }); render(); };
 msPriority.onChange  = vals => { clearPinned(); setState({ priority:  vals }); render(); };
 msStatus.onChange    = vals => { clearPinned(); setState({ status:    vals }); render(); };
+msLabel.onChange     = vals => { clearPinned(); setState({ label:     vals }); render(); };
 
 // ─── Populate filter options after data load ──────────────────────────────
+const PRIORITY_NAMES = { P0: 'Critical', P1: 'High', P2: 'Medium', P3: 'Low' };
+
+const LABEL_EXCLUDES = new Set([
+  'graph:lane/', 'size:', 'XS', 'S', 'M', 'L', 'XL',
+  'P0', 'priority:P0', 'P1-high', 'priority:high', 'priority:P1',
+  'P2-medium', 'priority:medium', 'priority:P2',
+  'P3-low', 'priority:low', 'priority: low', 'priority:P3',
+]);
+
+function isStructuredLabel(lbl) {
+  if (LABEL_EXCLUDES.has(lbl)) return true;
+  if (lbl.startsWith('graph:lane/') || lbl.startsWith('size:')) return true;
+  return false;
+}
+
 function populateFilters(repos) {
   const nodes = state.nodes;
 
@@ -186,11 +203,17 @@ function populateFilters(repos) {
   }
   const msItems = [...msMap.entries()]
     .sort((a, b) => a[1] - b[1])
-    .map(([v]) => ({ value: v, label: v }));
+    .map(([v]) => {
+      const node = nodes.find(n => (n.milestone_code ?? '(None)') === v);
+      const name = node?.milestone_name ?? null;
+      return { value: v, label: v, sublabel: (name && name !== v) ? name : undefined };
+    });
   msMilestone.setItems(msItems, state.milestone);
 
   msPriority.setItems(
-    ['P0', 'P1', 'P2', 'P3', '(None)'].map(v => ({ value: v, label: v })),
+    ['P0', 'P1', 'P2', 'P3', '(None)'].map(v => ({
+      value: v, label: v, sublabel: PRIORITY_NAMES[v],
+    })),
     state.priority
   );
 
@@ -198,6 +221,11 @@ function populateFilters(repos) {
     ['ready', 'blocked', 'done'].map(v => ({ value: v, label: v })),
     state.status
   );
+
+  const allLabels = [...new Set(nodes.flatMap(n => n.labels ?? []))]
+    .filter(l => !isStructuredLabel(l))
+    .sort();
+  msLabel.setItems(allLabels.map(l => ({ value: l, label: l })), state.label);
 }
 
 function restoreControls() {
@@ -213,25 +241,15 @@ async function loadGraphData() {
   return resp.json();
 }
 
-async function loadRepos() {
-  try {
-    const resp = await fetch('/api/repos');
-    if (!resp.ok) throw new Error(`/api/repos ${resp.status}`);
-    const j = await resp.json();
-    return (j.repos ?? []).map(r => r.repo);
-  } catch {
-    return [...new Set(state.nodes.map(n => n.repo))].sort();
-  }
-}
-
-// Re-fetch graph data + repos and re-render, preserving view/filters (held in state).
+// Re-fetch graph data and re-render, preserving view/filters (held in state).
 async function loadAndRender() {
-  const [data, repos] = await Promise.all([loadGraphData(), loadRepos()]);
+  const data = await loadGraphData();
   const nodes = data.nodes || [];
   const edges = data.edges || [];
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
   state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
+  const repos = [...new Set(nodes.map(n => n.repo))].sort();
   populateFilters(repos);
   render();
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,6 +52,14 @@
     </div>
 
     <div class="ms-wrap">
+      <button id="ms-label-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by label">
+        <span class="ms-placeholder">All labels</span>
+      </button>
+      <button id="ms-label-clear" class="ms-clear-inline" aria-label="Clear label filter" hidden>×</button>
+      <div id="ms-label-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
       <button id="ms-status-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by status">
         <span class="ms-placeholder">All statuses</span>
       </button>

--- a/frontend/multi_select.js
+++ b/frontend/multi_select.js
@@ -114,7 +114,14 @@ export class MultiSelect {
       const span = document.createElement('span');
       span.textContent = item.label;
 
-      lbl.append(cb, span);
+      if (item.sublabel) {
+        const sub = document.createElement('span');
+        sub.className = 'ms-sub';
+        sub.textContent = item.sublabel;
+        lbl.append(cb, span, sub);
+      } else {
+        lbl.append(cb, span);
+      }
       li.appendChild(lbl);
       ul.appendChild(li);
     }

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -36,6 +36,7 @@ export const state = {
   milestone: SS.getJSON('v6:milestone', []),
   priority:  SS.getJSON('v6:priority', []),
   status:    SS.getJSON('v6:status', ['ready', 'blocked']),
+  label:     SS.getJSON('v6:label', []),
   search:    SS.get('v6:search', ''),
   pivotRow:  SS.get('v6:pivotRow', 'milestone'),
   pivotCol:  SS.get('v6:pivotCol', 'lane'),
@@ -59,6 +60,7 @@ const SS_KEYS = {
   milestone:   { key: 'v6:milestone',   json: true  },
   priority:    { key: 'v6:priority',    json: true  },
   status:      { key: 'v6:status',      json: true  },
+  label:       { key: 'v6:label',       json: true  },
   search:      { key: 'v6:search',      json: false },
   pivotRow:    { key: 'v6:pivotRow',    json: false },
   pivotCol:    { key: 'v6:pivotCol',    json: false },
@@ -231,6 +233,7 @@ export function applyFilters(nodes, filters) {
     const pri = n.priority ?? '(None)';
     if (filters.priority.length && !filters.priority.includes(pri)) return false;
     if (filters.status.length && !filters.status.includes(n._status)) return false;
+    if (filters.label?.length && !filters.label.some(l => (n.labels ?? []).includes(l))) return false;
     if (q) {
       const hay = `${n.key} ${n.title ?? ''} ${(n.labels ?? []).join(' ')}`.toLowerCase();
       if (!hay.includes(q)) return false;
@@ -246,6 +249,7 @@ export function filteredNodes() {
     milestone: state.milestone,
     priority:  state.priority,
     status:    state.status,
+    label:     state.label,
     search:    state.search,
   });
 }
@@ -261,6 +265,7 @@ export function filteredNodesForGraph() {
     milestone: state.milestone,
     priority:  state.priority,
     status:    [],   // bypass status here, re-apply with override below
+    label:     state.label,
     search:    '',
   });
   if (state.status.length === 0) return base;


### PR DESCRIPTION
## Summary

- Fix repo filter regression: drop `/api/repos` round-trip, derive repos from loaded nodes synchronously (eliminates race between `Promise.all` legs)
- Add label filter (multi-select, OR semantics): excludes structured labels (graph:lane/, size:, priority variants); persisted to sessionStorage
- Show milestone/priority full names as `sublabel` in dropdown panels; pills stay compact
- Add `.ms-sub` CSS rule for muted secondary text in dropdowns
- Extend `MultiSelect._buildPanel` with optional `item.sublabel` (no change to pill rendering)

## Test plan

- [ ] Load dep-graph; verify repo filter dropdown populates correctly (regression fix)
- [ ] Filter by repo — nodes/graph update as expected
- [ ] Milestone dropdown shows code + name (e.g. "M3" + "Production"); pill shows code only
- [ ] Priority dropdown shows "P1" + "High" etc.; pill shows "P1" only
- [ ] Label filter appears after priority, before status; filters nodes with OR semantics
- [ ] Label filter excludes graph:lane/, size:, XS/S/M/L/XL, all priority-encoding variants
- [ ] Filter state persists across page refresh (sessionStorage)
- [ ] `node --check` passes on all 5 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)