### PR TITLE
promote: toolbar filters + lyra-ghost prune + archived repos (#128–#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@ Let:
 
 ## Project
 
-**Roxabi Live** — operations cockpit (FastAPI + aiosqlite + Tailscale Funnel)
-- Exposes `~/.roxabi/corpus.db` via live HTTP API (`GET /api/*`)
-- Receives GitHub org webhooks at `POST /webhook/github` (HMAC-gated)
-- Frontend: static HTML/JS (dep-graph tab first, see spec #866)
-- Public via Tailscale Funnel on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (`roxabi.dev` zone migrated to Cloudflare as of 2026-06-05 → Cloudflare Tunnel now unblocked but not yet deployed; Funnel remains the live ingress)
+**Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
+- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev** behind Cloudflare Access (Email-OTP, mickael@bouly.io)
+- Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
+- Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 * * * *` + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
+- Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)
+- `/admin/*` gated by `ADMIN_TOKEN` secret (defense-in-depth, #123) in addition to edge Access
+- M₁ (roxabituwer) **decommissioned 2026-06-08**: `live.service` stopped+disabled, Tailscale Funnel retired, `~/.roxabi/corpus.db` archived
 
 → `docs/ARCHITECTURE.md` (to be created)
 
@@ -24,31 +26,72 @@ Let:
 
 ## Key files
 
+**Worker (prod — primary)**
+
 | File | Role |
 |---|---|
-| `src/roxabi_live/app.py` | FastAPI application factory |
-| `src/roxabi_live/__main__.py` | uvicorn entry point |
-| `src/roxabi_live/corpus/` | Issue sync GraphQL → `~/.roxabi/corpus.db` (migrated from lyra) |
-| `src/roxabi_live/dep_graph/v1/` | Legacy CLI renderer (frozen) |
-| `src/roxabi_live/dep_graph/v5/` | Matrix + graph HTML renderer (frozen) |
-| `src/roxabi_live/dep_graph/v6/` | API-first renderer → `GET /api/graph` |
-| `src/roxabi_live/reconciler.py` | Hourly corpus sync heal loop + startup one-shot |
-| `src/roxabi_live/api/issues.py` | `GET /api/issues`, `GET /api/issues/:key` |
-| `src/roxabi_live/webhook/` | GitHub webhook handlers (HMAC verify + issues/deps/sub_issues dispatch) |
-| `deploy/systemd/live.service` | systemd user unit (M₁ boot) |
-| `frontend/` | Static HTML/JS/CSS (dep-graph tab + future tabs) |
+| `worker/src/index.ts` | Worker entry point (`fetch` + `scheduled` handlers) |
+| `worker/src/router.ts` | Request routing |
+| `worker/src/types.ts` | `Env` interface + shared types |
+| `worker/src/api/issues.ts` | `GET /api/issues`, `GET /api/issues/:key` |
+| `worker/src/api/graph.ts` | `GET /api/graph` |
+| `worker/src/api/admin.ts` | `POST /admin/sync` (ADMIN_TOKEN-gated) |
+| `worker/src/api/version.ts` | `GET /api/version` |
+| `worker/src/sync/sync.ts` | Hourly sync orchestrator + R2 audit write |
+| `worker/src/sync/graphql.ts` | GitHub GraphQL client (`fetch()`) |
+| `worker/src/sync/queries.ts` | GraphQL query strings |
+| `worker/src/sync/parse.ts` | Issue/edge parsing |
+| `worker/src/webhook/handlers.ts` | Webhook dispatch (issues/deps/sub_issues) |
+| `worker/src/webhook/hmac.ts` | HMAC verification |
+| `worker/src/webhook/mutations.ts` | D1 write helpers |
+| `worker/migrations/` | D1 schema migrations |
+| `wrangler.toml` | Worker config (bindings, Cron, routes, environments) |
+| `frontend/` | Static HTML/JS/CSS served via ASSETS binding |
 | `artifacts/` | Frames, specs, plans (dev-core) |
-| `.env.example` | Env var reference (CORPUS_DB_PATH, GITHUB_WEBHOOK_SECRET, …) |
+
+**Legacy Python app (pre-CF, M₁-era — decommissioned 2026-06-08, code kept for reference)**
+
+| File | Role |
+|---|---|
+| `src/roxabi_live/app.py` | ~~FastAPI application factory~~ |
+| `src/roxabi_live/__main__.py` | ~~uvicorn entry point~~ |
+| `src/roxabi_live/corpus/` | ~~Issue sync GraphQL → `~/.roxabi/corpus.db`~~ |
+| `src/roxabi_live/dep_graph/v1/` | ~~Legacy CLI renderer (frozen)~~ |
+| `src/roxabi_live/dep_graph/v5/` | ~~Matrix + graph HTML renderer (frozen)~~ |
+| `src/roxabi_live/dep_graph/v6/` | ~~API-first renderer~~ |
+| `src/roxabi_live/reconciler.py` | ~~Hourly corpus sync heal loop~~ |
+| `src/roxabi_live/api/issues.py` | ~~`GET /api/issues`~~ |
+| `src/roxabi_live/webhook/` | ~~GitHub webhook handlers~~ |
+| `deploy/systemd/live.service` | ~~systemd user unit (M₁ boot)~~ |
+| `.env.example` | Env var reference (legacy Python env; CF secrets via `wrangler secret put`) |
 
 ## Dep-graph versions
 
 | Version | Status | Entry |
 |---|---|---|
-| v1 | frozen (legacy CLI) | `dep-graph` script |
-| v5 | frozen (static HTML build) | `dep-graph-v5` script · `GET /dep-graph/` (auto-rebuild when corpus.db newer) |
-| v6 | **primary** — API-first | `GET /api/graph` · `dep-graph-v6` CLI (debug) |
+| v1 | frozen (legacy CLI — decommissioned) | `dep-graph` script |
+| v5 | frozen (static HTML build — decommissioned) | `dep-graph-v5` script |
+| v6 | **primary** — served by CF Worker ASSETS | `GET /api/graph` · Worker ASSETS binding |
 
 ## Package layout
+
+**Worker (active)**
+
+```
+worker/
+  src/
+    index.ts        # fetch + scheduled entry
+    router.ts
+    types.ts
+    api/            # issues, graph, admin, version
+    sync/           # sync, graphql, queries, parse
+    webhook/        # handlers, hmac, mutations
+  migrations/
+wrangler.toml       # repo root — binds both envs
+frontend/           # served via ASSETS binding
+```
+
+**Legacy Python app (decommissioned 2026-06-08)**
 
 ```
 src/roxabi_live/
@@ -59,11 +102,11 @@ tests/
   test_health.py
 ```
 
-Module name: `roxabi_live` (underscore). CLI: `roxabi-live` (hyphen).
+Module name: `roxabi_live` (underscore). CLI: `roxabi-live` (hyphen). ¬running in prod.
 
 ## Corpus sync — edge algorithm
 
-GitHub issue relationships map to `corpus.db` edges table with specific `kind` values:
+GitHub issue relationships map to D1 `edges` table with specific `kind` values (algorithm identical to pre-CF; implementation moved to `worker/src/sync/sync.ts` + `worker/src/sync/parse.ts`):
 
 | Relationship | GraphQL field | Edge direction | `kind` |
 |--------------|---------------|----------------|--------|
@@ -75,14 +118,12 @@ GitHub issue relationships map to `corpus.db` edges table with specific `kind` v
 - `parent`: `src` is the parent issue, `dst` is a sub-issue. Parent must complete before children can proceed.
 - `blocks`: `src` blocks `dst`. If `src` is open, `dst` is "blocked"; if `src` is closed, `dst` is "ready".
 
-**Sync flow** (`src/roxabi_live/corpus/sync.py`):
+**Sync flow** (`worker/src/sync/sync.ts`):
 1. Fetch issues via GraphQL with `subIssues`, `parent`, `blockedBy`, `blocking` fields
-2. For each issue:
-   - `upsert_edges(conn, key, parents, children, kind="parent")` — parents point to this issue, this issue points to children
-   - `upsert_edges(conn, key, blocked_by, blocking, kind="blocks")` — blockers point to this issue, this issue points to blockees
-3. `upsert_edges` deletes only edges of the same `kind` for the issue, allowing multiple edge types per issue
+2. For each issue: upsert parent edges + blocks edges (deletes only edges of same `kind`)
+3. Write per-run audit to R2 bucket `roxabi-live-logs`
 
-**Frontend status computation** (`src/roxabi_live/dep_graph/v6/frontend/state.js`):
+**Frontend status computation** (`frontend/` → `state.js`, served via ASSETS binding):
 ```js
 // Any edge where this node is dst → src blocks it
 if (node.state === 'closed') return 'done';
@@ -104,11 +145,29 @@ File/rename → update P immediately
 |---|---|
 | `CLAUDE.md` | project root |
 
-Rules: add/delete/move → update P | new `src/roxabi_live/` subdir → nearest P (¬nested)
+Rules: add/delete/move → update P | new `worker/src/` subdir → update Key files table
 
 ## Deploy pattern
 
-M₁ (prod): `deploy/systemd/live.service` — systemd user unit, installed to `~/.config/systemd/user/live.service`, enabled via linger.
-Service control on M₁: `systemctl --user {start,stop,status,restart} live.service` (no `make live` wrapper — supervisor no longer manages this service).
-M₂ (dev): start manually with `uv run roxabi-live`.
-Log dir: `~/.local/state/roxabi-live/logs/`
+**Prod (Cloudflare — CI-driven)**
+
+Push to `main` → CI `deploy` job → `wrangler deploy` (binds `live.roxabi.dev` via top-level `routes` in `wrangler.toml`).
+Push to `staging` → `wrangler deploy --env staging`.
+
+Secrets (set once; `CLOUDFLARE_ACCOUNT_ID` required — token sees 2 accounts):
+```bash
+# prod
+printf %s '<value>' | wrangler secret put SECRET_NAME
+# staging
+printf %s '<value>' | wrangler secret put SECRET_NAME --env staging
+```
+
+Local worker dev:
+```bash
+cd worker && npm ci && npx wrangler dev
+```
+
+**M₁ / systemd — decommissioned 2026-06-08**
+
+`live.service` stopped+disabled. `uv run roxabi-live` (M₂ dev server) no longer reflects prod.
+Legacy log dir: `~/.local/state/roxabi-live/logs/` (archived on M₁).

--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -3,8 +3,20 @@ title: Cloudflared Tunnel Setup
 description: One-time provisioning of the Cloudflare Tunnel that exposes dashboard.roxabi.dev, and migration from M₂ to M₁.
 ---
 
+> [!WARNING]
+> **ARCHIVED — historical reference only (as of 2026-06-08)**
+>
+> This document describes infrastructure that was **never deployed** and is now superseded.
+> The production ingress is **Cloudflare Access + Worker** at `https://live.roxabi.dev`.
+> Tailscale Funnel on M₁ has been **retired** (`tailscale funnel --https=443 off`).
+> M₁ `live.service` is **stopped and disabled**. The `cloudflared` Tunnel approach
+> described below was deferred and ultimately skipped — the S9 cutover went directly
+> to the CF Worker + Access model (Email-OTP, no `cloudflared` daemon needed).
+>
+> See `docs/s9-cutover.md` for the completed cutover runbook.
+
 > [!NOTE]
-> **Status (updated 2026-06-05):** the `roxabi.dev` zone has **migrated to Cloudflare** (NS: `donald`/`mia.ns.cloudflare.com`), so the previous blocker is gone — Cloudflare Tunnel + Access **can** now front it. This setup is, however, **still not deployed**: production ingress remains **Tailscale Funnel** on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (see "Current deployment" below). This document is the runbook for the eventual migration to Cloudflare Tunnel.
+> **Status (updated 2026-06-05, superseded 2026-06-08):** the `roxabi.dev` zone has **migrated to Cloudflare** (NS: `donald`/`mia.ns.cloudflare.com`), so the previous blocker is gone — Cloudflare Tunnel + Access **can** now front it. This setup is, however, **still not deployed**: production ingress remains **Tailscale Funnel** on M₁ at `https://roxabituwer.goose-logarithm.ts.net/` (see "Current deployment" below). This document is the runbook for the eventual migration to Cloudflare Tunnel.
 
 ## Current deployment (Tailscale Funnel)
 
@@ -263,3 +275,5 @@ Webhook delivery:
 - Rotate the service token: Zero Trust → Service Tokens → `github-webhook` → **Refresh**. Update the worker secret. Redeliver a test webhook to confirm.
 - Rotate the identity-provider allowlist: edit the `Allow owner` policy (Step A.5).
 - After a `_halted` reconciler event (CRITICAL log emitted due to repeated auth failures): rotate the GitHub token, then restart the live service to clear the sticky halt state: `systemctl --user restart live.service`. The reconciler will resume on the next hourly tick.
+
+> **Note (2026-06-08 — decommissioned):** `live.service` no longer runs on M₁. The CF Worker handles sync via `ADMIN_TOKEN`-gated `/admin/sync` (manual) or hourly Cron Trigger. To clear a halted sync on the Worker: rotate `GITHUB_TOKEN` via `wrangler secret put`, then trigger `POST /admin/sync` with `Authorization: Bearer <ADMIN_TOKEN>`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,18 @@
 # Getting Started
 
+> [!NOTE]
+> **Production (2026-06-08+):** Roxabi Live runs as a **Cloudflare Worker** at
+> `https://live.roxabi.dev` (CF Access Email-OTP). Python/systemd/M₁ is decommissioned.
+> For Worker local dev: `cd worker && npm ci && npx wrangler dev`.
+> The Python setup below applies to the legacy app only.
+
 ## Prerequisites
 
+**Worker dev (active):**
+- Node.js (for `wrangler`) — `npx wrangler dev` works without a global install
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) — `npm ci` in `worker/`
+
+**Legacy Python app (decommissioned — reference only):**
 - Python 3.12 (managed via `.python-version` — `pyenv` or system install)
 - [uv](https://docs.astral.sh/uv/) — package manager
 - [GitHub CLI](https://cli.github.com/) (`gh`) — authenticated via `gh auth login` (needs `read:org`, `repo` scopes)
@@ -86,13 +97,42 @@ For local dev, use a tunnel (e.g. `ngrok http 8000`) to expose the local server.
 
 See [GitHub docs — Creating webhooks](https://docs.github.com/en/webhooks/using-webhooks/creating-webhooks) for details.
 
-## Production Deployment (systemd)
+## Production Deployment (Cloudflare Worker — CI-driven)
 
-Roxabi Live is deployed as a systemd user service on M1 (`roxabituwer`). The unit is at `deploy/systemd/live.service`.
+> **Decommissioned (2026-06-08):** The Python/systemd/M₁ deployment described below has been retired. See the archived sections.
 
-### Install
+Production is a Cloudflare Worker deployed via CI. Push to `main` → `wrangler deploy` (prod, `live.roxabi.dev`). Push to `staging` → `wrangler deploy --env staging`.
 
-Run once on the target machine:
+### Local Worker dev
+
+```bash
+cd worker && npm ci && npx wrangler dev
+```
+
+Worker binds a local D1 preview. No Python/uvicorn needed.
+
+### Secrets (set once per environment)
+
+```bash
+printf %s '<value>' | wrangler secret put SECRET_NAME           # prod
+printf %s '<value>' | wrangler secret put SECRET_NAME --env staging
+```
+
+Required secrets: `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET`, `ADMIN_TOKEN`.
+
+---
+
+## Legacy: Production Deployment via systemd (decommissioned 2026-06-08)
+
+> [!WARNING]
+> M₁ (`roxabituwer`) `live.service` was stopped and disabled on 2026-06-08. The
+> Python FastAPI app (`src/roxabi_live/`) is kept in the repo as a historical reference
+> but is no longer deployed. `~/.roxabi/corpus.db` was archived as `.bak` on M₁.
+> The sections below are preserved for reference only.
+
+Roxabi Live was deployed as a systemd user service on M1 (`roxabituwer`). The unit is at `deploy/systemd/live.service`.
+
+### Install (historical)
 
 ```bash
 cp deploy/systemd/live.service ~/.config/systemd/user/live.service
@@ -101,22 +141,17 @@ systemctl --user enable live.service
 systemctl --user start live.service
 ```
 
-Requires `loginctl enable-linger $USER` (already set on M1).
-
-### Service control
+### Service control (historical)
 
 ```bash
 systemctl --user status live.service
-systemctl --user start live.service
-systemctl --user stop live.service
-systemctl --user restart live.service
 journalctl --user -u live.service -f   # follow logs
 ```
 
-Logs also written to `~/.local/state/roxabi-live/logs/`:
-- `live.log` — stdout
-- `live_error.log` — stderr
+Logs were written to `~/.local/state/roxabi-live/logs/` (archived on M₁).
 
-### Tailscale Funnel
+### Tailscale Funnel (retired)
 
-On M1, the server is exposed publicly via Tailscale Funnel. Start it once with `tailscale funnel --bg 8000` (no `sudo` — the Tailscale operator is set to the host user); the binding survives `tailscaled` restarts. Verify with `tailscale funnel status`. Disable all bindings with `tailscale funnel --https=443 off`.
+The Tailscale Funnel (`tailscale funnel --bg 8000`) that fronted M₁ has been retired
+(`tailscale funnel --https=443 off`). Ingress is now `https://live.roxabi.dev` via
+Cloudflare Access (Email-OTP).

--- a/docs/s8-cron-observability.md
+++ b/docs/s8-cron-observability.md
@@ -7,8 +7,11 @@ handler, and the auth-halt → `NOTIFY_URL` alert all exist. This slice adds the
 **observability config** and the **operational steps** that can't live in the repo, plus
 two code hardening changes (typed `Env.NOTIFY_URL`, halt-alert test).
 
-This is the **hard go/no-go gate** before S9 cutover (#101): do **not** decommission M₁
+This was the **hard go/no-go gate** before S9 cutover (#101): do **not** decommission M₁
 until a **persistent prod audit trail** exists, because M₁'s local logs vanish with it.
+
+> **Update (2026-06-08):** S9 cutover is **DONE**. The gate passed — prod R2 audit confirmed
+> before M₁ decommission. See `docs/s9-cutover.md` for the completed cutover record.
 
 > **Update (#120):** Logpush was abandoned — it requires the Workers **Paid** plan and
 > this account is on **Free**. The persistent audit is instead written by the Worker

--- a/docs/s9-cutover.md
+++ b/docs/s9-cutover.md
@@ -2,6 +2,27 @@
 
 Issue [#101](https://github.com/Roxabi/roxabi-live/issues/101) · epic [#92](https://github.com/Roxabi/roxabi-live/issues/92).
 
+## Status: DONE (2026-06-08)
+
+All go/no-go items confirmed green. Cutover and decommission completed.
+
+| Item | Result |
+|---|---|
+| CF Access Email-OTP app live (`live.roxabi.dev`) | ✅ confirmed |
+| Bypass policy on `/webhook/*` | ✅ confirmed — no OTP challenge |
+| `live.roxabi.dev` bound to prod Worker | ✅ DNS + TLS live, CF-Ray present |
+| GitHub org webhook repointed → `https://live.roxabi.dev/webhook/github` | ✅ 200 OK on redeliver |
+| R2 audit object present (prod cron confirmed via `wrangler tail`) | ✅ confirmed |
+| `ADMIN_TOKEN` set on prod + staging (PR #124) | ✅ set |
+| M₁ `live.service` stopped + disabled | ✅ done |
+| Tailscale Funnel retired (`tailscale funnel --https=443 off`) | ✅ done |
+| `~/.roxabi/corpus.db` archived as `.bak` on M₁ | ✅ done |
+| `~/projects/CLAUDE.md` updated (M₁ roles) | handled separately |
+
+The runbook below is preserved as historical reference.
+
+---
+
 Final slice of the Cloudflare serverless migration. Goes live on `live.roxabi.dev`
 and retires M₁. **No bridge** — the Tailscale Funnel
 (`https://roxabituwer.goose-logarithm.ts.net`) served as the interim public ingress

--- a/frontend/app.css
+++ b/frontend/app.css
@@ -363,6 +363,18 @@ main { padding-bottom: 24px; }
 .ms-item:hover { background: var(--bg-card); color: var(--text); }
 .ms-item input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
 
+.ms-sep {
+  display: flex; align-items: center;
+  padding: 4px 12px; margin-top: 2px;
+  font-size: 10px; color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  pointer-events: none; user-select: none;
+}
+.ms-sub {
+  margin-left: auto; font-size: 10px; color: var(--text-dim); font-style: italic;
+}
+.ms-item-archived { opacity: 0.7; }
+
 .ms-clear {
   display: block; width: 100%; margin-top: 4px; padding: 4px 12px;
   border: 0; border-top: 1px solid var(--border);

--- a/frontend/app.css
+++ b/frontend/app.css
@@ -360,6 +360,11 @@ main { padding-bottom: 24px; }
   font-family: 'Inter', sans-serif; font-size: 12px;
   color: var(--text-muted); transition: background 0.08s;
 }
+.ms-sub {
+  color: var(--text-dim);
+  font-size: 10px;
+  margin-left: 6px;
+}
 .ms-item:hover { background: var(--bg-card); color: var(--text); }
 .ms-item input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -56,6 +56,7 @@ const msRepo      = new MultiSelect($('ms-repo-btn'),      $('ms-repo-panel'),  
 const msMilestone = new MultiSelect($('ms-milestone-btn'), $('ms-milestone-panel'), { placeholder: 'All milestones', clearBtn: $('ms-milestone-clear') });
 const msPriority  = new MultiSelect($('ms-priority-btn'),  $('ms-priority-panel'),  { placeholder: 'All priorities', clearBtn: $('ms-priority-clear') });
 const msStatus    = new MultiSelect($('ms-status-btn'),    $('ms-status-panel'),    { placeholder: 'All statuses',   clearBtn: $('ms-status-clear') });
+const msLabel     = new MultiSelect($('ms-label-btn'),     $('ms-label-panel'),     { placeholder: 'All labels',     clearBtn: $('ms-label-clear') });
 
 // ─── Render ───────────────────────────────────────────────────────────────
 function render() {
@@ -170,8 +171,24 @@ msRepo.onChange      = vals => { clearPinned(); setState({ repo:      vals }); r
 msMilestone.onChange = vals => { clearPinned(); setState({ milestone: vals }); render(); };
 msPriority.onChange  = vals => { clearPinned(); setState({ priority:  vals }); render(); };
 msStatus.onChange    = vals => { clearPinned(); setState({ status:    vals }); render(); };
+msLabel.onChange     = vals => { clearPinned(); setState({ label:     vals }); render(); };
 
 // ─── Populate filter options after data load ──────────────────────────────
+const PRIORITY_NAMES = { P0: 'Critical', P1: 'High', P2: 'Medium', P3: 'Low' };
+
+const LABEL_EXCLUDES = new Set([
+  'graph:lane/', 'size:', 'XS', 'S', 'M', 'L', 'XL',
+  'P0', 'priority:P0', 'P1-high', 'priority:high', 'priority:P1',
+  'P2-medium', 'priority:medium', 'priority:P2',
+  'P3-low', 'priority:low', 'priority: low', 'priority:P3',
+]);
+
+function isStructuredLabel(lbl) {
+  if (LABEL_EXCLUDES.has(lbl)) return true;
+  if (lbl.startsWith('graph:lane/') || lbl.startsWith('size:')) return true;
+  return false;
+}
+
 function populateFilters(repos) {
   const nodes = state.nodes;
 
@@ -186,11 +203,17 @@ function populateFilters(repos) {
   }
   const msItems = [...msMap.entries()]
     .sort((a, b) => a[1] - b[1])
-    .map(([v]) => ({ value: v, label: v }));
+    .map(([v]) => {
+      const node = nodes.find(n => (n.milestone_code ?? '(None)') === v);
+      const name = node?.milestone_name ?? null;
+      return { value: v, label: v, sublabel: (name && name !== v) ? name : undefined };
+    });
   msMilestone.setItems(msItems, state.milestone);
 
   msPriority.setItems(
-    ['P0', 'P1', 'P2', 'P3', '(None)'].map(v => ({ value: v, label: v })),
+    ['P0', 'P1', 'P2', 'P3', '(None)'].map(v => ({
+      value: v, label: v, sublabel: PRIORITY_NAMES[v],
+    })),
     state.priority
   );
 
@@ -198,6 +221,11 @@ function populateFilters(repos) {
     ['ready', 'blocked', 'done'].map(v => ({ value: v, label: v })),
     state.status
   );
+
+  const allLabels = [...new Set(nodes.flatMap(n => n.labels ?? []))]
+    .filter(l => !isStructuredLabel(l))
+    .sort();
+  msLabel.setItems(allLabels.map(l => ({ value: l, label: l })), state.label);
 }
 
 function restoreControls() {
@@ -213,25 +241,15 @@ async function loadGraphData() {
   return resp.json();
 }
 
-async function loadRepos() {
-  try {
-    const resp = await fetch('/api/repos');
-    if (!resp.ok) throw new Error(`/api/repos ${resp.status}`);
-    const j = await resp.json();
-    return (j.repos ?? []).map(r => r.repo);
-  } catch {
-    return [...new Set(state.nodes.map(n => n.repo))].sort();
-  }
-}
-
-// Re-fetch graph data + repos and re-render, preserving view/filters (held in state).
+// Re-fetch graph data and re-render, preserving view/filters (held in state).
 async function loadAndRender() {
-  const [data, repos] = await Promise.all([loadGraphData(), loadRepos()]);
+  const data = await loadGraphData();
   const nodes = data.nodes || [];
   const edges = data.edges || [];
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
   state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
+  const repos = [...new Set(nodes.map(n => n.repo))].sort();
   populateFilters(repos);
   render();
 }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -257,11 +257,12 @@ async function loadAndRender() {
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
   state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
+  const reposWithIssues = new Set(nodes.map(n => n.repo));
   let repoData;
   if (data.repos && data.repos.length) {
-    repoData = data.repos;
+    repoData = data.repos.filter(r => reposWithIssues.has(r.repo)); // preserves server order (live→archived, alpha) + archived flag
   } else {
-    const derived = [...new Set(nodes.map(n => n.repo))].sort();
+    const derived = [...reposWithIssues].sort();
     repoData = derived.map(repo => ({ repo, archived: false }));
   }
   populateFilters(repoData);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -172,10 +172,17 @@ msPriority.onChange  = vals => { clearPinned(); setState({ priority:  vals }); r
 msStatus.onChange    = vals => { clearPinned(); setState({ status:    vals }); render(); };
 
 // ─── Populate filter options after data load ──────────────────────────────
-function populateFilters(repos) {
+// repoData: Array<{ repo: string, archived: boolean }>
+function populateFilters(repoData) {
   const nodes = state.nodes;
 
-  const repoItems = repos.map(r => ({ value: r, label: r.split('/')[1] || r, tone: repoTone(r) }));
+  const live     = repoData.filter(r => !r.archived);
+  const archived = repoData.filter(r => r.archived);
+  const liveItems = live.map(r => ({ value: r.repo, label: r.repo.split('/')[1] || r.repo, tone: repoTone(r.repo) }));
+  const archItems = archived.map(r => ({ value: r.repo, label: r.repo.split('/')[1] || r.repo, tone: repoTone(r.repo), archived: true }));
+  const repoItems = archItems.length
+    ? [...liveItems, { separator: true, label: 'Archived' }, ...archItems]
+    : liveItems;
   msRepo.setItems(repoItems, state.repo);
 
   const msMap = new Map();
@@ -213,26 +220,23 @@ async function loadGraphData() {
   return resp.json();
 }
 
-async function loadRepos() {
-  try {
-    const resp = await fetch('/api/repos');
-    if (!resp.ok) throw new Error(`/api/repos ${resp.status}`);
-    const j = await resp.json();
-    return (j.repos ?? []).map(r => r.repo);
-  } catch {
-    return [...new Set(state.nodes.map(n => n.repo))].sort();
-  }
-}
-
-// Re-fetch graph data + repos and re-render, preserving view/filters (held in state).
+// Re-fetch graph data and re-render, preserving view/filters (held in state).
+// Uses data.repos (Array<{repo,archived}>) from /api/graph; falls back to nodes-derived if absent.
 async function loadAndRender() {
-  const [data, repos] = await Promise.all([loadGraphData(), loadRepos()]);
+  const data  = await loadGraphData();
   const nodes = data.nodes || [];
   const edges = data.edges || [];
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
   state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
-  populateFilters(repos);
+  let repoData;
+  if (data.repos && data.repos.length) {
+    repoData = data.repos;
+  } else {
+    const derived = [...new Set(nodes.map(n => n.repo))].sort();
+    repoData = derived.map(repo => ({ repo, archived: false }));
+  }
+  populateFilters(repoData);
   render();
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,6 +52,14 @@
     </div>
 
     <div class="ms-wrap">
+      <button id="ms-label-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by label">
+        <span class="ms-placeholder">All labels</span>
+      </button>
+      <button id="ms-label-clear" class="ms-clear-inline" aria-label="Clear label filter" hidden>×</button>
+      <div id="ms-label-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
       <button id="ms-status-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by status">
         <span class="ms-placeholder">All statuses</span>
       </button>

--- a/frontend/multi_select.js
+++ b/frontend/multi_select.js
@@ -114,7 +114,14 @@ export class MultiSelect {
       const span = document.createElement('span');
       span.textContent = item.label;
 
-      lbl.append(cb, span);
+      if (item.sublabel) {
+        const sub = document.createElement('span');
+        sub.className = 'ms-sub';
+        sub.textContent = item.sublabel;
+        lbl.append(cb, span, sub);
+      } else {
+        lbl.append(cb, span);
+      }
       li.appendChild(lbl);
       ul.appendChild(li);
     }

--- a/frontend/multi_select.js
+++ b/frontend/multi_select.js
@@ -92,12 +92,27 @@ export class MultiSelect {
     ul.setAttribute('aria-multiselectable', 'true');
 
     for (const item of this.items) {
+      // Separator item — non-interactive divider
+      if (item.separator) {
+        const li = document.createElement('li');
+        li.className = 'ms-sep';
+        li.setAttribute('role', 'separator');
+        li.setAttribute('aria-hidden', 'true');
+        if (item.label) {
+          const span = document.createElement('span');
+          span.textContent = item.label;
+          li.appendChild(span);
+        }
+        ul.appendChild(li);
+        continue;
+      }
+
       const li = document.createElement('li');
       li.setAttribute('role', 'option');
       li.setAttribute('aria-selected', this.selected.has(item.value) ? 'true' : 'false');
 
       const lbl = document.createElement('label');
-      lbl.className = 'ms-item';
+      lbl.className = 'ms-item' + (item.archived ? ' ms-item-archived' : '');
 
       const cb = document.createElement('input');
       cb.type    = 'checkbox';
@@ -115,6 +130,14 @@ export class MultiSelect {
       span.textContent = item.label;
 
       lbl.append(cb, span);
+
+      if (item.archived) {
+        const sub = document.createElement('span');
+        sub.className = 'ms-sub';
+        sub.textContent = 'archived';
+        lbl.appendChild(sub);
+      }
+
       li.appendChild(lbl);
       ul.appendChild(li);
     }

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -36,6 +36,7 @@ export const state = {
   milestone: SS.getJSON('v6:milestone', []),
   priority:  SS.getJSON('v6:priority', []),
   status:    SS.getJSON('v6:status', ['ready', 'blocked']),
+  label:     SS.getJSON('v6:label', []),
   search:    SS.get('v6:search', ''),
   pivotRow:  SS.get('v6:pivotRow', 'milestone'),
   pivotCol:  SS.get('v6:pivotCol', 'lane'),
@@ -59,6 +60,7 @@ const SS_KEYS = {
   milestone:   { key: 'v6:milestone',   json: true  },
   priority:    { key: 'v6:priority',    json: true  },
   status:      { key: 'v6:status',      json: true  },
+  label:       { key: 'v6:label',       json: true  },
   search:      { key: 'v6:search',      json: false },
   pivotRow:    { key: 'v6:pivotRow',    json: false },
   pivotCol:    { key: 'v6:pivotCol',    json: false },
@@ -231,6 +233,7 @@ export function applyFilters(nodes, filters) {
     const pri = n.priority ?? '(None)';
     if (filters.priority.length && !filters.priority.includes(pri)) return false;
     if (filters.status.length && !filters.status.includes(n._status)) return false;
+    if (filters.label?.length && !filters.label.some(l => (n.labels ?? []).includes(l))) return false;
     if (q) {
       const hay = `${n.key} ${n.title ?? ''} ${(n.labels ?? []).join(' ')}`.toLowerCase();
       if (!hay.includes(q)) return false;
@@ -246,6 +249,7 @@ export function filteredNodes() {
     milestone: state.milestone,
     priority:  state.priority,
     status:    state.status,
+    label:     state.label,
     search:    state.search,
   });
 }
@@ -261,6 +265,7 @@ export function filteredNodesForGraph() {
     milestone: state.milestone,
     priority:  state.priority,
     status:    [],   // bypass status here, re-apply with override below
+    label:     state.label,
     search:    '',
   });
   if (state.status.length === 0) return base;

--- a/worker/migrations/0002_repos.sql
+++ b/worker/migrations/0002_repos.sql
@@ -1,0 +1,11 @@
+-- migration: 0002_repos.sql
+-- Applied via: wrangler d1 execute <DB> --config ../wrangler.toml --remote --file=worker/migrations/0002_repos.sql
+
+-- D1 runs in WAL mode natively; `PRAGMA journal_mode` is rejected at
+-- `wrangler d1 migrations apply` time, so it must not appear here.
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS repos (
+    repo     TEXT PRIMARY KEY,  -- e.g. 'Roxabi/voiceCLI'
+    archived INTEGER NOT NULL DEFAULT 0
+);

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -7,17 +7,19 @@ afterEach(() => {
 });
 
 /**
- * graph.ts fires 4 prepare().all() calls — dispatched by SQL content:
+ * graph.ts fires 5 prepare().all() calls — dispatched by SQL content:
  *   "FROM labels"   → labels fixture
  *   "FROM pr_state" → pr_state fixture
  *   "FROM issues"   → issues fixture
  *   "FROM edges"    → edges fixture
+ *   "FROM repos"    → repos fixture
  */
 function makeGraphEnv(
   labels: unknown[],
   prState: unknown[],
   issues: unknown[],
   edges: unknown[],
+  repos: unknown[] = [],
 ): Env {
   return {
     DB: {
@@ -27,6 +29,7 @@ function makeGraphEnv(
           if (sql.includes("FROM pr_state")) return { results: prState };
           if (sql.includes("FROM issues")) return { results: issues };
           if (sql.includes("FROM edges")) return { results: edges };
+          if (sql.includes("FROM repos")) return { results: repos };
           return { results: [] };
         },
       }),
@@ -409,11 +412,30 @@ describe("GET /api/graph", () => {
   });
 
   describe("empty database", () => {
-    it("returns {nodes:[], edges:[]} when all tables empty", async () => {
+    it("returns {nodes:[], edges:[], repos:[]} when all tables empty", async () => {
       const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], []));
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body).toEqual({ nodes: [], edges: [] });
+      expect(body).toEqual({ nodes: [], edges: [], repos: [] });
+    });
+  });
+
+  describe("repos field", () => {
+    it("returns live repos before archived repos, both alpha within group", async () => {
+      const repoRows = [
+        { repo: "Roxabi/roxabi-factory", archived: 0 },
+        { repo: "Roxabi/roxabi-live", archived: 0 },
+        { repo: "Roxabi/roxabi-vault", archived: 1 },
+      ];
+      // SQL ORDER BY archived ASC, repo ASC — fixture already sorted correctly
+      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], [], repoRows));
+      expect(res.status).toBe(200);
+      const body = await res.json<{ repos: { repo: string; archived: boolean }[] }>();
+      expect(body.repos).toEqual([
+        { repo: "Roxabi/roxabi-factory", archived: false },
+        { repo: "Roxabi/roxabi-live", archived: false },
+        { repo: "Roxabi/roxabi-vault", archived: true },
+      ]);
     });
   });
 });

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -199,5 +199,18 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     kind: row.kind,
   }));
 
