### PR TITLE
feat(roxabi-issues): relocate issue-triage plugin from dev-core

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "roxabi-live-marketplace",
+  "version": "1.0.0",
+  "description": "Roxabi Live — issue management plugin (relocated from dev-core, labels + native relations, no Projects V2).",
+  "owner": {
+    "name": "Roxabi",
+    "url": "https://github.com/Roxabi"
+  },
+  "plugins": [
+    {
+      "name": "roxabi-issues",
+      "description": "Issue triage — set labels (size/priority/lane/type), manage blocked-by dependencies and parent/child sub-issues on GitHub issues. Labels + native relations, no Projects V2 board.",
+      "source": "./plugins/roxabi-issues",
+      "category": "development"
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Let:
 
 → `docs/ARCHITECTURE.md` (to be created)
 
+## Plugins
+
+`plugins/roxabi-issues/` — Claude Code plugin (own `.claude-plugin/marketplace.json`), relocated from dev-core 2026-06-09. Skill `issue-triage` (invoked `roxabi-issues:issue-triage`): set labels (size/priority/lane/type) + manage blocked-by deps + parent/child sub-issues on GitHub issues. **Labels + native relations only — no ProjectV2 board** (board read is the cockpit's job). Self-contained bun project (`bun run typecheck|test`). Registered in `roxabi-plugins/.claude-plugin/external-registry.json`.
+
 ## TL;DR
 
 - Entry: `/dev #N` → tier (S/F-lite/F-full) → lifecycle

--- a/plugins/roxabi-issues/.claude-plugin/plugin.json
+++ b/plugins/roxabi-issues/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "roxabi-issues",
+  "version": "0.1.0",
+  "description": "Issue triage — set labels (size/priority/lane/type), manage blocked-by dependencies and parent/child sub-issues on GitHub issues. Labels + native relations, no Projects V2 board.",
+  "author": {
+    "name": "Roxabi"
+  }
+}

--- a/plugins/roxabi-issues/.gitignore
+++ b/plugins/roxabi-issues/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/plugins/roxabi-issues/bun.lock
+++ b/plugins/roxabi-issues/bun.lock
@@ -1,0 +1,173 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@roxabi/issue-triage-plugin",
+      "devDependencies": {
+        "bun-types": "^1.3.14",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7",
+      },
+    },
+  },
+  "packages": {
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.8", "", { "dependencies": { "@vitest/spy": "4.1.8", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "pathe": "^2.0.3" } }, "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "@vitest/utils": "4.1.8", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.8", "", {}, "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "obug": ["obug@2.1.2", "", {}, "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+
+    "vitest": ["vitest@4.1.8", "", { "dependencies": { "@vitest/expect": "4.1.8", "@vitest/mocker": "4.1.8", "@vitest/pretty-format": "4.1.8", "@vitest/runner": "4.1.8", "@vitest/snapshot": "4.1.8", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.8", "@vitest/browser-preview": "4.1.8", "@vitest/browser-webdriverio": "4.1.8", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+  }
+}

--- a/plugins/roxabi-issues/package.json
+++ b/plugins/roxabi-issues/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@roxabi/issue-triage-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/plugins/roxabi-issues/skills/issue-triage/README.md
+++ b/plugins/roxabi-issues/skills/issue-triage/README.md
@@ -1,0 +1,61 @@
+# issue-triage
+
+Create and triage GitHub issues — set size, priority, lane, type labels and manage parent/child/blocker relationships.
+
+## Why
+
+Raw GitHub issues lack structure. `/issue-triage` adds Size (XS→XL), Priority (P0→P3), Lane, and Type via native GitHub labels and issue relations — making the backlog plannable and giving downstream skills (`/dev`, `/plan`) the metadata they need to tier and prioritize work. No Project board required.
+
+## Usage
+
+```
+/issue-triage list                           List all open issues (tree view)
+/issue-triage list --untriaged               Show issues missing Size or Priority
+/issue-triage set 42 --size M --priority High
+/issue-triage set 91 --blocked-by 117
+/issue-triage set 164 --parent 163
+/issue-triage create --title "..." --size S --priority Medium --type feat --lane b --parent 163
+```
+
+`create` accepts the same field flags as `set`: `--size`, `--priority`, `--lane`, `--type` (plus `--parent`, `--add-child`, `--blocked-by`, `--blocks`) — set everything in one shot at creation instead of a follow-up `set`.
+
+Triggers: `"triage"` | `"create issue"` | `"set size"` | `"set priority"` | `"blocked by"` | `"set parent"` | `"sub-issue"` | `"file an issue"` | `"open an issue"`
+
+## Cross-repo create
+
+Prefix `GITHUB_REPO=<owner/repo>` to create an issue in a different repo than the current cwd:
+
+```bash
+GITHUB_REPO=Roxabi/voiceCLI /issue-triage create --title "..." --blocked-by Roxabi/lyra#728
+```
+
+Cross-repo relation flags (`--blocked-by`, `--blocks`, `--parent`, `--add-child`) accept `OWNER/REPO#N` natively and work independently of `GITHUB_REPO`. When the env var is set, always use fully-qualified refs — bare `#N` resolves against the overridden repo.
+
+## Size Guidelines
+
+| Size | Description |
+|------|-------------|
+| **XS** | Trivial, < 1 hour |
+| **S** | Small, < 4 hours |
+| **M** | Medium, 1–2 days |
+| **L** | Large, 3–5 days |
+| **XL** | Very large, > 1 week |
+
+## Priority Guidelines
+
+| Priority | Action |
+|----------|--------|
+| **Urgent** (P0) | Do immediately |
+| **High** (P1) | Do this sprint |
+| **Medium** (P2) | Plan for next sprint |
+| **Low** (P3) | Backlog |
+
+## Complexity Scoring
+
+Assigns a κ ∈ [1,10] score to determine implementation tier:
+
+| Score | Tier | Mode |
+|-------|------|------|
+| 1–3 | S | Single session, direct |
+| 4–6 | F-lite | 1–2 subagents |
+| 7–10 | F-full | Full agent team |

--- a/plugins/roxabi-issues/skills/issue-triage/SKILL.md
+++ b/plugins/roxabi-issues/skills/issue-triage/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: issue-triage
+argument-hint: [list | set <num> | create --title "..." [--parent N] [--size S] [--priority P] [--type T] [--lane L]]
+description: Triage/create GitHub issues — set size/priority/lane/type labels, manage dependencies & parent/child. Triggers: "triage" | "create issue" | "set size" | "set priority" | "blocked by" | "set parent" | "child of" | "sub-issue" | "file an issue" | "log a bug" | "open an issue" | "file a bug" | "add issue" | "new issue" | "set lane" | "set type".
+version: 0.4.0
+allowed-tools: Bash, Read, ToolSearch
+---
+
+# Issue Triage
+
+Let: τ := `bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts` | κ := complexity score
+
+Create GitHub issues, assign Size/Priority labels, manage blockedBy dependencies and parent/child relationships.
+
+## Instructions
+
+1. List all open issues: `τ list` | List untriaged only: `τ list --untriaged`
+2. ∀ issue: determine Size, Priority, κ (see [Complexity Scoring](#complexity-scoring))
+3. Set values: `τ set <number> --size <S> --priority <P>`
+4. Create issues: `τ create --title "Title" [--body "Body"] [--label "bug,frontend"] [--size M] [--priority High] [--type feat] [--lane b] [--parent 163]`
+5. → DP(B)if unsure about Size ∨ Priority.
+
+## Size Guidelines
+
+| Size | Description | Example |
+|------|-------------|---------|
+| **XS** | Trivial, < 1 hour | Typo fix, config tweak |
+| **S** | Small, < 4 hours | Single file change, simple feature |
+| **M** | Medium, 1-2 days | Multi-file feature, requires testing |
+| **L** | Large, 3-5 days | Complex feature, architectural changes |
+| **XL** | Very large, > 1 week | Major refactor, new system |
+
+**Canonical tier names:** `S / F-lite / F-full` (maps to dev tiers: S=simple, F-lite=subagents, F-full=agent team). Legacy size labels use `XS / S / M / L / XL`. Both are accepted as `--size` input. When a canonical name is used it aliases to the nearest size label (`F-full`→`XL`/`L`, `F-lite`→`M`, `S`→`S`/`XS`) — this is expected presentation drift, not a bug.
+
+## Priority Guidelines
+
+| Priority | Description | Action |
+|----------|-------------|--------|
+| **Urgent** (P0) | Blocking or critical | Do immediately |
+| **High** (P1) | Important for current milestone | Do this sprint |
+| **Medium** (P2) | Should be done soon | Plan for next sprint |
+| **Low** (P3) | Nice to have | Backlog |
+
+## Commands
+
+### `list` — Show open issues
+
+| Flag | Description |
+|------|-------------|
+| *(none)* | Tree of all open issues with N-level parent-child hierarchy. Parents with ≥1 closed child show `… ✓ Done`. |
+| `--untriaged` | Flat table of issues missing Size or Priority |
+| `--json` | JSON output (all open issues); combine with `--untriaged` to filter |
+
+### `set <num>` — Update an existing issue
+
+| Flag | Description |
+|------|-------------|
+| `--size <S>` | Set size label — canonical `S/F-lite/F-full` or legacy `XS/S/M/L/XL` (canonical names alias to nearest legacy label) |
+| `--priority <P>` | Set priority label (Urgent, High, Medium, Low) |
+| `--blocked-by <REF>[,<REF>...]` | Add blocked-by dependency. REF = `#N` or `owner/repo#N` |
+| `--blocks <REF>[,<REF>...]` | Add blocking dependency. REF = `#N` or `owner/repo#N` |
+| `--rm-blocked-by <REF>[,<REF>...]` | Remove blocked-by dependency |
+| `--rm-blocks <REF>[,<REF>...]` | Remove blocking dependency |
+| `--parent <REF>` | Set parent issue. REF = `#N` or `owner/repo#N` |
+| `--add-child <REF>[,<REF>...]` | Add child sub-issues |
+| `--rm-parent` | Remove parent relationship |
+| `--rm-child <REF>[,<REF>...]` | Remove child sub-issues |
+| `--lane <L>` | Set lane label (optional, additive). Valid: `a1`, `a2`, `a3`, `b`, `c1`, `c2`, `c3`, `d`–`o`, `standalone` |
+| `--type <T>` | Set org issueType (optional, additive). Valid: `fix`, `feat`, `docs`, `test`, `chore`, `ci`, `perf`, `epic`, `research`, `refactor` |
+
+### `create` — Create a new issue
+
+| Flag | Description |
+|------|-------------|
+| `--title "..."` | Issue title (**required**) |
+| `--body "..."` | Issue body/description |
+| `--label "l1,l2"` | Comma-separated labels |
+| `--size <S>` | Set size on creation — canonical `S/F-lite/F-full` or legacy `XS/S/M/L/XL` accepted |
+| `--priority <P>` | Set priority on creation |
+| `--lane <L>` | Set lane on creation (label-only, additive). Valid: `a1`, `a2`, `a3`, `b`, `c1`, `c2`, `c3`, `d`–`o`, `standalone` |
+| `--type <T>` | Set org issueType on creation (additive). Valid: `fix`, `feat`, `docs`, `test`, `chore`, `ci`, `perf`, `epic`, `research`, `refactor` |
+| `--parent <REF>` | Set parent issue on creation. REF = `#N` or `owner/repo#N` |
+| `--add-child <REF>[,<REF>...]` | Add existing issues as children |
+| `--blocked-by <REF>[,<REF>...]` | Set blocked-by on creation |
+| `--blocks <REF>[,<REF>...]` | Set blocking on creation |
+
+### Cross-repo create
+
+Set `GITHUB_REPO=<owner/repo>` to retarget the CREATE to a different repo than the cwd's git remote:
+
+```bash
+# File a voiceCLI issue while cwd is lyra (or any other repo)
+GITHUB_REPO=Roxabi/voiceCLI τ create \
+  --title 'STT: audio dropout at segment boundary' \
+  --blocked-by Roxabi/lyra#728
+```
+
+Cross-repo **relations** (`--blocked-by`, `--blocks`, `--parent`, `--add-child`) accept `OWNER/REPO#N` natively — they work regardless of `GITHUB_REPO`.
+
+**Caveat — keep refs fully-qualified:** `GITHUB_REPO` retargets the entire invocation. A bare `#N` in any ref resolves against the overridden repo, not the cwd repo → always use `OWNER/REPO#N` for any cross-repo ref when the env var is set.
+
+**Resolution order** (`detectGitHubRepo`): (1) `github_repo` in dev-core config ∨ `GITHUB_REPO` env var (validated as `owner/repo`) → (2) fallback `git remote get-url origin` of the cwd.
+
+## Deferred Follow-Ups — Sibling Rule
+
+**Defer ≠ decomposition.** When an issue A defers work to a new follow-up B (out-of-scope finding, post-merge gap, "do this later"), B is a **sibling** of A under their shared parent — NOT a child of A.
+
+```
+       Epic E
+      ╱      ╲
+     A ←—————— B     B.parent = A.parent (= E)
+       blocked-by    B.blocked-by = A   (traceability of origin)
+```
+
+**Why:**
+- `gh issue view E` shows the full fan-out flat (A + B + future C…) — true scope of the epic, ¬nested cascade
+- `/dev` re-scan retombe correctement sur l'épic origin pour tout follow-up
+- Multi-level deferrals (A→B→C) stay flat under E — ¬arbre profond ingérable
+
+**Decomposition vs deferral:**
+
+| Pattern | Parent-child? | Example |
+|---------|---------------|---------|
+| **Epic → phase** (planned decomposition) | ✓ child of epic | `/spec` smart-splitting: phase 1, phase 2 are children of epic |
+| **Issue → follow-up** (deferral, post-hoc) | ✗ sibling under shared parent | `/fix` Phase 5 Defer: out-of-scope finding becomes sibling |
+| **Bug → regression** (related ¬caused) | ✗ standalone | New bug surfaced post-merge, ¬child, ¬sibling necessarily |
+
+**Recipe — defer A → create follow-up B:**
+
+```bash
+# 1. Resolve A's parent (may be null if A is top-level)
+A_PARENT=$(gh api graphql -f query="query{repository(owner:\"$OWNER\",name:\"$REPO\"){issue(number:$A){parent{number}}}}" \
+  --jq '.data.repository.issue.parent.number // empty')
+
+# 2. Create B as sibling: same parent as A, blocked-by A
+τ create \
+  --title "{deferred title}" \
+  --body "**Origin:** #${A} (deferred from ...)\n\n{details}" \
+  --blocked-by "#${A}" \
+  ${A_PARENT:+--parent "#${A_PARENT}"}
+```
+
+**Edge cases:**
+- A has no parent → B has no parent either (both top-level). Consider whether A should be re-parented under a freshly-created epic if the fan-out grows.
+- A is already top-level epic → defer creates child of A (epic decomposition pattern applies).
+- Existing follow-up issue B mis-parented under A → fix retroactively:
+  ```bash
+  τ set <B> --rm-parent
+  τ set <B> --parent "#${A_PARENT}"
+  τ set <B> --blocked-by "#${A}"  # ensure traceability link
+  ```
+
+## Complexity Scoring
+
+Assess κ ∈ [1,10] to inform tier (S / F-lite / F-full). Record by appending to issue body:
+
+```bash
+BODY=$(gh issue view <number> --json body --jq .body)
+gh issue edit <number> --body "$BODY
+
+<!-- complexity: <score> -->"
+```
+
+`<!-- complexity: N -->` is machine-parseable; downstream tools (e.g. `/plan`) read it.
+
+**Factors (each 1-10, weighted):**
+
+| Factor | Weight | 1 (Low) | 5 (Medium) | 10 (High) |
+|--------|--------|---------|------------|-----------|
+| **Files touched** | 20% | 1-3 files | 5-10 files | 15+ files |
+| **Technical risk** | 25% | Known patterns | New library/pattern in 1 domain | New architecture |
+| **Architectural impact** | 25% | Single module | Shared types, 2 modules | Cross-domain, new abstractions |
+| **Unknowns count** | 15% | 0 unknowns | 1-2 open questions | 3+ unknowns |
+| **Domain breadth** | 15% | 1 domain | 2 domains | 3+ domains |
+
+**Formula:** `κ = round(files × 0.20 + risk × 0.25 + arch × 0.25 + unknowns × 0.15 + domains × 0.15)`
+
+**Tier mapping:**
+
+| Score | Tier | Process | Agent Mode |
+|-------|------|---------|-----------|
+| 1-3 | **S** | Worktree + direct implementation + PR | Single session, no agents |
+| 4-6 | **F-lite** | Worktree + subagents + /code-review | Task subagents (1-2 domain + tester) |
+| 7-10 | **F-full** | Bootstrap + worktree + agent team + /code-review | TeamCreate (3+ agents, test-first) |
+
+κ is advisory. Human judgment overrides. → DP(B)if score ≠ intuition.
+
+See [Tier Classification Reference](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/tier-classification.md) for full rules.
+Reference: `artifacts/analyses/280-token-consumption.mdx` for scoring examples.
+
+## Example Workflow
+
+```bash
+τ list
+τ list --untriaged
+τ set 42 --size M --priority High
+τ set 91 --blocked-by 117
+τ set 117 --blocks 91,118
+τ set 91 --rm-blocked-by 117
+τ set 164 --parent 163
+τ set 163 --add-child 164,165,166
+τ set 164 --rm-parent
+τ set 163 --rm-child 166
+
+# Cross-repo dependencies (owner/repo#N format)
+τ set 42 --blocked-by Roxabi/lyra#728
+τ set 42 --blocks Roxabi/voiceCLI#94
+
+τ create \
+  --title "research: compare against example/repo" \
+  --body "Deep analysis of example/repo" \
+  --label "research" \
+  --size S --priority Medium \
+  --parent 163
+τ create \
+  --title "epic: improve CI pipeline" \
+  --size L --priority High \
+  --add-child 150,151,152
+
+# Lane and type (additive, optional)
+τ set 42 --lane b
+τ set 42 --type feat
+τ set 42 --size M --priority High --lane c1 --type fix
+```
+
+## Chain Position
+
+- **Phase:** Frame
+- **Predecessor:** — (entry point)
+- **Successor:** `/frame`
+- **Class:** adv (continuous flow, no gate)
+
+## Task Integration
+
+- `/dev` owns the dev-pipeline task lifecycle externally
+- This skill does NOT update its own dev-pipeline task
+- Sub-tasks created: none
+
+## Exit
+
+- **Success via `/dev`:** return control silently. ¬write summary. ¬ask user. ¬announce `/frame`. `/dev` re-scans and advances.
+- **Success standalone:** print one line: `Done. Next: /frame --issue N`. Stop.
+- **Failure:** return error. `/dev` presents Retry | Skip | Abort.
+
+## Related
+
+- [Taxonomy SSoT](../../references/issue-taxonomy.md) — field set, cross-repo behavior, plugin contracts, anti-patterns
+
+$ARGUMENTS

--- a/plugins/roxabi-issues/skills/issue-triage/__tests__/create.test.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/__tests__/create.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+process.env.GITHUB_REPO = 'Test/test-repo'
+
+vi.mock('../../shared/adapters/config-helpers', () => ({
+  GITHUB_REPO: 'Test/test-repo',
+  resolveStatus: (input: string) => {
+    const canonical = new Set(['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      BACKLOG: 'Backlog',
+      ANALYSIS: 'Analysis',
+      SPECS: 'Specs',
+      'IN PROGRESS': 'In Progress',
+      IN_PROGRESS: 'In Progress',
+      INPROGRESS: 'In Progress',
+      REVIEW: 'Review',
+      DONE: 'Done',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveSize: (input: string) => {
+    const u = input.toUpperCase()
+    return new Set(['XS', 'S', 'M', 'L', 'XL']).has(u) ? u : undefined
+  },
+  resolvePriority: (input: string) => {
+    const canonical = new Set(['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      URGENT: 'P0 - Urgent',
+      HIGH: 'P1 - High',
+      MEDIUM: 'P2 - Medium',
+      LOW: 'P3 - Low',
+      P0: 'P0 - Urgent',
+      P1: 'P1 - High',
+      P2: 'P2 - Medium',
+      P3: 'P3 - Low',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveLane: (input: string) =>
+    new Set(['a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3', 'd', 'e']).has(input) ? input : undefined,
+}))
+
+vi.mock('../../shared/adapters/github-infra', () => ({
+  syncPriorityLabel: vi.fn(),
+  syncSizeLabel: vi.fn(),
+  syncLaneLabel: vi.fn(),
+  syncStatusLabel: vi.fn(),
+}))
+
+vi.mock('../../shared/adapters/github-adapter', () => ({
+  createGitHubIssue: vi.fn(),
+  getNodeId: vi.fn(),
+  addBlockedBy: vi.fn(),
+  addSubIssue: vi.fn(),
+  resolveIssueTypeId: vi.fn(),
+  updateIssueIssueType: vi.fn(),
+}))
+
+const github = await import('../../shared/adapters/github-adapter')
+const mockCreateGitHubIssue = github.createGitHubIssue as ReturnType<typeof vi.fn>
+const mockGetNodeId = github.getNodeId as ReturnType<typeof vi.fn>
+const mockAddBlockedBy = github.addBlockedBy as ReturnType<typeof vi.fn>
+const mockAddSubIssue = github.addSubIssue as ReturnType<typeof vi.fn>
+
+const githubInfra = await import('../../shared/adapters/github-infra')
+const mockSyncPriorityLabel = githubInfra.syncPriorityLabel as ReturnType<typeof vi.fn>
+const mockSyncSizeLabel = githubInfra.syncSizeLabel as ReturnType<typeof vi.fn>
+const mockSyncLaneLabel = githubInfra.syncLaneLabel as ReturnType<typeof vi.fn>
+const mockSyncStatusLabel = githubInfra.syncStatusLabel as ReturnType<typeof vi.fn>
+const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
+const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
+
+const { createIssue } = await import('../lib/create')
+
+function setupMocks() {
+  vi.clearAllMocks()
+  mockCreateGitHubIssue.mockResolvedValue({
+    url: 'https://github.com/test/repo/issues/99',
+    number: 99,
+  })
+  mockGetNodeId.mockImplementation(async (num) => `node-${num}`)
+  mockResolveIssueTypeId.mockResolvedValue('issue-type-id')
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+}
+
+describe('issue-triage/create > basic creation', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates an issue with title', async () => {
+    await createIssue(['--title', 'Test issue'])
+    expect(mockCreateGitHubIssue).toHaveBeenCalledWith('Test issue', undefined, undefined)
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Created #99'))
+  })
+
+  it('syncs size label on creation', async () => {
+    await createIssue(['--title', 'Test', '--size', 'M'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(99, 'M')
+  })
+
+  it('syncs priority label on creation', async () => {
+    await createIssue(['--title', 'Test', '--priority', 'High'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(99, 'P1 - High')
+  })
+
+  it('syncs status label on creation', async () => {
+    await createIssue(['--title', 'Test', '--status', 'In Progress'])
+    expect(mockSyncStatusLabel).toHaveBeenCalledWith(99, 'In Progress')
+  })
+})
+
+describe('issue-triage/create > relationships', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('sets parent relationship', async () => {
+    await createIssue(['--title', 'Child', '--parent', '50'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-50', 'node-99')
+  })
+
+  it('sets cross-repo parent relationship', async () => {
+    await createIssue(['--title', 'Child', '--parent', 'Roxabi/lyra#100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-100', 'node-99')
+  })
+
+  it('adds children', async () => {
+    await createIssue(['--title', 'Epic', '--add-child', '60,61'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-99', 'node-60')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-99', 'node-61')
+  })
+
+  it('adds cross-repo children', async () => {
+    await createIssue(['--title', 'Epic', '--add-child', 'Roxabi/lyra#60'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(60, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-99', 'node-60')
+  })
+
+  it('sets blocked-by dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocked-by', '10,11'])
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-99', 'node-10')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-99', 'node-11')
+  })
+
+  it('sets cross-repo blocked-by dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocked-by', 'Roxabi/lyra#728'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-99', 'node-728')
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Roxabi/lyra#728'))
+  })
+
+  it('sets blocking dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocks', '20'])
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-20', 'node-99')
+  })
+
+  it('sets cross-repo blocking dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocks', 'Roxabi/voiceCLI#94'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(94, 'Roxabi/voiceCLI')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-94', 'node-99')
+  })
+
+  it('handles mixed local and cross-repo refs', async () => {
+    await createIssue(['--title', 'Test', '--blocked-by', '10, Roxabi/lyra#728, #11'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(10, undefined)
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockGetNodeId).toHaveBeenCalledWith(11, undefined)
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('issue-triage/create > options and error handling', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('includes labels in create call', async () => {
+    await createIssue(['--title', 'Test', '--label', 'bug,frontend'])
+    expect(mockCreateGitHubIssue).toHaveBeenCalledWith('Test', undefined, ['bug', 'frontend'])
+  })
+
+  it('includes body in create call', async () => {
+    await createIssue(['--title', 'Test', '--body', 'Description here'])
+    expect(mockCreateGitHubIssue).toHaveBeenCalledWith('Test', 'Description here', undefined)
+  })
+})
+
+describe('issue-triage/create > priority label sync', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('syncs priority label when --priority is provided', async () => {
+    await createIssue(['--title', 'Test', '--priority', 'High'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(99, 'P1 - High')
+  })
+
+  it('does not sync priority label when --priority is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockSyncPriorityLabel).not.toHaveBeenCalled()
+  })
+
+  it('syncs size label when --size is provided', async () => {
+    await createIssue(['--title', 'Test', '--size', 'M'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(99, 'M')
+  })
+
+  it('syncs status label when --status is provided', async () => {
+    await createIssue(['--title', 'Test', '--status', 'In Progress'])
+    expect(mockSyncStatusLabel).toHaveBeenCalledWith(99, 'In Progress')
+  })
+})
+
+describe('issue-triage/create > type', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('sets issue type on creation', async () => {
+    await createIssue(['--title', 'Test', '--type', 'feat'])
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'feat')
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-99', 'issue-type-id')
+  })
+
+  it('accepts extended types (epic)', async () => {
+    await createIssue(['--title', 'Test', '--type', 'epic'])
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-99', 'issue-type-id')
+  })
+
+  it('normalizes type case', async () => {
+    await createIssue(['--title', 'Test', '--type', 'FIX'])
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'fix')
+  })
+
+  it('does not set type when --type is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/create > lane', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('syncs lane label when --lane is provided', async () => {
+    await createIssue(['--title', 'Test', '--lane', 'a1'])
+    expect(mockSyncLaneLabel).toHaveBeenCalledWith(99, 'a1')
+  })
+
+  it('does not sync lane label when --lane is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockSyncLaneLabel).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/roxabi-issues/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/__tests__/set.test.ts
@@ -1,0 +1,460 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
+
+// Provide base project config for tests
+process.env.GITHUB_REPO = 'Test/test-repo'
+
+// Mock config before github — vi.mock is hoisted before process.env assignments,
+// so importOriginal would load config.ts with empty env vars. Manual factory is required.
+vi.mock('../../shared/adapters/config-helpers', () => ({
+  NOT_CONFIGURED_MSG: 'GitHub Project V2 is not configured.',
+  GITHUB_REPO: 'Test/test-repo',
+  DEFAULT_SIZE_OPTIONS: ['S', 'F-lite', 'F-full'],
+  resolveStatus: (input: string) => {
+    const canonical = new Set(['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      BACKLOG: 'Backlog',
+      ANALYSIS: 'Analysis',
+      SPECS: 'Specs',
+      'IN PROGRESS': 'In Progress',
+      IN_PROGRESS: 'In Progress',
+      INPROGRESS: 'In Progress',
+      REVIEW: 'Review',
+      DONE: 'Done',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveSize: (input: string) => {
+    const valid = new Set(['S', 'F-lite', 'F-full'])
+    if (valid.has(input)) return input
+    const u = input.toUpperCase().replace(/[-\s]/g, '-')
+    if (valid.has(u as 'S' | 'F-lite' | 'F-full')) return u
+    // Aliases
+    if (u === 'XS') return 'S'
+    if (u === 'M') return 'F-lite'
+    if (u === 'L' || u === 'XL') return 'F-full'
+    return undefined
+  },
+  resolvePriority: (input: string) => {
+    const canonical = new Set(['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      URGENT: 'P0 - Urgent',
+      HIGH: 'P1 - High',
+      MEDIUM: 'P2 - Medium',
+      LOW: 'P3 - Low',
+      P0: 'P0 - Urgent',
+      P1: 'P1 - High',
+      P2: 'P2 - Medium',
+      P3: 'P3 - Low',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveLane: (input: string) => {
+    const valid = new Set(['a1', 'a2', 'b', 'c1', 'c2', 'c3', 'd', 'e', 'f', 'standalone'])
+    return valid.has(input) ? input : undefined
+  },
+}))
+
+vi.mock('../../shared/adapters/github-infra', () => ({
+  syncPriorityLabel: vi.fn(),
+  syncSizeLabel: vi.fn(),
+  syncLaneLabel: vi.fn(),
+  syncStatusLabel: vi.fn(),
+}))
+
+vi.mock('../../shared/adapters/github-adapter', () => ({
+  getNodeId: vi.fn(),
+  getParentNumber: vi.fn(),
+  addBlockedBy: vi.fn(),
+  removeBlockedBy: vi.fn(),
+  addSubIssue: vi.fn(),
+  removeSubIssue: vi.fn(),
+  resolveIssueTypeId: vi.fn(),
+  updateIssueIssueType: vi.fn(),
+}))
+
+const github = await import('../../shared/adapters/github-adapter')
+const mockGetNodeId = github.getNodeId as ReturnType<typeof vi.fn>
+const mockAddBlockedBy = github.addBlockedBy as ReturnType<typeof vi.fn>
+const mockRemoveBlockedBy = github.removeBlockedBy as ReturnType<typeof vi.fn>
+const mockAddSubIssue = github.addSubIssue as ReturnType<typeof vi.fn>
+const mockRemoveSubIssue = github.removeSubIssue as ReturnType<typeof vi.fn>
+const mockGetParentNumber = github.getParentNumber as ReturnType<typeof vi.fn>
+const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
+const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
+
+const githubInfra = await import('../../shared/adapters/github-infra')
+const mockSyncPriorityLabel = githubInfra.syncPriorityLabel as ReturnType<typeof vi.fn>
+const mockSyncSizeLabel = githubInfra.syncSizeLabel as ReturnType<typeof vi.fn>
+const mockSyncLaneLabel = githubInfra.syncLaneLabel as ReturnType<typeof vi.fn>
+const mockSyncStatusLabel = githubInfra.syncStatusLabel as ReturnType<typeof vi.fn>
+
+const { setIssue } = await import('../lib/set')
+
+function setupMocks() {
+  vi.clearAllMocks()
+  // repo included in key so cross-repo calls return distinguishable node IDs
+  mockGetNodeId.mockImplementation(async (num, repo?: string) =>
+    repo ? `node-${repo.replace('/', '-')}-${num}` : `node-${num}`,
+  )
+  mockResolveIssueTypeId.mockResolvedValue('type-id-feat')
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  // console.error spy installed here — .mock.calls still accessible when impl is () => {}
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+}
+
+describe('issue-triage/set > field updates', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('updates size via label', async () => {
+    await setIssue(['42', '--size', 'F-lite'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(42, 'F-lite')
+  })
+
+  it('updates priority via label with alias', async () => {
+    await setIssue(['42', '--priority', 'High'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(42, 'P1 - High')
+  })
+
+  it('updates status — no status:* label sync (issues-only model)', async () => {
+    await setIssue(['42', '--status', 'In Progress'])
+    // issues-only model: status is open/closed; no redundant status:* label
+    expect(mockSyncStatusLabel).not.toHaveBeenCalled()
+  })
+
+  it('exits with error for invalid --size value', async () => {
+    // Arrange — throw on exit so execution stops after the guard, matching real process.exit semantics
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`process.exit:${code}`)
+    }) as never)
+    // Act
+    await setIssue(['42', '--size', 'bogus']).catch(() => {})
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('Invalid size'))).toBe(true)
+  })
+
+  it('logs Size= exactly once for --size (no duplicate)', async () => {
+    // Arrange
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(String(args[0])))
+    // Act
+    await setIssue(['42', '--size', 'F-lite'])
+    // Assert
+    expect(logs.filter((l) => l.startsWith('Size=')).length).toBe(1)
+  })
+})
+
+describe('issue-triage/set > dependencies', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('adds blocked-by dependency', async () => {
+    await setIssue(['42', '--blocked-by', '100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(42, undefined)
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, undefined)
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-42', 'node-100')
+  })
+
+  it('adds multiple comma-separated blocked-by deps', async () => {
+    await setIssue(['42', '--blocked-by', '100,101,102'])
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(3)
+  })
+
+  it('adds blocking dependency (reverse direction)', async () => {
+    await setIssue(['42', '--blocks', '50'])
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-50', 'node-42')
+  })
+
+  it('removes blocked-by dependency', async () => {
+    await setIssue(['42', '--rm-blocked-by', '100'])
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-42', 'node-100')
+  })
+
+  it('removes blocking dependency', async () => {
+    await setIssue(['42', '--rm-blocks', '50'])
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-50', 'node-42')
+  })
+
+  it('adds cross-repo blocked-by dependency', async () => {
+    await setIssue(['42', '--blocked-by', 'Roxabi/lyra#728'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-42', 'node-Roxabi-lyra-728')
+  })
+
+  it('adds cross-repo blocks dependency', async () => {
+    await setIssue(['42', '--blocks', 'Roxabi/voiceCLI#94'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(94, 'Roxabi/voiceCLI')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-Roxabi-voiceCLI-94', 'node-42')
+  })
+
+  it('handles mixed local and cross-repo refs', async () => {
+    await setIssue(['42', '--blocked-by', '100, Roxabi/lyra#728, #101'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, undefined)
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockGetNodeId).toHaveBeenCalledWith(101, undefined)
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('issue-triage/set > parent-child relationships', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('sets parent relationship', async () => {
+    await setIssue(['42', '--parent', '10'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-10', 'node-42')
+  })
+
+  it('sets cross-repo parent relationship', async () => {
+    await setIssue(['42', '--parent', 'Roxabi/lyra#100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-lyra-100', 'node-42')
+  })
+
+  it('adds children', async () => {
+    await setIssue(['42', '--add-child', '50,51'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-50')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-51')
+  })
+
+  it('adds cross-repo children', async () => {
+    await setIssue(['42', '--add-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-Roxabi-lyra-50')
+  })
+
+  it('removes parent', async () => {
+    mockGetParentNumber.mockResolvedValue(10)
+    await setIssue(['42', '--rm-parent'])
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith('node-10', 'node-42')
+  })
+
+  it('removes children', async () => {
+    await setIssue(['42', '--rm-child', '50'])
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith('node-42', 'node-50')
+  })
+})
+
+describe('issue-triage/set > combined flags', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('handles multiple flags at once', async () => {
+    await setIssue(['42', '--size', 'F-full', '--priority', 'Urgent', '--blocked-by', '99'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(42, 'F-full')
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(42, 'P0 - Urgent')
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(1)
+  })
+
+  it('strips # prefix from issue numbers', async () => {
+    await setIssue(['42', '--blocked-by', '#100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, undefined)
+  })
+})
+
+describe('issue-triage/set > priority label sync', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('syncs priority label when --priority is provided', async () => {
+    await setIssue(['42', '--priority', 'Medium'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(42, 'P2 - Medium')
+  })
+
+  it('does not sync priority label when --priority is not provided', async () => {
+    await setIssue(['42', '--size', 'F-lite'])
+    expect(mockSyncPriorityLabel).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > --lane flag', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('updates lane via label', async () => {
+    await setIssue(['123', '--lane', 'c1'])
+    expect(mockSyncLaneLabel).toHaveBeenCalledWith(123, 'c1')
+  })
+
+  it('does nothing for invalid lane key (resolveLane returns undefined)', async () => {
+    await setIssue(['123', '--lane', 'zzz'])
+    expect(mockSyncLaneLabel).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > --type flag', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves type id and calls updateIssueIssueType for valid type', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--type', 'feat'])
+    // Assert
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'feat')
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', 'type-id-feat')
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls process.exit(1) and prints error for invalid type', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--type', 'bogus'])
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((msg) => msg.includes('Invalid type') || msg.includes('Valid'))).toBe(true)
+  })
+})
+
+describe('issue-triage/set > cross-repo subject', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves cross-repo subject for --blocked-by', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--blocked-by', 'Roxabi/lyra#1063,Roxabi/lyra#1064'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1063, 'Roxabi/lyra')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1064, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves cross-repo subject for --blocks', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--blocks', 'Roxabi/lyra#200'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-Roxabi-lyra-200', 'node-Roxabi-voiceCLI-144')
+  })
+
+  it('resolves cross-repo subject for --parent', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--parent', 'Roxabi/lyra#10'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(10, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-lyra-10', 'node-Roxabi-voiceCLI-144')
+  })
+
+  it('resolves cross-repo subject for --add-child', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--add-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-50')
+  })
+
+  it('skips label sync for cross-repo subject with --status (no-op, no error)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['Roxabi/voiceCLI#144', '--status', 'Backlog'])
+    expect(exitSpy).not.toHaveBeenCalled()
+    // issues-only model: --status is a no-op (open/closed only), no label sync for any subject
+    expect(mockSyncStatusLabel).not.toHaveBeenCalled()
+    // No label-sync warning fires for --status-only cross-repo call
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.every((m) => !m.includes('label sync'))).toBe(true)
+  })
+
+  it('skips label sync for cross-repo subject with --size', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--size', 'S'])
+    expect(mockSyncSizeLabel).not.toHaveBeenCalled()
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('label sync') && m.includes('cross-repo'))).toBe(true)
+  })
+
+  it('exits with error for --rm-parent on cross-repo subject', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-parent'])
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('--rm-parent') && m.includes('cross-repo'))).toBe(true)
+  })
+
+  it('log output shows cross-repo subject correctly', async () => {
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(String(args[0])))
+    await setIssue(['Roxabi/voiceCLI#144', '--blocked-by', '100'])
+    expect(logs.some((l) => l.includes('Roxabi/voiceCLI#144'))).toBe(true)
+    expect(logs.some((l) => l.includes('#100'))).toBe(true)
+  })
+
+  it('removes blocked-by with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-blocked-by', 'Roxabi/lyra#1063'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1063, 'Roxabi/lyra')
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-1063')
+  })
+
+  it('removes blocks with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-blocks', 'Roxabi/lyra#200'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-Roxabi-lyra-200', 'node-Roxabi-voiceCLI-144')
+  })
+
+  it('removes child with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-50')
+  })
+})
+
+describe('issue-triage/set > additive regression', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('--size alone does not call lane or type mutations', async () => {
+    await setIssue(['123', '--size', 'S'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(123, 'S')
+    expect(mockSyncLaneLabel).not.toHaveBeenCalled()
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > applyType accepts all 10 canonical values', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  const ALL_VALID_TYPES = [...ISSUE_TYPE_NAMES, ...EXTENDED_ISSUE_TYPES]
+
+  it('accepts every value in the canonical set without calling process.exit', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    for (const t of ALL_VALID_TYPES) {
+      vi.clearAllMocks()
+      mockGetNodeId.mockResolvedValue(`node-123`)
+      mockResolveIssueTypeId.mockResolvedValue(`type-id-${t}`)
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      await setIssue(['123', '--type', t])
+      expect(exitSpy).not.toHaveBeenCalled()
+      expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', `type-id-${t}`)
+    }
+  })
+
+  it('rejects an unknown type and calls process.exit(1)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['123', '--type', 'unknown-type'])
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('Invalid type'))).toBe(true)
+  })
+})
+
+describe('issue-triage/set > combined --lane + --type + --size', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('applies all three mutations when combined flags provided', async () => {
+    await setIssue(['123', '--lane', 'a1', '--type', 'feat', '--size', 'S'])
+    // Assert — size label
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(123, 'S')
+    // Assert — lane label
+    expect(mockSyncLaneLabel).toHaveBeenCalledWith(123, 'a1')
+    // Assert — type mutation
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', 'type-id-feat')
+  })
+})

--- a/plugins/roxabi-issues/skills/issue-triage/lib/create.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/lib/create.ts
@@ -1,0 +1,192 @@
+/**
+ * Create a new GitHub issue with optional labels, parent, children, and dependencies.
+ * Issues-only mode: size/priority/status/lane are set via labels only (no ProjectV2 board).
+ */
+
+import {
+  GITHUB_REPO,
+  resolveLane,
+  resolvePriority,
+  resolveSize,
+  resolveStatus,
+} from '../../shared/adapters/config-helpers'
+import {
+  addBlockedBy,
+  addSubIssue,
+  createGitHubIssue,
+  getNodeId,
+  resolveIssueTypeId,
+  updateIssueIssueType,
+} from '../../shared/adapters/github-adapter'
+import { syncLaneLabel, syncPriorityLabel, syncSizeLabel, syncStatusLabel } from '../../shared/adapters/github-infra'
+import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
+import { formatRef, parseIssueRefs } from '../../shared/domain/parse-issue-ref'
+
+interface CreateOptions {
+  title: string
+  body?: string
+  labels?: string
+  size?: string
+  priority?: string
+  status?: string
+  lane?: string
+  type?: string
+  parent?: string
+  blockedBy?: string
+  blocks?: string
+  addChild?: string
+}
+
+function parseArgs(args: string[]): CreateOptions {
+  const opts: CreateOptions = { title: '' }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    switch (arg) {
+      case '--title':
+        opts.title = args[++i]
+        break
+      case '--body':
+        opts.body = args[++i]
+        break
+      case '--label':
+        opts.labels = args[++i]
+        break
+      case '--size':
+        opts.size = args[++i]
+        break
+      case '--priority':
+        opts.priority = args[++i]
+        break
+      case '--status':
+        opts.status = args[++i]
+        break
+      case '--lane':
+        opts.lane = args[++i]
+        break
+      case '--type':
+        opts.type = args[++i]
+        break
+      case '--parent':
+        opts.parent = args[++i]
+        break
+      case '--blocked-by':
+        opts.blockedBy = args[++i]
+        break
+      case '--blocks':
+        opts.blocks = args[++i]
+        break
+      case '--add-child':
+        opts.addChild = args[++i]
+        break
+      default:
+        console.error(`Error: Unknown option '${arg}'`)
+        process.exit(1)
+    }
+    i++
+  }
+
+  return opts
+}
+
+const VALID_TYPES: string[] = [...ISSUE_TYPE_NAMES, ...EXTENDED_ISSUE_TYPES]
+
+async function applyType(issueNumber: number, nodeId: string, type: string): Promise<void> {
+  const canonical = type.toLowerCase()
+  if (!VALID_TYPES.includes(canonical)) {
+    console.error(`Error: Invalid type. Valid: ${VALID_TYPES.join(', ')}`)
+    process.exit(1)
+  }
+  const org = GITHUB_REPO.split('/')[0]
+  const typeId = await resolveIssueTypeId(org, canonical)
+  await updateIssueIssueType(nodeId, typeId)
+  console.log(`Type=${canonical} #${issueNumber}`)
+}
+
+async function syncLabels(issueNumber: number, opts: CreateOptions): Promise<void> {
+  if (opts.priority) {
+    const canonical = resolvePriority(opts.priority)
+    if (canonical) await syncPriorityLabel(issueNumber, canonical)
+  }
+  if (opts.size) {
+    const canonical = resolveSize(opts.size)
+    if (canonical) await syncSizeLabel(issueNumber, canonical)
+  }
+  if (opts.lane) {
+    const canonical = resolveLane(opts.lane)
+    if (canonical) {
+      await syncLaneLabel(issueNumber, canonical)
+      console.log(`Lane=${canonical} #${issueNumber}`)
+    }
+  }
+  if (opts.status) {
+    const canonical = resolveStatus(opts.status)
+    if (canonical) await syncStatusLabel(issueNumber, canonical)
+  }
+}
+
+async function applyRelationships(nodeId: string, issueNumber: number, opts: CreateOptions): Promise<void> {
+  if (opts.parent) {
+    const parentRef = parseIssueRefs(opts.parent)[0]
+    if (parentRef) {
+      const parentNodeId = await getNodeId(parentRef.number, parentRef.repo)
+      await addSubIssue(parentNodeId, nodeId)
+      console.log(`Parent=${formatRef(parentRef)} #${issueNumber}`)
+    }
+  }
+
+  if (opts.addChild) {
+    for (const childRef of parseIssueRefs(opts.addChild)) {
+      const childNodeId = await getNodeId(childRef.number, childRef.repo)
+      await addSubIssue(nodeId, childNodeId)
+      console.log(`Child=${formatRef(childRef)} #${issueNumber}`)
+    }
+  }
+
+  if (opts.blockedBy) {
+    for (const ref of parseIssueRefs(opts.blockedBy)) {
+      const blockingNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(nodeId, blockingNodeId)
+      console.log(`BlockedBy=${formatRef(ref)} #${issueNumber}`)
+    }
+  }
+
+  if (opts.blocks) {
+    for (const ref of parseIssueRefs(opts.blocks)) {
+      const blockedNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(blockedNodeId, nodeId)
+      console.log(`Blocks=${formatRef(ref)} #${issueNumber}`)
+    }
+  }
+}
+
+export async function createIssue(args: string[]): Promise<void> {
+  const opts = parseArgs(args)
+
+  if (!opts.title) {
+    console.error('Error: --title is required')
+    process.exit(1)
+  }
+
+  // Create the issue via REST API
+  const labels = opts.labels
+    ?.split(',')
+    .map((l) => l.trim())
+    .filter(Boolean)
+  const result = await createGitHubIssue(opts.title, opts.body, labels)
+  const issueNumber = result.number
+  console.log(`Created #${issueNumber}: ${opts.title}`)
+
+  const nodeId = await getNodeId(issueNumber)
+
+  // Issue type is independent of the project board
+  if (opts.type) {
+    await applyType(issueNumber, nodeId, opts.type)
+  }
+
+  // Set size/priority/status/lane via labels only (issues-only mode)
+  await syncLabels(issueNumber, opts)
+
+  await applyRelationships(nodeId, issueNumber, opts)
+}

--- a/plugins/roxabi-issues/skills/issue-triage/lib/set.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/lib/set.ts
@@ -1,0 +1,292 @@
+/**
+ * Update an existing issue: labels, dependencies, and parent/child relations.
+ * Replaces set.sh.
+ */
+
+import {
+  DEFAULT_SIZE_OPTIONS,
+  GITHUB_REPO,
+  resolveLane,
+  resolvePriority,
+  resolveSize,
+} from '../../shared/adapters/config-helpers'
+import {
+  addBlockedBy,
+  addSubIssue,
+  getNodeId,
+  getParentNumber,
+  removeBlockedBy,
+  removeSubIssue,
+  resolveIssueTypeId,
+  updateIssueIssueType,
+} from '../../shared/adapters/github-adapter'
+import { syncLaneLabel, syncPriorityLabel, syncSizeLabel } from '../../shared/adapters/github-infra'
+import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
+import { formatRef, parseIssueRef, parseIssueRefs } from '../../shared/domain/parse-issue-ref'
+
+interface SetOptions {
+  issueNumber: number
+  subjectRepo?: string
+  size?: string
+  priority?: string
+  status?: string
+  lane?: string
+  type?: string
+  blockedBy?: string
+  blocks?: string
+  rmBlockedBy?: string
+  rmBlocks?: string
+  parent?: string
+  addChild?: string
+  rmParent: boolean
+  rmChild?: string
+}
+
+function parseArgs(args: string[]): SetOptions {
+  const opts: SetOptions = { issueNumber: 0, rmParent: false }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    switch (arg) {
+      case '--size':
+        opts.size = args[++i]
+        break
+      case '--priority':
+        opts.priority = args[++i]
+        break
+      case '--status':
+        opts.status = args[++i]
+        break
+      case '--lane':
+        opts.lane = args[++i]
+        break
+      case '--type':
+        opts.type = args[++i]
+        break
+      case '--blocked-by':
+        opts.blockedBy = args[++i]
+        break
+      case '--blocks':
+        opts.blocks = args[++i]
+        break
+      case '--rm-blocked-by':
+        opts.rmBlockedBy = args[++i]
+        break
+      case '--rm-blocks':
+        opts.rmBlocks = args[++i]
+        break
+      case '--parent':
+        opts.parent = args[++i]
+        break
+      case '--add-child':
+        opts.addChild = args[++i]
+        break
+      case '--rm-parent':
+        opts.rmParent = true
+        break
+      case '--rm-child':
+        opts.rmChild = args[++i]
+        break
+      default:
+        if (!opts.issueNumber) {
+          if (/^\d+$/.test(arg)) {
+            opts.issueNumber = Number(arg)
+          } else {
+            const ref = parseIssueRef(arg)
+            if (ref) {
+              opts.issueNumber = ref.number
+              opts.subjectRepo = ref.repo
+            }
+          }
+        }
+        break
+    }
+    i++
+  }
+
+  return opts
+}
+
+function subjectStr(issueNumber: number, repo?: string): string {
+  return repo ? `${repo}#${issueNumber}` : `#${issueNumber}`
+}
+
+const VALID_TYPES: string[] = [...ISSUE_TYPE_NAMES, ...EXTENDED_ISSUE_TYPES]
+
+async function applyType(issueNumber: number, type: string): Promise<void> {
+  const canonical = type.toLowerCase()
+  if (!VALID_TYPES.includes(canonical)) {
+    console.error(`Error: Invalid type. Valid: ${VALID_TYPES.join(', ')}`)
+    process.exit(1)
+  }
+  const issueNodeId = await getNodeId(issueNumber)
+  const org = GITHUB_REPO.split('/')[0]
+  const typeId = await resolveIssueTypeId(org, canonical)
+  await updateIssueIssueType(issueNodeId, typeId)
+  console.log(`Type=${canonical} #${issueNumber}`)
+}
+
+async function applyDependencies(issueNumber: number, opts: SetOptions): Promise<void> {
+  const subjStr = subjectStr(issueNumber, opts.subjectRepo)
+
+  if (opts.blockedBy) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.blockedBy)) {
+      const blockingNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(issueNodeId, blockingNodeId)
+      console.log(`BlockedBy=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+
+  if (opts.blocks) {
+    const blockingNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.blocks)) {
+      const blockedNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(blockedNodeId, blockingNodeId)
+      console.log(`Blocks=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+
+  if (opts.rmBlockedBy) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.rmBlockedBy)) {
+      const blockingNodeId = await getNodeId(ref.number, ref.repo)
+      await removeBlockedBy(issueNodeId, blockingNodeId)
+      console.log(`RemovedBlockedBy=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+
+  if (opts.rmBlocks) {
+    const blockingNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.rmBlocks)) {
+      const blockedNodeId = await getNodeId(ref.number, ref.repo)
+      await removeBlockedBy(blockedNodeId, blockingNodeId)
+      console.log(`RemovedBlocks=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+}
+
+async function applyParentChild(issueNumber: number, opts: SetOptions): Promise<void> {
+  const subjStr = subjectStr(issueNumber, opts.subjectRepo)
+
+  if (opts.parent) {
+    const parentRef = parseIssueRefs(opts.parent)[0]
+    if (parentRef) {
+      const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+      const parentNodeId = await getNodeId(parentRef.number, parentRef.repo)
+      await addSubIssue(parentNodeId, issueNodeId)
+      console.log(`Parent=${formatRef(parentRef)} ${subjStr}`)
+    }
+  }
+
+  if (opts.addChild) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const childRef of parseIssueRefs(opts.addChild)) {
+      const childNodeId = await getNodeId(childRef.number, childRef.repo)
+      await addSubIssue(issueNodeId, childNodeId)
+      console.log(`Child=${formatRef(childRef)} ${subjStr}`)
+    }
+  }
+
+  if (opts.rmParent) {
+    if (opts.subjectRepo) {
+      console.error(`Error: --rm-parent is not supported for cross-repo subjects (${subjStr}) — use direct GraphQL`)
+      process.exit(1)
+    }
+    const parentNum = await getParentNumber(issueNumber)
+    if (parentNum) {
+      const issueNodeId = await getNodeId(issueNumber)
+      const parentNodeId = await getNodeId(parentNum)
+      await removeSubIssue(parentNodeId, issueNodeId)
+      console.log(`RemovedParent=#${parentNum} ${subjStr}`)
+    } else {
+      console.log(`No parent found for ${subjStr}`)
+    }
+  }
+
+  if (opts.rmChild) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const childRef of parseIssueRefs(opts.rmChild)) {
+      const childNodeId = await getNodeId(childRef.number, childRef.repo)
+      await removeSubIssue(issueNodeId, childNodeId)
+      console.log(`RemovedChild=${formatRef(childRef)} ${subjStr}`)
+    }
+  }
+}
+
+export async function setIssue(args: string[]): Promise<void> {
+  const opts = parseArgs(args)
+
+  if (!opts.issueNumber) {
+    console.error('Error: Issue number required')
+    process.exit(1)
+  }
+
+  const hasAction =
+    opts.size ||
+    opts.priority ||
+    opts.status ||
+    opts.lane ||
+    opts.type ||
+    opts.blockedBy ||
+    opts.blocks ||
+    opts.rmBlockedBy ||
+    opts.rmBlocks ||
+    opts.parent ||
+    opts.addChild ||
+    opts.rmParent ||
+    opts.rmChild
+
+  if (!hasAction) {
+    console.error(
+      'Error: Specify --size, --priority, --status, --lane, --type, --blocked-by, --blocks, --rm-blocked-by, --rm-blocks, --parent, --add-child, --rm-parent, and/or --rm-child',
+    )
+    process.exit(1)
+  }
+
+  // Type is independent of project board
+  if (opts.type) {
+    if (opts.subjectRepo) {
+      console.error(
+        `Warning: --type is not supported for cross-repo subjects (${opts.subjectRepo}#${opts.issueNumber}) — skipped`,
+      )
+    } else {
+      await applyType(opts.issueNumber, opts.type)
+    }
+  }
+
+  // Sync labels — skipped for cross-repo subjects.
+  // Status is intentionally excluded: in the issues-only model status is just
+  // open/closed and the dep-graph derives ready/blocked/done from edges, so a
+  // `status:*` label is redundant (and noisy on repos that lack the label).
+  if (opts.subjectRepo && (opts.priority || opts.size || opts.lane)) {
+    console.error(
+      `Warning: --size/--priority/--lane label sync is not supported for cross-repo subjects (${opts.subjectRepo}#${opts.issueNumber}) — skipped`,
+    )
+  } else {
+    if (opts.priority) {
+      const canonical = resolvePriority(opts.priority)
+      if (canonical) await syncPriorityLabel(opts.issueNumber, canonical)
+    }
+    if (opts.size) {
+      const canonical = resolveSize(opts.size)
+      if (!canonical) {
+        console.error(`Error: Invalid size '${opts.size}'. Valid: ${DEFAULT_SIZE_OPTIONS.join(', ')}`)
+        process.exit(1)
+      }
+      await syncSizeLabel(opts.issueNumber, canonical)
+      console.log(`Size=${canonical} #${opts.issueNumber}`)
+    }
+    if (opts.lane) {
+      const canonical = resolveLane(opts.lane)
+      if (canonical) {
+        await syncLaneLabel(opts.issueNumber, canonical)
+        console.log(`Lane=${canonical} #${opts.issueNumber}`)
+      }
+    }
+  }
+
+  await applyDependencies(opts.issueNumber, opts)
+  await applyParentChild(opts.issueNumber, opts)
+}

--- a/plugins/roxabi-issues/skills/issue-triage/triage.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/triage.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+/**
+ * Issue triage CLI — router that delegates to command modules.
+ * Replaces triage.sh.
+ *
+ * Usage:
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set <number> [--size S] [--priority P] [--lane L] [--blocked-by N] [--parent N] [--child N] ...
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts create --title "Title" [--body "Body"] ...
+ */
+
+const args = process.argv.slice(2)
+const command = args[0] ?? ''
+const rest = args.slice(1)
+
+switch (command) {
+  case 'set': {
+    const { setIssue } = await import('./lib/set')
+    await setIssue(rest)
+    break
+  }
+  case 'create': {
+    const { createIssue } = await import('./lib/create')
+    await createIssue(rest)
+    break
+  }
+  default:
+    console.error('Usage: triage.ts [set|create] ...')
+    process.exit(1)
+}

--- a/plugins/roxabi-issues/skills/shared/adapters/config-helpers.ts
+++ b/plugins/roxabi-issues/skills/shared/adapters/config-helpers.ts
@@ -1,0 +1,273 @@
+/**
+ * Pure config helper functions extracted from the legacy config.ts shim.
+ * These are used by EnvConfigAdapter and re-exported from config.ts for backward compat.
+ */
+
+import { readFileSync } from 'node:fs'
+import { ConfigError } from '../domain/errors'
+
+/**
+ * Load a config value from .claude/dev-core.yml with 3-tier fallback:
+ *   1st: .claude/dev-core.yml (YAML key lookup)
+ *   2nd: process.env[envKey]
+ *   3rd: gh CLI auto-detect (github_repo, gh_project_id)
+ */
+function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
+  // 1st: Try .claude/dev-core.yml
+  try {
+    const yaml = readFileSync('.claude/dev-core.yml', 'utf-8')
+    const match = yaml.match(new RegExp(`^${key}:\\s*['"]?(.+?)['"]?\\s*$`, 'm'))
+    const value = match?.[1]
+    if (value && value !== "''") return value
+  } catch {
+    /* file not found — fall through */
+  }
+
+  // 2nd: Fall back to env var
+  const envValue = process.env[envKey ?? key.toUpperCase()]
+  if (envValue) return envValue
+
+  // 3rd: Auto-detect via gh CLI for supported keys
+  if (key === 'github_repo') {
+    try {
+      const proc = Bun.spawnSync(['gh', 'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (proc.exitCode === 0) return new TextDecoder().decode(proc.stdout).trim()
+    } catch {
+      /* gh not available */
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * A GitHub repo slug: exactly `owner/repo`.
+ * Owner: alphanumeric + hyphen, must start with an alphanumeric character
+ * (GitHub username rule — dots/underscores not allowed in owner segment).
+ * Name: allows dots/underscores after a leading alphanumeric character.
+ * Callers do `detectGitHubRepo().split('/')` and expect exactly two non-empty segments.
+ */
+export const REPO_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/**
+ * Validate a candidate GitHub repo slug and throw a clear error if it doesn't match.
+ * Used by both the yaml/env path and the git-remote fallback in detectGitHubRepo().
+ */
+function assertValidRepoSlug(value: string): string {
+  if (!REPO_SLUG_RE.test(value)) {
+    throw new ConfigError(
+      `Invalid GitHub repo "${value}". Expected "owner/repo" format ` +
+        '(set github_repo in dev-core config or the GITHUB_REPO env var).',
+    )
+  }
+  return value
+}
+
+export function detectGitHubRepo(): string {
+  const fromYamlOrEnv = loadDevCoreConfig('github_repo', 'GITHUB_REPO')
+  if (fromYamlOrEnv) {
+    // Guard the yaml/env path: callers do `detectGitHubRepo().split('/')` and
+    // expect `owner/repo`. A bare value (e.g. `GITHUB_REPO=myrepo`) would slip
+    // through as a silent `undefined` repo → malformed GraphQL. Fail loud here.
+    return assertValidRepoSlug(fromYamlOrEnv)
+  }
+  try {
+    const proc = Bun.spawnSync(['git', 'remote', 'get-url', 'origin'], { stdout: 'pipe', stderr: 'pipe' })
+    const url = new TextDecoder().decode(proc.stdout).trim()
+    // SSH: git@github.com:owner/repo.git  |  HTTPS: https://github.com/owner/repo.git
+    const match = url.match(/[:/]([^/:]+\/[^/]+?)(?:\.git)?$/)
+    // Validate the extracted candidate — a malformed remote must not silently
+    // return a bad slug that callers would split('/') into garbage GraphQL args.
+    if (match?.[1]) return assertValidRepoSlug(match[1])
+  } catch {}
+  throw new ConfigError(
+    'Cannot detect GitHub repo. Set GITHUB_REPO env var or ensure git remote "origin" is configured.',
+  )
+}
+
+// CLI aliases — map loose user input to canonical option keys
+export const STATUS_ALIASES: Record<string, string> = {
+  BACKLOG: 'Backlog',
+  ANALYSIS: 'Analysis',
+  SPECS: 'Specs',
+  'IN PROGRESS': 'In Progress',
+  IN_PROGRESS: 'In Progress',
+  INPROGRESS: 'In Progress',
+  REVIEW: 'Review',
+  DONE: 'Done',
+}
+
+export const PRIORITY_ALIASES: Record<string, string> = {
+  URGENT: 'P0 - Urgent',
+  HIGH: 'P1 - High',
+  MEDIUM: 'P2 - Medium',
+  LOW: 'P3 - Low',
+  P0: 'P0 - Urgent',
+  P1: 'P1 - High',
+  P2: 'P2 - Medium',
+  P3: 'P3 - Low',
+}
+
+// Canonical field option arrays — single source of truth for field creation and validation
+export const DEFAULT_STATUS_OPTIONS = ['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done']
+// Tier-based sizes: S (simple), F-lite (subagents), F-full (agent team)
+export const DEFAULT_SIZE_OPTIONS = ['S', 'F-lite', 'F-full']
+export const PRIORITY_VALUES = ['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'] as const
+export const DEFAULT_PRIORITY_OPTIONS: string[] = [...PRIORITY_VALUES]
+export const DEFAULT_LANE_OPTIONS = [
+  'a1',
+  'a2',
+  'a3',
+  'b',
+  'c1',
+  'c2',
+  'c3',
+  'd',
+  'e',
+  'f',
+  'g',
+  'h',
+  'i',
+  'j',
+  'k',
+  'l',
+  'm',
+  'n',
+  'o',
+  'standalone',
+]
+
+const CANONICAL_STATUSES = new Set(DEFAULT_STATUS_OPTIONS)
+const CANONICAL_SIZES = new Set(DEFAULT_SIZE_OPTIONS)
+const CANONICAL_PRIORITIES = new Set(DEFAULT_PRIORITY_OPTIONS)
+export const CANONICAL_LANES = new Set(DEFAULT_LANE_OPTIONS)
+
+/** Resolve loose user input to a canonical status key, or undefined. */
+export function resolveStatus(input: string): string | undefined {
+  if (CANONICAL_STATUSES.has(input)) return input
+  return STATUS_ALIASES[input.toUpperCase()]
+}
+
+/** Resolve loose user input to a canonical priority key, or undefined. */
+export function resolvePriority(input: string): string | undefined {
+  if (CANONICAL_PRIORITIES.has(input)) return input
+  return PRIORITY_ALIASES[input.toUpperCase()]
+}
+
+/** Resolve loose user input to a canonical size key, or undefined. */
+export function resolveSize(input: string): string | undefined {
+  const upper = input.toUpperCase().replace(/[-\s]/g, '-')
+  // Tier-based schema (S / F-lite / F-full).
+  if (CANONICAL_SIZES.has(input)) return input
+  if (CANONICAL_SIZES.has(upper)) return upper
+  // Legacy → new schema aliasing.
+  if (upper === 'XS') return 'S'
+  if (upper === 'M') return 'F-lite'
+  if (upper === 'L' || upper === 'XL') return 'F-full'
+  // F-lite variations
+  if (upper === 'FLITE' || upper === 'F_LITE' || upper === 'F-LITE') return 'F-lite'
+  // F-full variations
+  if (upper === 'FFULL' || upper === 'F_FULL' || upper === 'F-FULL') return 'F-full'
+  return
+}
+
+/** Resolve loose user input to a canonical lane key, or undefined. */
+export function resolveLane(input: string): string | undefined {
+  if (CANONICAL_LANES.has(input)) return input
+  return
+}
+
+// --- Exports consolidated from legacy config.ts shim ---
+
+export const GITHUB_REPO = detectGitHubRepo()
+
+export const PRIORITY_SHORT: Record<string, string> = {
+  'P0 - Urgent': 'P0',
+  'P1 - High': 'P1',
+  'P2 - Medium': 'P2',
+  'P3 - Low': 'P3',
+}
+
+/** Map canonical project priority → GitHub label name. */
+export const PRIORITY_LABEL_MAP: Record<string, string> = {
+  'P0 - Urgent': 'P0-critical',
+  'P1 - High': 'P1-high',
+  'P2 - Medium': 'P2-medium',
+  'P3 - Low': 'P3-low',
+}
+
+/** Set of all priority label names (for stale label removal). */
+export const PRIORITY_LABELS_SET = new Set(Object.values(PRIORITY_LABEL_MAP))
+
+/** Map canonical size → GitHub label name. */
+export const SIZE_LABEL_MAP: Record<string, string> = {
+  S: 'size:S',
+  'F-lite': 'size:F-lite',
+  'F-full': 'size:F-full',
+}
+
+/** Set of all size label names (for stale label removal). */
+export const SIZE_LABELS_SET = new Set(Object.values(SIZE_LABEL_MAP))
+
+/** Map canonical lane → GitHub label name. */
+export const LANE_LABEL_MAP: Record<string, string> = Object.fromEntries(
+  DEFAULT_LANE_OPTIONS.map((lane) => [lane, `graph:lane/${lane}`]),
+)
+
+/** Set of all lane label names (for stale label removal). */
+export const LANE_LABELS_SET = new Set(Object.values(LANE_LABEL_MAP))
+
+/** Map canonical status → GitHub label name. */
+export const STATUS_LABEL_MAP: Record<string, string> = {
+  Backlog: 'status:Backlog',
+  Analysis: 'status:Analysis',
+  Specs: 'status:Specs',
+  'In Progress': 'status:In Progress',
+  Review: 'status:Review',
+  Done: 'status:Done',
+}
+
+/** Set of all status label names (for stale label removal). */
+export const STATUS_LABELS_SET = new Set(Object.values(STATUS_LABEL_MAP))
+
+export const STATUS_SHORT: Record<string, string> = {
+  'In Progress': 'In Prog',
+  Backlog: 'Backlog',
+  Analysis: 'Analysis',
+  Specs: 'Specs',
+  Review: 'Review',
+  Done: 'Done',
+}
+
+export const PRIORITY_ORDER: Record<string, number> = {
+  'P0 - Urgent': 0,
+  'P1 - High': 1,
+  'P2 - Medium': 2,
+  'P3 - Low': 3,
+  '-': 99,
+}
+
+export const SIZE_ORDER: Record<string, number> = {
+  'F-full': 0,
+  'F-lite': 1,
+  S: 2,
+  '-': 99,
+}
+
+export const STATUS_ORDER: Record<string, number> = {
+  Review: 0,
+  'In Progress': 1,
+  Specs: 2,
+  Analysis: 3,
+  Backlog: 4,
+  '-': 99,
+}
+
+export const BLOCK_ORDER: Record<string, number> = {
+  blocking: 0,
+  ready: 1,
+  blocked: 2,
+}

--- a/plugins/roxabi-issues/skills/shared/adapters/github-adapter.ts
+++ b/plugins/roxabi-issues/skills/shared/adapters/github-adapter.ts
@@ -1,0 +1,233 @@
+/**
+ * GitHub adapter — standalone helper functions wrapping GitHub REST + GraphQL APIs.
+ * Exports canonical getGitHubToken() for auth, plus all operational helpers.
+ */
+
+import { ConfigError, DevCoreError, GitHubApiError } from '../domain/errors'
+import {
+  ADD_BLOCKED_BY_MUTATION,
+  ADD_SUB_ISSUE_MUTATION,
+  ORG_ISSUE_TYPES_QUERY,
+  PARENT_QUERY,
+  REMOVE_BLOCKED_BY_MUTATION,
+  REMOVE_SUB_ISSUE_MUTATION,
+  UPDATE_ISSUE_ISSUE_TYPE_MUTATION,
+  UPDATE_ISSUE_TYPE_MUTATION,
+} from '../queries'
+
+const GITHUB_API = 'https://api.github.com'
+const GRAPHQL_URL = `${GITHUB_API}/graphql`
+
+// --- Standalone helper functions ---
+
+import { GITHUB_REPO } from './config-helpers'
+
+let cachedToken: string | undefined
+
+export function getGitHubToken(): string {
+  if (cachedToken) return cachedToken
+
+  if (process.env.GITHUB_TOKEN) {
+    cachedToken = process.env.GITHUB_TOKEN
+    return cachedToken
+  }
+
+  try {
+    const proc = Bun.spawnSync(['gh', 'auth', 'token'], { stdout: 'pipe', stderr: 'pipe' })
+    const token = new TextDecoder().decode(proc.stdout).trim()
+    if (token) {
+      cachedToken = token
+      return cachedToken
+    }
+  } catch {
+    // gh not available
+  }
+
+  throw new ConfigError('GITHUB_TOKEN env var required (or gh auth login for local dev)')
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${getGitHubToken()}`,
+    'Content-Type': 'application/json',
+    'User-Agent': 'roxabi-skills',
+  }
+}
+
+/** Run a local shell command and return trimmed stdout. Throws on non-zero exit. */
+export async function run(cmd: string[], cwd?: string): Promise<string> {
+  const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe', cwd })
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const code = await proc.exited
+
+  if (code !== 0) {
+    throw new DevCoreError(`Command failed (${code}): ${cmd.join(' ')}\n${stderr}`)
+  }
+  return stdout.trim()
+}
+
+/** Execute a GraphQL query/mutation against GitHub API. */
+export async function ghGraphQL(query: string, variables: Record<string, unknown>): Promise<unknown> {
+  const res = await fetch(GRAPHQL_URL, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ query, variables }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new GitHubApiError(`GitHub GraphQL error (${res.status}): ${text}`, res.status)
+  }
+
+  const json = (await res.json()) as { errors?: { message: string }[] }
+  if (json.errors?.length) {
+    throw new GitHubApiError(`GitHub GraphQL error: ${JSON.stringify(json.errors)}`)
+  }
+  return json
+}
+
+/** Get issue node ID via REST API. */
+export async function getNodeId(issueNumber: number | string, repo?: string): Promise<string> {
+  const repoSlug = repo ?? GITHUB_REPO
+  const res = await fetch(`${GITHUB_API}/repos/${repoSlug}/issues/${issueNumber}`, {
+    headers: authHeaders(),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new GitHubApiError(`Failed to get node ID for #${issueNumber} (${res.status}): ${text}`, res.status)
+  }
+  const data = (await res.json()) as { node_id: string }
+  return data.node_id
+}
+
+/** Create a new GitHub issue via REST API. Returns the issue URL and number. */
+export async function createGitHubIssue(
+  title: string,
+  body?: string,
+  labels?: string[],
+): Promise<{ url: string; number: number }> {
+  const payload: Record<string, unknown> = { title }
+  if (body) payload.body = body
+  if (labels?.length) payload.labels = labels
+
+  const res = await fetch(`${GITHUB_API}/repos/${GITHUB_REPO}/issues`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new GitHubApiError(`Failed to create issue (${res.status}): ${text}`, res.status)
+  }
+
+  const data = (await res.json()) as { html_url: string; number: number }
+  return { url: data.html_url, number: data.number }
+}
+
+/** Add a blocked-by dependency between two issues. */
+export async function addBlockedBy(issueId: string, blockingId: string): Promise<void> {
+  await ghGraphQL(ADD_BLOCKED_BY_MUTATION, { issueId, blockingId })
+}
+
+/** Remove a blocked-by dependency between two issues. */
+export async function removeBlockedBy(issueId: string, blockingId: string): Promise<void> {
+  await ghGraphQL(REMOVE_BLOCKED_BY_MUTATION, { issueId, blockingId })
+}
+
+/** Add a sub-issue (parent/child) relationship. */
+export async function addSubIssue(parentId: string, childId: string): Promise<void> {
+  await ghGraphQL(ADD_SUB_ISSUE_MUTATION, { parentId, childId })
+}
+
+/** Remove a sub-issue (parent/child) relationship. */
+export async function removeSubIssue(parentId: string, childId: string): Promise<void> {
+  await ghGraphQL(REMOVE_SUB_ISSUE_MUTATION, { parentId, childId })
+}
+
+export interface OrgIssueType {
+  id: string
+  name: string
+  color: string
+  isEnabled: boolean
+}
+
+export async function listOrgIssueTypes(login: string): Promise<OrgIssueType[]> {
+  const data = (await ghGraphQL(ORG_ISSUE_TYPES_QUERY, { login })) as {
+    data: { organization: { issueTypes: { nodes: OrgIssueType[] } } }
+  }
+  return data.data.organization.issueTypes.nodes
+}
+
+export async function updateIssueType(
+  issueTypeId: string,
+  patch: { name?: string; description?: string; color?: string; isEnabled?: boolean },
+): Promise<OrgIssueType> {
+  const data = (await ghGraphQL(UPDATE_ISSUE_TYPE_MUTATION, {
+    issueTypeId,
+    ...(patch.name !== undefined && { name: patch.name }),
+    ...(patch.description !== undefined && { description: patch.description }),
+    ...(patch.color !== undefined && { color: patch.color }),
+    ...(patch.isEnabled !== undefined && { isEnabled: patch.isEnabled }),
+  })) as { data: { updateIssueType: { issueType: OrgIssueType } } }
+  return data.data.updateIssueType.issueType
+}
+
+/** Update labels on a GitHub issue: add and/or remove labels. */
+export async function updateLabels(issueNumber: number, add: string[], remove: string[]): Promise<void> {
+  let removeExisting = remove
+  if (remove.length) {
+    const out = await run([
+      'gh',
+      'label',
+      'list',
+      '--repo',
+      GITHUB_REPO,
+      '--limit',
+      '200',
+      '--json',
+      'name',
+      '--jq',
+      '.[].name',
+    ])
+    const existing = new Set(
+      out
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+    removeExisting = remove.filter((l) => existing.has(l))
+  }
+  const args = ['gh', 'issue', 'edit', String(issueNumber), '--repo', GITHUB_REPO]
+  if (add.length) args.push('--add-label', add.join(','))
+  if (removeExisting.length) args.push('--remove-label', removeExisting.join(','))
+  await run(args)
+}
+
+/** Update the issue type on a GitHub issue. Pass null issueTypeId to clear. */
+export async function updateIssueIssueType(issueNodeId: string, issueTypeId: string | null): Promise<void> {
+  // FIXME(#121): revert with null issueTypeId is unverified — schema allows it but API behaviour unconfirmed.
+  // Manual verification needed before production revert. Raw mutation error surfaces via ghGraphQL throw.
+  await ghGraphQL(UPDATE_ISSUE_ISSUE_TYPE_MUTATION, { issueId: issueNodeId, issueTypeId })
+}
+
+/** Resolve an issue type name to its node ID for a given org (case-insensitive). */
+export async function resolveIssueTypeId(org: string, typeName: string): Promise<string> {
+  const types = await listOrgIssueTypes(org)
+  const match = types.find((t) => t.name.toLowerCase() === typeName.toLowerCase())
+  if (!match) {
+    const valid = types.map((t) => t.name).join(', ')
+    throw new GitHubApiError(`Unknown issue type: ${typeName}. Valid: ${valid}`)
+  }
+  return match.id
+}
+
+/** Get the parent issue number for an issue, or null if none. */
+export async function getParentNumber(issueNumber: number): Promise<number | null> {
+  const [owner, repo] = GITHUB_REPO.split('/')
+  const data = (await ghGraphQL(PARENT_QUERY, { owner, repo, number: issueNumber })) as {
+    data: { repository: { issue: { parent: { number: number } | null } } }
+  }
+  return data.data.repository.issue.parent?.number ?? null
+}

--- a/plugins/roxabi-issues/skills/shared/adapters/github-infra.ts
+++ b/plugins/roxabi-issues/skills/shared/adapters/github-infra.ts
@@ -1,0 +1,109 @@
+/**
+ * GitHub label constants and sync helpers used by issue-triage skills.
+ *
+ * Dependency direction: github-infra → github-adapter (clean, no cycle).
+ */
+
+import {
+  LANE_LABEL_MAP,
+  LANE_LABELS_SET,
+  PRIORITY_LABEL_MAP,
+  PRIORITY_LABELS_SET,
+  SIZE_LABEL_MAP,
+  SIZE_LABELS_SET,
+  STATUS_LABEL_MAP,
+  STATUS_LABELS_SET,
+} from './config-helpers'
+
+export interface LabelDef {
+  name: string
+  color: string
+  description: string
+  category: 'type' | 'area'
+}
+
+export const STANDARD_LABELS: LabelDef[] = [
+  { name: 'bug', color: 'd73a4a', description: "Something isn't working", category: 'type' },
+  { name: 'feature', color: '0075ca', description: 'New functionality', category: 'type' },
+  { name: 'enhancement', color: 'a2eeef', description: 'Improve existing functionality', category: 'type' },
+  { name: 'docs', color: '5319e7', description: 'Documentation only', category: 'type' },
+  { name: 'chore', color: 'ededed', description: 'Maintenance, deps, config', category: 'type' },
+  { name: 'research', color: 'd4c5f9', description: 'Investigation or spike', category: 'type' },
+  { name: 'frontend', color: '1d76db', description: 'Frontend', category: 'area' },
+  { name: 'backend', color: 'e99695', description: 'Backend', category: 'area' },
+  { name: 'infra', color: 'f9d0c4', description: 'Infrastructure', category: 'area' },
+  { name: 'api', color: 'bfd4f2', description: 'API', category: 'area' },
+  { name: 'design', color: 'c5def5', description: 'Design', category: 'area' },
+]
+
+/**
+ * Sync priority label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncPriorityLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = PRIORITY_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...PRIORITY_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync priority label for #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Sync size label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncSizeLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = SIZE_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...SIZE_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync size label for #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Sync lane label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncLaneLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = LANE_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...LANE_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync lane label for #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Sync status label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncStatusLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = STATUS_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...STATUS_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync status label for #${issueNumber}: ${err}`)
+  }
+}

--- a/plugins/roxabi-issues/skills/shared/domain/errors.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Dev-core error hierarchy — plugin-specific exceptions replacing generic Error throws.
+ */
+
+export class DevCoreError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DevCoreError'
+  }
+}
+
+export class GitHubApiError extends DevCoreError {
+  readonly statusCode: number | undefined
+
+  constructor(message: string, statusCode?: number) {
+    super(message)
+    this.name = 'GitHubApiError'
+    this.statusCode = statusCode
+  }
+}
+
+export class ConfigError extends DevCoreError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConfigError'
+  }
+}
+
+export class WorkspaceError extends DevCoreError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorkspaceError'
+  }
+}
+
+export class ArtifactError extends DevCoreError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ArtifactError'
+  }
+}

