### PR TITLE
fix(frontend): repo filter lists only repos with issues (archived still last)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -257,11 +257,12 @@ async function loadAndRender() {
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
   state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
+  const reposWithIssues = new Set(nodes.map(n => n.repo));
   let repoData;
   if (data.repos && data.repos.length) {
-    repoData = data.repos;
+    repoData = data.repos.filter(r => reposWithIssues.has(r.repo)); // preserves server order (live→archived, alpha) + archived flag
   } else {
-    const derived = [...new Set(nodes.map(n => n.repo))].sort();
+    const derived = [...reposWithIssues].sort();
     repoData = derived.map(repo => ({ repo, archived: false }));
   }
   populateFilters(repoData);


### PR DESCRIPTION
The repo multi-select was populated from all ~34 org repos returned by `/api/graph`, including ~17 with zero issues — dead filter options that never match any node.

Intersect `data.repos` with the set of repos present in `nodes` before passing to `populateFilters()`, preserving the server-side live-first/archived-last ordering and the archived flag (separator logic in `multi_select.js` unchanged).