### PR TITLE
chore: promote staging to main — webhook live-refresh (#133)

### DIFF
--- a/worker/migrations/0003_data_version.sql
+++ b/worker/migrations/0003_data_version.sql
@@ -1,0 +1,7 @@
+-- Migration: seed data_version key in sync_control
+-- This key is bumped on every mutating webhook dispatch so that /api/version
+-- reflects real-time board changes (≤15 s poll) instead of only the hourly
+-- cron tick.
+
+INSERT OR IGNORE INTO sync_control (key, value, updated_at)
+VALUES ('data_version', '', datetime('now'));

--- a/worker/src/api/version.test.ts
+++ b/worker/src/api/version.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { app } from "../router";
 import type { Env } from "../types";
 
-/** Minimal D1/ASSETS stub — returns a fixed row for the first() query. */
+/**
+ * Minimal D1/ASSETS stub for version endpoint tests.
+ * The UNION ALL query calls .first() on a single prepared statement, so we
+ * only need to intercept that one call and return the row we want.
+ */
 function mockEnv(row: Record<string, unknown> | null): Env {
   return {
     DB: {
@@ -16,14 +20,36 @@ function mockEnv(row: Record<string, unknown> | null): Env {
 }
 
 describe("GET /api/version", () => {
-  it("returns MAX(last_synced_at) as the version token", async () => {
-    const res = await app.request("/api/version", {}, mockEnv({ ts: "2026-06-05T12:00:00Z" }));
+  it("returns the MAX version token when cron sync is newest", async () => {
+    // Simulates: cron ran at 12:00, last webhook at 11:00 — cron wins
+    const res = await app.request(
+      "/api/version",
+      {},
+      mockEnv({ version: "2026-06-05T12:00:00.000Z" }),
+    );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ version: "2026-06-05T12:00:00Z" });
+    expect(await res.json()).toEqual({ version: "2026-06-05T12:00:00.000Z" });
   });
 
-  it("returns an empty version when no sync has run yet", async () => {
-    const res = await app.request("/api/version", {}, mockEnv({ ts: null }));
+  it("returns the MAX version token when webhook mutation is newest", async () => {
+    // Simulates: data_version bumped at 12:30 after a webhook, cron only at 12:00
+    const res = await app.request(
+      "/api/version",
+      {},
+      mockEnv({ version: "2026-06-05T12:30:00.000Z" }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ version: "2026-06-05T12:30:00.000Z" });
+  });
+
+  it("returns an empty version when no sync or webhook mutation has run yet", async () => {
+    const res = await app.request("/api/version", {}, mockEnv({ version: null }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ version: "" });
+  });
+
+  it("returns an empty string when the db returns a null row", async () => {
+    const res = await app.request("/api/version", {}, mockEnv(null));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ version: "" });
   });

--- a/worker/src/api/version.ts
+++ b/worker/src/api/version.ts
@@ -8,18 +8,21 @@ import type { Env } from "../types";
  * Response shape MUST stay `{ version: string }` — matches the Python
  * `app.py::api_version` contract consumed by `frontend/app.js::fetchVersion`.
  *
- * The Python impl returned the max mtime across corpus.db + WAL/SHM, catching
- * BOTH webhook and reconciler writes. D1 has no file mtime, so we use
- * `MAX(last_synced_at)` from sync_state (per spec #92 §2).
+ * Returns MAX across:
+ *   - sync_state.last_synced_at  (advances on hourly cron)
+ *   - sync_control['data_version'] (bumped on every mutating webhook dispatch)
  *
- * TODO(#97/#98, S5/S6): `last_synced_at` only advances on the hourly cron sync,
- * not on webhook-driven writes — so webhook board changes won't trigger a
- * live-refresh. Restore parity with a per-write mutation token (e.g. a
- * `sync_control` row bumped on every webhook upsert) when those paths land.
+ * Both columns are ISO-8601 strings and compare lexicographically, so MAX()
+ * over the UNION ALL correctly returns the most-recent write regardless of
+ * which path produced it. Resolves #133.
  */
 export const versionRoute = async (c: Context<{ Bindings: Env }>) => {
   const row = await c.env.DB.prepare(
-    "SELECT MAX(last_synced_at) AS ts FROM sync_state",
-  ).first<{ ts: string | null }>();
-  return c.json({ version: row?.ts ?? "" });
+    `SELECT MAX(v) AS version FROM (
+       SELECT COALESCE(MAX(last_synced_at), '') AS v FROM sync_state
+       UNION ALL
+       SELECT COALESCE(value, '') AS v FROM sync_control WHERE key = 'data_version'
+     )`,
+  ).first<{ version: string | null }>();
+  return c.json({ version: row?.version ?? "" });
 };

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -992,4 +992,94 @@ describe("webhookRoute", () => {
       expect(json["ok"]).toBe(true);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // data_version bump (#133)
+  // -------------------------------------------------------------------------
+
+  describe("data_version bump", () => {
+    /** Build a context that exposes the db so we can inspect db.batch calls. */
+    async function dispatchWithDb(
+      body: string,
+      event: string,
+      envOverrides: Partial<Env> = {},
+    ): Promise<{ res: Response; db: D1Database & { _recorded: FakeStmt[] } }> {
+      const bodyBytes = new TextEncoder().encode(body).buffer as ArrayBuffer;
+      const sig = await computeHmac(bodyBytes, SECRET);
+      const req = makeRequest(body, sig, event);
+      const env = makeEnv({ ...envOverrides });
+      const { c, db } = makeContext(req, env);
+      const res = await webhookRoute(c);
+      return { res, db };
+    }
+
+    it("bumps data_version after a mutating issues event", async () => {
+      // Arrange
+      const payload = makeIssuePayload("opened");
+
+      // Act
+      const { res, db } = await dispatchWithDb(JSON.stringify(payload), "issues");
+
+      // Assert — response OK
+      expect(res.status).toBe(200);
+
+      // db.batch should have been called at least once; verify a sync_control
+      // statement (the data_version bump) was recorded among all prepared stmts.
+      expect(vi.mocked(db.batch)).toHaveBeenCalled();
+
+      const recorded = db._recorded;
+      const bumpStmt = recorded.find(
+        (s) => s.sql.includes("sync_control") && s.args.length >= 1,
+      );
+      expect(bumpStmt).toBeDefined();
+      // First arg is the ISO timestamp — must be a non-empty string.
+      expect(typeof bumpStmt!.args[0]).toBe("string");
+      expect((bumpStmt!.args[0] as string).length).toBeGreaterThan(0);
+    });
+
+    it("does NOT bump data_version for an unknown (ignored) event", async () => {
+      // Arrange — unknown event short-circuits before setting mutated=true
+      const body = JSON.stringify({ action: "something" });
+
+      // Act
+      const { res, db } = await dispatchWithDb(body, "unknown_event_xyz");
+
+      // Assert — response carries ignored flag
+      const json = (await res.json()) as Record<string, unknown>;
+      expect(json["ignored"]).toBe("unknown_event_xyz");
+
+      // db.batch must NOT have been called (no bump, no handler writes)
+      expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+    });
+
+    it("does NOT bump data_version for issue_dependencies blocking_added (returns 0 changes)", async () => {
+      // blocking_added is ignored by handleDeps (returns 0 immediately) →
+      // mutated stays false → no db.batch call for the bump.
+      const payload = {
+        action: "blocking_added",
+        issue: {
+          number: 10,
+          title: "Blocker",
+          state: "open",
+          html_url: "https://github.com/Roxabi/lyra/issues/10",
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+          closed_at: null,
+          milestone: null,
+          labels: [],
+        },
+        repository: { full_name: REPO },
+      };
+
+      const { res, db } = await dispatchWithDb(
+        JSON.stringify(payload),
+        "issue_dependencies",
+      );
+
+      expect(res.status).toBe(200);
+
+      // db.batch must NOT have been called (no handler writes, no version bump)
+      expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -23,6 +23,7 @@ import {
   setActiveBranch,
   upsertPrState,
   renameMilestone,
+  bumpDataVersion,
   type WebhookIssue,
 } from "./mutations";
 import { BRANCH_ISSUE_RE, canonicalKey, extractFromLabels, syncBranches } from "../sync/sync";
@@ -494,27 +495,52 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
   const event = c.req.header("x-github-event") ?? null;
   const db = c.env.DB;
 
+  // Unknown events short-circuit here — no data_version bump.
+  if (
+    event !== "issues" &&
+    event !== "issue_dependencies" &&
+    event !== "sub_issues" &&
+    event !== "create" &&
+    event !== "delete" &&
+    event !== "pull_request" &&
+    event !== "milestone"
+  ) {
+    return c.json({ ok: true, ignored: event });
+  }
+
+  let mutated = false;
+
   try {
     if (event === "issues") {
       await handleIssues(payload, db);
+      mutated = true;
     } else if (event === "issue_dependencies") {
-      await handleDeps(payload, db, c.env);
+      const changed = await handleDeps(payload, db, c.env);
+      mutated = changed > 0;
     } else if (event === "sub_issues") {
-      await handleSubIssues(payload, db);
+      const changed = await handleSubIssues(payload, db);
+      mutated = changed > 0;
     } else if (event === "create") {
       await handleRefCreate(payload, db);
+      mutated = true;
     } else if (event === "delete") {
       await handleRefDelete(payload, db, c.env);
+      mutated = true;
     } else if (event === "pull_request") {
       await handlePullRequest(payload, db);
+      mutated = true;
     } else if (event === "milestone") {
       await handleMilestone(payload, db);
-    } else {
-      return c.json({ ok: true, ignored: event });
+      mutated = true;
     }
   } catch (err) {
     console.error("[webhook] unhandled handler error", err);
     return c.json({ ok: true, error: "internal" });
+  }
+
+  if (mutated) {
+    const iso = new Date().toISOString();
+    await db.batch([bumpDataVersion(db, iso)]);
   }
 
   return c.json({ ok: true });

--- a/worker/src/webhook/mutations.ts
+++ b/worker/src/webhook/mutations.ts
@@ -68,6 +68,15 @@ const SET_ACTIVE_BRANCH_OFF_SQL =
 const RENAME_MILESTONE_SQL =
   "UPDATE issues SET milestone = ? WHERE repo = ? AND milestone = ?";
 
+/** Upsert the data_version key in sync_control with the given ISO-8601 timestamp. */
+export const BUMP_DATA_VERSION_SQL = `
+  INSERT INTO sync_control (key, value, updated_at)
+  VALUES ('data_version', ?, ?)
+  ON CONFLICT(key) DO UPDATE SET
+      value      = excluded.value,
+      updated_at = excluded.updated_at
+`;
+
 // ---------------------------------------------------------------------------
 // WebhookIssue — partial issue shape expected by upsertIssue
 // ---------------------------------------------------------------------------
@@ -224,6 +233,15 @@ export function upsertPrState(
     closingIssueKeysJson,
     updatedAt,
   );
+}
+
+/**
+ * Prepare a statement that bumps the data_version key in sync_control.
+ * The iso parameter must be an ISO-8601 string (used as both value and updated_at).
+ * Returns a D1PreparedStatement — caller folds it into the batch; never calls .run() here.
+ */
+export function bumpDataVersion(db: D1Database, iso: string): D1PreparedStatement {
+  return db.prepare(BUMP_DATA_VERSION_SQL).bind(iso, iso);
 }
 
 /**


### PR DESCRIPTION
## Promotion: staging → main

Promotes the webhook live-refresh fix (#133, PR #134) to production.

### Changes
- `/api/version` now returns `MAX(sync_state.last_synced_at ∪ sync_control['data_version'])`
- Webhook dispatch bumps `sync_control['data_version']` on every mutating event
- → open browser tabs at live.roxabi.dev reload within ≤15 s of a webhook write (was ≤1 h)
- migration `0003_data_version.sql` seeds the `data_version` row

### Pre-flight
- [x] CI passing on staging (ci + worker green)
- [x] 2 commits ahead of main; no other open PRs targeting staging (only stale #118)
- [x] Staging Worker deployed + D1 migrated (`data_version` row present on `roxabi-live-staging`)
- [ ] Prod D1 migration (`0003`) — applied post-merge

Versioning/changelog/tag handled by release-please on main.

---
Generated with [Claude Code](https://claude.com/claude-code) via `/promote`