--- a/plugins/roxabi-issues/skills/shared/domain/issue-types.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/issue-types.ts
@@ -1,0 +1,8 @@
+/**
+ * Issue type constants — single source of truth for issue classification strings.
+ * Consumed by set.ts (validation) and migrate.ts (legacy map keys).
+ */
+
+export const ISSUE_TYPE_NAMES = ['feat', 'fix', 'docs', 'test', 'chore', 'ci', 'perf', 'refactor'] as const
+
+export const EXTENDED_ISSUE_TYPES = ['epic', 'research'] as const

--- a/plugins/roxabi-issues/skills/shared/domain/parse-issue-ref.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/parse-issue-ref.ts
@@ -1,0 +1,63 @@
+/**
+ * Parse issue references — local (#123) or cross-repo (owner/repo#123).
+ */
+
+import type { ParsedIssueRef } from './types'
+
+const CROSS_REPO_RE = /^([A-Za-z0-9_-]+\/[A-Za-z0-9_-]+)#(\d+)$/
+const LOCAL_RE = /^#?(\d+)$/
+
+/**
+ * Parse a single issue reference string.
+ *
+ * Formats:
+ *   - "123" or "#123" → local ref (number only)
+ *   - "owner/repo#123" → cross-repo ref (number + repo)
+ *
+ * Returns undefined for invalid input.
+ */
+export function parseIssueRef(input: string): ParsedIssueRef | undefined {
+  const trimmed = input.trim()
+
+  // Cross-repo: owner/repo#123
+  const crossMatch = trimmed.match(CROSS_REPO_RE)
+  if (crossMatch) {
+    return { repo: crossMatch[1], number: Number(crossMatch[2]) }
+  }
+
+  // Local: #123 or 123
+  const localMatch = trimmed.match(LOCAL_RE)
+  if (localMatch) {
+    return { number: Number(localMatch[1]) }
+  }
+
+  return undefined
+}
+
+/** Format a ParsedIssueRef as "repo#number" (cross-repo) or "#number" (local). */
+export function formatRef(ref: ParsedIssueRef): string {
+  return ref.repo ? `${ref.repo}#${ref.number}` : `#${ref.number}`
+}
+
+/**
+ * Parse a comma-separated list of issue references.
+ * Skips invalid entries (logs warning to console.error).
+ *
+ * @example
+ *   parseIssueRefs("100, #101, Roxabi/lyra#728")
+ *   // → [{ number: 100 }, { number: 101 }, { number: 728, repo: "Roxabi/lyra" }]
+ */
+export function parseIssueRefs(input: string): ParsedIssueRef[] {
+  const refs: ParsedIssueRef[] = []
+
+  for (const part of input.split(',')) {
+    const ref = parseIssueRef(part)
+    if (ref) {
+      refs.push(ref)
+    } else {
+      console.error(`Warning: Invalid issue reference "${part.trim()}" — skipped`)
+    }
+  }
+
+  return refs
+}

