### PR TITLE
docs(readme,claude): document the roxabi-issues plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,13 @@ wrangler.toml       # repo root — binds both envs
 frontend/           # served via ASSETS binding
 ```
 
+**Plugin (issue mgmt — relocated from dev-core)**
+
+```
+.claude-plugin/marketplace.json   # single-plugin marketplace
+plugins/roxabi-issues/            # roxabi-issues:issue-triage (bun; labels + native relations)
+```
+
 **Legacy Python app (decommissioned 2026-06-08)**
 
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ Copy `.env.example` to `.env` and set values.
 | `GITHUB_WEBHOOK_SECRET` | — | HMAC secret for webhook verification |
 | `CORPUS_SYNC_INTERVAL_SECONDS` | `3600` | Reconciler interval in seconds |
 
+## Plugins
+
+This repo also hosts the **`roxabi-issues`** Claude Code plugin (`plugins/roxabi-issues/`), relocated from `dev-core` — issue triage that pairs with the cockpit.
+
+```bash
+claude plugin marketplace add Roxabi/roxabi-live
+claude plugin install roxabi-issues
+```
+
+The `issue-triage` skill (invoked `roxabi-issues:issue-triage`) sets labels (size / priority / lane / type) and manages blocked-by dependencies and parent/child sub-issues on GitHub issues — **labels + native relations only, no Projects V2 board** (the cockpit owns the read/dashboard side). Self-contained bun project.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Documents the relocated `roxabi-issues` plugin (from #139).

- **README.md** — new Plugins section (marketplace install + scope: labels + native relations, no Projects V2).
- **CLAUDE.md** — package-layout entry for `plugins/roxabi-issues` (the Plugins section already landed in #139).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)