### PR TITLE
docs(spec): repo-canonical pivot — amend #141 specs + analysis addendum

### DIFF
--- a/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+++ b/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
@@ -282,3 +282,86 @@ guards + staging URL + staging R2 (dec. 17–20), Access staging-gate (dec. 21),
 machine + honesty surface (dec. 22–23), payload/title/body product calls (dec. 24). RS256 +
 subIssues moved to pre-impl validation tasks. Mermaid corrected (install async; cron bidirectional);
 composite-PK duplication removed.
+
+---
+
+## Addendum (2026-06-10) — repo-canonical pivot
+
+### What changed and why
+
+Decisions 8, 9, and 10 in this analysis (lines above) specified the original **per-tenant**
+data model: composite PKs `(tenant_id, issue_key)` on `issues`/`edges`, a `tenant_id` column
+on data tables, a live-table PK recreation migration (M-a), and a backfill of `tenant_id` into
+existing rows. That model is **superseded** by the **repo-canonical** model ratified 2026-06-10.
+
+**The superseded decisions (preserved above as historical record):**
+- Dec. 8: composite PK `(tenant_id, key)` on `issues` — superseded
+- Dec. 9: live-table composite-PK recreation migration — superseded (eliminated)
+- Dec. 10: `COUNT(*) WHERE tenant_id IS NULL = 0` backfill gate — superseded (no backfill)
+
+### Repo-canonical model
+
+PKs on `issues` (`key = owner/repo#N`) and `edges` remain **unchanged** — globally unique,
+no `tenant_id` column added. Authorization is a JOIN at read time:
+
+```sql
+-- Superseded (stale):
+WHERE i.tenant_id = ?
+
+-- Current (repo-canonical):
+JOIN tenant_repo_access tra
+  ON tra.repo = i.repo
+  AND tra.tenant_id = ?
+```
+
+### Risk eliminated
+
+The riskiest migration step — recreating PKs on `issues`/`edges` live tables — is eliminated.
+No M-a migration. No M-b NOT NULL cutover on existing tables. S7 scope shrinks to: NOT NULL
+on **new tables only** + CF Access narrowed to `/admin/*`.
+
+### New tables (10 new + 2 ALTERs)
+
+New tables added by S1 migrations (#144): `tenants`, `users`, `user_installations`, `sessions`,
+`oauth_state`, `install_tokens`, `tenant_repo_access`, `user_repo_permission_cache`,
+`sync_control`, `zk_payloads`. Existing tables receive only:
+- `ALTER TABLE issues ADD COLUMN payload TEXT`
+- `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE`
+
+No `tenant_id` column on `issues`, `edges`, `labels`, or `pr_state`.
+
+### Corrections to prior synthesis
+
+| Item | Prior synthesis | Ratified (this addendum) |
+|---|---|---|
+| `zk_payloads` PK | `(tenant_id, issue_key)` | `(user_id, issue_key)` — ZK keys are per-user browser keys |
+| `installations` table | named `installations` | renamed `tenants` (has `installation_id` column) |
+| `sync_control` PK | `(tenant_id, key)` | confirmed `(tenant_id, key)` — unchanged |
+
+### Session SELECT (authoritative)
+
+```sql
+SELECT s.*, u.github_id, u.github_login
+FROM sessions s
+JOIN users u ON u.id = s.user_id
+WHERE s.token_hash = ?
+  AND s.expires_at > datetime('now')
+  AND s.revoked_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM tenants t
+    WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL
+  )
+```
+
+The NOT-EXISTS guard enforces suspended-tenant revocation without an immediate session flush.
+
+### Spec files updated (2026-06-10)
+
+All slice specs amended to reflect this pivot:
+- `141-multi-tenant-github-app-auth-spec.mdx` — pivot note + mermaid (repo-canonical)
+- `144-schema-tenant-migrations-spec.mdx` — full rewrite (10 tables + 2 ALTERs; no composite-PK recreation)
+- `145-github-app-oauth-sessions-spec.mdx` — `SameSite=Strict`; suspended-tenant guard; PKCS#8 contract; vitest RS256 CI guard
+- `146-installation-sync-backfill-spec.mdx` — per-repo fan-out; AES-GCM tokens; slot-rotation; SYNC_QUEUE DORMANT; PAT retirement; no backfill
+- `147-webhook-tenant-routing-spec.mdx` — lifecycle handlers; issue rows retained on `installation.deleted`; `user_repo_permission_cache` invalidation
+- `148-tenant-filtered-reads-spec.mdx` — JOIN `tenant_repo_access`; private-repo permission cache; no `tenant_id` in response shapes
+- `150-notnull-access-cutover-spec.mdx` — NOT NULL on new tables only; no backfill on old tables; CF Access → `/admin/*`

--- a/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
+++ b/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
@@ -5,7 +5,13 @@ status: approved
 tier: F-full
 date: 2026-06-09
 promoted_from: artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Data model amended from per-tenant (composite PKs + `tenant_id` on
+> all tables) to **repo-canonical**. `issues`/`edges`/`labels`/`pr_state` PKs are **unchanged**;
+> `tenant_id` is **never added** to those tables. Authorization is a JOIN-only layer
+> (`tenant_repo_access`). Risky table-recreation step eliminated. See analysis addendum.
 
 ## Context
 
@@ -34,50 +40,52 @@ with tenant isolation verified — without an auth rewrite when Phase-2 ZK lands
 1. **Logged-out** visitor hits `/` → unauthenticated landing with a **Log in with GitHub** button.
 2. **Login:** `/login` → GitHub authorize (with single-use `state`) → `/oauth/callback` exchanges
    `code`→token (`client_secret`), creates/updates the `users` row, mints a **fresh** session
-   (cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`).
+   (cookie `HttpOnly; Secure; SameSite=Strict; Domain=<exact host>`).
 3. **Not installed yet:** if the user has no installation, callback lands on an **"install the App"**
    CTA → GitHub App install page → on return, `installation` webhook (or callback re-check) populates
-   `installations` + `user_installations`.
+   `tenants` + `user_installations` + `tenant_repo_access` rows.
 4. **Consent:** before any issue data renders, the user must **acknowledge** a notice — "the operator
    can read your issue data in this phase; don't paste secrets into issue bodies." A persistent
    dashboard notice repeats it.
 5. **Active tenant:** exactly one installation → it becomes the active tenant; more than one → an
    **org-picker** sets the active `tenant_id` (switchable). The session carries one active `tenant_id`.
 6. **Viewing:** `/api/issues`, `/api/issues/:key`, `/api/graph` return **only** rows where
-   `tenant_id = session.active_tenant`. No session → **401 before any DB query**.
+   `tenant_repo_access.tenant_id = session.active_tenant` (JOIN filter). No session → **401 before any DB query**.
 7. **Sync:** hourly cron loops installations, mints an installation token (App-JWT RS256) per install,
    syncs that install's repos, writes rows tagged with the installation's `tenant_id`. The org webhook
    delivers to one endpoint (one App secret); each event is routed to a tenant by `installation.id`;
    an unknown installation → 200 OK, **no write**.
 8. **Logout / uninstall:** logout deletes the session row; GitHub App `installation.deleted` deletes
-   all sessions + data for that `tenant_id`.
+   `tenant_repo_access` rows for that tenant — **issue/edge rows are retained** (globally-keyed data).
 
 ## Data Model & Consumers
 
 ```mermaid
 classDiagram
-  class User { github_user_id PK; login; created_at }
-  class Installation { installation_id PK; account_login; account_type; suspended_at }
-  class UserInstallation { github_user_id FK; installation_id FK; "PK(user,install)" }
-  class Session { token_hash PK; github_user_id FK; active_tenant_id; expires_at; created_at }
+  class User { id PK; github_id UNIQUE; github_login; created_at }
+  class Tenant { id PK; installation_id UNIQUE; account_login; account_type; suspended_at }
+  class UserInstallation { user_id FK; tenant_id FK; "PK(user_id,tenant_id)" }
+  class Session { id PK; user_id FK; tenant_id FK; token_hash UNIQUE; expires_at; revoked_at }
   class OAuthState { state PK; redirect_after; expires_at }
-  class Issue { "PK(tenant_id,key)"; tenant_id; key; repo; number; state; payload_JSON_title_only; url; ...; is_stub }
-  class Edge { "PK(tenant_id,src_key,dst_key,kind)"; tenant_id; src_key; dst_key; kind }
-  class Label { "PK(tenant_id,issue_key,name)"; tenant_id; issue_key; name }
-  class PrState { "PK(tenant_id,repo,number)"; tenant_id; repo; number; state; ... }
-  class SyncControl { "PK(tenant_id,key)"; tenant_id; key; value; updated_at }
+  class InstallToken { tenant_id PK FK; token_enc; token_iv; expires_at }
+  class TenantRepoAccess { tenant_id FK; repo; "PK(tenant_id,repo)" }
+  class Issue { key PK; repo; number; state; payload; url; ...; is_stub }
+  class Edge { "PK(src_key,dst_key,kind)"; src_key; dst_key; kind }
+  class SyncControl { "PK(tenant_id,key)"; tenant_id FK; key; value; updated_at }
   User "1" --> "*" UserInstallation
-  Installation "1" --> "*" UserInstallation
+  Tenant "1" --> "*" UserInstallation
   User "1" --> "*" Session
-  Installation "1" --> "*" Issue : tenant_id
-  Installation "1" --> "*" Edge : tenant_id
+  Tenant "1" --> "*" TenantRepoAccess
+  Tenant "1" --> "*" SyncControl
+  Tenant "1" --> "1" InstallToken
+  TenantRepoAccess "*" --> "*" Issue : repo filter
   Issue "1" --> "*" Edge : key
 ```
 
 > **`payload` (D24, Phase-2 ZK seam):** `issues` has **no top-level `title` column** — `title` lives
-> inside `payload` JSON (`JSON_EXTRACT(payload,'$.title')`); `body` is **absent** in Phase 1. Composite
-> PKs (table-recreation, D9) apply to `issues`, `edges`, **`labels`**, **`pr_state`**. `tenant_id` is
-> also added to existing `sync_state`, `repos`, `repo_allowlist` (D8).
+> inside `payload` JSON (`JSON_EXTRACT(payload,'$.title')`); `body` is **absent** in Phase 1.
+> `issues`/`edges`/`labels`/`pr_state` **PKs are unchanged** — no `tenant_id` column added to those
+> tables. Authorization is a JOIN through `tenant_repo_access` (fail-closed: no row → no data).
 
 ```mermaid
 flowchart LR
@@ -95,11 +103,11 @@ flowchart LR
 
 | Consumer | Fields consumed | When | Status |
 |---|---|---|---|
-| session middleware | `Session.token_hash`, `active_tenant_id`, `expires_at` | every `/api/*` | this issue |
-| `api/graph` | `Issue.{tenant_id,key,state,payload.title}`, `Edge.*` | page load / refresh | this issue |
-| `api/issues` | `Issue.*` (tenant-scoped) | list / detail | this issue |
-| cron sync | `Installation.installation_id`, per-tenant `SyncControl` | hourly | this issue |
-| webhook router | `Installation.installation_id` → `tenant_id` | on event | this issue |
+| session middleware | `Session.token_hash`, `tenant_id`, `expires_at`; NOT-suspended guard via `tenants` | every `/api/*` | this issue |
+| `api/graph` | `Issue.{key,state,payload.title}`, `Edge.*`, JOIN `tenant_repo_access` | page load / refresh | this issue |
+| `api/issues` | `Issue.*` + JOIN `tenant_repo_access` (+ `user_repo_permission_cache` for private) | list / detail | this issue |
+| cron sync | `Tenant.installation_id`, `InstallToken.token_enc/iv`, per-tenant `SyncControl` | hourly | this issue |
+| webhook router | `payload.installation.id` → `tenants` lookup → `tenant_repo_access` writes | on event | this issue |
 | Phase-2 client | `Issue.payload` (→ ciphertext) | opt-in ZK | **future (#142)** — payload column accessible |
 
 ## Breadboard
@@ -113,11 +121,11 @@ flowchart LR
 | N3 | `GET /api/me` | session→user + installations + active tenant | `sessions`,`user_installations` |
 | N4 | `POST /logout` | delete session row | `sessions` |
 | N5 | `POST /api/active-tenant` | set `Session.active_tenant_id` (membership-checked) | `sessions`,`user_installations` |
-| N6 | `POST /webhook/github` (extend) | HMAC → `installation.id`→tenant → scoped mutate; `installation`/`installation.deleted` events | all tenant tables,`installations`,`sessions` |
-| N7 | `GET /api/issues` (extend) | middleware → `WHERE tenant_id=?` | `issues`,`labels` |
-| N8 | `GET /api/issues/:key` (extend) | middleware → `WHERE key=? AND tenant_id=?` | `issues`,`edges`,`labels` |
-| N9 | `GET /api/graph` (extend) | middleware → all 5 queries `WHERE tenant_id=?` | `issues`,`edges`,`labels`,`pr_state`,`repos` |
-| N10 | `scheduled` cron (extend) | loop installations → mint token → per-tenant sync | `installations`,`issues`,`edges`,per-tenant `sync_control` |
+| N6 | `POST /webhook/github` (extend) | HMAC → `installation.id`→`tenants` lookup → scoped mutate; `installation.created/deleted/suspend/unsuspend`, `installation_repositories`, `repository.renamed/transferred/privatized/publicized`, `member.removed`/`membership.removed` | `tenants`,`tenant_repo_access`,`user_installations`,`sessions` |
+| N7 | `GET /api/issues` (extend) | middleware → `JOIN tenant_repo_access WHERE tenant_id=?` | `issues`,`labels`,`tenant_repo_access` |
+| N8 | `GET /api/issues/:key` (extend) | middleware → `JOIN tenant_repo_access WHERE key=? AND tra.tenant_id=?` | `issues`,`edges`,`labels`,`tenant_repo_access` |
+| N9 | `GET /api/graph` (extend) | middleware → all 5 queries `JOIN tenant_repo_access WHERE tenant_id=?` | `issues`,`edges`,`labels`,`pr_state`,`repos`,`tenant_repo_access` |
+| N10 | `scheduled` cron (extend) | loop repos (from `tenant_repo_access`) → AES-GCM decrypt install token → per-repo sync + slot-rotation | `tenants`,`install_tokens`,`tenant_repo_access`,`issues`,`edges`,`sync_control` |
 
 **UI (U):**
 
@@ -140,11 +148,11 @@ Vertical increments, dependency-ordered. **Each slice = one child issue.**
 
 | # | Slice | Demo-able outcome | Depends |
 |---|-------|-------------------|---------|
-| **S1** | **Schema & auth-table migrations + CI/infra** | **M-a** migration: `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist` + **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`) on `issues`/`edges`/`labels`/`pr_state` + new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state` + per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent). `ci.yml`: add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, in the `deploy:` job, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`). `wrangler.toml`: `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`. **Excludes the NOT-NULL migration (ships in S7).** | — |
+| **S1** | **Schema & auth-table migrations + CI/infra** | **M-a** migration: **10 new tables** (`tenants`, `users`, `user_installations`, `sessions`, `oauth_state`, `install_tokens`, `tenant_repo_access`, `user_repo_permission_cache`, `sync_control` with composite PK `(tenant_id,key)`, `zk_payloads`) + **2 ALTERs** (`ALTER TABLE issues ADD COLUMN payload TEXT`; `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE`). **No composite-PK recreation; no `tenant_id` column on `issues`/`edges`/`labels`/`pr_state`.** **`title` moved into `payload` JSON** (no top-level `title`; `body` absent). `ci.yml`: add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, in the `deploy:` job, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`). `wrangler.toml`: `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true` + `SYNC_QUEUE` binding declared **DORMANT**. **Excludes the NOT-NULL migration (ships in S7).** | — |
 | **S2** | **GitHub App + OAuth login + sessions** | user OAuths → fresh session cookie; `GET /api/me` returns identity; logout revokes; `state` single-use+TTL; new secrets wired (per-env) | S1 |
-| **S3** | **Installation linking + per-installation sync (PAT retired) + backfill** | App install webhook populates `installations`/`user_installations`; `runSync` per-installation fan-out (App-JWT → install token); per-tenant `sync_control`/auth-halt; `closedHopPass` scoped per-tenant; **`GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete` — no fallback**; **backfill** existing rows to the operator's **real installation_id** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0` | S2 |
+| **S3** | **Per-repo sync fan-out + AES-GCM install tokens + PAT retired** | `installation` webhook populates `tenants`/`user_installations`/`tenant_repo_access`; `runSync` loops **repos** (from `tenant_repo_access`) not installations — deduplicated fan-out; credentials = AES-GCM-decrypted install token (`install_tokens.token_enc/iv`, DEK = `INSTALL_TOKEN_KEY` secret); per-tenant `sync_control` slot-rotation; `SYNC_QUEUE` binding declared **DORMANT** (no active consumer); **`GITHUB_TOKEN` (PAT) removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete` — no fallback**; PAT retired after **first successful installation sync, staging first**. No `tenant_id` backfill (no column to fill). | S2 |
 | **S4** | **Webhook tenant routing + stub policy** | webhook event from install A writes only A's rows (route by `installation.id`); unknown install → 200 no-write; cross-tenant dep ref → tenant-local title-less stub; `installation.deleted` wipes tenant | S3 |
-| **S5** | **Tenant-filtered reads + active-tenant + org-picker** | `/api/*` behind fail-closed middleware; all reads `WHERE tenant_id=?` (IDOR on `/:key` closed); active tenant in session; org-picker for >1 install — **second user sees only their own issues + graph** | S2, S3 |
+| **S5** | **Tenant-filtered reads + active-tenant + org-picker** | `/api/*` behind fail-closed middleware (session includes NOT-suspended-tenant guard); all reads filtered via `JOIN tenant_repo_access WHERE tenant_id=?` (IDOR on `/:key` closed); private repos add `user_repo_permission_cache` check; active tenant in session; org-picker for >1 install — **second user sees only their own issues + graph** | S2, S3 |
 | **S6** | **Login / account-link / consent UI** | full browser flow logged-out → login → install CTA → consent acknowledge → org-picker → scoped dashboard | S5 |
 | **S7** | **NOT-NULL migration + CF Access cutover + runbook** | re-verify `COUNT NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill); staging smoke-test gate passes (sessions return 401 unauth) → Access scoped to `/admin/*` only (`/webhook/*` keeps its bypass) → prod cutover; rollback runbook (re-enable Access rule) written to a tracked file | S6 |
 
@@ -153,22 +161,22 @@ Vertical increments, dependency-ordered. **Each slice = one child issue.**
 
 ## Success Criteria
 
-- [ ] **M-a** migration applies cleanly on **staging D1**: `tenant_id` nullable on issues/edges/labels/pr_state/sync_state/repos/repo_allowlist; **composite PKs via table-recreation on `issues`, `edges`, `labels`, `pr_state`**; 5 new auth tables; per-tenant `sync_control`.
+- [ ] **M-a** migration applies cleanly on **staging D1**: **10 new tables** created; `ALTER TABLE issues ADD COLUMN payload TEXT` + `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` applied; **no `tenant_id` column on `issues`/`edges`/`labels`/`pr_state`; no composite-PK table-recreation**.
 - [ ] `issues` has **no top-level `title` column** — `title` is stored inside `payload` and read via `JSON_EXTRACT(payload,'$.title')`; **`body` is absent** from the Phase-1 payload schema. (D24 ZK seam.)
 - [ ] `ci.yml` `deploy:` job runs `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`**; a CI secret-presence step (same pattern as `CF_API_TOKEN`) fails the deploy when any `GITHUB_APP_*` secret is empty.
 - [ ] `wrangler.toml` sets `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` and `[env.staging] workers_dev=true` (staging reachable for end-to-end auth test).
 - [ ] A user completes GitHub OAuth and receives a session; `GET /api/me` returns their GitHub identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
 - [ ] OAuth `state` is single-use (deleted on verify), TTL ≤ 10 min, and `redirect_uri` is Worker-hard-coded; a replayed `state` is rejected.
-- [ ] **Session security:** the token issued after OAuth is **freshly minted** (no pre-auth value reused); `sessions.token_hash` stores the **SHA-256 hash** of the token (never the token); the cookie is `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>` (not `.roxabi.dev`); presenting an old pre-auth value after login returns 401.
-- [ ] Cron sync mints a **per-installation** token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; `GITHUB_TOKEN` is removed from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` with **no fallback**; RS256 sign errors log the message only (never key/JWT).
-- [ ] Webhook resolves `payload.installation.id` → `tenant_id` via DB lookup **before** any INSERT/UPDATE/DELETE; unknown — or known-but-missing-`tenant_id` — installation → 200, **no write**; `installation.deleted` deletes that tenant's sessions + data.
+- [ ] **Session security:** the token issued after OAuth is **freshly minted** (no pre-auth value reused); `sessions.token_hash` stores the **SHA-256 hash** of the token (never the token); the cookie is `HttpOnly; Secure; SameSite=Strict; Domain=<exact host>` (not `.roxabi.dev`); presenting an old pre-auth value after login returns 401.
+- [ ] Cron sync loops **repos** (from `tenant_repo_access`) — not installations — deduplicated fan-out; credentials = AES-GCM-decrypted install token (`install_tokens.token_enc/iv`, DEK = `INSTALL_TOKEN_KEY` secret); per-tenant `sync_control` slot-rotation; `GITHUB_TOKEN` is removed from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` with **no fallback**; RS256 sign errors log the message only (never key/JWT). No `tenant_id` backfill (no column to fill).
+- [ ] Webhook resolves `payload.installation.id` → `tenants` lookup **before** any INSERT/UPDATE/DELETE; unknown installation → 200, **no write**; handles `installation.created/deleted/suspend/unsuspend`, `installation_repositories.added/removed`, `repository.renamed/transferred/privatized/publicized`, `member.removed`/`membership.removed`; `installation.deleted` deletes `tenant_repo_access` rows only — **issue/edge rows are retained** (globally-keyed data).
 - [ ] A cross-tenant dependency reference materializes only as a `tenant_id`=requester, `is_stub=1`, `title=NULL` row — never another tenant's real title/body.
 - [ ] Every `/api/*` route is gated by fail-closed session middleware (no/invalid session → 401 **before** any DB statement).
-- [ ] `GET /api/issues/:key` and its label/edge sub-queries include `AND tenant_id=?` bound to the session's `active_tenant_id` **in the SQL** (code-review-verified); `GET /api/issues` + all 5 `GET /api/graph` queries filter by `tenant_id`; fetching a key that exists for another tenant returns **404** (not 200/500). [IDOR closed]
+- [ ] `GET /api/issues/:key` and its label/edge sub-queries are filtered via **`JOIN tenant_repo_access tra ON tra.repo=i.repo AND tra.tenant_id=?`** bound to the session's `active_tenant` **in the SQL** (code-review-verified); `GET /api/issues` + all 5 `GET /api/graph` queries use the same JOIN; private repos add a `user_repo_permission_cache` check; fetching a key that belongs to another tenant returns **404** (not 200/500). [IDOR closed]
 - [ ] A user with >1 installation gets an org-picker; the session carries exactly one active `tenant_id`; **no query UNIONs across tenants**.
 - [ ] Before any issue data renders, the user must acknowledge the operator-read consent notice; a persistent dashboard notice is present.
 - [ ] **Acceptance:** a *second* GitHub account logs in, links its account, sees **only its own** issues + dep-graph; the operator account sees only `Roxabi`'s — verified live on staging.
-- [ ] **S7 cutover:** backfill re-verified (`COUNT NULL = 0`) → **M-b NOT-NULL migration** committed + applied (NOT-NULL file ships in S7, never earlier); app sessions verified returning 401 unauth on staging → CF Access scoped to `/admin/*` only (`/webhook/*` keeps bypass); rollback (re-enable Access) documented in a tracked runbook file.
+- [ ] **S7 cutover:** **M-b NOT-NULL migration** applies only to new tables (no NOT-NULL on `issues`/`edges`/`labels`/`pr_state` — no backfill required); NOT-NULL file committed + applied (ships in S7, never earlier); app sessions verified returning 401 unauth on staging → CF Access scoped to `/admin/*` only (`/webhook/*` keeps bypass); rollback (re-enable Access) documented in a tracked runbook file.
 
 ## Out of Scope (→ #142 or follow-up)
 

--- a/artifacts/specs/144-schema-tenant-migrations-spec.mdx
+++ b/artifacts/specs/144-schema-tenant-migrations-spec.mdx
@@ -1,27 +1,148 @@
 ---
-title: "feat(schema): tenant_id + auth-table migrations + CI/infra (Phase 1 S1)"
+title: "feat(schema): auth-table migrations + CI/infra (Phase 1 S1)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 144
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Scope rewritten from "nullable `tenant_id` on 7 existing tables +
+> composite-PK recreation + 5 new auth tables" to **10 new tables + 2 ALTERs only**.
+> No `tenant_id` column on `issues`/`edges`/`labels`/`pr_state`; no composite-PK table-recreation.
 
 ## Scope
 
 Slice **S1** of #141. Foundation migration + deploy plumbing — no runtime auth behavior yet.
 
-- **M-a migration:** `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist`; **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`, preserving indexes/FKs) on `issues`/`edges`/`labels`/`pr_state`; new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state`; per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent).
-- **CI (`ci.yml`, `deploy:` job):** add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`).
-- **`wrangler.toml`:** `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`.
-- **Excludes the NOT-NULL migration** (ships in S7/#150).
+- **M-a migration:** Create **10 new tables** (all nullable-safe; no existing table PK recreation):
+  `tenants`, `users`, `user_installations`, `sessions`, `oauth_state`, `install_tokens`,
+  `tenant_repo_access`, `user_repo_permission_cache`, `sync_control` (composite PK `(tenant_id,key)`),
+  `zk_payloads` (PK `(user_id,issue_key)` — per-user browser keys, not per-tenant).
+- **2 ALTERs on existing tables:**
+  - `ALTER TABLE issues ADD COLUMN payload TEXT` — ZK seam (D24); `title` lives inside `payload`
+    JSON (`JSON_EXTRACT(payload,'$.title')`); `body` absent in Phase 1.
+  - `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` — rename anchor for `repository.renamed`
+    webhook events.
+- **No composite-PK recreation.** `issues`/`edges`/`labels`/`pr_state` keep globally-unique PKs
+  unchanged; `tenant_id` is **never added** to those tables.
+- **CI (`ci.yml`, `deploy:` job):** add `wrangler d1 migrations apply DB [--env staging]` **inside
+  the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence
+  guard (same pattern as `CF_API_TOKEN`).
+- **`wrangler.toml`:** `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` +
+  `[env.staging] workers_dev=true` + `SYNC_QUEUE` binding declared **DORMANT** (no active consumer;
+  placeholder for future Queues-based fan-out).
+- **Excludes the NOT-NULL migration** (ships in S7/#150 — applies only to new tables).
+
+## DDL
+
+```sql
+-- tenants: one row per GitHub App installation
+CREATE TABLE tenants (
+  id              INTEGER PRIMARY KEY,
+  installation_id INTEGER NOT NULL UNIQUE,
+  account_login   TEXT NOT NULL,
+  account_type    TEXT NOT NULL CHECK(account_type IN ('User','Organization')),
+  suspended_at    TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- users: one row per GitHub user who has authorized the App
+CREATE TABLE users (
+  id           INTEGER PRIMARY KEY,
+  github_id    INTEGER NOT NULL UNIQUE,
+  github_login TEXT NOT NULL,
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- user_installations: which users belong to which tenant
+CREATE TABLE user_installations (
+  user_id   INTEGER NOT NULL REFERENCES users(id),
+  tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+  PRIMARY KEY (user_id, tenant_id)
+);
+
+-- sessions: D1 (not KV) for strongly-consistent revocation
+CREATE TABLE sessions (
+  id          INTEGER PRIMARY KEY,
+  user_id     INTEGER NOT NULL REFERENCES users(id),
+  tenant_id   INTEGER NOT NULL REFERENCES tenants(id),
+  token_hash  TEXT NOT NULL UNIQUE,
+  expires_at  TEXT NOT NULL,
+  revoked_at  TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- oauth_state: single-use PKCE-like state for OAuth flow
+CREATE TABLE oauth_state (
+  state         TEXT PRIMARY KEY,
+  redirect_after TEXT,
+  expires_at    TEXT NOT NULL,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- install_tokens: AES-GCM-encrypted installation access tokens; DEK = INSTALL_TOKEN_KEY secret
+CREATE TABLE install_tokens (
+  tenant_id  INTEGER NOT NULL REFERENCES tenants(id) PRIMARY KEY,
+  token_enc  TEXT NOT NULL,
+  token_iv   TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- tenant_repo_access: authorization layer (fail-closed: no row → no data)
+CREATE TABLE tenant_repo_access (
+  tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+  repo      TEXT NOT NULL,
+  PRIMARY KEY (tenant_id, repo)
+);
+
+-- user_repo_permission_cache: per-user private-repo permission; 24h TTL
+CREATE TABLE user_repo_permission_cache (
+  user_id    INTEGER NOT NULL REFERENCES users(id),
+  repo       TEXT NOT NULL,
+  has_access INTEGER NOT NULL DEFAULT 0,
+  checked_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, repo)
+);
+
+-- sync_control: per-tenant lock/slot-rotation state; composite PK avoids cross-tenant contention
+CREATE TABLE sync_control (
+  tenant_id  INTEGER NOT NULL REFERENCES tenants(id),
+  key        TEXT NOT NULL,
+  value      TEXT,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, key)
+);
+
+-- zk_payloads: Phase-2 ZK seam; PK is per-user (browser keys, not per-tenant)
+CREATE TABLE zk_payloads (
+  user_id           INTEGER NOT NULL REFERENCES users(id),
+  issue_key         TEXT NOT NULL,
+  pubkey_fp         TEXT NOT NULL,
+  encrypted_payload TEXT NOT NULL,
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, issue_key)
+);
+
+-- ALTERs on existing tables (safe: nullable, no PK change)
+ALTER TABLE issues ADD COLUMN payload TEXT;
+ALTER TABLE repos  ADD COLUMN repo_node_id TEXT UNIQUE;
+```
 
 ## Success Criteria
 
-- [ ] M-a applies cleanly on staging D1 (nullable `tenant_id` on 7 tables; composite PKs on `issues`/`edges`/`labels`/`pr_state`; 5 new auth tables; per-tenant `sync_control`).
+- [ ] M-a applies cleanly on staging D1: **10 new tables** created; `ALTER TABLE issues ADD COLUMN
+  payload TEXT` + `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` applied; **no `tenant_id`
+  column on `issues`/`edges`/`labels`/`pr_state`; no composite-PK table-recreation**.
 - [ ] `issues` has no top-level `title` column — `title` in `payload` (`JSON_EXTRACT(payload,'$.title')`); `body` absent.
+- [ ] `zk_payloads` PK is `(user_id, issue_key)` (not `tenant_id`) — verified in migration DDL.
+- [ ] `sync_control` PK is `(tenant_id, key)` composite — verified in migration DDL.
 - [ ] `ci.yml` migrate-step inside `CF_API_TOKEN` guard in `deploy:` job between `npm ci` and `wrangler deploy`; `GITHUB_APP_*` secret-presence guard present.
-- [ ] `wrangler.toml` staging R2 = `roxabi-live-logs-staging` + `[env.staging] workers_dev=true`.
+- [ ] `wrangler.toml` staging R2 = `roxabi-live-logs-staging` + `[env.staging] workers_dev=true` + `SYNC_QUEUE` binding present but **DORMANT** (no active consumer).
 
 ## Dependencies
 

--- a/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
+++ b/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
@@ -5,22 +5,37 @@ parent_issue: 141
 issue: 145
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** SameSite=Lax → **SameSite=Strict**. Added: suspended-tenant session
+> guard; PKCS#8 private-key conversion contract; vitest RS256 sign/verify CI guard.
 
 ## Scope
 
 Slice **S2** of #141. Identity layer.
 
 - Register the single **GitHub App**; provision per-env secrets `GITHUB_APP_{ID,CLIENT_ID,CLIENT_SECRET,PRIVATE_KEY,WEBHOOK_SECRET}` (rotatable, never logged).
-- **App-JWT (RS256) signer** util (`crypto.subtle` RSASSA-PKCS1-v1_5). **Pre-impl gate: RS256-in-workerd smoke-test** — if it fails, re-evaluate the App-JWT path.
+- **`GITHUB_APP_PRIVATE_KEY` contract:** convert the PEM once:
+  `openssl pkcs8 -topk8 -nocrypt -in app.pem -outform DER | base64 -w0` → secret = `base64(PKCS#8 DER)`.
+  Worker: `atob(secret) → importKey('pkcs8', …, { name:'RSASSA-PKCS1-v1_5', hash:'SHA-256' }, false, ['sign'])`.
+  RS256 natively supported. Rotation: 2 active keys = zero-downtime; redeploy coupled; document in runbook.
+- **App-JWT (RS256) signer** util (`crypto.subtle` RSASSA-PKCS1-v1_5). **Pre-impl gate: RS256-in-workerd smoke-test** — if it fails, re-evaluate the App-JWT path. Add **vitest (workers pool) test** for RS256 sign/verify with a throwaway key as a permanent CI guard.
 - `GET /login` (redirect to GitHub authorize + single-use `state`) and `GET /oauth/callback` (verify+delete `state`, `code`→token with `client_secret`, upsert `users`, mint **fresh** session).
-- **`sessions`** writes (token **hashed at rest**); fail-closed session middleware (Hono, mirrors `checkAdminAuth`).
+- **`sessions`** writes (token **hashed at rest**, returned raw once, hash stored only); fail-closed session middleware (Hono, mirrors `checkAdminAuth`). Session SELECT includes NOT-suspended-tenant guard (see below).
 
 ## Success Criteria
 
 - [ ] OAuth → fresh session; `GET /api/me` returns identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
 - [ ] `state` single-use (deleted on verify), TTL ≤ 10 min, `redirect_uri` Worker-hard-coded; replay rejected.
-- [ ] Session token freshly minted post-auth (no pre-auth value reused); `sessions.token_hash` = SHA-256 of token; cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`.
+- [ ] Session token freshly minted post-auth (no pre-auth value reused); `sessions.token_hash` = SHA-256 of token; raw token returned once only; cookie `HttpOnly; Secure; SameSite=Strict; Domain=<exact host>`.
+- [ ] Session SELECT includes suspended-tenant guard:
+  ```sql
+  WHERE s.token_hash=? AND s.expires_at>datetime('now') AND s.revoked_at IS NULL
+    AND NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id=s.tenant_id AND t.suspended_at IS NOT NULL)
+  ```
+- [ ] `GITHUB_APP_PRIVATE_KEY` secret = `base64(PKCS#8 DER)`; Worker imports via `importKey('pkcs8', …)`; PKCS#1 PEM never stored.
+- [ ] Vitest (workers pool) RS256 sign/verify test with throwaway key passes in CI.
 
 ## Dependencies
 

--- a/artifacts/specs/146-installation-sync-backfill-spec.mdx
+++ b/artifacts/specs/146-installation-sync-backfill-spec.mdx
@@ -1,32 +1,114 @@
 ---
-title: "feat(sync): installation linking + per-install sync + PAT retired + backfill (Phase 1 S3)"
+title: "feat(sync): installation sync + per-repo fan-out + PAT retirement (Phase 1 S3)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 146
 status: approved
-tier: L
+tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Title + scope rewritten. Original tier: L. Original scope:
+> per-installation loop writing rows tagged with `tenant_id`, backfill, `COUNT(*) WHERE
+> tenant_id IS NULL = 0`. **New scope:** per-repo deduplicated fan-out + AES-GCM install
+> token management + slot-rotation under subrequest cap + SYNC_QUEUE DORMANT + PAT retirement.
+> No `tenant_id` on `issues`/`edges` — no backfill step. `installations` table renamed `tenants`.
 
 ## Scope
 
-Slice **S3** of #141. Data-access + sync fan-out (the largest slice).
+Slice **S3** of #141. Sync layer wired to GitHub App installation tokens.
 
-- `installation` webhook → populate `installations` + `user_installations`; onboarding "authorized-not-installed" handled in S6.
-- `runSync` becomes a **per-installation loop:** App-JWT → `POST /app/installations/:id/access_tokens` (cache ≤ 1 h) → sync that install's repos → write rows tagged with its `tenant_id`.
-- Per-tenant `sync_control` / auth-halt breaker; **`closedHopPass` scoped per-tenant** (walk only that tenant's edge graph).
-- **Remove `GITHUB_TOKEN` (PAT)** from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` — **no fallback**.
-- **Backfill** existing rows to the operator's **real `installation_id`** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0`.
-- **Pre-impl gate:** `subIssues`/`parent` GraphQL via an installation token (confirm no preview header post-GA — token type changed from PAT).
+### Installation token management
+
+On each cron tick (and on `POST /admin/sync`), the Worker:
+
+1. Reads `install_tokens` rows for all tenants (`token_enc`, `token_iv`, `expires_at`).
+2. For tokens expired or expiring within 5 min: re-mint via App-JWT RS256 →
+   `POST /app/installations/:id/access_tokens` → AES-GCM-encrypt new plaintext token →
+   upsert `install_tokens (tenant_id, token_enc, token_iv, expires_at)`.
+3. DEK = `INSTALL_TOKEN_KEY` Worker secret (set via `wrangler secret put INSTALL_TOKEN_KEY`).
+   Plaintext token is **never logged, never stored raw**.
+
+```
+encrypt: iv = crypto.getRandomValues(12 bytes)
+         ciphertext = AES-GCM.encrypt(DEK, iv, plaintext_token)
+         store (base64(ciphertext), base64(iv))
+
+decrypt: plaintext = AES-GCM.decrypt(DEK, base64decode(iv), base64decode(token_enc))
+```
+
+### Per-repo deduplicated fan-out
+
+The Cron Trigger (`0 * * * *`) iterates `tenant_repo_access`, **deduplicates by repo across
+all tenants**, and issues **one GitHub GraphQL call per unique repo** — not per tenant.
+Deduplication prevents N×redundant API calls for repos shared by colleagues under the same
+installation.
+
+Issue/edge writes go to the globally-keyed `issues`/`edges` tables (`owner/repo#N` PKs).
+No `tenant_id` column on those tables.
+
+**Subrequest cap:** Cloudflare Workers free tier: ~50 subrequests/invocation.
+At ~22 unique repos/tick, slot-rotation via `sync_control` is used to spread work across ticks:
+
+- `sync_control (tenant_id, 'sync_slot')` holds the last-synced repo offset.
+- Each tick syncs a window of repos; the slot advances per tick.
+- A full pass completes over N ticks (N = ceil(unique_repos / per_tick_limit)).
+- `sync_control (tenant_id, 'sync_running')` / `'sync_started_at'` guard against concurrent
+  invocations for that tenant. A per-installation failure must **not** hold another tenant's lock.
+
+**`sync_control` composite PK is `(tenant_id, key)`.** Per-tenant keys: `sync_slot`,
+`sync_running`, `sync_started_at`, `auth_halt_count`, `last_auth_halt_at`. Global key
+`data_version` uses a sentinel `tenant_id = 0` (or a separate non-FK row — implementation
+choice; document in code).
+
+### SYNC_QUEUE (DORMANT)
+
+A `SYNC_QUEUE` Cloudflare Queues binding is declared in `wrangler.toml` but has **no active
+consumer in Phase 1**. It is a placeholder for a future fan-out upgrade where each repo-sync
+task is enqueued independently. Do not wire a consumer handler in Phase 1.
+
+### PAT retirement
+
+`GITHUB_TOKEN` (PAT) is **removed** from `Env`, `wrangler.toml` (both envs), `handleDeps`,
+`handleRefDelete`, and all `sync/` paths — **no fallback**.
+
+Retirement order:
+1. Deploy S3 to **staging**.
+2. Verify one successful cron tick: `wrangler tail --env staging` confirms issue rows written.
+3. Remove `GITHUB_TOKEN` from staging secrets: `wrangler secret delete GITHUB_TOKEN --env staging`.
+4. Confirm next tick clean (no 401s, no PAT references in logs).
+5. Repeat steps 1–4 for **prod**.
+
+### No backfill
+
+`issues`/`edges` have no `tenant_id` column. No `COUNT(*) WHERE tenant_id IS NULL` check.
+No backfill migration. The original backfill step is superseded by the repo-canonical model
+(see analysis addendum, `artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx`).
+
+### Pre-impl gate
+
+`subIssues`/`parent` GraphQL via an installation token — confirm no preview header needed
+post-GA when token type changes from PAT → installation. Gates this slice.
 
 ## Success Criteria
 
-- [ ] Cron mints a per-installation token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; RS256 sign errors log message only (never key/JWT).
-- [ ] `GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete`; no fallback.
-- [ ] Backfill executed; `COUNT(*) WHERE tenant_id IS NULL = 0` verified.
+- [ ] AES-GCM encrypt/decrypt round-trips for install tokens; DEK = `INSTALL_TOKEN_KEY`;
+  plaintext never logged; `token_enc` + `token_iv` stored in `install_tokens`.
+- [ ] Install token refreshed when `expires_at` ≤ now + 5 min; fresh token written to D1.
+- [ ] Cron fan-out deduplicates repos across tenants: 1 GraphQL call per unique repo (not per tenant).
+- [ ] Slot-rotation: `sync_control (tenant_id, 'sync_slot')` advances per tick; repos beyond
+  the per-tick cap deferred to next tick; no subrequest-cap breach under ~22 repos/tick.
+- [ ] SYNC_QUEUE binding declared in `wrangler.toml`; **no consumer handler registered** (DORMANT).
+- [ ] `GITHUB_TOKEN` removed from `Env` / `wrangler.toml` / `handleDeps` / `handleRefDelete`;
+  no PAT fallback anywhere.
+- [ ] PAT deleted from staging secrets after first verified installation sync tick; then prod.
+- [ ] No `tenant_id` column on `issues`/`edges`; no backfill step.
+- [ ] `subIssues`/`parent` GraphQL pre-impl gate cleared before implementation begins.
 
 ## Dependencies
 
-Blocked by **#145** (S2 — App/OAuth/sessions).
+Blocked by **#145** (S2 — App-JWT signer ready, `install_tokens` + `sync_control` tables exist)
+and **#144** (S1 — `tenant_repo_access`, `install_tokens`, `sync_control` tables created).
 
 ## Reference
 

--- a/artifacts/specs/147-webhook-tenant-routing-spec.mdx
+++ b/artifacts/specs/147-webhook-tenant-routing-spec.mdx
@@ -1,31 +1,142 @@
 ---
-title: "feat(webhook): tenant routing + cross-tenant stub policy (Phase 1 S4)"
+title: "feat(webhook): tenant routing + installation lifecycle handlers (Phase 1 S4)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 147
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Title + scope rewritten. Original scope: routing via
+> `installations` table, `installation.deleted` deletes all tenant sessions + data,
+> cross-tenant dep stub policy. **New scope:** routing via `payload.installation.id` →
+> `tenants`; `installation.deleted` retains global issue rows, deletes `tenant_repo_access`
+> only; full lifecycle handlers for install/repo/member events; `user_repo_permission_cache`
+> invalidation. `installations` table renamed `tenants`. Cross-tenant stub policy superseded
+> by repo-canonical model (issue rows globally shared; authorization via `tenant_repo_access`).
 
 ## Scope
 
 Slice **S4** of #141. Webhook isolation. Reuses the existing single-secret HMAC (`webhook/hmac.ts`).
 
-- After HMAC pass, **mandatory** `payload.installation.id` → `installations` lookup → `tenant_id` **before any** INSERT/UPDATE/DELETE.
-- Unknown / known-but-missing-`tenant_id` installation → **200 OK, no DB write** (so GitHub doesn't retry; no orphan/wrong-tenant rows).
-- All webhook mutations (`webhook/mutations.ts`) tenant-scoped.
-- **Cross-tenant dep stub policy:** a referenced foreign-repo issue materializes only as `tenant_id`=requester, `is_stub=1`, `title=NULL`, `body=NULL` — never another tenant's real content fetched under another installation's token.
-- `installation.deleted` → delete that tenant's sessions + data.
+### Routing
+
+After HMAC pass, **mandatory**: `payload.installation.id` → `tenants` lookup → resolve
+`tenant_id` **before any** INSERT/UPDATE/DELETE.
+
+Unknown installation (not in `tenants`) → **200 OK, no DB write** (GitHub does not retry;
+no orphan rows). Suspended tenant → log, 200, no write.
+
+All webhook mutations remain in `webhook/mutations.ts`; all use repo-canonical tables
+(`issues`, `edges`) with no `tenant_id` filter.
+
+### Installation lifecycle handlers
+
+#### `installation.created`
+
+1. Upsert row in `tenants` (`installation_id`, `account_login`, `account_type`, `app_id`,
+   `suspended_at=NULL`, `installed_at=now`).
+2. For each repo in `repositories`: upsert `tenant_repo_access (tenant_id, repo, is_private)`.
+3. Enqueue a sync for newly accessible repos (via `sync_control` slot or direct cron hint).
+
+#### `installation.deleted`
+
+1. Delete `tenant_repo_access` rows where `tenant_id = ?`.
+2. Delete `install_tokens` for that tenant.
+3. Delete `sessions` for that tenant.
+4. **Retain** all rows in `issues` and `edges` — global issue data is not tenant-owned.
+5. Mark `tenants` row with `deleted_at = now` (soft-delete; do not hard-delete for audit trail).
+
+#### `installation.suspend`
+
+Set `tenants.suspended_at = now`. Active sessions will fail the NOT-EXISTS guard on next
+request (no immediate invalidation needed; session SELECT includes the guard).
+
+#### `installation.unsuspend`
+
+Set `tenants.suspended_at = NULL`. Sessions resume automatically on next request.
+
+### Repository lifecycle handlers
+
+#### `installation_repositories.added`
+
+For each added repo: upsert `tenant_repo_access (tenant_id, repo, is_private)`.
+Trigger sync for those repos via `sync_control`.
+
+#### `installation_repositories.removed`
+
+Delete `tenant_repo_access (tenant_id, repo)` rows for each removed repo.
+Issue rows in `issues` / `edges` are **retained** (globally shared; other tenants may still
+have access).
+
+#### `repository.renamed`
+
+Anchor: `repo_node_id` (GitHub node ID; stable across renames). Steps:
+1. Look up current `repo` slug by `repo_node_id` in `repos.repo_node_id`.
+2. Cascade update: `repos.repo = new_full_name` + `tenant_repo_access.repo = new_full_name`
+   + `issues.repo = new_full_name` + `edges` entries that embed the repo component of `key`.
+3. If `repo_node_id` not found: upsert with new name (first-time rename before node_id was
+   stored — fallback to `previous_repository.full_name` lookup by old slug).
+
+#### `repository.transferred`
+
+Same cascade as `repository.renamed` (repo gets a new owner/name; node_id stable).
+
+#### `repository.privatized`
+
+Set `tenant_repo_access.is_private = 1` for that repo. Invalidate
+`user_repo_permission_cache` rows for that repo (`DELETE WHERE repo = ?`).
+
+#### `repository.publicized`
+
+Set `tenant_repo_access.is_private = 0` for that repo. Invalidate
+`user_repo_permission_cache` rows for that repo (`DELETE WHERE repo = ?`).
+
+### Member / membership handlers (permission-cache invalidation)
+
+#### `member.removed`
+
+A collaborator was removed from a specific repo. Delete `user_repo_permission_cache` rows
+for `(user_id matching github_id, repo)`.
+
+#### `membership.removed`
+
+A member was removed from the org (or a team). Delete all `user_repo_permission_cache` rows
+for that `github_id` (all repos in that installation's scope — conservative invalidation;
+next read triggers live API fallback and re-populates).
+
+### No cross-tenant stub policy
+
+The original cross-tenant dep stub (`is_stub=1, title=NULL`) is superseded. In the
+repo-canonical model, `issues` rows are globally unique by `owner/repo#N`. A dep that
+references a foreign repo simply resolves to that repo's row (if synced) or is absent.
+No stub insertion. Authorization is at read time via `tenant_repo_access`.
 
 ## Success Criteria
 
-- [ ] Webhook resolves `installation.id` → `tenant_id` via DB lookup **before** any write; unknown/missing-tenant installation → 200, no write.
-- [ ] Cross-tenant dep reference → `tenant_id`=requester, `is_stub=1`, `title=NULL` row only.
-- [ ] `installation.deleted` deletes that tenant's sessions + data.
+- [ ] `payload.installation.id` → `tenants` lookup before any write; unknown installation
+  → 200, no write; suspended tenant → 200, no write.
+- [ ] `installation.created`: `tenants` row upserted + `tenant_repo_access` rows upserted
+  for each repo.
+- [ ] `installation.deleted`: `tenant_repo_access` + `install_tokens` + `sessions` deleted;
+  `issues`/`edges` rows **retained**; `tenants.deleted_at` set.
+- [ ] `installation.suspend` / `installation.unsuspend`: `tenants.suspended_at` toggled;
+  session NOT-EXISTS guard enforces revocation without immediate session flush.
+- [ ] `installation_repositories.added` / `removed`: `tenant_repo_access` upsert / delete;
+  issue rows retained on removal.
+- [ ] `repository.renamed` + `repository.transferred`: cascade update anchored by
+  `repo_node_id`; `repos`, `tenant_repo_access`, `issues` all consistent.
+- [ ] `repository.privatized` / `publicized`: `is_private` updated + `user_repo_permission_cache`
+  invalidated.
+- [ ] `member.removed` / `membership.removed`: `user_repo_permission_cache` rows deleted
+  for affected user+repo scope.
+- [ ] No cross-tenant stub insertion logic.
 
 ## Dependencies
 
-Blocked by **#146** (S3 — installations table + per-tenant writes).
+Blocked by **#144** (S1 — `tenants`, `tenant_repo_access`, `user_repo_permission_cache`
+tables created) and **#145** (S2 — sessions + HMAC infra).
 
 ## Reference
 

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -1,30 +1,130 @@
 ---
-title: "feat(api): tenant-filtered reads + active-tenant + org-picker (Phase 1 S5)"
+title: "feat(api): tenant-filtered reads + repo-canonical auth + org-picker (Phase 1 S5)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 148
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Title + scope rewritten. Original scope: `AND tenant_id=?`
+> filter injected into every read; no `user_repo_permission_cache`. **New scope:**
+> authorization via `JOIN tenant_repo_access` (repo-canonical model); private-repo reads add
+> `user_repo_permission_cache` check (24h TTL, live API fallback); session middleware includes
+> NOT-EXISTS suspended-tenant guard; no `tenant_id` in response shapes.
 
 ## Scope
 
 Slice **S5** of #141. **This slice satisfies the epic acceptance criterion.**
 
-- Fail-closed **session middleware on `/api/*`**: no/invalid session → **401 before any DB statement**.
-- Inject `tenant_id` (= session's active tenant) into every read: `listIssuesRoute`, all 5 `graphRoute` queries, and **`getIssueRoute`** (issue + labels + edges) with SQL-level **`AND tenant_id=?`** (closes the IDOR — keys are public GitHub URLs).
-- Session encodes **one active `tenant_id`**; user with >1 installation → **org-picker** (`POST /api/active-tenant`, membership-checked). **No cross-tenant UNION** queries.
+### Session middleware
+
+All `/api/*` routes go through a fail-closed session middleware:
+- No session cookie → **401** before any DB statement.
+- Invalid / expired / revoked session → **401**.
+- Suspended tenant → **401** (NOT-EXISTS guard in the SELECT itself).
+
+Session SELECT (authoritative):
+
+```sql
+SELECT s.*, u.github_id, u.github_login
+FROM sessions s
+JOIN users u ON u.id = s.user_id
+WHERE s.token_hash = ?
+  AND s.expires_at > datetime('now')
+  AND s.revoked_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM tenants t
+    WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL
+  )
+```
+
+The middleware injects `{ tenant_id, user_id, github_id, github_login }` into the request
+context. No downstream handler calls the DB before this context is populated.
+
+### Repo-canonical auth filter
+
+**Superseded (stale — do not use):**
+```sql
+WHERE i.tenant_id = ?
+```
+
+**Current (repo-canonical):**
+```sql
+JOIN tenant_repo_access tra
+  ON tra.repo = i.repo
+  AND tra.tenant_id = ?
+```
+
+This JOIN applies to:
+- `listIssuesRoute` — all issue rows visible to this tenant
+- `getIssueRoute` — single issue + labels + edges (IDOR closed: unknown repo → 0 rows → 404)
+- All 5 `graphRoute` queries (nodes, edges, labels, etc.)
+
+### Private-repo permission check (`user_repo_permission_cache`)
+
+When `tenant_repo_access.is_private = 1`:
+
+1. **Cache hit** (row in `user_repo_permission_cache` where `user_id=? AND repo=?` and
+   `cached_at > now - 24h`): use `has_access` value directly — **fail-closed** (if
+   `has_access=0`, 404, no data returned).
+2. **Cache miss** (no row, or row older than 24h): call GitHub API
+   `GET /repos/:owner/:repo/collaborators/:username` with the installation token.
+   - 204 → `has_access=1`; upsert cache.
+   - 404/403 → `has_access=0`; upsert cache.
+   - API error / timeout → **fail-closed** (treat as no access, 404); do not cache.
+3. **Cache error** (D1 read failure): fail-closed → 404.
+
+Public repos (`is_private = 0`) skip the permission check entirely.
+
+TTL: 24 hours from `cached_at`. Cache is invalidated by webhook events
+(`member.removed` / `membership.removed` / `repository.privatized` — see #147).
+
+### `GET /api/me`
+
+Returns authenticated user info and installation list:
+```json
+{
+  "github_login": "...",
+  "active_tenant_id": 42,
+  "installations": [
+    { "tenant_id": 42, "account_login": "Roxabi", "account_type": "Organization" }
+  ]
+}
+```
+
+No `tenant_id` column exposed from `issues`/`edges` rows. Response shapes are identical to
+single-tenant responses — authorization is fully backend-side.
+
+### Org-picker (`POST /api/active-tenant`)
+
+When a user has >1 installation: a picker UI (see #149) POSTs `{ tenant_id }`. The endpoint:
+1. Verifies the user has a row in `user_installations` for that `tenant_id`.
+2. Updates `sessions.tenant_id = ?` for the current session token.
+3. Returns 200 + updated session context.
+
+No cross-tenant UNION queries anywhere.
 
 ## Success Criteria
 
-- [ ] Every `/api/*` route gated by fail-closed middleware (no/invalid session → 401 before any DB statement).
-- [ ] `getIssueRoute` issue/label/edge queries include SQL-level `AND tenant_id=?` (code-review-verified); foreign-tenant key → 404; `listIssuesRoute` + 5 `graphRoute` queries tenant-filtered. [IDOR closed]
-- [ ] >1 installation → org-picker; session carries exactly one active `tenant_id`; no cross-tenant UNION.
-- [ ] **Acceptance:** a second GitHub account sees only its own issues + graph; operator sees only `Roxabi` — verified on staging.
+- [ ] Every `/api/*` route gated by fail-closed session middleware; no/invalid session →
+  401 before any DB statement; suspended tenant → 401 (NOT-EXISTS guard in session SELECT).
+- [ ] `getIssueRoute` issue/label/edge queries use `JOIN tenant_repo_access` (no
+  `AND tenant_id=?`); foreign-tenant or unknown repo key → 404. [IDOR closed]
+- [ ] `listIssuesRoute` + all 5 `graphRoute` queries use `JOIN tenant_repo_access`.
+- [ ] Private-repo reads check `user_repo_permission_cache` (24h TTL); cache miss → live API
+  fallback; any error path → fail-closed (404).
+- [ ] `GET /api/me` returns `installations` array; no `tenant_id` in issue/edge response shapes.
+- [ ] `POST /api/active-tenant` switches session tenant; membership verified before update.
+- [ ] >1 installation → org-picker flow works end-to-end.
+- [ ] **Acceptance:** a second GitHub account sees only its own repos' issues + graph;
+  operator sees only `Roxabi` — verified on staging.
 
 ## Dependencies
 
-Blocked by **#145** (S2 — sessions) and **#146** (S3 — tenant data).
+Blocked by **#147** (S4 — `tenant_repo_access` populated by webhook; `user_repo_permission_cache`
+invalidation wired) and **#145** (S2 — sessions + `user_installations` table).
 
 ## Reference
 

--- a/artifacts/specs/150-notnull-access-cutover-spec.mdx
+++ b/artifacts/specs/150-notnull-access-cutover-spec.mdx
@@ -1,30 +1,50 @@
 ---
-title: "feat(deploy): NOT-NULL migration + CF Access cutover + runbook (Phase 1 S7)"
+title: "feat(deploy): NOT-NULL migration (new tables) + CF Access cutover + runbook (Phase 1 S7)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 150
 status: approved
 tier: S
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Scope shrunk. NOT-NULL cutover applies only to **new tables** created
+> in S1. No `COUNT(*) WHERE tenant_id IS NULL = 0` check (no `tenant_id` column on old tables).
+> No backfill step. CF Access narrowed to `/admin/*` only (coordinated with S2 deploy).
 
 ## Scope
 
 Slice **S7** of #141. Final cutover (one-way edge change — gated).
 
-- Re-verify `COUNT(*) WHERE tenant_id IS NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill runs).
-- **Staging smoke-test gate:** app sessions verified returning **401** for unauthenticated callers on staging.
-- → CF Access scoped to **`/admin/*` only** (`/webhook/*` keeps its existing bypass) → prod cutover.
-- Rollback runbook (re-enable the Access rule) written to a tracked file.
+- **M-b NOT-NULL migration** (`000N_new_tables_not_null.sql`): tighten nullable columns on the
+  **10 new tables** from S1 only (e.g. add NOT NULL constraints where nullable was used during
+  initial migration for safety). **No changes to `issues`/`edges`/`labels`/`pr_state`** — those
+  tables have no new nullable columns from this epic.
+  The SQL file is authored in S1's design but **committed here**, so CI never applies it before
+  S5 (reads) and S6 (UI) are verified on staging.
+- **Staging smoke-test gate:** app sessions verified returning **401** for unauthenticated callers
+  on staging before CF Access change is applied.
+- **CF Access narrowing:** scope CF Access rule from the entire Worker to **`/admin/*` only**.
+  `/webhook/*` retains its existing bypass. All other routes (`/login`, `/oauth/*`, `/api/*`)
+  rely on Worker-level session auth (S2) — CF Access is defense-in-depth for admin only.
+  Coordinate timing with S2 deploy completion to avoid lockout window.
+- **Rollback runbook:** re-enable the CF Access rule to full Worker scope; written to a tracked
+  file in `docs/runbooks/`.
 
 ## Success Criteria
 
-- [ ] Backfill re-verified (`COUNT NULL = 0`) → M-b NOT-NULL migration committed + applied (never earlier).
-- [ ] App sessions verified 401 unauth on staging → CF Access scoped to `/admin/*` only; `/webhook/*` bypass retained.
-- [ ] Rollback (re-enable Access) documented in a tracked runbook file.
+- [ ] M-b NOT-NULL migration applies cleanly on staging; only new-table columns affected; no
+  changes to `issues`/`edges`/`labels`/`pr_state` schema.
+- [ ] No `COUNT(*) WHERE tenant_id IS NULL` check — not applicable (no `tenant_id` column on
+  old tables).
+- [ ] App sessions verified → 401 unauth on staging before CF Access change.
+- [ ] CF Access rule scoped to `/admin/*` only; `/webhook/*` bypass retained; `/api/*` and
+  `/login` reachable without CF Access (Worker session auth governs).
+- [ ] Rollback runbook (re-enable Access to full Worker) committed to `docs/runbooks/`.
 
 ## Dependencies
 
-Blocked by **#149** (S6 — full UI flow shippable).
+Blocked by **#149** (S6 — full UI flow shippable on staging).
 
 ## Reference
 


### PR DESCRIPTION
Ratified 2026-06-10: repo-canonical data model for epic #141 (supersedes per-tenant rows).

## What
- **No `tenant_id` on data tables** — `issues`/`edges`/`labels`/`pr_state` keep their global PKs; authorization = `tenant_repo_access` JOIN (fail-closed) + per-user permission cache for private repos.
- **S1 #144**: 10 new tables + 2 nullable ALTERs; composite-PK recreation dropped.
- **S2 #145**: suspended-tenant session guard + `GITHUB_APP_PRIVATE_KEY` PKCS#8 contract + RS256 vitest CI guard.
- **S3 #146**: per-repo deduplicated fan-out, AES-GCM-encrypted install tokens, slot-rotation under 50-subreq cap, dormant `SYNC_QUEUE`, PAT retirement.
- **S4 #147**: installation/member lifecycle handlers; issue rows retained on uninstall.
- **S5 #148**: JOIN-based filtering + private-repo user-permission layer.
- **S7 #150**: NOT NULL cutover scoped to new tables only.
- Analysis: dated addendum (history preserved, superseded decisions flagged).

Issue bodies (#141, #144–#148, #150) already aligned; #142 commented (ZK seam + `zk_payloads` PK `(user_id, issue_key)`).

Refs #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)