--- a/plugins/roxabi-issues/skills/shared/domain/types.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/types.ts
@@ -1,0 +1,134 @@
+/**
+ * Dev-core domain types — replaces ad-hoc inline types across skills.
+ * These are the canonical representations of GitHub entities within dev-core.
+ */
+
+export interface SubIssue {
+  number: number
+  state: string
+  title: string
+}
+
+export interface BlockRef {
+  number: number
+  state: string
+}
+
+export interface Issue {
+  number: number
+  title: string
+  url: string
+  state: string
+  status: string
+  size: string | null
+  priority: string | null
+  labels: string[]
+  assignees: string[]
+  children: SubIssue[]
+  blockStatus?: 'ready' | 'blocked' | 'blocking'
+  blockedBy?: BlockRef[]
+  blocking?: BlockRef[]
+  projectLabel?: string
+}
+
+export interface CICheck {
+  name: string
+  status: string
+  conclusion: string
+  detailsUrl: string
+}
+
+export interface PR {
+  number: number
+  title: string
+  branch: string
+  state: string
+  isDraft: boolean
+  url: string
+  author: string
+  updatedAt: string
+  additions: number
+  deletions: number
+  reviewDecision: string
+  labels: string[]
+  mergeable: string
+  checks: CICheck[]
+}
+
+export interface Project {
+  id: string
+  title: string
+  repo: string
+}
+
+export interface Branch {
+  name: string
+  isCurrent: boolean
+}
+
+export interface Worktree {
+  path: string
+  branch: string
+  commit: string
+  isBare: boolean
+}
+
+export interface BuildStep {
+  name: string
+  status: 'done' | 'running' | 'pending' | 'error'
+}
+
+export interface VercelDeployment {
+  uid: string
+  url: string
+  name: string
+  state: string
+  isCurrent?: boolean
+  target: string
+  createdAt: number
+  buildingAt: number
+  ready: number
+  source: string
+  meta: { githubCommitRef?: string; githubCommitMessage?: string }
+  inspectorUrl: string
+  buildSteps: BuildStep[]
+}
+
+export interface BranchCI {
+  branch: string
+  commitSha: string
+  commitMessage: string
+  committedAt: string
+  overallState: string
+  checks: CICheck[]
+}
+
+export interface WorkflowRun {
+  id: number
+  name: string
+  displayTitle: string
+  event: string
+  status: string
+  conclusion: string | null
+  htmlUrl: string
+  createdAt: string
+  updatedAt: string
+  headBranch: string
+  headCommitMessage: string
+}
+
+export interface ProjectFieldIds {
+  status?: string
+  col2?: string
+  col3?: string
+  statusOptions?: Record<string, string>
+  col2Options?: Record<string, string>
+  col3Options?: Record<string, string>
+}
+
+/** Parsed issue reference — local (#123) or cross-repo (owner/repo#123). */
+export interface ParsedIssueRef {
+  number: number
+  /** Undefined for local refs (use default repo). */
+  repo?: string
+}

