### PR TITLE
feat(frontend): repo filter — archived repos last with separator

### DIFF
--- a/frontend/app.css
+++ b/frontend/app.css
@@ -363,6 +363,18 @@ main { padding-bottom: 24px; }
 .ms-item:hover { background: var(--bg-card); color: var(--text); }
 .ms-item input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
 
+.ms-sep {
+  display: flex; align-items: center;
+  padding: 4px 12px; margin-top: 2px;
+  font-size: 10px; color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  pointer-events: none; user-select: none;
+}
+.ms-sub {
+  margin-left: auto; font-size: 10px; color: var(--text-dim); font-style: italic;
+}
+.ms-item-archived { opacity: 0.7; }
+
 .ms-clear {
   display: block; width: 100%; margin-top: 4px; padding: 4px 12px;
   border: 0; border-top: 1px solid var(--border);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -172,10 +172,17 @@ msPriority.onChange  = vals => { clearPinned(); setState({ priority:  vals }); r
 msStatus.onChange    = vals => { clearPinned(); setState({ status:    vals }); render(); };
 
 // ─── Populate filter options after data load ──────────────────────────────
-function populateFilters(repos) {
+// repoData: Array<{ repo: string, archived: boolean }>
+function populateFilters(repoData) {
   const nodes = state.nodes;
 
-  const repoItems = repos.map(r => ({ value: r, label: r.split('/')[1] || r, tone: repoTone(r) }));
+  const live     = repoData.filter(r => !r.archived);
+  const archived = repoData.filter(r => r.archived);
+  const liveItems = live.map(r => ({ value: r.repo, label: r.repo.split('/')[1] || r.repo, tone: repoTone(r.repo) }));
+  const archItems = archived.map(r => ({ value: r.repo, label: r.repo.split('/')[1] || r.repo, tone: repoTone(r.repo), archived: true }));
+  const repoItems = archItems.length
+    ? [...liveItems, { separator: true, label: 'Archived' }, ...archItems]
+    : liveItems;
   msRepo.setItems(repoItems, state.repo);
 
   const msMap = new Map();
@@ -213,26 +220,23 @@ async function loadGraphData() {
   return resp.json();
 }
 
-async function loadRepos() {
-  try {
-    const resp = await fetch('/api/repos');
-    if (!resp.ok) throw new Error(`/api/repos ${resp.status}`);
-    const j = await resp.json();
-    return (j.repos ?? []).map(r => r.repo);
-  } catch {
-    return [...new Set(state.nodes.map(n => n.repo))].sort();
-  }
-}
-
-// Re-fetch graph data + repos and re-render, preserving view/filters (held in state).
+// Re-fetch graph data and re-render, preserving view/filters (held in state).
+// Uses data.repos (Array<{repo,archived}>) from /api/graph; falls back to nodes-derived if absent.
 async function loadAndRender() {
-  const [data, repos] = await Promise.all([loadGraphData(), loadRepos()]);
+  const data  = await loadGraphData();
   const nodes = data.nodes || [];
   const edges = data.edges || [];
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
   state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
-  populateFilters(repos);
+  let repoData;
+  if (data.repos && data.repos.length) {
+    repoData = data.repos;
+  } else {
+    const derived = [...new Set(nodes.map(n => n.repo))].sort();
+    repoData = derived.map(repo => ({ repo, archived: false }));
+  }
+  populateFilters(repoData);
   render();
 }
 

--- a/frontend/multi_select.js
+++ b/frontend/multi_select.js
@@ -92,12 +92,27 @@ export class MultiSelect {
     ul.setAttribute('aria-multiselectable', 'true');
 
     for (const item of this.items) {
+      // Separator item — non-interactive divider
+      if (item.separator) {
+        const li = document.createElement('li');
+        li.className = 'ms-sep';
+        li.setAttribute('role', 'separator');
+        li.setAttribute('aria-hidden', 'true');
+        if (item.label) {
+          const span = document.createElement('span');
+          span.textContent = item.label;
+          li.appendChild(span);
+        }
+        ul.appendChild(li);
+        continue;
+      }
+
       const li = document.createElement('li');
       li.setAttribute('role', 'option');
       li.setAttribute('aria-selected', this.selected.has(item.value) ? 'true' : 'false');
 
       const lbl = document.createElement('label');
-      lbl.className = 'ms-item';
+      lbl.className = 'ms-item' + (item.archived ? ' ms-item-archived' : '');
 
       const cb = document.createElement('input');
       cb.type    = 'checkbox';
@@ -115,6 +130,14 @@ export class MultiSelect {
       span.textContent = item.label;
 
       lbl.append(cb, span);
+
+      if (item.archived) {
+        const sub = document.createElement('span');
+        sub.className = 'ms-sub';
+        sub.textContent = 'archived';
+        lbl.appendChild(sub);
+      }
+
       li.appendChild(lbl);
       ul.appendChild(li);
     }


### PR DESCRIPTION
## Summary

- Consume `data.repos: Array<{ repo: string, archived: boolean }>` from `/api/graph` response (graceful fallback to nodes-derived when absent)
- `populateFilters()` builds MultiSelect items: live repos first → `{ separator: true, label: 'Archived' }` divider → archived repos with `archived: true` flag
- `MultiSelect._buildPanel()` renders separator items as non-interactive `<li class="ms-sep" role="separator" aria-hidden="true">`, archived rows get `.ms-item-archived` opacity + `<span class="ms-sub">archived</span>` sub-text
- Added `.ms-sep`, `.ms-sub`, `.ms-item-archived` CSS rules using existing tokens (`--text-muted`, `--border`, `--text-dim`)
- Removed now-unused `loadRepos()` function (was fetching `/api/repos` separately)
- Pills for archived repos unchanged — compact/toned, identical to live repo pills

## Test plan

- [ ] `node --check frontend/app.js && node --check frontend/multi_select.js` — passes (verified)
- [ ] Load `/dep-graph/` with a mix of live and archived repos — archived repos appear after the "Archived" separator in the repo filter dropdown
- [ ] When `data.repos` is absent from `/api/graph` response — fallback derives repos from nodes, all treated as non-archived, no separator shown
- [ ] Select an archived repo — pill renders identically to a live repo pill
- [ ] Keyboard navigation skips the separator row

🤖 Generated with [Claude Code](https://claude.com/claude-code)