### PR TITLE
feat(worker): sync prune renamed/deleted repos + archived tracking + /api/graph repos

### DIFF
--- a/worker/migrations/0002_repos.sql
+++ b/worker/migrations/0002_repos.sql
@@ -1,0 +1,11 @@
+-- migration: 0002_repos.sql
+-- Applied via: wrangler d1 execute <DB> --config ../wrangler.toml --remote --file=worker/migrations/0002_repos.sql
+
+-- D1 runs in WAL mode natively; `PRAGMA journal_mode` is rejected at
+-- `wrangler d1 migrations apply` time, so it must not appear here.
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS repos (
+    repo     TEXT PRIMARY KEY,  -- e.g. 'Roxabi/voiceCLI'
+    archived INTEGER NOT NULL DEFAULT 0
+);

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -7,17 +7,19 @@ afterEach(() => {
 });
 
 /**
- * graph.ts fires 4 prepare().all() calls — dispatched by SQL content:
+ * graph.ts fires 5 prepare().all() calls — dispatched by SQL content:
  *   "FROM labels"   → labels fixture
  *   "FROM pr_state" → pr_state fixture
  *   "FROM issues"   → issues fixture
  *   "FROM edges"    → edges fixture
+ *   "FROM repos"    → repos fixture
  */
 function makeGraphEnv(
   labels: unknown[],
   prState: unknown[],
   issues: unknown[],
   edges: unknown[],
+  repos: unknown[] = [],
 ): Env {
   return {
     DB: {
@@ -27,6 +29,7 @@ function makeGraphEnv(
           if (sql.includes("FROM pr_state")) return { results: prState };
           if (sql.includes("FROM issues")) return { results: issues };
           if (sql.includes("FROM edges")) return { results: edges };
+          if (sql.includes("FROM repos")) return { results: repos };
           return { results: [] };
         },
       }),
@@ -409,11 +412,30 @@ describe("GET /api/graph", () => {
   });
 
   describe("empty database", () => {
-    it("returns {nodes:[], edges:[]} when all tables empty", async () => {
+    it("returns {nodes:[], edges:[], repos:[]} when all tables empty", async () => {
       const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], []));
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body).toEqual({ nodes: [], edges: [] });
+      expect(body).toEqual({ nodes: [], edges: [], repos: [] });
+    });
+  });
+
+  describe("repos field", () => {
+    it("returns live repos before archived repos, both alpha within group", async () => {
+      const repoRows = [
+        { repo: "Roxabi/roxabi-factory", archived: 0 },
+        { repo: "Roxabi/roxabi-live", archived: 0 },
+        { repo: "Roxabi/roxabi-vault", archived: 1 },
+      ];
+      // SQL ORDER BY archived ASC, repo ASC — fixture already sorted correctly
+      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], [], repoRows));
+      expect(res.status).toBe(200);
+      const body = await res.json<{ repos: { repo: string; archived: boolean }[] }>();
+      expect(body.repos).toEqual([
+        { repo: "Roxabi/roxabi-factory", archived: false },
+        { repo: "Roxabi/roxabi-live", archived: false },
+        { repo: "Roxabi/roxabi-vault", archived: true },
+      ]);
     });
   });
 });

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -199,5 +199,18 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     kind: row.kind,
   }));
 
-  return c.json({ nodes, edges });
+  // (e) repos — live first (archived=0), then archived (archived=1), both alpha
+  interface RepoRow {
+    repo: string;
+    archived: number;
+  }
+  const repoRows = await c.env.DB.prepare(
+    "SELECT repo, archived FROM repos ORDER BY archived ASC, repo ASC",
+  ).all<RepoRow>();
+  const repos = (repoRows.results ?? []).map((r) => ({
+    repo: r.repo,
+    archived: Boolean(r.archived),
+  }));
+
+  return c.json({ nodes, edges, repos });
 };