--- a/plugins/roxabi-issues/skills/shared/ports/workspace.ts
+++ b/plugins/roxabi-issues/skills/shared/ports/workspace.ts
@@ -1,0 +1,36 @@
+/**
+ * WorkspacePort — role interface for workspace/worktree/git operations.
+ */
+import type { Branch, ProjectFieldIds, Worktree } from '../domain/types'
+
+export interface VercelProjectRef {
+  projectId: string
+  teamId: string
+}
+
+export interface WorkspaceProject {
+  repo: string
+  projectId: string
+  label: string
+  type?: 'technical' | 'company'
+  fieldIds?: ProjectFieldIds
+  vercelProjectId?: string // single Vercel project ID (legacy / single-project)
+  vercelTeamId?: string // Vercel team ID for single project
+  vercelProjects?: VercelProjectRef[]
+  localPath?: string
+}
+
+export type ProjectType = 'technical' | 'company'
+
+export interface Workspace {
+  projects: WorkspaceProject[]
+  roadmapProjectId?: string
+}
+
+export interface WorkspacePort {
+  readWorkspace(): Workspace
+  writeWorkspace(ws: Workspace): void
+  discoverProject(repo: string, localPath?: string): Promise<WorkspaceProject[]>
+  listBranches(): Promise<Branch[]>
+  listWorktrees(): Promise<Worktree[]>
+}