-  return c.json({ nodes, edges });
+  // (e) repos — live first (archived=0), then archived (archived=1), both alpha
+  interface RepoRow {
+    repo: string;
+    archived: number;
+  }
+  const repoRows = await c.env.DB.prepare(
+    "SELECT repo, archived FROM repos ORDER BY archived ASC, repo ASC",
+  ).all<RepoRow>();
+  const repos = (repoRows.results ?? []).map((r) => ({
+    repo: r.repo,
+    archived: Boolean(r.archived),
+  }));
+
+  return c.json({ nodes, edges, repos });
 };

--- a/worker/src/sync/queries.ts
+++ b/worker/src/sync/queries.ts
@@ -53,6 +53,23 @@ query($org: String!, $cursor: String) {
 }
 `;
 
+export const ARCHIVED_REPOS_QUERY = `
+query($org: String!, $cursor: String) {
+  organization(login: $org) {
+    repositories(
+      first: 100
+      after: $cursor
+      isArchived: true
+      orderBy: { field: NAME, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes { nameWithOwner }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
 export const REFS_QUERY = `
 query($owner: String!, $name: String!, $cursor: String) {
   repository(owner: $owner, name: $name) {

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -54,7 +54,7 @@ function makeFakeStmt(
 /** Simple in-memory FakeD1 builder. */
 function makeFakeDb(
   stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
-): D1Database {
+): D1Database & { _recorded: FakeStmt[] } {
   const recorded: FakeStmt[] = [];
 
   const db = {
@@ -607,6 +607,7 @@ vi.mock("./graphql", () => ({
 }));
 
 vi.mock("./queries", () => ({
+  ARCHIVED_REPOS_QUERY: "ARCHIVED_REPOS_QUERY",
   ISSUES_QUERY: "ISSUES_QUERY",
   PRS_QUERY: "PRS_QUERY",
   REFS_QUERY: "REFS_QUERY",
@@ -1065,6 +1066,297 @@ describe("runSync", () => {
     const [key, body] = put.mock.calls[0];
     expect(key).toMatch(/^runs\/\d{4}-\d{2}-\d{2}\/.+\.json$/);
     expect(JSON.parse(body as string).outcome).toBe("halted");
+  });
+
+  // Prune + archived-repo tracking (#N) -------------------------------------
+
+  /**
+   * Builds a FakeD1 that drives runSync through the prune path:
+   *   isHalted=0 → lock acquired → allowlist=[Roxabi/roxabi-factory] →
+   *   ghGraphql returns live=[roxabi-factory] + archived=[roxabi-vault] →
+   *   DB SELECT DISTINCT queries return stale=[Roxabi/lyra] in issues/edges/pr_state/sync_state →
+   *   batchChunked invoked with DELETE stmts for Roxabi/lyra
+   *
+   * Callers replace ghGraphql mocks before calling makeFullSyncDb.
+   */
+  function makeFullSyncDb(opts: {
+    issueRepos?: string[];
+    edgeSrcRepos?: string[];
+    edgeDstRepos?: string[];
+    prStateRepos?: string[];
+    syncStateRepos?: string[];
+  } = {}) {
+    const {
+      issueRepos = ["Roxabi/lyra", "Roxabi/roxabi-factory"],
+      edgeSrcRepos = ["Roxabi/lyra"],
+      edgeDstRepos = [],
+      prStateRepos = ["Roxabi/lyra"],
+      syncStateRepos = ["Roxabi/lyra", "Roxabi/roxabi-factory"],
+    } = opts;
+
+    return makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      }
+      // Prune SELECT DISTINCT queries
+      if (sql.includes("SELECT DISTINCT repo FROM issues")) {
+        return makeFakeStmt(sql, args, issueRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT DISTINCT substr(src_key")) {
+        return makeFakeStmt(sql, args, edgeSrcRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT DISTINCT substr(dst_key")) {
+        return makeFakeStmt(sql, args, edgeDstRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT DISTINCT repo FROM pr_state")) {
+        return makeFakeStmt(sql, args, prStateRepos.map((r) => ({ repo: r })));
+      }
+      if (sql.includes("SELECT repo FROM sync_state")) {
+        return makeFakeStmt(sql, args, syncStateRepos.map((r) => ({ repo: r })));
+      }
+      // releaseSyncLock, writeRunAudit queries
+      return makeFakeStmt(sql, args, [], 1);
+    });
+  }
+
+  it("prunes issues/edges/pr_state/sync_state for a deleted repo (Roxabi/lyra)", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → live: only roxabi-factory (lyra is gone)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // syncRepoBundle calls (REPO_BUNDLE_QUERY) for roxabi-factory — empty result
+    mockGhGraphql.mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFullSyncDb();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // Verify DELETE FROM issues was issued for Roxabi/lyra
+    const deletedIssueStmts = db._recorded.filter(
+      (s) => s.sql.includes("DELETE FROM issues") && s.args.includes("Roxabi/lyra"),
+    );
+    expect(deletedIssueStmts.length).toBeGreaterThan(0);
+
+    // Verify DELETE FROM edges was issued for Roxabi/lyra
+    const deletedEdgeStmts = db._recorded.filter(
+      (s) => s.sql.includes("DELETE FROM edges") && s.args.includes("Roxabi/lyra"),
+    );
+    expect(deletedEdgeStmts.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT prune rows for an archived repo (roxabi-vault stays)", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → live: only roxabi-factory
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault (it IS in archived, not stale)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // syncRepoBundle empty result for roxabi-factory
+    mockGhGraphql.mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    // DB returns roxabi-vault as present in issues — but it's archived, so NOT stale
+    const db = makeFullSyncDb({
+      issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+      edgeSrcRepos: [],
+      edgeDstRepos: [],
+      prStateRepos: [],
+      syncStateRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // No DELETE statements should target roxabi-vault
+    const deletedVaultStmts = db._recorded.filter(
+      (s) => s.sql.includes("DELETE") && s.args.includes("Roxabi/roxabi-vault"),
+    );
+    expect(deletedVaultStmts).toHaveLength(0);
+  });
+
+  it("skips all prune logic (warn) when live repo enumeration returns 0 repos", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → live: empty (transient error)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // Safety guard must have warned
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("live repo enumeration returned 0 repos"),
+    );
+
+    // No DELETE statements should have been issued
+    const deleteStmts = db._recorded.filter((s) => s.sql.includes("DELETE"));
+    expect(deleteStmts).toHaveLength(0);
+  });
+
+  it("upserts repos table with archived=1 when a repo moves live→archived", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    // REPOS_QUERY → roxabi-factory live (roxabi-vault is now archived, not in live list)
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // ARCHIVED_REPOS_QUERY → roxabi-vault is now archived
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+    // syncRepoBundle empty result
+    mockGhGraphql.mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFullSyncDb({
+      issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+      edgeSrcRepos: [],
+      edgeDstRepos: [],
+      prStateRepos: [],
+      syncStateRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // The upsert INSERT stmt for Roxabi/roxabi-vault must use the archived=1 SQL variant
+    // (literal `1` is in the SQL text, not in bind args — only the repo name is bound)
+    const archivedUpsertStmts = db._recorded.filter(
+      (s) =>
+        s.sql.includes("INSERT INTO repos") &&
+        s.sql.includes("VALUES (?, 1)") &&
+        s.args.includes("Roxabi/roxabi-vault"),
+    );
+    expect(archivedUpsertStmts.length).toBeGreaterThan(0);
   });
 });
 

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -11,6 +11,7 @@
 
 import { ghGraphql, GraphQLError } from "./graphql";
 import {
+  ARCHIVED_REPOS_QUERY,
   ISSUES_QUERY,
   PRS_QUERY,
   REFS_QUERY,
@@ -317,6 +318,43 @@ export async function enumerateOrgRepos(
     }
 
     const pageInfo: { hasNextPage: boolean; endCursor: string | null } = data.organization.repositories.pageInfo;
+    if (!pageInfo.hasNextPage) break;
+    cursor = pageInfo.endCursor;
+    if (!cursor) break;
+  }
+
+  return repos;
+}
+
+interface ArchivedReposData {
+  organization: {
+    repositories: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: Array<{ nameWithOwner: string }>;
+    };
+  };
+  rateLimit: { cost: number; remaining: number; resetAt: string };
+}
+
+export async function enumerateArchivedOrgRepos(
+  org: string,
+  token: string,
+): Promise<string[]> {
+  const repos: string[] = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const response: { data: ArchivedReposData } & Record<string, unknown> =
+      await ghGraphql<ArchivedReposData>(ARCHIVED_REPOS_QUERY, { org, cursor }, token);
+    const data: ArchivedReposData = response.data;
+    const rl = data.rateLimit;
+    console.log(`[sync] archived-repos cost=${rl.cost} remaining=${rl.remaining}`);
+
+    for (const node of data.organization.repositories.nodes) {
+      repos.push(node.nameWithOwner);
+    }
+
+    const pageInfo = data.organization.repositories.pageInfo;
     if (!pageInfo.hasNextPage) break;
     cursor = pageInfo.endCursor;
     if (!cursor) break;
@@ -1122,23 +1160,113 @@ export async function runSync(env: Env): Promise<void> {
     const orgRepos = await enumerateOrgRepos(env.GITHUB_ORG, env.GITHUB_TOKEN);
     const active = orgRepos.filter((r) => allowlist.includes(`${r.owner}/${r.name}`));
 
-    // Prune stale sync_state rows for repos removed from the allowlist (faithful
-    // to sync.py run_sync: diff sync_state against the active allowlist∩org set).
-    const activeKeys = new Set(active.map((r) => `${r.owner}/${r.name}`));
-    const syncStateRows = await db
-      .prepare("SELECT repo FROM sync_state")
-      .all<{ repo: string }>();
-    const staleRepos = (syncStateRows.results ?? [])
-      .map((r) => r.repo)
-      .filter((repo) => !activeKeys.has(repo));
-    if (staleRepos.length > 0) {
-      await batchChunked(
-        db,
-        staleRepos.map((repo) =>
-          db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo),
+    // Enumerate archived repos for tracking + prune safety.
+    const archivedRepoNames = await enumerateArchivedOrgRepos(
+      env.GITHUB_ORG,
+      env.GITHUB_TOKEN,
+    );
+    const liveRepoNames = orgRepos.map((r) => `${r.owner}/${r.name}`);
+
+    // SAFETY GUARD: if live enumeration returned 0 repos (transient API error),
+    // skip all prune logic to prevent wiping the entire DB. This is NOT a halt —
+    // sync continues with the (empty) active set, which means no issues are synced
+    // this run, but existing DB rows are preserved.
+    if (liveRepoNames.length === 0) {
+      console.warn("[sync] live repo enumeration returned 0 repos — skipping prune");
+    } else {
+      // Upsert repos table: live repos with archived=0, archived repos with archived=1.
+      const repoUpsertStmts: D1PreparedStatement[] = [
+        ...liveRepoNames.map((repo) =>
+          db
+            .prepare(
+              "INSERT INTO repos (repo, archived) VALUES (?, 0) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
+            )
+            .bind(repo),
         ),
-      );
-      console.log(`[sync] pruned ${staleRepos.length} stale sync_state row(s)`);
+        ...archivedRepoNames.map((repo) =>
+          db
+            .prepare(
+              "INSERT INTO repos (repo, archived) VALUES (?, 1) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
+            )
+            .bind(repo),
+        ),
+      ];
+      if (repoUpsertStmts.length > 0) {
+        await batchChunked(db, repoUpsertStmts);
+        console.log(
+          `[sync] upserted ${liveRepoNames.length} live + ${archivedRepoNames.length} archived repo(s)`,
+        );
+      }
+
+      // Full prune: delete issues (+ cascaded labels), edges, pr_state, sync_state
+      // for repos absent from live ∪ archived. Chunk at ≤90 to stay under D1 limits.
+      const knownRepos = new Set([...liveRepoNames, ...archivedRepoNames]);
+      const CHUNK = 90;
+
+      // Collect all repos currently in DB tables.
+      const [issueRepos, edgeSrcRepos, edgeDstRepos, prStateRepos, syncStateRepos] =
+        await Promise.all([
+          db.prepare("SELECT DISTINCT repo FROM issues").all<{ repo: string }>(),
+          db.prepare("SELECT DISTINCT substr(src_key, 1, instr(src_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+          db.prepare("SELECT DISTINCT substr(dst_key, 1, instr(dst_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+          db.prepare("SELECT DISTINCT repo FROM pr_state").all<{ repo: string }>(),
+          db.prepare("SELECT repo FROM sync_state").all<{ repo: string }>(),
+        ]);
+
+      const staleIssueRepos = (issueRepos.results ?? [])
+        .map((r) => r.repo)
+        .filter((r) => !knownRepos.has(r));
+      const staleEdgeRepos = [
+        ...(edgeSrcRepos.results ?? []).map((r) => r.repo),
+        ...(edgeDstRepos.results ?? []).map((r) => r.repo),
+      ].filter((r) => !knownRepos.has(r));
+      const stalePrStateRepos = (prStateRepos.results ?? [])
+        .map((r) => r.repo)
+        .filter((r) => !knownRepos.has(r));
+      const staleSyncStateRepos = (syncStateRepos.results ?? [])
+        .map((r) => r.repo)
+        .filter((r) => !knownRepos.has(r));
+
+      const pruneStmts: D1PreparedStatement[] = [];
+      for (let i = 0; i < staleIssueRepos.length; i += CHUNK) {
+        for (const repo of staleIssueRepos.slice(i, i + CHUNK)) {
+          pruneStmts.push(db.prepare("DELETE FROM issues WHERE repo=?").bind(repo));
+        }
+      }
+      // Deduplicate stale edge repos before chunking
+      const staleEdgeReposUniq = [...new Set(staleEdgeRepos)];
+      for (let i = 0; i < staleEdgeReposUniq.length; i += CHUNK) {
+        for (const repo of staleEdgeReposUniq.slice(i, i + CHUNK)) {
+          pruneStmts.push(
+            db
+              .prepare(
+                "DELETE FROM edges WHERE substr(src_key,1,instr(src_key,'#')-1)=? OR substr(dst_key,1,instr(dst_key,'#')-1)=?",
+              )
+              .bind(repo, repo),
+          );
+        }
+      }
+      for (let i = 0; i < stalePrStateRepos.length; i += CHUNK) {
+        for (const repo of stalePrStateRepos.slice(i, i + CHUNK)) {
+          pruneStmts.push(db.prepare("DELETE FROM pr_state WHERE repo=?").bind(repo));
+        }
+      }
+      for (let i = 0; i < staleSyncStateRepos.length; i += CHUNK) {
+        for (const repo of staleSyncStateRepos.slice(i, i + CHUNK)) {
+          pruneStmts.push(db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo));
+        }
+      }
+
+      if (pruneStmts.length > 0) {
+        await batchChunked(db, pruneStmts);
+        const totalStale = new Set([
+          ...staleIssueRepos,
+          ...staleEdgeReposUniq,
+          ...stalePrStateRepos,
+          ...staleSyncStateRepos,
+        ]).size;
+        console.log(`[sync] pruned data for ${totalStale} stale repo(s)`);
+      }
     }
 
     // Pass 1: bundled issues + refs + PRs per repo (1 subreq/repo instead of 3)


### PR DESCRIPTION
Promote staging → production (live.roxabi.dev).

- **#128** toolbar: fix empty repo filter (derive from nodes), milestone & priority names (sub-labels), new label filter.
- **#129** repo filter: archived repos shown last after a separator.
- **#130** worker: sync **prune** for renamed/deleted repos (lyra→roxabi-factory ghost) with empty-live-set safety guard; `repos` table + archived enumeration; `/api/graph` returns `repos:[{repo,archived}]`. Migration `0002_repos.sql` already applied to prod D1.
- **#131** repo filter: list only repos that have issues (archived still last).
- **#127** docs: CF cutover reflected.

Verified end-to-end on staging (repos table 30 live + 4 archived; `/api/graph.repos` sorted; roxabi-vault archived-last). Prod D1 lyra ghost already purged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)