### PR TITLE
chore: promote staging to main — dev-core config realign (#136, board cleanup)

### DIFF
--- a/.claude/dev-core.yml
+++ b/.claude/dev-core.yml
@@ -1,10 +1,3 @@
-# Roxabi Hub project board (PVT_kwDOB8J6DM4BVWlE)
-gh_project_id: 'PVT_kwDOB8J6DM4BVWlE'
-status_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy83E'
-size_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy838'
-priority_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy834'
-lane_field_id: 'PVTSSF_lADOB8J6DM4BVWlEzhQy830'
-status_options_json: '{"Todo":"fb4666b4","Ready":"9a1e7011","In Progress":"f972685d","Blocked":"93ed3508","Done":"833e5ce2","Backlog":"fb4666b4","Analysis":"fb4666b4","Specs":"fb4666b4","Review":"f972685d"}'
-size_options_json: '{"S":"0e7a5f75","F-lite":"33ba8e50","F-full":"c67a71e0","XS":"0e7a5f75","M":"33ba8e50","L":"c67a71e0","XL":"c67a71e0"}'
-priority_options_json: '{"P0 - Urgent":"1869a39d","P1 - High":"8ce35f78","P2 - Medium":"c54358fe","P3 - Low":"f5160185"}'
-lane_options_json: '{"a1":"37e922a5","a2":"4adaf605","a3":"439b1e49","b":"405ef672","c1":"2dc55a75","c2":"7cadbf6e","c3":"13dc3bfb","d":"53688630","e":"3b91e2a2","f":"47d23510","g":"da0857d9","h":"cf0e69b7","i":"44b4f2c8","j":"290d193f","k":"369edbea","l":"10431d4a","m":"6e85f6b8","n":"acb15dcd","o":"3fa48df2","standalone":"f8fcc5f9"}'
+# dev-core plugin configuration
+# 3-tier fallback: this file → process.env → gh CLI (github_repo only)
+github_repo: Roxabi/roxabi-live

--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -1,27 +1,29 @@
 # .claude/stack.yml — dev-core stack configuration
 schema_version: "1.0"
 
-runtime: python
-package_manager: uv
+runtime: node
+package_manager: npm
 
 backend:
-  framework: fastapi
-  path: src/roxabi_live
+  framework: hono
+  path: worker/src
+
+frontend:
+  framework: none  # static HTML/JS/CSS; served via CF Worker ASSETS binding
+  path: frontend
 
 build:
-  formatter: ruff
-  formatter_config: pyproject.toml
-  formatter_fix_cmd: "uv run ruff format . && uv run ruff check --fix ."
+  formatter: none  # no formatter configured for the worker; no lint/format script in worker/package.json
 
 testing:
-  unit: pytest
+  unit: vitest
 
 lsp:
   enabled: true
-  server: pyright
+  server: typescript-language-server
 
 deploy:
-  platform: none
+  platform: cloudflare  # wrangler deploy via CI; push to staging → staging env, push to main → prod
 
 docs:
   framework: none
@@ -29,12 +31,13 @@ docs:
   format: md
 
 commands:
-  dev: uv run roxabi-live
-  test: uv run pytest
-  lint: uv run ruff check .
-  format: uv run ruff format .
-  typecheck: uv run pyright
-  install: uv sync
+  dev: cd worker && npm run dev
+  test: cd worker && npm test
+  typecheck: cd worker && npm run typecheck
+  install: cd worker && npm ci
+  # lint and format: no script defined in worker/package.json and no tool configured
+  # (.pre-commit-config.yaml still references legacy ruff/pyright for frozen Python src/)
+  # Add lint/format here once a TS linter (eslint/biome) is wired up — see #136 follow-up
 
 artifacts:
   analyses: artifacts/analyses
@@ -47,12 +50,18 @@ quality_gates:
     enabled: true
     metric: sloc
     max_lines: 300
+    # NOTE: tools/qg.conf (CI-authoritative) still scopes this gate to src/**/*.py (legacy Python,
+    # frozen for reference). Regenerating qg.conf for worker/ requires /release-setup and is
+    # deferred to a follow-up — see #136. CI stays green: src/ exists, Python files pass.
+    # Worker TS file length is governed by tsc + code review until qg.conf is regenerated.
     globs: ["src/**/*.py"]
     exemptions_file: tools/file_exemptions.txt
 
   folder_size:
     enabled: true
     max_files: 12
+    # Same note as file_length: qg.conf + check_folder_size.sh both target src/**/*.py.
+    # tools/qg.conf left unchanged to preserve CI green baseline — see #136 follow-up.
     globs: ["src/**"]
     exemptions_file: tools/folder_exemptions.txt
 


### PR DESCRIPTION
## Promotion: staging → main

Config-only — no worker runtime changes.

### Changes
- `.claude/stack.yml` — realigned to the Cloudflare Worker / TS (#136, PR #137)
- `.claude/dev-core.yml` — dropped deprecated ProjectV2 board pointers

### Pre-flight
- [x] CI passing on staging
- [x] staging ahead of main by 2 config commits; only stale #118 open on staging (acknowledged)
- [x] No prod runtime impact (dev-core config files only)

Versioning/changelog/tag handled by release-please on main.

---
Generated with [Claude Code](https://claude.com/claude-code) via `/promote`