--- a/plugins/roxabi-issues/skills/shared/queries.ts
+++ b/plugins/roxabi-issues/skills/shared/queries.ts
@@ -1,0 +1,177 @@
+/**
+ * All GraphQL query and mutation strings — single source of truth.
+ *
+ * Mock routing pattern (for tests):
+ * Import constants and route via exact match: `if (query === MILESTONE_QUERY)`.
+ * Throw explicit error on unexpected queries — no silent {} fallback.
+ * This makes query refactors immediately visible in test output.
+ */
+
+/** Get parent issue number. */
+export const PARENT_QUERY = `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) { parent { number } }
+  }
+}`
+
+export const ADD_BLOCKED_BY_MUTATION = `
+mutation($issueId: ID!, $blockingId: ID!) {
+  addBlockedBy(input: { issueId: $issueId, blockingIssueId: $blockingId }) {
+    issue { number } blockingIssue { number }
+  }
+}`
+
+export const REMOVE_BLOCKED_BY_MUTATION = `
+mutation($issueId: ID!, $blockingId: ID!) {
+  removeBlockedBy(input: { issueId: $issueId, blockingIssueId: $blockingId }) {
+    issue { number } blockingIssue { number }
+  }
+}`
+
+/** Open PRs with CI checks — used by dashboard. */
+export const PRS_QUERY = `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: 50, states: OPEN) {
+      nodes {
+        number
+        title
+        headRefName
+        state
+        isDraft
+        url
+        author { login }
+        updatedAt
+        additions
+        deletions
+        reviewDecision
+        labels(first: 10) { nodes { name } }
+        mergeable
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                contexts(first: 50) {
+                  nodes {
+                    ... on CheckRun {
+                      __typename
+                      name
+                      status
+                      conclusion
+                      detailsUrl
+                    }
+                    ... on StatusContext {
+                      __typename
+                      context
+                      state
+                      targetUrl
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+/** CI status for main/master and staging branches — used by dashboard. */
+export const BRANCH_CI_QUERY = `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    main: ref(qualifiedName: "refs/heads/main") { ...BranchCI }
+    master: ref(qualifiedName: "refs/heads/master") { ...BranchCI }
+    staging: ref(qualifiedName: "refs/heads/staging") { ...BranchCI }
+  }
+}
+fragment BranchCI on Ref {
+  name
+  target {
+    ... on Commit {
+      oid
+      messageHeadline
+      committedDate
+      statusCheckRollup {
+        state
+        contexts(first: 50) {
+          nodes {
+            ... on CheckRun {
+              __typename name status conclusion detailsUrl
+            }
+            ... on StatusContext {
+              __typename context state targetUrl
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+export const ADD_SUB_ISSUE_MUTATION = `
+mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { number } subIssue { number }
+  }
+}`
+
+export const REMOVE_SUB_ISSUE_MUTATION = `
+mutation($parentId: ID!, $childId: ID!) {
+  removeSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { number } subIssue { number }
+  }
+}`
+
+/** Get repository node ID. */
+export const REPO_ID_QUERY = `
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) { id }
+}`
+
+/** Fetch milestones for a repository. */
+export const MILESTONE_QUERY = `
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      milestones(first: 50, states: OPEN) {
+        nodes {
+          id
+          title
+        }
+      }
+    }
+  }
+`
+
+export const CREATE_ISSUE_TYPE_MUTATION = `
+mutation($ownerId: ID!, $name: String!, $description: String, $color: IssueTypeColor!, $isEnabled: Boolean!) {
+  createIssueType(input: { ownerId: $ownerId, name: $name, description: $description, color: $color, isEnabled: $isEnabled }) {
+    issueType { id name color isEnabled }
+  }
+}`
+
+export const UPDATE_ISSUE_TYPE_MUTATION = `
+mutation($issueTypeId: ID!, $name: String, $description: String, $color: IssueTypeColor, $isEnabled: Boolean) {
+  updateIssueType(input: { issueTypeId: $issueTypeId, name: $name, description: $description, color: $color, isEnabled: $isEnabled }) {
+    issueType { id name color isEnabled }
+  }
+}`
+
+export const UPDATE_ISSUE_ISSUE_TYPE_MUTATION = `
+mutation($issueId: ID!, $issueTypeId: ID) {
+  updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $issueTypeId }) {
+    issue { id issueType { id name } }
+  }
+}`
+
+export const ORG_ISSUE_TYPES_QUERY = `
+query($login: String!) {
+  organization(login: $login) {
+    id
+    issueTypes(first: 50) { nodes { id name color isEnabled } }
+  }
+}`
+
+

--- a/plugins/roxabi-issues/tsconfig.json
+++ b/plugins/roxabi-issues/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["vitest.config.ts", "vitest.setup.ts", "skills/**/*.ts"],
+  "exclude": ["node_modules", "skills/issue-triage/triage.ts"]
+}

--- a/plugins/roxabi-issues/vitest.config.ts
+++ b/plugins/roxabi-issues/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**'],
+    setupFiles: ['./vitest.setup.ts'],
+    env: {
+      // Prevent config from throwing during module evaluation.
+      GITHUB_REPO: 'Test/test-repo',
+    },
+  },
+})

--- a/plugins/roxabi-issues/vitest.setup.ts
+++ b/plugins/roxabi-issues/vitest.setup.ts
@@ -1,0 +1,42 @@
+import { spawnSync as nodeSpawnSync } from 'node:child_process'
+
+/**
+ * Bun global shim for Vitest (Node.js worker) environment.
+ *
+ * Tests that spy on Bun.spawnSync / Bun.spawn via vi.spyOn need Bun to be
+ * defined — the spy wraps the shim and the mock replaces the return value,
+ * so the shim implementation only matters for tests that call it directly
+ * (e.g. doctor.test.ts subprocess integration tests).
+ */
+if (typeof globalThis.Bun === 'undefined') {
+  // biome-ignore lint/suspicious/noExplicitAny: bun-types makes the Bun global too complex to satisfy without any
+  ;(globalThis as any).Bun = {
+    spawnSync: (
+      cmd: string[],
+      opts?: {
+        stdout?: string
+        stderr?: string
+        cwd?: string
+        env?: Record<string, string>
+      },
+    ) => {
+      const result = nodeSpawnSync(cmd[0], cmd.slice(1), {
+        cwd: opts?.cwd,
+        env: opts?.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      return {
+        stdout: result.stdout ? new Uint8Array(result.stdout) : new Uint8Array(),
+        stderr: result.stderr ? new Uint8Array(result.stderr) : new Uint8Array(),
+        exitCode: result.status ?? 1,
+        success: (result.status ?? 1) === 0,
+      }
+    },
+    // Async spawn — tests that use it mock it via vi.spyOn(Bun, 'spawn')
+    spawn: (..._args: unknown[]) => ({
+      exited: Promise.resolve(1),
+      stdout: null,
+      stderr: null,
+    }),
+  }
+}


### PR DESCRIPTION
Relocates the **issue-triage** skill out of `roxabi-plugins/dev-core` into a self-contained Claude plugin here (`plugins/roxabi-issues/`, own `marketplace.json`). Pairs with roxabi-plugins PR (dev-core decouple).

## What
- **Issues-only triage**: `set` labels (size/priority/lane/type), blocked-by dependencies, parent/child sub-issues; `create`. **No GitHub Projects V2 board** — board reads are the cockpit's job.
- Stripped from the relocated copy: the board `list` subcommand, all `*_FIELD_ID`/`updateField`/`ProjectV2`/`LIST_QUERY`/`GH_PROJECT_ID` code, the `migrate-*` board-migration tooling.
- Vendored + trimmed shared layer (labels + native relations only).
- Self-contained **bun** toolchain (`bun run typecheck` / `test`).

## Invocation
`roxabi-issues:issue-triage` (skill name unchanged). Registered in `roxabi-plugins/.claude-plugin/external-registry.json`.

## Verification
- `bun run typecheck` ✓
- `bun run test` → **67 passed**
- adversarial audit: zero executable ProjectV2 residue

🤖 Generated with [Claude Code](https://claude.com/claude-code)