### PR TITLE
ci: close the TypeScript feedback-loop gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,20 @@ jobs:
       - name: Test (vitest)
         run: cd worker && npm test
 
+  plugin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install plugin deps
+        run: cd plugins/roxabi-issues && bun install --frozen-lockfile
+      - name: Typecheck (tsc)
+        run: cd plugins/roxabi-issues && bun run typecheck
+      - name: Test (vitest)
+        run: cd plugins/roxabi-issues && bun run test
+
   deploy:
     needs: [ci, worker]
     if: github.event_name == 'push' && (github.ref_name == 'staging' || github.ref_name == 'main')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,9 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+      - id: worker-typecheck
+        name: worker typecheck (tsc)
+        entry: bash -c 'cd worker && npm run typecheck'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]


### PR DESCRIPTION
## What
- **`.pre-commit-config.yaml`** — add `worker-typecheck` (tsc) **pre-push** hook. The active TS surface (`worker/`) was CI-only; now caught locally before push.
- **`ci.yml`** — add a `plugin` job (typecheck + test) for `plugins/roxabi-issues`. The relocated issue-triage skill (used cross-project) was **ungated** in CI.

## Why
Closes the TypeScript feedback-loop asymmetry from the Stripe-practices portfolio review (E1 / E5). Python had ruff+pyright pre-commit; TS had nothing.

## Validation
- `worker` tsc: ✅ exit 0
- `roxabi-issues` plugin: ✅ tsc clean, 67/67 tests pass (locally)
- Follows the dev-core `ci-setup` hook standard.

> Pre-push `worker-typecheck` needs `worker/node_modules` (`cd worker && npm ci` once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)