--- a/worker/src/sync/queries.ts
+++ b/worker/src/sync/queries.ts
@@ -53,6 +53,23 @@ query($org: String!, $cursor: String) {
 }
 `;
 
+export const ARCHIVED_REPOS_QUERY = `
+query($org: String!, $cursor: String) {
+  organization(login: $org) {
+    repositories(
+      first: 100
+      after: $cursor
+      isArchived: true
+      orderBy: { field: NAME, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes { nameWithOwner }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
 export const REFS_QUERY = `
 query($owner: String!, $name: String!, $cursor: String) {
   repository(owner: $owner, name: $name) {

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -54,7 +54,7 @@ function makeFakeStmt(
 /** Simple in-memory FakeD1 builder. */
 function makeFakeDb(
   stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
-): D1Database {
+): D1Database & { _recorded: FakeStmt[] } {
   const recorded: FakeStmt[] = [];
 
   const db = {
@@ -607,6 +607,7 @@ vi.mock("./graphql", () => ({
 }));
 
 vi.mock("./queries", () => ({
+  ARCHIVED_REPOS_QUERY: "ARCHIVED_REPOS_QUERY",
   ISSUES_QUERY: "ISSUES_QUERY",
   PRS_QUERY: "PRS_QUERY",
   REFS_QUERY: "REFS_QUERY",
@@ -1065,6 +1066,297 @@ describe("runSync", () => {
     const [key, body] = put.mock.calls[0];
     expect(key).toMatch(/^runs\/\d{4}-\d{2}-\d{2}\/.+\.json$/);
     expect(JSON.parse(body as string).outcome).toBe("halted");
+  });
+
+  // Prune + archived-repo tracking (#N) -------------------------------------
+
+  /**
+   * Builds a FakeD1 that drives runSync through the prune path:
+   *   isHalted=0 → lock acquired → allowlist=[Roxabi/roxabi-factory] →
+   *   ghGraphql returns live=[roxabi-factory] + archived=[roxabi-vault] →
+   *   DB SELECT DISTINCT queries return stale=[Roxabi/lyra] in issues/edges/pr_state/sync_state →
+   *   batchChunked invoked with DELETE stmts for Roxabi/lyra
+   *
+   * Callers replace ghGraphql mocks before calling makeFullSyncDb.
+   */
+  function makeFullSyncDb(opts: {
+    issueRepos?: string[];
+    edgeSrcRepos?: string[];
+    edgeDstRepos?: string[];
+    prStateRepos?: string[];
+    syncStateRepos?: string[];
+  } = {}) {
+    const {
+      issueRepos = ["Roxabi/lyra", "Roxabi/roxabi-factory"],
+      edgeSrcRepos = ["Roxabi/lyra"],
+      edgeDstRepos = [],
+      prStateRepos = ["Roxabi/lyra"],
+      syncStateRepos = ["Roxabi/lyra", "Roxabi/roxabi-factory"],
+    } = opts;
+
+    return makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      }
+      // Prune SELECT DISTINCT queries
+      if (sql.includes("SELECT DISTINCT repo FROM issues")) {
+        return makeFakeStmt(sql, args, issueRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT DISTINCT substr(src_key")) {
+        return makeFakeStmt(sql, args, edgeSrcRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT DISTINCT substr(dst_key")) {
+        return makeFakeStmt(sql, args, edgeDstRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT DISTINCT repo FROM pr_state")) {
+        return makeFakeStmt(sql, args, prStateRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT repo FROM sync_state")) {
+        return makeFakeStmt(sql, args, syncStateRepos.map((r) => ({ repo: r })));
+      }
+      // releaseSyncLock, writeRunAudit queries
+      return makeFakeStmt(sql, args, [], 1);
+    });
+  }
+
+  it("prunes issues/edges/pr_state/sync_state for a deleted repo (Roxabi/lyra)", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → live: only roxabi-factory (lyra is gone)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // syncRepoBundle calls (REPO_BUNDLE_QUERY) for roxabi-factory — empty result
+    mockGhGraphql.mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFullSyncDb();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // Verify DELETE FROM issues was issued for Roxabi/lyra
+    const deletedIssueStmts = db._recorded.filter(
+      (s) => s.sql.includes("DELETE FROM issues") && s.args.includes("Roxabi/lyra"),
+    );
+    expect(deletedIssueStmts.length).toBeGreaterThan(0);
+
+    // Verify DELETE FROM edges was issued for Roxabi/lyra
+    const deletedEdgeStmts = db._recorded.filter(
+      (s) => s.sql.includes("DELETE FROM edges") && s.args.includes("Roxabi/lyra"),
+    );
+    expect(deletedEdgeStmts.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT prune rows for an archived repo (roxabi-vault stays)", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → live: only roxabi-factory
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault (it IS in archived, not stale)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // syncRepoBundle empty result for roxabi-factory
+    mockGhGraphql.mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    // DB returns roxabi-vault as present in issues — but it's archived, so NOT stale
+    const db = makeFullSyncDb({
+      issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+      edgeSrcRepos: [],
+      edgeDstRepos: [],
+      prStateRepos: [],
+      syncStateRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // No DELETE statements should target roxabi-vault
+    const deletedVaultStmts = db._recorded.filter(
+      (s) => s.sql.includes("DELETE") && s.args.includes("Roxabi/roxabi-vault"),
+    );
+    expect(deletedVaultStmts).toHaveLength(0);
+  });
+
+  it("skips all prune logic (warn) when live repo enumeration returns 0 repos", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → live: empty (transient error)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // Safety guard must have warned
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("live repo enumeration returned 0 repos"),
+    );
+
+    // No DELETE statements should have been issued
+    const deleteStmts = db._recorded.filter((s) => s.sql.includes("DELETE"));
+    expect(deleteStmts).toHaveLength(0);
+  });
+
+  it("upserts repos table with archived=1 when a repo moves live→archived", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → roxabi-factory live (roxabi-vault is now archived, not in live list)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY → roxabi-vault is now archived
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // syncRepoBundle empty result
+    mockGhGraphql.mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFullSyncDb({
+      issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+      edgeSrcRepos: [],
+      edgeDstRepos: [],
+      prStateRepos: [],
+      syncStateRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // The upsert INSERT stmt for Roxabi/roxabi-vault must use the archived=1 SQL variant
+    // (literal `1` is in the SQL text, not in bind args — only the repo name is bound)
+    const archivedUpsertStmts = db._recorded.filter(
+      (s) =>
+        s.sql.includes("INSERT INTO repos") &&
+        s.sql.includes("VALUES (?, 1)") &&
+        s.args.includes("Roxabi/roxabi-vault"),
+    );
+    expect(archivedUpsertStmts.length).toBeGreaterThan(0);
   });
 });
 

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -11,6 +11,7 @@
 
 import { ghGraphql, GraphQLError } from "./graphql";
 import {
+  ARCHIVED_REPOS_QUERY,
   ISSUES_QUERY,
   PRS_QUERY,
   REFS_QUERY,
@@ -317,6 +318,43 @@ export async function enumerateOrgRepos(
     }
 
     const pageInfo: { hasNextPage: boolean; endCursor: string | null } = data.organization.repositories.pageInfo;
+    if (!pageInfo.hasNextPage) break;
+    cursor = pageInfo.endCursor;
+    if (!cursor) break;
+  }
+
+  return repos;
+}
+
+interface ArchivedReposData {
+  organization: {
+    repositories: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: Array<{ nameWithOwner: string }>;
+    };
+  };
+  rateLimit: { cost: number; remaining: number; resetAt: string };
+}
+
+export async function enumerateArchivedOrgRepos(
+  org: string,
+  token: string,
+): Promise<string[]> {
+  const repos: string[] = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const response: { data: ArchivedReposData } & Record<string, unknown> =
+      await ghGraphql<ArchivedReposData>(ARCHIVED_REPOS_QUERY, { org, cursor }, token);
+    const data: ArchivedReposData = response.data;
+    const rl = data.rateLimit;
+    console.log(`[sync] archived-repos cost=${rl.cost} remaining=${rl.remaining}`);
+
+    for (const node of data.organization.repositories.nodes) {
+      repos.push(node.nameWithOwner);
+    }
+
+    const pageInfo = data.organization.repositories.pageInfo;
     if (!pageInfo.hasNextPage) break;
     cursor = pageInfo.endCursor;
     if (!cursor) break;
@@ -1122,23 +1160,113 @@ export async function runSync(env: Env): Promise<void> {
     const orgRepos = await enumerateOrgRepos(env.GITHUB_ORG, env.GITHUB_TOKEN);
     const active = orgRepos.filter((r) => allowlist.includes(`${r.owner}/${r.name}`));
 
-    // Prune stale sync_state rows for repos removed from the allowlist (faithful
-    // to sync.py run_sync: diff sync_state against the active allowlist∩org set).
-    const activeKeys = new Set(active.map((r) => `${r.owner}/${r.name}`));
-    const syncStateRows = await db
-      .prepare("SELECT repo FROM sync_state")
-      .all<{ repo: string }>();
-    const staleRepos = (syncStateRows.results ?? [])
-      .map((r) => r.repo)
-      .filter((repo) => !activeKeys.has(repo));
-    if (staleRepos.length > 0) {
-      await batchChunked(
-        db,
-        staleRepos.map((repo) =>
-          db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo),
+    // Enumerate archived repos for tracking + prune safety.
+    const archivedRepoNames = await enumerateArchivedOrgRepos(
+      env.GITHUB_ORG,
+      env.GITHUB_TOKEN,
+    );
+    const liveRepoNames = orgRepos.map((r) => `${r.owner}/${r.name}`);
+
+    // SAFETY GUARD: if live enumeration returned 0 repos (transient API error),
+    // skip all prune logic to prevent wiping the entire DB. This is NOT a halt —
+    // sync continues with the (empty) active set, which means no issues are synced
+    // this run, but existing DB rows are preserved.
+    if (liveRepoNames.length === 0) {
+      console.warn("[sync] live repo enumeration returned 0 repos — skipping prune");
+    } else {
+      // Upsert repos table: live repos with archived=0, archived repos with archived=1.
+      const repoUpsertStmts: D1PreparedStatement[] = [
+        ...liveRepoNames.map((repo) =>
+          db
+            .prepare(
+              "INSERT INTO repos (repo, archived) VALUES (?, 0) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
+            )
+            .bind(repo),
         ),
-      );
-      console.log(`[sync] pruned ${staleRepos.length} stale sync_state row(s)`);
+        ...archivedRepoNames.map((repo) =>
+          db
+            .prepare(
+              "INSERT INTO repos (repo, archived) VALUES (?, 1) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
+            )
+            .bind(repo),
+        ),
+      ];
+      if (repoUpsertStmts.length > 0) {
+        await batchChunked(db, repoUpsertStmts);
+        console.log(
+          `[sync] upserted ${liveRepoNames.length} live + ${archivedRepoNames.length} archived repo(s)`,
+        );
+      }
+
+      // Full prune: delete issues (+ cascaded labels), edges, pr_state, sync_state
+      // for repos absent from live ∪ archived. Chunk at ≤90 to stay under D1 limits.
+      const knownRepos = new Set([...liveRepoNames, ...archivedRepoNames]);
+      const CHUNK = 90;
+
+      // Collect all repos currently in DB tables.
+      const [issueRepos, edgeSrcRepos, edgeDstRepos, prStateRepos, syncStateRepos] =
+        await Promise.all([
+          db.prepare("SELECT DISTINCT repo FROM issues").all<{ repo: string }>(),
+          db.prepare("SELECT DISTINCT substr(src_key, 1, instr(src_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+          db.prepare("SELECT DISTINCT substr(dst_key, 1, instr(dst_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+          db.prepare("SELECT DISTINCT repo FROM pr_state").all<{ repo: string }>(),
+          db.prepare("SELECT repo FROM sync_state").all<{ repo: string }>(),
+        ]);
+
+      const staleIssueRepos = (issueRepos.results ?? [])
+        .map((r) => r.repo)
+        .filter((r) => !knownRepos.has(r));
+      const staleEdgeRepos = [
+        ...(edgeSrcRepos.results ?? []).map((r) => r.repo),
+        ...(edgeDstRepos.results ?? []).map((r) => r.repo),
+      ].filter((r) => !knownRepos.has(r));
+      const stalePrStateRepos = (prStateRepos.results ?? [])
+        .map((r) => r.repo)
+        .filter((r) => !knownRepos.has(r));
+      const staleSyncStateRepos = (syncStateRepos.results ?? [])
+        .map((r) => r.repo)
+        .filter((r) => !knownRepos.has(r));
+
+      const pruneStmts: D1PreparedStatement[] = [];
+      for (let i = 0; i < staleIssueRepos.length; i += CHUNK) {
+        for (const repo of staleIssueRepos.slice(i, i + CHUNK)) {
+          pruneStmts.push(db.prepare("DELETE FROM issues WHERE repo=?").bind(repo));
+        }
+      }
+      // Deduplicate stale edge repos before chunking
+      const staleEdgeReposUniq = [...new Set(staleEdgeRepos)];
+      for (let i = 0; i < staleEdgeReposUniq.length; i += CHUNK) {
+        for (const repo of staleEdgeReposUniq.slice(i, i + CHUNK)) {
+          pruneStmts.push(
+            db
+              .prepare(
+                "DELETE FROM edges WHERE substr(src_key,1,instr(src_key,'#')-1)=? OR substr(dst_key,1,instr(dst_key,'#')-1)=?",
+              )
+              .bind(repo, repo),
+          );
+        }
+      }
+      for (let i = 0; i < stalePrStateRepos.length; i += CHUNK) {
+        for (const repo of stalePrStateRepos.slice(i, i + CHUNK)) {
+          pruneStmts.push(db.prepare("DELETE FROM pr_state WHERE repo=?").bind(repo));
+        }
+      }
+      for (let i = 0; i < staleSyncStateRepos.length; i += CHUNK) {
+        for (const repo of staleSyncStateRepos.slice(i, i + CHUNK)) {
+          pruneStmts.push(db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo));
+        }
+      }
+
+      if (pruneStmts.length > 0) {
+        await batchChunked(db, pruneStmts);
+        const totalStale = new Set([
+          ...staleIssueRepos,
+          ...staleEdgeReposUniq,
+          ...stalePrStateRepos,
+          ...staleSyncStateRepos,
+        ]).size;
+        console.log(`[sync] pruned data for ${totalStale} stale repo(s)`);
+      }
     }
 
     // Pass 1: bundled issues + refs + PRs per repo (1 subreq/repo instead of 3)


### PR DESCRIPTION
Prevents the lyra-style ghost recurrence + tracks archived repos for the UI.

- **Prune**: after each sync, deletes issues/edges/labels/pr_state for repos absent from (live ∪ archived) — handles renamed/deleted repos (e.g. lyra→roxabi-factory). **Safety guard**: never prunes when the live enumeration returns 0 repos (transient API error → skip, not halt).
- **`repos` table** (migration `0002_repos.sql`, applied to staging+production D1): live repos `archived=0`, archived repos `archived=1`, via a new `repositories(isArchived:true)` name enumeration.
- **`/api/graph`** now returns `repos: [{repo, archived}]` sorted (archived ASC, repo ASC) — consumed by frontend #129 (archived repos shown last).

Refs the lyra investigation. Migration already applied to both remote D1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)