### PR TITLE
docs(spec): multi-tenant GitHub App auth Phase 1 — planning baseline + #141 decomposition

### DIFF
--- a/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+++ b/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
@@ -1,0 +1,284 @@
+---
+title: "Multi-tenant GitHub App auth — Phase 1 implementation analysis (#141)"
+description: "Codebase-grounded, review-hardened shapes for Phase 1 of ADR Shape D: tenant model, sessions, schema/migration, sync+webhook isolation, deploy sequencing. Folds in architect/security/devops/product/doc review."
+---
+
+## Source
+
+> "On voulait étendre ça avec une authentification GitHub […] permettre aux utilisateurs de relier
+> leur compte GitHub à l'outil […] que ça devienne un outil pour tout le monde plutôt qu'un outil
+> que pour moi." — Phase 1 of `artifacts/analyses/zk-encryption-spike-analysis.mdx` (ADR → Shape D).
+
+The ADR settled the **archetype** (single GitHub App, server-centric, single D1 + `tenant_id`,
+phased toward an opt-in Phase-2 ZK mode). This analysis decides the **implementation shape** for
+Phase 1 — grounded in the *actual* current Worker — and locks the sub-decisions `/spec` will split
+into child issues. **Review-hardened**: 5 expert reviews (architect, security, devops, product, doc)
+folded in; see Review Log.
+
+## Problem
+
+The Worker is single-tenant to the bone (verified in `worker/src/`):
+
+- **One credential, one org:** sync reads a single `GITHUB_TOKEN` (**PAT**) + `GITHUB_ORG` var;
+  `runSync` syncs exactly one org per cron tick. No App, OAuth, installation tokens, or user identity.
+- **No identity layer:** no `users`/`sessions`/`tenants`/`installations`/`oauth_state` tables; the
+  Worker is blind to the user — Cloudflare Access at the edge is the *sole* guard except `/admin/*`.
+- **Globally-shared data:** `issues` (PK `key` = `owner/repo#N`), `edges` (PK `(src,dst,kind)`),
+  `labels`, `pr_state`, `repos`, `sync_state` — **none** carry a tenant column. Every read in
+  `api/issues.ts` + `api/graph.ts` is unfiltered; `GET /api/graph` dumps the entire corpus; and
+  `GET /api/issues/:key` returns any issue by key (a latent IDOR once multi-tenant).
+- **One webhook:** single `GITHUB_WEBHOOK_SECRET`, keys from `repository.full_name`, one org.
+
+So "let any GitHub user see their own issues" touches every layer: auth (new), schema (breaking),
+sync (per-tenant loop), webhook (tenant routing), reads (tenant filter, fail-closed), frontend (login).
+
+## Outcome
+
+A second GitHub user logs in, links their account, and sees **only their own** issues + dep-graph in
+prod, with tenant isolation verified, and no auth rewrite when Phase-2 ZK lands. (Frame #141.)
+
+## Appetite
+
+F-full epic; `/spec` smart-splits into child issues. Likely split: **(1)** schema migrations +
+auth tables · **(2)** App-JWT + OAuth + sessions module · **(3)** per-installation sync fan-out +
+PAT retirement · **(4)** webhook tenant routing + stub policy · **(5)** tenant-filtered reads +
+middleware · **(6)** login/account-link/consent UI · **(7)** CI migrate-step + staging URL + R2 +
+Access-policy deploy runbook.
+
+---
+
+## Current architecture (grounding)
+
+| Layer | Today | Phase-1 delta |
+|---|---|---|
+| Auth | CF Access (edge) + `ADMIN_TOKEN` on `/admin/*` | + app sessions (fail-closed) on public app; Access → `/admin/*` only |
+| GitHub creds | 1 PAT (`GITHUB_TOKEN`) + 1 `GITHUB_ORG` | GitHub App: App-JWT (RS256) → per-installation tokens; **PAT removed** |
+| Identity | none | `users` + `sessions` + `installations` + `user_installations` + `oauth_state` |
+| Schema | `issues` PK `key`; `edges` PK `(src,dst,kind)`; no tenant | `tenant_id` everywhere; **composite PKs** (table-recreation) |
+| Reads | all unfiltered | middleware-gated `/api/*`; every WHERE + every single-fetch `AND tenant_id=?` |
+| Writes | `sync.ts`, `webhook/mutations.ts` | every write carries `tenant_id`; stubs tenant-local + title-less |
+| Webhook | 1 org secret, keys from `repository.full_name` | 1 App secret; route by `installation.id`; unknown install → 200 no-write |
+| Frontend | no login; `app.js` → `/api/graph`,`/api/version` | login + account-link + consent UI |
+| Runtime | Hono on workerd; Web Crypto already used (HMAC) | + RS256 App-JWT + session crypto via Web Crypto |
+| Deploy/CI | `ci.yml`: `npm ci` + `wrangler deploy` (no migrate step) | + `wrangler d1 migrations apply` per-env; secret guards; staging URL + R2 |
+
+Bindings today = `DB` (D1), `ASSETS`, `LOGS` (R2, optional). **No KV, no DO, no Queues.**
+
+---
+
+## Core decision — what is a "tenant", and which credential syncs it?
+
+Everything downstream follows from this axis. Three mutually-exclusive shapes:
+
+**Shape 1 — Installation-as-tenant.** App installed on the user's account/org → `installation_id` =
+tenant + sync credential; OAuth only for identity. Sync mints installation tokens (App-JWT →
+`POST /app/installations/:id/access_tokens`). Webhooks routed by `payload.installation.id`.
+*Pro:* high rate limits, auto-rotation, **no broad user-token at rest**, native webhooks. *Con:*
+install step; multi-org user → N installations (needs membership). **Scope L.**
+
+**Shape 2 — User-token sync.** OAuth-only; **store user-to-server token server-side** and sync with it.
+`tenant_id` = user id. *Pro:* lightest onboarding. *Con:* token refresh machinery, **lower rate
+limits**, **large user-token-at-rest liability**, **no webhooks → polling** (kills the real-time
+model), stalls on expiry. **Weaker outcome, contradicts the ADR.** Scope L.
+
+**Shape 3 — Hybrid: installation for sync + OAuth for identity. ← adopt.** OAuth user-to-server =
+identity/session (token **discardable** after identity — minimal liability, reused live in Phase 2);
+App installation = data access + sync credential. Tables: `users`, `installations`,
+`user_installations` (membership). `tenant_id` = `installation_id` on data rows. One user → many
+installations; one installation → many authorized users (same-org colleagues share one tenant, **no
+data duplication**). *Con:* most moving parts; onboarding = authorize **and** install. **Scope L–XL.**
+
+### Fit Check
+
+| | Shape 1 | Shape 2 | **Shape 3** |
+|---|---|---|---|
+| Real-time webhooks (keep model) | ✓ | ✗ | **✓** |
+| Sync rate limits at scale | ✓ | ✗ | **✓** |
+| Token-at-rest liability | low | **high** | **low** |
+| Multi-org user supported | ✗ | ✓ | **✓** |
+| Phase-2 ZK seam ready | partial | ✓ | **✓** |
+| Matches ADR Shape A/D | ✓ | ✗ | **✓✓** |
+
+**Eliminated: Shape 2** (weaker outcome, contradicts ADR). **Shape 1 vs 3:** 3 = 1 + the membership
+join that "link your account and see your org's issues" requires. **Adopt Shape 3.** (Architect:
+shapes cover all viable combinations; Shape 3 is the only consistent option.)
+
+```mermaid
+flowchart LR
+  U[User] -. "App install (async, GitHub-side)" .-> GH[(GitHub)]
+  subgraph Browser
+    U -->|1. GET /login| W
+    W -->|2. set session cookie| U
+  end
+  subgraph Worker[CF Worker]
+    W[/login + /oauth/callback<br/>state single-use, client_secret/]
+    CRON[cron] <-->|App-JWT RS256 ⇄ install token| GH
+    CRON -->|write tenant_id=installation_id| D[(D1)]
+    WH[/webhook/github/] -->|installation.id → tenant_id| D
+    API[/api/* — middleware 401 if no session<br/>WHERE tenant_id = active tenant/] --> D
+  end
+  W <-->|code ⇄ token| GH
+  GH -->|webhook: 1 secret + installation.id| WH
+```
+
+---
+
+## Settled sub-decisions
+
+### Sessions & access enforcement
+1. **D1 `sessions` table** — opaque random token **hashed at rest** (store SHA-256 of token, compare
+   hash), FK→`users`, `tenant_id` of the **active** installation, `expires_at` (short TTL), index on
+   `tenant_id`. Transport: cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>` (**not** a
+   wildcard `.roxabi.dev`). *Rejected:* stateless JWT (can't revoke day-one), KV (no binding; D1 keeps
+   revocation transactional).
+2. **Revocation (mandatory, day-one):** logout → `DELETE FROM sessions WHERE token_hash=?`;
+   `installation.deleted` / user-removed webhook → `DELETE FROM sessions WHERE tenant_id=?`. TTL expiry
+   is **not** revocation — both paths required.
+3. **Session fixation:** mint a **new** token *after* OAuth completes; never reuse any pre-auth value.
+4. **Enforcement point:** a named session middleware on the **`/api/*` group** (mirrors the existing
+   `checkAdminAuth` Hono pattern). **Fail-closed:** absent/expired/invalid session → **401 before any
+   DB statement executes**. "Every WHERE gets `tenant_id`" is the data guard *behind* the gate, not the
+   gate itself.
+
+### OAuth code-exchange
+5. **Routes:** `GET /login` (redirect to GitHub authorize + `state`), `GET /oauth/callback` (verify
+   `state`, exchange `code`→token with `GITHUB_APP_CLIENT_SECRET`). No PKCE (we hold the secret).
+6. **`state` (CSRF):** stored in D1 `oauth_state` table, **single-use** (deleted atomically on first
+   successful verify), **TTL ≤ 10 min** enforced at verify, abandoned rows swept. **`redirect_uri` is
+   hard-coded in the Worker**, never caller-supplied. (`SameSite=Lax` is acceptable *only* because
+   `state` defends the GET callback — documented constraint for future route authors.)
+7. **Secrets:** `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`,
+   `GITHUB_APP_PRIVATE_KEY` (PEM), `GITHUB_APP_WEBHOOK_SECRET` — per-env via `wrangler secret put …
+   [--env staging]`. **Rotatable, never logged**; RS256 signing errors log message only, never key/JWT.
+   Private-key rotation = dual-key overlap (GitHub allows 2 active) + `wrangler secret put` + redeploy
+   (deploy-coupled, document in runbook).
+
+### Schema & migration
+8. **`tenant_id TEXT`** added to `issues`, `edges`, `labels`, `pr_state`, `sync_state`, `repos`,
+   `repo_allowlist`. New tables: `users`, `installations`, `user_installations`, `sessions`,
+   `oauth_state`.
+9. **Composite PKs (fail-closed isolation):** `issues` → `(tenant_id, key)`; `edges` →
+   `(tenant_id, src_key, dst_key, kind)`; same on `labels`/`pr_state`. **D1/SQLite has no
+   `ALTER TABLE … ADD PRIMARY KEY`** → each is a **table-recreation** migration
+   (`CREATE new → INSERT … SELECT → DROP old → ALTER … RENAME`), preserving all indexes/FKs, within one
+   migration file. The `tenant_id` predicate is the live guard; composite PK makes a missing predicate
+   fail-closed (no silent cross-tenant overwrite).
+10. **Migration sequence (non-transactional CF deploy):** **M-a** add `tenant_id` *nullable* + recreate
+    PKs + add auth tables → **backfill** → **M-b** set `tenant_id NOT NULL`. **Backfill is a runtime
+    op, not SQL-file-embeddable** (installation_id is a runtime value): after the App is installed on
+    the `Roxabi` org, set existing rows to that **real installation_id** (not a sentinel) via a
+    **chunked admin endpoint / `wrangler d1 execute … UPDATE … WHERE tenant_id IS NULL`** (mind D1
+    per-statement row caps; trivial at current data size but state the assumption + verify row-count =
+    0 NULLs before applying M-b). Define rollback for orphan rows.
+11. **`sync_control` per-tenant:** key-value bag becomes keyed by `(tenant_id, key)` (or a sibling
+    `tenant_sync_control`). Per-tenant: `auth_halt_count`, `last_auth_halt_at`, `sync_running`,
+    `sync_started_at`. Global: `data_version`. A per-installation failure must **not** hold another
+    tenant's lock or trip a global halt.
+
+### Sync & webhook isolation
+12. **Per-installation sync fan-out:** `runSync` loops installations → mint token → sync repos → write
+    scoped by `tenant_id`. Per-tenant auth-halt breaker (decision 11). **Remove `GITHUB_TOKEN` (PAT)**
+    from `Env` + `wrangler.toml` in the same child issue that ships installation tokens — **no PAT
+    fallback** (also retire its uses in `handleDeps`/`handleRefDelete`).
+13. **Webhook routing:** single App secret (reuse `webhook/hmac.ts`); after HMAC pass, **mandatory**
+    `payload.installation.id` → `installations` lookup → `tenant_id` **before any DB write**. Unknown/
+    deleted/suspended installation → **return 200 OK, perform no mutation** (so GitHub doesn't retry;
+    no orphan/wrong-tenant rows).
+14. **Cross-tenant edge / stub policy (security-critical):** stubs are **always written under the
+    requesting tenant's `tenant_id`**, `is_stub=1`, `title=NULL`, `body=NULL` — **never** populated with
+    content fetched under another installation's token. `closedHopPass` (currently a tenant-blind
+    `UNION` over all edges, `sync.ts:985`) is **scoped per-tenant** (walk only that tenant's edge
+    graph). Cross-tenant dep references therefore materialize as tenant-local title-less stubs, never as
+    another tenant's real data.
+
+### Reads & isolation
+15. **Every read tenant-scoped:** `listIssuesRoute` + `graphRoute` (5 queries) gain `WHERE tenant_id=?`;
+    **`getIssueRoute`** issue/labels/edges fetches gain **`AND tenant_id=?`** (closes the IDOR — keys
+    are public GitHub URLs). `tenant_id` always from the **validated session**, never a request param.
+16. **Multi-installation contract:** the **session encodes a single *active* `tenant_id`**. Login: if
+    the user has exactly one installation → use it; if >1 → **org-picker** sets the active tenant
+    (switchable later). **No UNION-across-tenants** queries (they would defeat composite-PK isolation
+    and complicate pagination). This makes every `/api/*` query single-tenant.
+
+### Deploy / CI (devops)
+17. **Add `wrangler d1 migrations apply` to `ci.yml`** per-env **before** each `wrangler deploy`
+    (`… apply DB --env staging` / `… apply DB`). It does **not** exist today → without it the
+    nullable→NOT-NULL sequence never runs.
+18. **Secret-presence guard** in CI for `GITHUB_APP_*` (a deploy with missing app secrets succeeds but
+    fails at first OAuth) — pre-deploy check or documented `wrangler secret put` pre-flight per env.
+19. **Staging needs a testable URL:** staging `route=[]` today → enable `workers_dev=true` (or a test
+    route) so the Access-boundary change can be validated end-to-end before prod.
+20. **Separate staging R2 bucket** `roxabi-live-logs-staging` (both envs currently point at prod
+    `roxabi-live-logs` → staging cron fan-out would pollute the prod audit trail).
+21. **CF Access boundary = explicit deployment gate (one-way):** session middleware deployed and
+    **verified returning 401** for unauthenticated callers **on staging** *before* the Access policy is
+    relaxed on any env. Order: staging smoke-test → Access policy update (Access → `/admin/*` only;
+    `/webhook/*` keeps its existing bypass) → prod. Rollback = re-enable the Access rule.
+
+### UX & honesty (product)
+22. **Onboarding state machine:** OAuth callback with **no installation for the user** → "authorized,
+    not installed" state → guided redirect to the App **install URL** with a clear CTA → re-check on
+    return. The acceptance path "logs in → sees issues" has no dead-end.
+23. **Operator-read honesty (concrete surface + AC):** a **consent step in the OAuth flow** (before
+    first data view) the user must **acknowledge**, plus a **persistent dashboard notice**. Copy warns
+    Phase-1 data is operator-readable and **not to paste secrets into issue bodies**. Binary AC: notice
+    acknowledged before any issue data renders.
+24. **`payload` shape (locked, product calls — see gate):** introduce `payload TEXT` JSON.
+    **`title` moves into `payload`** now (graph reads `JSON_EXTRACT(payload,'$.title')`; `state`/`edges`
+    stay structural/plaintext). **`body` deferred** (not synced in Phase 1 — broadens operator-readable
+    surface, no value to the Phase-1 graph; `payload` shape already accommodates it later). Phase 2 then
+    swaps **one** column to ciphertext.
+
+---
+
+## Key risks (beyond the settled mitigations)
+
+- **Composite-PK table-recreation** (dec. 9) is the riskiest migration: a partial failure leaves a
+  half-migrated table with no auto-rollback → must be a single, tested migration with a staging dry-run.
+- **CF Access one-way relax** (dec. 21): the window between relax and a working session = public data
+  exposure → the staging-gate is non-negotiable.
+- **Backfill correctness** (dec. 10): any row left `NULL` when M-b applies fails the migration; verify
+  `COUNT(*) WHERE tenant_id IS NULL = 0` first.
+
+## Pre-impl validation tasks (binary, do before writing the code they gate)
+
+- **RS256 in workerd:** confirm `crypto.subtle` `importKey(pkcs8, RSASSA-PKCS1-v1_5)` + `sign` works at
+  the App-JWT path (distinct from the ADR-verified RSA-OAEP). Fallback if not: re-evaluate App-JWT
+  approach. *Gates decision 7/12.*
+- **`subIssues`/`parent` via installation token:** one live call confirming no preview header needed
+  post-GA when the token type changes from PAT → installation. *Gates decision 12.*
+
+---
+
+## Files / surfaces impacted
+
+| Surface | Current file(s) | Phase-1 change |
+|---|---|---|
+| Auth (new) | `api/auth.ts` (`ADMIN_TOKEN` only) | `worker/src/auth/*`: App-JWT, OAuth exchange, sessions, middleware |
+| Schema | `migrations/0001..0003` | `000N_tenant_nullable+pks.sql` (recreate), `000N_auth_tables.sql`, `000N_tenant_not_null.sql` |
+| Env | `types.ts`, `wrangler.toml` (×2 envs) | + `GITHUB_APP_*`; **remove `GITHUB_TOKEN`**; staging URL + `roxabi-live-logs-staging` |
+| Sync | `sync/sync.ts`, `sync/graphql.ts` | per-installation loop + token mint; tenant-scoped writes; per-tenant `sync_control`; scoped `closedHopPass` |
+| Webhook | `webhook/handlers.ts`, `hmac.ts`, `mutations.ts` | `installation.id`→tenant routing; unknown→200 no-write; tenant-local title-less stubs |
+| Reads | `api/issues.ts`, `api/graph.ts` | middleware gate; `tenant_id`/`AND tenant_id=?` on all queries |
+| Routing | `router.ts` | `/login`, `/oauth/callback`; session middleware on `/api/*` |
+| Frontend | `frontend/app.js`, `index.html` | unauthenticated landing; login; account-link; org-picker; consent notice |
+| CI/deploy | `ci.yml`, `wrangler.toml`, CF Access policy | `d1 migrations apply` step; secret guards; Access→`/admin/*`; staging gate |
+
+## Open questions (genuinely open)
+
+- **Membership view evolution:** active-tenant + org-picker is the Phase-1 contract (dec. 16); a merged
+  cross-installation view is a possible later enhancement (out of Phase-1 scope).
+- **Private-key rotation runbook** detail (dual-key overlap mechanics) — documented at impl, not a gate.
+
+## Review Log
+
+5 parallel expert reviews (architect, security-auditor, devops, product-lead, doc-writer); all
+"needs improvement." Must-fixes folded into settled decisions: closedHopPass scoping (dec. 14),
+backfill procedure (dec. 10), composite-PK recreation (dec. 9), per-tenant `sync_control` (dec. 11),
+oauth_state single-use/TTL/redirect_uri (dec. 6), multi-installation contract (dec. 16), session
+revocation + fixation + cookie scope (dec. 1–3), `/api/*` middleware fail-closed + IDOR (dec. 4, 15),
+webhook unknown-installation no-write (dec. 13), PAT retirement (dec. 12), CI migrate-step + secret
+guards + staging URL + staging R2 (dec. 17–20), Access staging-gate (dec. 21), onboarding state
+machine + honesty surface (dec. 22–23), payload/title/body product calls (dec. 24). RS256 +
+subIssues moved to pre-impl validation tasks. Mermaid corrected (install async; cron bidirectional);
+composite-PK duplication removed.

--- a/artifacts/frames/141-multi-tenant-github-app-auth-frame.mdx
+++ b/artifacts/frames/141-multi-tenant-github-app-auth-frame.mdx
@@ -1,0 +1,105 @@
+---
+title: "Multi-tenant GitHub App auth — make roxabi-live a multi-user tool (Phase 1)"
+issue: 141
+status: approved
+tier: F-full
+date: 2026-06-09
+---
+
+## Problem
+
+`roxabi-live` is single-tenant. One CF Worker + one D1 sit behind CF Access for a single
+identity (`mickael@bouly.io`). The corpus, the hourly cron sync, the GitHub org webhook, and
+the dep-graph all assume **one operator's org data**. There is no path for another GitHub user
+to authenticate and see *their own* issues — it is a personal cockpit, not a product.
+
+Now is the trigger: the CF Worker + D1 stack was validated in production (M₁ cutover complete
+2026-06-08, `live.roxabi.dev` fully independent), so the foundation is proven and ready to
+extend from one user to many.
+
+This is **Phase 1** of the decision recorded in
+`artifacts/analyses/zk-encryption-spike-analysis.mdx` (ADR → Shape D, hybrid/phased). Phase 1
+is the multi-tenant, **server-centric** baseline. It deliberately does **not** make data
+operator-blind — that is Phase 2 (epic #142, blocked-by this). The auth primitive is chosen
+here so Phase 2 needs no auth rewrite.
+
+## Who
+
+- **Primary:** any GitHub user who installs / links the GitHub App → authenticates and sees
+  **only their own** issues + dep-graph in the cockpit.
+- **Secondary:** the operator (mickael) — runs and maintains sync, holds the D1 database. Must
+  now (a) enforce tenant isolation on every read, and (b) communicate honestly that in Phase 1
+  the operator **can** read user data (same trust users already place in GitHub for the same
+  issues), warning users not to paste secrets into issue bodies.
+
+## Constraints
+
+- **Auth primitive = a single GitHub App** (not an OAuth App). Issues both *installation
+  tokens* (server-to-server: cron, webhooks; `Issues:Read` covers `subIssues`/`parent`/
+  `blockedBy`/`blocking`, all GA) and *user-to-server tokens* (reused by Phase 2). Picking it
+  now means Phase 2 does not re-litigate auth.
+- **Server-side OAuth code-exchange endpoint holding `client_secret`** — GitHub PKCE does not
+  remove the secret, so a thin Worker endpoint is unavoidable. Secret must be **rotatable** and
+  **never logged**.
+- **App-level sessions replace CF Access** for the public app; CF Access stays only on
+  `/admin/*`. From day one: short TTL, **server-side revocation**, and a defined reaction to
+  GitHub App **un-installation**. (Retrofitting session invalidation later is harder than the
+  rest.) NOTE: session tokens at rest in D1 are operator-readable.
+- **D1 schema: single DB + `tenant_id`** on issues/edges (Durable-Object-per-tenant explicitly
+  rejected at this scale). The migration is **breaking** on the live DB (backfill existing rows
+  to a seed tenant); CF deploy + migration are **not transactional** → sequence
+  **migration-before-code** with a rollback path for orphan rows.
+- **Isolate a `payload` column** (title/body/notes JSON) from structural metadata (`state`,
+  `edges` stay plaintext) — so Phase 2 swaps **one column** to ciphertext, not the row shape.
+- **Per-install webhooks + tenant routing**; per-tenant sync scoping; cron fan-out within the
+  workerd limits (10k subrequests / 15 min CPU per invocation) → fine for hundreds of users;
+  move to Cloudflare Queues only beyond that.
+- **Runtime:** Cloudflare Workers (workerd) — `fetch()` + Web Crypto + D1 binding only.
+
+## Out of Scope
+
+- **Phase 2 client-side zero-knowledge / operator-blind mode** → epic **#142** (blocked-by
+  this). No ECIES, no browser-local keys, no ciphertext storage in Phase 1.
+- **Cloudflare Queues** migration for cron fan-out — deferred until ~hundreds of users.
+- **At-rest content encryption in Phase 1** — optional, a *product call* per the ADR open
+  questions, not a hard requirement here. Default = honest "operator can read." (Can be added
+  later as anti-DB-breach without being advertised as operator-blind.)
+- **Billing, plans, quotas, rate-limit tiering.**
+- **Multi-device key bootstrap, WASM-Argon2id** — Phase-2 concerns.
+
+## Premise Validity
+
+**Success in 6 months:** ≥1 GitHub user *other than the operator* has logged in via the GitHub
+App, linked their account, and sees **only their own** issues + dep-graph in production; tenant
+isolation is verified (no cross-tenant leakage observed). The epic's acceptance criterion — "a
+second GitHub user can log in, link their account, and see only their own issues + graph" — is
+met live.
+
+**Failure in 6 months (falsifiable):** after ship, **either** (i) external-tenant count = **0**
+(no non-operator user has successfully linked and used the tool across the period) **or**
+(ii) **≥1 observed cross-tenant data-exposure incident** in production (one tenant's issues
+rendered to another). Both are observable boolean/threshold states on a 6-month horizon and
+would trigger redesign-or-abort.
+
+**Simplest alternative:** keep CF Access and expand its allow-list to multiple emails — one
+shared single-org corpus, no GitHub App, no `tenant_id`.
+
+**Why not simplest:** a multi-email CF Access list still shows every allowed user the **same**
+corpus (the operator's org data), not their *own* GitHub issues. No per-user GitHub data, no
+isolation, no user token — it cannot become "their" tool, and it cannot graduate to Phase-2
+zero-knowledge (no user-to-server token, no per-tenant payload column). It fails the core
+outcome ("a tool for everyone").
+
+## Complexity
+
+**Tier: F-full** — multi-domain, new architecture, and a breaking migration on a live database.
+
+Signals observed:
+- **Multi-domain:** auth (GitHub App + OAuth exchange + sessions) · DB (breaking `tenant_id`
+  migration + `payload` column) · sync/webhook (per-install tokens, tenant routing) · API
+  (tenant-filtered reads) · frontend (login + account-link UI).
+- **New architecture:** GitHub App as auth primitive; app-level session layer replacing edge
+  CF Access; tenant model across the whole data path.
+- **Unknowns:** session revocation / App-uninstall reaction design; breaking live-DB migration
+  sequencing (non-transactional deploy+migrate) + orphan-row rollback.
+- **Size label:** `size:F-full` (L/XL).

--- a/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
+++ b/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
@@ -1,0 +1,176 @@
+---
+title: "Multi-tenant GitHub App auth — Phase 1 (#141)"
+issue: 141
+status: approved
+tier: F-full
+date: 2026-06-09
+promoted_from: artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+---
+
+## Context
+
+Source: `artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx` (approved, review-hardened)
+→ ADR `artifacts/analyses/zk-encryption-spike-analysis.mdx` (Shape D, Phase 1). Frame:
+`artifacts/frames/141-multi-tenant-github-app-auth-frame.mdx`.
+
+Turn the single-tenant cockpit (CF Worker + D1 behind CF Access for one identity) into a multi-user
+tool: any GitHub user logs in, links their account, sees **only their own** issues + dep-graph.
+Server-centric (operator *can* read — honest in UX); a single **GitHub App** serves both this phase
+and the future Phase-2 ZK mode (#142). Decision set = the analysis's 24 settled sub-decisions.
+
+## Goal
+
+A second GitHub user can log in, link their account, and see only their own issues + graph in prod,
+with tenant isolation verified — without an auth rewrite when Phase-2 ZK lands.
+
+## Users
+
+- **Primary:** any GitHub user (installs the App + authorizes) → scoped cockpit of their own issues.
+- **Secondary:** operator (mickael) — runs/maintains sync, holds D1; must enforce isolation and
+  honestly disclose Phase-1 operator-readability.
+
+## Expected Behavior
+
+1. **Logged-out** visitor hits `/` → unauthenticated landing with a **Log in with GitHub** button.
+2. **Login:** `/login` → GitHub authorize (with single-use `state`) → `/oauth/callback` exchanges
+   `code`→token (`client_secret`), creates/updates the `users` row, mints a **fresh** session
+   (cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`).
+3. **Not installed yet:** if the user has no installation, callback lands on an **"install the App"**
+   CTA → GitHub App install page → on return, `installation` webhook (or callback re-check) populates
+   `installations` + `user_installations`.
+4. **Consent:** before any issue data renders, the user must **acknowledge** a notice — "the operator
+   can read your issue data in this phase; don't paste secrets into issue bodies." A persistent
+   dashboard notice repeats it.
+5. **Active tenant:** exactly one installation → it becomes the active tenant; more than one → an
+   **org-picker** sets the active `tenant_id` (switchable). The session carries one active `tenant_id`.
+6. **Viewing:** `/api/issues`, `/api/issues/:key`, `/api/graph` return **only** rows where
+   `tenant_id = session.active_tenant`. No session → **401 before any DB query**.
+7. **Sync:** hourly cron loops installations, mints an installation token (App-JWT RS256) per install,
+   syncs that install's repos, writes rows tagged with the installation's `tenant_id`. The org webhook
+   delivers to one endpoint (one App secret); each event is routed to a tenant by `installation.id`;
+   an unknown installation → 200 OK, **no write**.
+8. **Logout / uninstall:** logout deletes the session row; GitHub App `installation.deleted` deletes
+   all sessions + data for that `tenant_id`.
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+  class User { github_user_id PK; login; created_at }
+  class Installation { installation_id PK; account_login; account_type; suspended_at }
+  class UserInstallation { github_user_id FK; installation_id FK; "PK(user,install)" }
+  class Session { token_hash PK; github_user_id FK; active_tenant_id; expires_at; created_at }
+  class OAuthState { state PK; redirect_after; expires_at }
+  class Issue { "PK(tenant_id,key)"; tenant_id; key; repo; number; state; payload_JSON_title_only; url; ...; is_stub }
+  class Edge { "PK(tenant_id,src_key,dst_key,kind)"; tenant_id; src_key; dst_key; kind }
+  class Label { "PK(tenant_id,issue_key,name)"; tenant_id; issue_key; name }
+  class PrState { "PK(tenant_id,repo,number)"; tenant_id; repo; number; state; ... }
+  class SyncControl { "PK(tenant_id,key)"; tenant_id; key; value; updated_at }
+  User "1" --> "*" UserInstallation
+  Installation "1" --> "*" UserInstallation
+  User "1" --> "*" Session
+  Installation "1" --> "*" Issue : tenant_id
+  Installation "1" --> "*" Edge : tenant_id
+  Issue "1" --> "*" Edge : key
+```
+
+> **`payload` (D24, Phase-2 ZK seam):** `issues` has **no top-level `title` column** — `title` lives
+> inside `payload` JSON (`JSON_EXTRACT(payload,'$.title')`); `body` is **absent** in Phase 1. Composite
+> PKs (table-recreation, D9) apply to `issues`, `edges`, **`labels`**, **`pr_state`**. `tenant_id` is
+> also added to existing `sync_state`, `repos`, `repo_allowlist` (D8).
+
+```mermaid
+flowchart LR
+  subgraph thisIssue[Phase 1 — this epic]
+    SES[session middleware] -->|active_tenant_id| READS[api/issues, api/graph]
+    CRON[cron fan-out] -->|installation token| ISS[(Issue/Edge rows<br/>tenant_id)]
+    WH[webhook router] -->|installation.id→tenant| ISS
+    READS --> ISS
+  end
+  subgraph future[Phase 2 #142 — out of scope]
+    CLIENT[browser ECIES] -.->|encrypts| PAY[payload column → ciphertext]
+  end
+  ISS -. payload swappable .-> PAY
+```
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| session middleware | `Session.token_hash`, `active_tenant_id`, `expires_at` | every `/api/*` | this issue |
+| `api/graph` | `Issue.{tenant_id,key,state,payload.title}`, `Edge.*` | page load / refresh | this issue |
+| `api/issues` | `Issue.*` (tenant-scoped) | list / detail | this issue |
+| cron sync | `Installation.installation_id`, per-tenant `SyncControl` | hourly | this issue |
+| webhook router | `Installation.installation_id` → `tenant_id` | on event | this issue |
+| Phase-2 client | `Issue.payload` (→ ciphertext) | opt-in ZK | **future (#142)** — payload column accessible |
+
+## Breadboard
+
+**Routes / handlers (N):**
+
+| ID | Affordance | Handler | Data touched |
+|----|-----------|---------|--------------|
+| N1 | `GET /login` | redirect→GitHub authorize + write `OAuthState` | `oauth_state` |
+| N2 | `GET /oauth/callback` | verify+delete `state`, `code`→token, upsert `User`, mint `Session` | `oauth_state`,`users`,`sessions` |
+| N3 | `GET /api/me` | session→user + installations + active tenant | `sessions`,`user_installations` |
+| N4 | `POST /logout` | delete session row | `sessions` |
+| N5 | `POST /api/active-tenant` | set `Session.active_tenant_id` (membership-checked) | `sessions`,`user_installations` |
+| N6 | `POST /webhook/github` (extend) | HMAC → `installation.id`→tenant → scoped mutate; `installation`/`installation.deleted` events | all tenant tables,`installations`,`sessions` |
+| N7 | `GET /api/issues` (extend) | middleware → `WHERE tenant_id=?` | `issues`,`labels` |
+| N8 | `GET /api/issues/:key` (extend) | middleware → `WHERE key=? AND tenant_id=?` | `issues`,`edges`,`labels` |
+| N9 | `GET /api/graph` (extend) | middleware → all 5 queries `WHERE tenant_id=?` | `issues`,`edges`,`labels`,`pr_state`,`repos` |
+| N10 | `scheduled` cron (extend) | loop installations → mint token → per-tenant sync | `installations`,`issues`,`edges`,per-tenant `sync_control` |
+
+**UI (U):**
+
+| ID | Affordance | Wires to |
+|----|-----------|----------|
+| U1 | Logged-out landing | N1 |
+| U2 | Log in with GitHub | N1 |
+| U3 | Install-App CTA (authorized-not-installed) | links to **GitHub App install URL (external)** → user installs → GitHub fires `installation` webhook → N6 |
+| U4 | Org-picker (>1 installation) | N5 |
+| U5 | Operator-read consent (acknowledge) | gates data render |
+| U6 | Persistent dashboard notice | — |
+| U7 | Logout | N4 |
+
+**Middleware/util (M):** M1 session middleware (fail-closed 401) on `/api/*`; M2 App-JWT RS256 signer;
+M3 installation-token minter (cache ≤1h); M4 HMAC verify (existing, reused).
+
+## Slices
+
+Vertical increments, dependency-ordered. **Each slice = one child issue.**
+
+| # | Slice | Demo-able outcome | Depends |
+|---|-------|-------------------|---------|
+| **S1** | **Schema & auth-table migrations + CI/infra** | **M-a** migration: `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist` + **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`) on `issues`/`edges`/`labels`/`pr_state` + new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state` + per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent). `ci.yml`: add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, in the `deploy:` job, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`). `wrangler.toml`: `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`. **Excludes the NOT-NULL migration (ships in S7).** | — |
+| **S2** | **GitHub App + OAuth login + sessions** | user OAuths → fresh session cookie; `GET /api/me` returns identity; logout revokes; `state` single-use+TTL; new secrets wired (per-env) | S1 |
+| **S3** | **Installation linking + per-installation sync (PAT retired) + backfill** | App install webhook populates `installations`/`user_installations`; `runSync` per-installation fan-out (App-JWT → install token); per-tenant `sync_control`/auth-halt; `closedHopPass` scoped per-tenant; **`GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete` — no fallback**; **backfill** existing rows to the operator's **real installation_id** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0` | S2 |
+| **S4** | **Webhook tenant routing + stub policy** | webhook event from install A writes only A's rows (route by `installation.id`); unknown install → 200 no-write; cross-tenant dep ref → tenant-local title-less stub; `installation.deleted` wipes tenant | S3 |
+| **S5** | **Tenant-filtered reads + active-tenant + org-picker** | `/api/*` behind fail-closed middleware; all reads `WHERE tenant_id=?` (IDOR on `/:key` closed); active tenant in session; org-picker for >1 install — **second user sees only their own issues + graph** | S2, S3 |
+| **S6** | **Login / account-link / consent UI** | full browser flow logged-out → login → install CTA → consent acknowledge → org-picker → scoped dashboard | S5 |
+| **S7** | **NOT-NULL migration + CF Access cutover + runbook** | re-verify `COUNT NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill); staging smoke-test gate passes (sessions return 401 unauth) → Access scoped to `/admin/*` only (`/webhook/*` keeps its bypass) → prod cutover; rollback runbook (re-enable Access rule) written to a tracked file | S6 |
+
+**Pre-impl validation (gates S2/S3, do first):** RS256 sign in workerd (`crypto.subtle` RSASSA-PKCS1-v1_5);
+`subIssues`/`parent` GraphQL via installation token (no preview header post-GA).
+
+## Success Criteria
+
+- [ ] **M-a** migration applies cleanly on **staging D1**: `tenant_id` nullable on issues/edges/labels/pr_state/sync_state/repos/repo_allowlist; **composite PKs via table-recreation on `issues`, `edges`, `labels`, `pr_state`**; 5 new auth tables; per-tenant `sync_control`.
+- [ ] `issues` has **no top-level `title` column** — `title` is stored inside `payload` and read via `JSON_EXTRACT(payload,'$.title')`; **`body` is absent** from the Phase-1 payload schema. (D24 ZK seam.)
+- [ ] `ci.yml` `deploy:` job runs `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`**; a CI secret-presence step (same pattern as `CF_API_TOKEN`) fails the deploy when any `GITHUB_APP_*` secret is empty.
+- [ ] `wrangler.toml` sets `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` and `[env.staging] workers_dev=true` (staging reachable for end-to-end auth test).
+- [ ] A user completes GitHub OAuth and receives a session; `GET /api/me` returns their GitHub identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
+- [ ] OAuth `state` is single-use (deleted on verify), TTL ≤ 10 min, and `redirect_uri` is Worker-hard-coded; a replayed `state` is rejected.
+- [ ] **Session security:** the token issued after OAuth is **freshly minted** (no pre-auth value reused); `sessions.token_hash` stores the **SHA-256 hash** of the token (never the token); the cookie is `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>` (not `.roxabi.dev`); presenting an old pre-auth value after login returns 401.
+- [ ] Cron sync mints a **per-installation** token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; `GITHUB_TOKEN` is removed from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` with **no fallback**; RS256 sign errors log the message only (never key/JWT).
+- [ ] Webhook resolves `payload.installation.id` → `tenant_id` via DB lookup **before** any INSERT/UPDATE/DELETE; unknown — or known-but-missing-`tenant_id` — installation → 200, **no write**; `installation.deleted` deletes that tenant's sessions + data.
+- [ ] A cross-tenant dependency reference materializes only as a `tenant_id`=requester, `is_stub=1`, `title=NULL` row — never another tenant's real title/body.
+- [ ] Every `/api/*` route is gated by fail-closed session middleware (no/invalid session → 401 **before** any DB statement).
+- [ ] `GET /api/issues/:key` and its label/edge sub-queries include `AND tenant_id=?` bound to the session's `active_tenant_id` **in the SQL** (code-review-verified); `GET /api/issues` + all 5 `GET /api/graph` queries filter by `tenant_id`; fetching a key that exists for another tenant returns **404** (not 200/500). [IDOR closed]
+- [ ] A user with >1 installation gets an org-picker; the session carries exactly one active `tenant_id`; **no query UNIONs across tenants**.
+- [ ] Before any issue data renders, the user must acknowledge the operator-read consent notice; a persistent dashboard notice is present.
+- [ ] **Acceptance:** a *second* GitHub account logs in, links its account, sees **only its own** issues + dep-graph; the operator account sees only `Roxabi`'s — verified live on staging.
+- [ ] **S7 cutover:** backfill re-verified (`COUNT NULL = 0`) → **M-b NOT-NULL migration** committed + applied (NOT-NULL file ships in S7, never earlier); app sessions verified returning 401 unauth on staging → CF Access scoped to `/admin/*` only (`/webhook/*` keeps bypass); rollback (re-enable Access) documented in a tracked runbook file.
+
+## Out of Scope (→ #142 or follow-up)
+
+Client-side ZK / operator-blind content; syncing issue `body`; merged cross-installation view;
+Cloudflare Queues fan-out; billing/quotas.

--- a/artifacts/specs/144-schema-tenant-migrations-spec.mdx
+++ b/artifacts/specs/144-schema-tenant-migrations-spec.mdx
@@ -1,0 +1,33 @@
+---
+title: "feat(schema): tenant_id + auth-table migrations + CI/infra (Phase 1 S1)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 144
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S1** of #141. Foundation migration + deploy plumbing — no runtime auth behavior yet.
+
+- **M-a migration:** `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist`; **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`, preserving indexes/FKs) on `issues`/`edges`/`labels`/`pr_state`; new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state`; per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent).
+- **CI (`ci.yml`, `deploy:` job):** add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`).
+- **`wrangler.toml`:** `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`.
+- **Excludes the NOT-NULL migration** (ships in S7/#150).
+
+## Success Criteria
+
+- [ ] M-a applies cleanly on staging D1 (nullable `tenant_id` on 7 tables; composite PKs on `issues`/`edges`/`labels`/`pr_state`; 5 new auth tables; per-tenant `sync_control`).
+- [ ] `issues` has no top-level `title` column — `title` in `payload` (`JSON_EXTRACT(payload,'$.title')`); `body` absent.
+- [ ] `ci.yml` migrate-step inside `CF_API_TOKEN` guard in `deploy:` job between `npm ci` and `wrangler deploy`; `GITHUB_APP_*` secret-presence guard present.
+- [ ] `wrangler.toml` staging R2 = `roxabi-live-logs-staging` + `[env.staging] workers_dev=true`.
+
+## Dependencies
+
+None (foundation).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx) ·
+ADR: [zk-encryption-spike-analysis.mdx](../analyses/zk-encryption-spike-analysis.mdx)

--- a/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
+++ b/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
@@ -1,0 +1,31 @@
+---
+title: "feat(auth): GitHub App + OAuth login + sessions (Phase 1 S2)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 145
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S2** of #141. Identity layer.
+
+- Register the single **GitHub App**; provision per-env secrets `GITHUB_APP_{ID,CLIENT_ID,CLIENT_SECRET,PRIVATE_KEY,WEBHOOK_SECRET}` (rotatable, never logged).
+- **App-JWT (RS256) signer** util (`crypto.subtle` RSASSA-PKCS1-v1_5). **Pre-impl gate: RS256-in-workerd smoke-test** — if it fails, re-evaluate the App-JWT path.
+- `GET /login` (redirect to GitHub authorize + single-use `state`) and `GET /oauth/callback` (verify+delete `state`, `code`→token with `client_secret`, upsert `users`, mint **fresh** session).
+- **`sessions`** writes (token **hashed at rest**); fail-closed session middleware (Hono, mirrors `checkAdminAuth`).
+
+## Success Criteria
+
+- [ ] OAuth → fresh session; `GET /api/me` returns identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
+- [ ] `state` single-use (deleted on verify), TTL ≤ 10 min, `redirect_uri` Worker-hard-coded; replay rejected.
+- [ ] Session token freshly minted post-auth (no pre-auth value reused); `sessions.token_hash` = SHA-256 of token; cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`.
+
+## Dependencies
+
+Blocked by **#144** (S1 — schema/auth tables).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/146-installation-sync-backfill-spec.mdx
+++ b/artifacts/specs/146-installation-sync-backfill-spec.mdx
@@ -1,0 +1,33 @@
+---
+title: "feat(sync): installation linking + per-install sync + PAT retired + backfill (Phase 1 S3)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 146
+status: approved
+tier: L
+---
+
+## Scope
+
+Slice **S3** of #141. Data-access + sync fan-out (the largest slice).
+
+- `installation` webhook → populate `installations` + `user_installations`; onboarding "authorized-not-installed" handled in S6.
+- `runSync` becomes a **per-installation loop:** App-JWT → `POST /app/installations/:id/access_tokens` (cache ≤ 1 h) → sync that install's repos → write rows tagged with its `tenant_id`.
+- Per-tenant `sync_control` / auth-halt breaker; **`closedHopPass` scoped per-tenant** (walk only that tenant's edge graph).
+- **Remove `GITHUB_TOKEN` (PAT)** from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` — **no fallback**.
+- **Backfill** existing rows to the operator's **real `installation_id`** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0`.
+- **Pre-impl gate:** `subIssues`/`parent` GraphQL via an installation token (confirm no preview header post-GA — token type changed from PAT).
+
+## Success Criteria
+
+- [ ] Cron mints a per-installation token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; RS256 sign errors log message only (never key/JWT).
+- [ ] `GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete`; no fallback.
+- [ ] Backfill executed; `COUNT(*) WHERE tenant_id IS NULL = 0` verified.
+
+## Dependencies
+
+Blocked by **#145** (S2 — App/OAuth/sessions).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/147-webhook-tenant-routing-spec.mdx
+++ b/artifacts/specs/147-webhook-tenant-routing-spec.mdx
@@ -1,0 +1,32 @@
+---
+title: "feat(webhook): tenant routing + cross-tenant stub policy (Phase 1 S4)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 147
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S4** of #141. Webhook isolation. Reuses the existing single-secret HMAC (`webhook/hmac.ts`).
+
+- After HMAC pass, **mandatory** `payload.installation.id` → `installations` lookup → `tenant_id` **before any** INSERT/UPDATE/DELETE.
+- Unknown / known-but-missing-`tenant_id` installation → **200 OK, no DB write** (so GitHub doesn't retry; no orphan/wrong-tenant rows).
+- All webhook mutations (`webhook/mutations.ts`) tenant-scoped.
+- **Cross-tenant dep stub policy:** a referenced foreign-repo issue materializes only as `tenant_id`=requester, `is_stub=1`, `title=NULL`, `body=NULL` — never another tenant's real content fetched under another installation's token.
+- `installation.deleted` → delete that tenant's sessions + data.
+
+## Success Criteria
+
+- [ ] Webhook resolves `installation.id` → `tenant_id` via DB lookup **before** any write; unknown/missing-tenant installation → 200, no write.
+- [ ] Cross-tenant dep reference → `tenant_id`=requester, `is_stub=1`, `title=NULL` row only.
+- [ ] `installation.deleted` deletes that tenant's sessions + data.
+
+## Dependencies
+
+Blocked by **#146** (S3 — installations table + per-tenant writes).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -1,0 +1,31 @@
+---
+title: "feat(api): tenant-filtered reads + active-tenant + org-picker (Phase 1 S5)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 148
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S5** of #141. **This slice satisfies the epic acceptance criterion.**
+
+- Fail-closed **session middleware on `/api/*`**: no/invalid session → **401 before any DB statement**.
+- Inject `tenant_id` (= session's active tenant) into every read: `listIssuesRoute`, all 5 `graphRoute` queries, and **`getIssueRoute`** (issue + labels + edges) with SQL-level **`AND tenant_id=?`** (closes the IDOR — keys are public GitHub URLs).
+- Session encodes **one active `tenant_id`**; user with >1 installation → **org-picker** (`POST /api/active-tenant`, membership-checked). **No cross-tenant UNION** queries.
+
+## Success Criteria
+
+- [ ] Every `/api/*` route gated by fail-closed middleware (no/invalid session → 401 before any DB statement).
+- [ ] `getIssueRoute` issue/label/edge queries include SQL-level `AND tenant_id=?` (code-review-verified); foreign-tenant key → 404; `listIssuesRoute` + 5 `graphRoute` queries tenant-filtered. [IDOR closed]
+- [ ] >1 installation → org-picker; session carries exactly one active `tenant_id`; no cross-tenant UNION.
+- [ ] **Acceptance:** a second GitHub account sees only its own issues + graph; operator sees only `Roxabi` — verified on staging.
+
+## Dependencies
+
+Blocked by **#145** (S2 — sessions) and **#146** (S3 — tenant data).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/149-login-consent-ui-spec.mdx
+++ b/artifacts/specs/149-login-consent-ui-spec.mdx
@@ -1,0 +1,30 @@
+---
+title: "feat(ui): login + account-link + operator-read consent (Phase 1 S6)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 149
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S6** of #141. Frontend (`frontend/index.html`, `app.js`).
+
+- Unauthenticated landing + **Log in with GitHub** button.
+- **Install-App CTA** for the authorized-not-installed state → links to the GitHub App install URL.
+- **Org-picker** UI (when >1 installation).
+- **Operator-read consent** the user must **acknowledge before any issue data renders** + a persistent dashboard notice ("operator can read your data this phase; don't paste secrets into issue bodies").
+
+## Success Criteria
+
+- [ ] Consent acknowledged before any issue data renders; persistent dashboard notice present.
+- [ ] Full browser flow works: logged-out → login → install CTA → consent → org-picker → scoped dashboard.
+
+## Dependencies
+
+Blocked by **#148** (S5 — tenant-filtered reads + active-tenant API).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/150-notnull-access-cutover-spec.mdx
+++ b/artifacts/specs/150-notnull-access-cutover-spec.mdx
@@ -1,0 +1,31 @@
+---
+title: "feat(deploy): NOT-NULL migration + CF Access cutover + runbook (Phase 1 S7)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 150
+status: approved
+tier: S
+---
+
+## Scope
+
+Slice **S7** of #141. Final cutover (one-way edge change — gated).
+
+- Re-verify `COUNT(*) WHERE tenant_id IS NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill runs).
+- **Staging smoke-test gate:** app sessions verified returning **401** for unauthenticated callers on staging.
+- → CF Access scoped to **`/admin/*` only** (`/webhook/*` keeps its existing bypass) → prod cutover.
+- Rollback runbook (re-enable the Access rule) written to a tracked file.
+
+## Success Criteria
+
+- [ ] Backfill re-verified (`COUNT NULL = 0`) → M-b NOT-NULL migration committed + applied (never earlier).
+- [ ] App sessions verified 401 unauth on staging → CF Access scoped to `/admin/*` only; `/webhook/*` bypass retained.
+- [ ] Rollback (re-enable Access) documented in a tracked runbook file.
+
+## Dependencies
+
+Blocked by **#149** (S6 — full UI flow shippable).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)


### PR DESCRIPTION
Planning baseline for **epic #141** (multi-tenant GitHub App auth, Phase 1 of ADR Shape D). **Docs-only — no worker code changes** (a staging deploy of unchanged code; safe).

## What this lands
- `frame` → `analysis` (Shape 3 + 24 settled decisions; 5 expert reviews folded) → `spec` (7 slices, 16 binary AC; 3 reviews folded) → 7 sub-specs.
- The ZK spike ADR is already on `staging` (commit 4421bec).

## Why now
Child worktrees (#144–#150) branch off `staging` and reference the parent spec — they need it published here before implementation starts.

## Epic decomposition (per-child `/dev`)
| Child | Slice | Size | blocked-by |
|---|---|---|---|
| #144 | schema + auth migrations + CI/infra | M | — |
| #145 | GitHub App + OAuth + sessions | M | #144 |
| #146 | install linking + per-install sync + PAT retired | L | #145 |
| #147 | webhook tenant routing + stub policy | M | #146 |
| #148 | tenant-filtered reads + active-tenant (acceptance) | M | #145, #146 |
| #149 | login + consent UI | M | #148 |
| #150 | NOT-NULL migration + CF Access cutover | S | #149 |

Implementation proceeds per-child starting `/dev #144`. Phase-2 (operator-blind ZK) = epic #142, blocked-by #141.

Refs #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)