### PR TITLE
feat(auth): GitHub App + OAuth login + sessions (Phase 1 S2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,11 @@ jobs:
       - if: steps.guard.outputs.enabled == 'true'
         id: app-secrets-guard
         name: Guard — GITHUB_APP_* secrets
+        # GitHub forbids GITHUB_-prefixed Actions secret names (422) — repo secrets are GH_APP_*
         env:
-          GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
-          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GITHUB_APP_WEBHOOK_SECRET }}
+          GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
         run: |
           missing=()
           [ -z "$GITHUB_APP_ID" ] && missing+=("GITHUB_APP_ID")

--- a/artifacts/plans/145-github-app-oauth-sessions-plan.mdx
+++ b/artifacts/plans/145-github-app-oauth-sessions-plan.mdx
@@ -1,0 +1,330 @@
+---
+title: "Plan: feat(auth): GitHub App + OAuth login + sessions (Phase 1 S2)"
+issue: 145
+spec: artifacts/specs/145-github-app-oauth-sessions-spec.mdx
+complexity: 6/10
+tier: F-lite
+generated: 2026-06-10T00:00:00Z
+---
+
+## Summary
+
+Identity layer for the multi-tenant pivot (#141 S2): RS256 App-JWT signer util (+ permanent CI
+guard), `GET /login` / `GET /oauth/callback` OAuth flow with single-use `state`, D1-backed
+sessions (SHA-256 at rest, fail-closed middleware with suspended-tenant guard), `GET /api/me` +
+`POST /logout`. GitHub App registered + all 10 Worker secrets provisioned out-of-band 2026-06-10.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph secrets["Worker secrets (provisioned 2026-06-10)"]
+    SK["GITHUB_APP_{ID,CLIENT_ID,CLIENT_SECRET,PRIVATE_KEY,WEBHOOK_SECRET}"]
+  end
+
+  subgraph oauth["worker/src/auth/oauth.ts"]
+    LOGIN["loginRoute: mint state → 302 authorize"]
+    CB["callbackRoute: verify+delete state → code→token → upserts → mint session"]
+  end
+
+  subgraph session["worker/src/auth/session.ts"]
+    MINT["mintSession: raw token → SHA-256 → INSERT sessions"]
+    VAL["validateSession: SELECT + suspended-tenant NOT EXISTS guard"]
+    MW["requireSession middleware (fail-closed 401)"]
+  end
+
+  subgraph jwt["worker/src/auth/jwt.ts (consumed by S3)"]
+    IMP["importAppPrivateKey: b64(PKCS#8 DER) → CryptoKey"]
+    SIGN["signAppJwt: RS256 {iss:app_id, iat-60, exp+540}"]
+  end
+
+  subgraph d1["D1 (migration 0004)"]
+    OS[(oauth_state)]
+    US[(users)]
+    TN[(tenants)]
+    UI[(user_installations)]
+    SS[(sessions)]
+  end
+
+  subgraph api["worker/src/api/me.ts"]
+    ME["meRoute: identity + installations"]
+    OUT["logoutRoute: DELETE session + clear cookie"]
+  end
+
+  LOGIN -->|INSERT state, TTL 10min| OS
+  CB -->|SELECT+DELETE single-use| OS
+  CB -->|"github.com/login/oauth/access_token (client_secret)"| GH["GitHub API"]
+  CB -->|"/user + /user/installations (user token)"| GH
+  CB -->|upsert| US
+  CB -->|"re-check upsert (D-1)"| TN
+  CB -->|"re-check upsert (D-1)"| UI
+  CB --> MINT --> SS
+  MW --> VAL --> SS
+  MW --> ME
+  MW --> OUT
+  SK --> CB
+  SK --> IMP --> SIGN
+  ME --> UI
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph jwt.ts["auth/jwt.ts"]
+    f1["importAppPrivateKey()"]
+    f2["signAppJwt()"]
+    f3["b64url()"]
+  end
+  subgraph oauth.ts["auth/oauth.ts"]
+    f4["loginRoute()"]
+    f5["callbackRoute()"]
+    f6["mintState()/consumeState()"]
+  end
+  subgraph session.ts["auth/session.ts"]
+    f7["mintSession()"]
+    f8["validateSession()"]
+    f9["requireSession()"]
+    f10["sessionCookie()/clearCookie()"]
+  end
+  subgraph me.ts["api/me.ts"]
+    f11["meRoute()"]
+    f12["logoutRoute()"]
+  end
+  subgraph router.ts
+    r1["app.get /login"]
+    r2["app.get /oauth/callback"]
+    r3["app.get /api/me (gated)"]
+    r4["app.post /logout (gated)"]
+  end
+  t1["auth/jwt.test.ts"] --> jwt.ts
+  t2["auth/oauth.test.ts"] --> oauth.ts
+  t3["auth/session.test.ts"] --> session.ts
+  t4["api/me.test.ts"] --> me.ts
+  f5 --> f6
+  f5 --> f7
+  f11 --> f9
+  f12 --> f9
+  r1 --> f4
+  r2 --> f5
+  r3 --> f11
+  r4 --> f12
+```
+
+## Bootstrap Context
+
+- Hono app (`worker/src/router.ts`), routes registered before ASSETS fallback.
+- Middleware pattern: `app.use("/admin/*", …)` + `checkAdminAuth` (`worker/src/api/auth.ts`) —
+  fail-closed, returns `Response` on deny, `null` on pass. `requireSession` mirrors this.
+- Test pattern: colocated `*.test.ts`, FakeD1 with captured SQL strings + fixture rows
+  (ref: `worker/src/webhook/mutations.test.ts`, `worker/src/api/issues.test.ts`).
+- crypto.subtle usage ref: `worker/src/webhook/hmac.ts` (HMAC import/verify).
+- Schema: migration `worker/migrations/0004_tenancy_auth.sql` (S1, live on staging).
+
+## Spec Deviations / Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D-1 | `callbackRoute` **re-check**: fetches `/user/installations` with the user token and upserts `tenants` + `user_installations` before minting the session | `sessions.tenant_id NOT NULL REFERENCES tenants` — without tenant rows (S3 webhook not built yet) no session can ever be minted. Parent spec flow §3 explicitly allows "installation webhook **(or callback re-check)**". User with 0 installations → no session, 302 to the App install page (full CTA UI = S6). |
+| D-2 | Session cookie is **host-only**: `Domain` attribute omitted; name `__Host-session` (requires Secure + Path=/ + no Domain, browser-enforced) | Spec says `Domain=<exact host>`, but per RFC 6265 an explicit Domain attribute ENABLES subdomains; omitting it is strictly tighter (exact host only). `__Host-` prefix makes the contract self-enforcing. |
+| D-3 | RS256 CI guard runs in plain vitest (node env, `globalThis.crypto.subtle`) — not `@cloudflare/vitest-pool-workers` | Suite is plain vitest (mocked D1); webcrypto API surface is identical. The *real-workerd* check is T1: one-shot smoke via `wrangler dev` (local = workerd runtime) before any GREEN code. Adding the workers pool = infra churn deferred. |
+| D-4 | Only `/api/me` + `/logout` are session-gated; existing `/api/issues`, `/api/graph` stay open | Gating all `/api/*` reads is S5 (#148) scope — needs tenant-filtered queries first. |
+| D-5 | ci.yml app-secrets-guard mapping fixed to `secrets.GH_APP_*` | GitHub rejects Actions secret names with `GITHUB_` prefix (HTTP 422, verified 2026-06-10) — guard as written in S1 could never pass. Env var names inside the step keep `GITHUB_APP_*`. |
+| D-6 | `redirect_uri` derived from `new URL(req.url).origin + "/oauth/callback"` | "Worker-hard-coded" = not attacker-suppliable (never read from query/body). Origin differs per env (live.roxabi.dev / workers.dev) — deriving from the CF-edge-trusted request URL covers both without per-env config. |
+
+## Agents
+
+| Instance | Tasks | Files |
+|----------|-------|-------|
+| devops-A | T1, T11 | scratch smoke, `.github/workflows/ci.yml` |
+| tester-A | T2, T13 | `auth/jwt.test.ts`, final verify |
+| tester-B | T4 | `auth/oauth.test.ts` |
+| tester-C | T6, T8 | `auth/session.test.ts`, `api/me.test.ts` |
+| backend-dev-A | T3, T5 | `auth/jwt.ts`, `auth/oauth.ts` |
+| backend-dev-B | T7, T9, T10 | `auth/session.ts`, `api/me.ts`, `router.ts` + `types.ts` |
+
+## Wave Structure
+
+4 waves + RED-GATE, max 4 parallel agents. Elapsed ~6 task-slots vs ~13 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 4 ∥ | devops-A: T1→T11 · tester-A: T2 · tester-B: T4 · tester-C: T6→T8 |
+| RG | T2,T4,T6,T8 done | lead | T12 RED-GATE (structural check, tests exist + fail) |
+| 2 | RG ∧ T1 PASS | 2 ∥ | backend-dev-A: T3 · backend-dev-B: T7 |
+| 3 | Wave 2 done | 2 ∥ | backend-dev-A: T5 · backend-dev-B: T9 |
+| 4 | Wave 3 done | 1 | backend-dev-B: T10 → tester-A: T13 |
+
+### Budget — per task
+
+| Task | Class | Est. ops | Split? |
+|------|-------|----------|--------|
+| T1 workerd RS256 smoke | judgmental | 6 | — |
+| T2 RED jwt | judgmental | 5 | — |
+| T3 GREEN jwt | judgmental | 5 | — |
+| T4 RED oauth | exploratory | 10 | — |
+| T5 GREEN oauth | exploratory | 12 | — |
+| T6 RED session | judgmental | 6 | — |
+| T7 GREEN session | judgmental | 6 | — |
+| T8 RED me/logout | judgmental | 5 | — |
+| T9 GREEN me/logout | bounded | 4 | — |
+| T10 wiring router+types | bounded | 3 | — |
+| T11 ci.yml guard fix | trivial | 2 | — |
+| T12 RED-GATE | trivial | 1 | — |
+| T13 final verify | bounded | 3 | — |
+
+**Total estimated ops: 68**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1, T11 | 8 | workerd, ci | — |
+| tester-A | T2, T13 | 8 | jwt, verify | — |
+| tester-B | T4 | 10 | oauth | — |
+| tester-C | T6, T8 | 11 | session, me | — |
+| backend-dev-A | T3, T5 | 17 | jwt, oauth | — |
+| backend-dev-B | T7, T9, T10 | 13 | session, http | — |
+
+## Consistency Report
+
+Covered 6/6 success criteria. Uncovered: none. Untraced tasks: T11 (D-5, infra debt from S1 —
+exemption: required for the S2 acceptance "secrets wired per-env" to be CI-visible), T12 (sentinel).
+
+| SC | Tasks |
+|----|-------|
+| SC-1 OAuth → session; /api/me; /logout → 401 | T4, T5, T8, T9, T10 |
+| SC-2 state single-use, TTL ≤10min, redirect_uri hard-coded | T4, T5 |
+| SC-3 fresh token, SHA-256 at rest, cookie attrs | T4, T6, T7 |
+| SC-4 suspended-tenant guard in session SELECT | T6, T7 |
+| SC-5 PRIVATE_KEY = b64(PKCS#8 DER), importKey('pkcs8') | T1, T3 (secrets already provisioned per contract) |
+| SC-6 vitest RS256 guard in CI | T2, T3 |
+
+## Micro-Tasks
+
+### Wave 1 — RED + gates
+
+**T1 — Pre-impl gate: RS256 sign/verify in real workerd** `[P]` — devops-A · workerd · GATE · diff 2 · ~8min
+- File: scratch only (`/tmp` worker entry or `--test-scheduled`-style probe; nothing committed except a PASS note in this plan)
+- Do: generate throwaway RSA-2048 PKCS#8; minimal worker route running `importKey('pkcs8', …, RSASSA-PKCS1-v1_5/SHA-256, ['sign'])` + `sign` + `verify`; run under `npx wrangler dev` (local mode = workerd) and curl it.
+- Verify: HTTP response shows `{imported:true, signed:true, verified:true}`.
+- Expected: PASS → unblocks Wave 2. FAIL → STOP, escalate (re-evaluate App-JWT path per spec).
+
+**T2 — RED: auth/jwt.test.ts** `[P]` — tester-A · jwt · RED · diff 2 · ~5min
+- File: `worker/src/auth/jwt.test.ts`
+- Tests: `crypto.subtle.generateKey` throwaway pair → export PKCS#8 → b64 → `importAppPrivateKey` → `signAppJwt('12345', key, now)` → split JWT: header `{alg:'RS256',typ:'JWT'}`, claims `{iss:'12345', iat:now-60, exp:now+540}`, b64url (no `=+/`), `crypto.subtle.verify` with public key = true; tampered payload → verify false.
+- Verify: `npx vitest run src/auth/jwt.test.ts` → fails (module missing) = RED OK.
+
+**T4 — RED: auth/oauth.test.ts** `[P]` — tester-B · oauth · RED · diff 3 · ~10min
+- File: `worker/src/auth/oauth.test.ts` (FakeD1 + mocked `fetch`)
+- Tests: `/login` → 302 Location = `github.com/login/oauth/authorize` with `client_id`, `state` (32 hex), `redirect_uri=<origin>/oauth/callback`; state row INSERTed with `expires_at` ≤ 10 min; `?redirect=/x` stored, `//evil` & `https://evil` rejected→`/`. Callback: unknown/expired state → 400; **replay (2nd use) → 400** (DELETE on first verify); happy path (mock token exchange + `/user` + `/user/installations`) → users upsert (on github_id), tenants+user_installations upserted (D-1), `Set-Cookie: __Host-session=…; HttpOnly; Secure; SameSite=Strict; Path=/` (no Domain), 302 to stored redirect; 0 installations → 302 to App install page, no session row.
+- Verify: file runs RED.
+
+**T6 — RED: auth/session.test.ts** `[P]` — tester-C · session · RED · diff 3 · ~6min
+- File: `worker/src/auth/session.test.ts` (FakeD1, captured SQL)
+- Tests: `mintSession` → INSERT binds SHA-256 hex of raw token (never raw), expires +8h, returns raw once; `validateSession` SQL `toContain` each guard: `token_hash=?`, `expires_at>datetime('now')` (or bound now), `revoked_at IS NULL`, `NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id=s.tenant_id AND t.suspended_at IS NOT NULL)`; behavior rows: valid→user, suspended-tenant fixture→null; `requireSession`: no cookie→401 JSON, bad token→401, valid→next() (fail-closed default).
+- Verify: file runs RED.
+
+**T8 — RED: api/me.test.ts** — tester-C · me · RED · diff 2 · ~5min (after T6, same instance)
+- File: `worker/src/api/me.test.ts`
+- Tests: GET `/api/me` no session → 401; with session fixture → 200 `{user:{github_id,github_login}, installations:[{tenant_id,installation_id,account_login}]}` (JOIN user_installations×tenants); POST `/logout` → DELETE session row by hash + `Set-Cookie` clearing (`Max-Age=0`) → subsequent me → 401.
+- Verify: file runs RED.
+
+**T11 — ci.yml: app-secrets-guard mapping fix** `[P]` — devops-A · ci · GREEN · diff 1 · ~3min (after T1, same instance)
+- File: `.github/workflows/ci.yml` (guard step only)
+- Do: `GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}`, `GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}`, `GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}` + comment `# GitHub forbids GITHUB_-prefixed Actions secret names (422) — repo secrets are GH_APP_*`.
+- Verify: `grep -c "secrets.GH_APP_" .github/workflows/ci.yml` → 3; `secrets.GITHUB_APP_` → 0.
+
+**T12 — RED-GATE** — lead · sentinel
+- Verify: T2/T4/T6/T8 files exist, suite fails on the 4 new files only, 265 pre-existing tests still green.
+
+### Wave 2 — GREEN core
+
+**T3 — GREEN: auth/jwt.ts** `[P]` — backend-dev-A · jwt · GREEN · diff 2 · ~5min
+- Exports: `importAppPrivateKey(b64: string): Promise<CryptoKey>` (atob→bytes→importKey pkcs8, non-extractable, ['sign']), `signAppJwt(appId: string, key: CryptoKey, nowSec?: number): Promise<string>` (iat-60/exp+540 per GitHub docs), internal `b64url`.
+- Verify: T2 green + `tsc --noEmit`.
+
+**T7 — GREEN: auth/session.ts** `[P]` — backend-dev-B · session · GREEN · diff 3 · ~6min
+- Exports: `mintSession(db, userId, tenantId)` (32B random hex raw, SHA-256 via crypto.subtle, INSERT, returns raw), `validateSession(db, rawToken)` (hash → guarded SELECT JOIN users → `{userId, tenantId, githubId, githubLogin}` | null), `requireSession(c, next)` Hono middleware (cookie parse `__Host-session`, fail-closed 401 JSON, sets `c.set('session', …)`), `sessionCookie(raw)` / `clearSessionCookie()`.
+- Verify: T6 green + tsc.
+
+### Wave 3 — GREEN flow
+
+**T5 — GREEN: auth/oauth.ts** — backend-dev-A · oauth · GREEN · diff 4 · ~12min
+- Exports: `loginRoute`, `callbackRoute`. State: 32B hex, INSERT oauth_state (TTL 10 min, redirect_after validated `/^\/(?!\/)/`). Callback: consume state (`DELETE … RETURNING` or SELECT+DELETE), `POST github.com/login/oauth/access_token` (Accept: application/json, client_id+client_secret+code+redirect_uri), `GET api.github.com/user` + `GET api.github.com/user/installations` (Bearer + `User-Agent: roxabi-live`), upsert users on github_id, D-1 upsert tenants (on installation_id) + user_installations, mint session on first tenant, Set-Cookie, 302 redirect_after; 0 installs → 302 `https://github.com/apps/roxabi-live/installations/new`, no session. Never log tokens/secrets.
+- Verify: T4 green + tsc.
+
+**T9 — GREEN: api/me.ts** — backend-dev-B · me · GREEN · diff 2 · ~5min
+- Exports: `meRoute` (reads `c.get('session')`, SELECT installations JOIN tenants), `logoutRoute` (DELETE sessions WHERE token_hash, clear cookie, 204).
+- Verify: T8 green + tsc.
+
+### Wave 4 — wiring + verify
+
+**T10 — Wire router + Env types** — backend-dev-B · http · GREEN · diff 2 · ~4min
+- `router.ts`: `app.get("/login", loginRoute)`, `app.get("/oauth/callback", callbackRoute)`, `app.use("/api/me", requireSession)` + `app.get("/api/me", meRoute)`, `app.use("/logout", requireSession)` + `app.post("/logout", logoutRoute)` — registered BEFORE ASSETS fallback; existing routes untouched (D-4). `types.ts`: add `GITHUB_APP_ID/CLIENT_ID/CLIENT_SECRET/PRIVATE_KEY/WEBHOOK_SECRET: string` with provisioning docstrings.
+- Verify: `tsc --noEmit` + full `vitest run` green.
+
+**T13 — Final verify** — tester-A · verify · diff 1 · ~4min
+- Full suite + count delta (≥ +20 new tests expected), grep no `console.log` of secrets/tokens in `worker/src/auth/`, spot edge cases (expired session row, malformed cookie).
+- Verify: `npm test` exit 0; report counts.
+
+## Task Seeding Blueprint
+
+<!-- Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 4 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | workerd |
+| T2 | tester-A | — | jwt |
+| T4 | tester-B | — | oauth |
+| T6 | tester-C | — | session |
+| T8 | tester-C | T6 | me |
+| T11 | devops-A | T1 | ci |
+
+### RED-GATE — after T2, T4, T6, T8
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T12 | lead | T2,T4,T6,T8 | sentinel |
+
+### Wave 2 — after RG ∧ T1 PASS, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T1,T12 | jwt |
+| T7 | backend-dev-B | T12 | session |
+
+### Wave 3 — after Wave 2, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | backend-dev-A | T3,T7 | oauth |
+| T9 | backend-dev-B | T7 | me |
+
+### Wave 4 — after Wave 3
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | backend-dev-B | T5,T9 | http |
+| T13 | tester-A | T10 | verify |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 33 — workerd
+- T2: 34 — jwt
+- T4: 35 — oauth
+- T6: 36 — session
+- T8: 37 — me
+- T11: 38 — ci
+- T12: 39 — sentinel
+- T3: 40 — jwt
+- T7: 41 — session
+- T5: 42 — oauth
+- T9: 43 — me
+- T10: 44 — http
+- T13: 45 — verify

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -335,4 +335,23 @@ describe("logoutRoute", () => {
     // Should still succeed (204) even with no cookie
     expect(res.status).toBe(204);
   });
+
+  it("returns 204 + clears session cookie even when no Cookie header is present (ungated — null-safe)", async () => {
+    // Arrange — bare app with no requireSession, no stub session middleware.
+    // This is the negative guard test: if /logout were gated by requireSession,
+    // this request (no cookie) would return 401 instead of 204, proving the guard was
+    // present. Its 204 response proves the route is truly ungated and null-safe.
+    const { db } = captureDb();
+    const logoutApp = new Hono<AuthEnv>();
+    logoutApp.post("/logout", logoutRoute);
+
+    // Act — POST /logout with no Cookie header
+    const res = await logoutApp.request("/logout", { method: "POST" }, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(204);
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("__Host-session=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
 });

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { meRoute, logoutRoute } from "./me";
+import type { AuthEnv, SessionContext } from "../auth/session";
+import { requireSession } from "../auth/session";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from src/webhook/mutations.test.ts
+// ---------------------------------------------------------------------------
+
+type FakeResult = { [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements — returns empty rows for every query. */
+function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/** Capture variant — every query returns the provided rows. */
+function captureDbWithRows(
+  rows: FakeResult[],
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+/** Build a minimal Env with the given D1 instance. */
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
+    GITHUB_TOKEN: "",
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+/**
+ * Build a test Hono app with a stub middleware that injects STUB_SESSION,
+ * then mounts meRoute + logoutRoute.
+ * This tests the route handlers in isolation — independent of requireSession.
+ */
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+
+  // Stub middleware: injects session without any cookie/DB check
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+
+  app.get("/api/me", meRoute);
+  app.post("/api/logout", logoutRoute);
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// meRoute
+// ---------------------------------------------------------------------------
+
+describe("meRoute", () => {
+  it("returns 200 with user fields from injected session", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json() as { user: { github_id: number; github_login: string } };
+    expect(body.user.github_id).toBe(42);
+    expect(body.user.github_login).toBe("alice");
+  });
+
+  it("response body contains an installations array", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json() as { installations: unknown[] };
+    expect(Array.isArray(body.installations)).toBe(true);
+  });
+
+  it("installations SELECT references user_installations table", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — the SQL issued must mention user_installations
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).toContain("user_installations");
+  });
+
+  it("installations SELECT JOINs the tenants table", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — the SQL must JOIN tenants
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).toContain("JOIN tenants");
+  });
+
+  it("surfaces installation rows returned by D1 in the response body", async () => {
+    // Arrange — FakeD1 returns one installation row
+    const fakeRow = { tenant_id: 9, installation_id: 5, account_login: "Roxabi" };
+    const { db } = captureDbWithRows([fakeRow]);
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json() as { installations: typeof fakeRow[] };
+    expect(body.installations).toHaveLength(1);
+    expect(body.installations[0]).toMatchObject({
+      tenant_id: 9,
+      installation_id: 5,
+      account_login: "Roxabi",
+    });
+  });
+
+  it("returns 401 when requireSession finds no session cookie (negative guard test)", async () => {
+    // Arrange — separate throwaway app mounting real requireSession, no stub session
+    // This verifies the guard is not tautological: deleting requireSession would let
+    // the request reach the handler without a session, changing the response.
+    const { db } = captureDb();
+    const guardApp = new Hono<AuthEnv>();
+    guardApp.use("/api/me", requireSession);
+    guardApp.get("/api/me", meRoute);
+
+    // Act — no Cookie header → requireSession should fail closed with 401
+    const res = await guardApp.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logoutRoute
+// ---------------------------------------------------------------------------
+
+describe("logoutRoute", () => {
+  it("returns 204 on successful logout", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert
+    expect(res.status).toBe(204);
+  });
+
+  it("issues DELETE FROM sessions WHERE token_hash when cookie present", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert — the SQL must be DELETE FROM sessions keyed on token_hash
+    const deleteStmt = stmts().find((s) => s.sql.includes("DELETE FROM sessions"));
+    expect(deleteStmt).toBeDefined();
+    expect(deleteStmt!.sql).toContain("token_hash");
+  });
+
+  it("binds a 64-char hex hash (SHA-256 of raw token) — not the raw token itself", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert — args[0] must be a 64-char lowercase hex string (SHA-256 digest)
+    const deleteStmt = stmts().find((s) => s.sql.includes("DELETE FROM sessions"));
+    expect(deleteStmt).toBeDefined();
+    expect(deleteStmt!.args[0]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("Set-Cookie response header clears the session cookie (Max-Age=0)", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("Max-Age=0");
+    expect(setCookie).toContain("__Host-session");
+  });
+
+  it("does NOT issue DELETE when no session cookie is present", async () => {
+    // Arrange — no Cookie header → logoutRoute guards if (raw) before calling deleteSession
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/logout", { method: "POST" }, makeEnv(db));
+
+    // Assert — no DELETE FROM sessions should have been issued
+    const deleteStmt = stmts().find((s) => s.sql.includes("DELETE FROM sessions"));
+    expect(deleteStmt).toBeUndefined();
+    // Should still succeed (204) even with no cookie
+    expect(res.status).toBe(204);
+  });
+});

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -17,6 +17,9 @@ import { readSessionToken, deleteSession, clearSessionCookie } from "../auth/ses
  */
 export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
   const s = c.get("session");
+  if (!s) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
 
   const rows = await c.env.DB
     .prepare(

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -1,0 +1,56 @@
+/**
+ * /api/me — current user profile + installations.
+ * /logout  — revoke session cookie.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/session";
+import { readSessionToken, deleteSession, clearSessionCookie } from "../auth/session";
+
+// ---------------------------------------------------------------------------
+// GET /api/me
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the authenticated user's GitHub identity and their GitHub App
+ * installations (tenants) linked to their account.
+ */
+export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
+  const s = c.get("session");
+
+  const rows = await c.env.DB
+    .prepare(
+      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login
+       FROM user_installations ui JOIN tenants t ON t.id = ui.tenant_id WHERE ui.user_id = ?`,
+    )
+    .bind(s.userId)
+    .all<{ tenant_id: number; installation_id: number; account_login: string }>();
+
+  return c.json({
+    user: {
+      github_id: s.githubId,
+      github_login: s.githubLogin,
+    },
+    installations: rows.results,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /logout
+// ---------------------------------------------------------------------------
+
+/**
+ * Revokes the current session (deletes from D1) and clears the session cookie.
+ * Gracefully handles the case where no cookie is present (returns 204 anyway).
+ */
+export async function logoutRoute(c: Context<AuthEnv>): Promise<Response> {
+  const raw = readSessionToken(c);
+  if (raw) {
+    await deleteSession(c.env.DB, raw);
+  }
+
+  return new Response(null, {
+    status: 204,
+    headers: { "Set-Cookie": clearSessionCookie() },
+  });
+}

--- a/worker/src/auth/jwt.test.ts
+++ b/worker/src/auth/jwt.test.ts
@@ -1,0 +1,316 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { importAppPrivateKey, signAppJwt } from "./jwt";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a throwaway RSA-2048 key pair (extractable) for use in tests. */
+async function generateTestKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  ) as Promise<CryptoKeyPair>;
+}
+
+/** Export a private CryptoKey as base64-encoded PKCS#8 DER. */
+async function exportPrivateKeyAsB64(key: CryptoKey): Promise<string> {
+  const der = (await crypto.subtle.exportKey("pkcs8", key)) as ArrayBuffer;
+  return btoa(String.fromCharCode(...new Uint8Array(der)));
+}
+
+/** Convert a base64url string to standard base64 (add padding, swap chars). */
+function b64urlToB64(s: string): string {
+  return s.replace(/-/g, "+").replace(/_/g, "/").padEnd(
+    s.length + ((4 - (s.length % 4)) % 4),
+    "=",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// importAppPrivateKey
+// ---------------------------------------------------------------------------
+
+describe("importAppPrivateKey", () => {
+  it("imports a base64 PKCS#8 private key and returns a CryptoKey usable for signing", async () => {
+    // Arrange
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+
+    // Act
+    const imported = await importAppPrivateKey(b64);
+
+    // Assert — should be a non-extractable CryptoKey with sign usage
+    expect(imported).toBeInstanceOf(CryptoKey);
+    expect(imported.type).toBe("private");
+    expect(imported.extractable).toBe(false);
+    expect(imported.usages).toContain("sign");
+  });
+
+  it("imported key can actually sign data (round-trip with crypto.subtle.sign)", async () => {
+    // Arrange
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    const imported = await importAppPrivateKey(b64);
+    const data = new TextEncoder().encode("test payload");
+
+    // Act — signing must not throw
+    const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", imported, data);
+
+    // Assert — signature has non-zero length (RSA-2048 produces 256 bytes)
+    expect(new Uint8Array(sig).length).toBe(256);
+  });
+
+  it("imported key can verify against the corresponding public key", async () => {
+    // Arrange
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    const imported = await importAppPrivateKey(b64);
+    const data = new TextEncoder().encode("test payload");
+
+    // Act
+    const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", imported, data);
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pair.publicKey,
+      sig,
+      data,
+    );
+
+    // Assert
+    expect(valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signAppJwt — structure
+// ---------------------------------------------------------------------------
+
+describe("signAppJwt", () => {
+  // Shared key pair for all signing tests
+  let privKey: CryptoKey;
+  let pubKey: CryptoKey;
+
+  // We generate once (before all) to keep tests fast — key generation is expensive
+  beforeAll(async () => {
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    privKey = await importAppPrivateKey(b64);
+    pubKey = pair.publicKey;
+  });
+
+  const NOW_SEC = 1_700_000_000;
+  const APP_ID = "123456";
+
+  it("produces a JWT with exactly 3 dot-separated parts", async () => {
+    // Arrange / Act
+    const token = await signAppJwt(APP_ID, privKey, NOW_SEC);
+
+    // Assert
+    const parts = token.split(".");
+    expect(parts).toHaveLength(3);
+  });
+
+  it("header decodes to { alg: 'RS256', typ: 'JWT' }", async () => {
+    // Arrange / Act
+    const token = await signAppJwt(APP_ID, privKey, NOW_SEC);
+    const [headerB64url] = token.split(".");
+
+    // Assert
+    const header = JSON.parse(atob(b64urlToB64(headerB64url))) as unknown;
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+  });
+
+  it("payload decodes to { iss, iat: now-60, exp: now+540 }", async () => {
+    // Arrange / Act
+    const token = await signAppJwt(APP_ID, privKey, NOW_SEC);
+    const [, payloadB64url] = token.split(".");
+
+    // Assert
+    const payload = JSON.parse(atob(b64urlToB64(payloadB64url))) as unknown;
+    expect(payload).toEqual({
+      iss: APP_ID,
+      iat: NOW_SEC - 60,
+      exp: NOW_SEC + 540,
+    });
+  });
+
+  it("iss equals the appId passed in", async () => {
+    // Arrange
+    const customId = "987654";
+    // Act
+    const token = await signAppJwt(customId, privKey, NOW_SEC);
+    const [, payloadB64url] = token.split(".");
+    const payload = JSON.parse(atob(b64urlToB64(payloadB64url))) as { iss: string };
+
+    // Assert
+    expect(payload.iss).toBe(customId);
+  });
+
+  it("uses Math.floor(Date.now()/1000) when nowSec is omitted", async () => {
+    // Arrange
+    const before = Math.floor(Date.now() / 1000);
+    // Act
+    const token = await signAppJwt(APP_ID, privKey);
+    const after = Math.floor(Date.now() / 1000);
+
+    const [, payloadB64url] = token.split(".");
+    const payload = JSON.parse(atob(b64urlToB64(payloadB64url))) as { iat: number; exp: number };
+
+    // Assert — iat = now - 60, exp = now + 540; before/after bracket the actual now
+    expect(payload.iat).toBeGreaterThanOrEqual(before - 60);
+    expect(payload.iat).toBeLessThanOrEqual(after - 60);
+    expect(payload.exp).toBeGreaterThanOrEqual(before + 540);
+    expect(payload.exp).toBeLessThanOrEqual(after + 540);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signAppJwt — base64url encoding (no padding, URL-safe chars)
+// ---------------------------------------------------------------------------
+
+describe("signAppJwt base64url encoding", () => {
+  let privKey: CryptoKey;
+
+  beforeAll(async () => {
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    privKey = await importAppPrivateKey(b64);
+  });
+
+  it("header part contains none of '=', '+', '/'", async () => {
+    // Arrange / Act
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [header] = token.split(".");
+
+    // Assert
+    expect(header).not.toContain("=");
+    expect(header).not.toContain("+");
+    expect(header).not.toContain("/");
+  });
+
+  it("payload part contains none of '=', '+', '/'", async () => {
+    // Arrange / Act
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [, payload] = token.split(".");
+
+    // Assert
+    expect(payload).not.toContain("=");
+    expect(payload).not.toContain("+");
+    expect(payload).not.toContain("/");
+  });
+
+  it("signature part contains none of '=', '+', '/'", async () => {
+    // Arrange / Act
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [,, sig] = token.split(".");
+
+    // Assert
+    expect(sig).not.toContain("=");
+    expect(sig).not.toContain("+");
+    expect(sig).not.toContain("/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signAppJwt — cryptographic signature verification
+// ---------------------------------------------------------------------------
+
+describe("signAppJwt signature verification", () => {
+  let privKey: CryptoKey;
+  let pubKey: CryptoKey;
+
+  beforeAll(async () => {
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    privKey = await importAppPrivateKey(b64);
+    pubKey = pair.publicKey;
+  });
+
+  it("crypto.subtle.verify returns true for the signed header.payload", async () => {
+    // Arrange
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [headerB64url, payloadB64url, sigB64url] = token.split(".");
+    const signingInput = new TextEncoder().encode(`${headerB64url}.${payloadB64url}`);
+
+    // Decode signature from base64url back to bytes
+    const sigBytes = Uint8Array.from(atob(b64urlToB64(sigB64url)), (c) =>
+      c.charCodeAt(0),
+    );
+
+    // Act
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pubKey,
+      sigBytes,
+      signingInput,
+    );
+
+    // Assert
+    expect(valid).toBe(true);
+  });
+
+  it("crypto.subtle.verify returns false when payload is tampered", async () => {
+    // Arrange
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [headerB64url, , sigB64url] = token.split(".");
+
+    // Tamper: use a different payload (different iat/exp)
+    const tamperedPayload = { iss: "123456", iat: 0, exp: 9_999_999_999 };
+    const tamperedPayloadB64url = btoa(JSON.stringify(tamperedPayload))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const signingInput = new TextEncoder().encode(
+      `${headerB64url}.${tamperedPayloadB64url}`,
+    );
+
+    const sigBytes = Uint8Array.from(atob(b64urlToB64(sigB64url)), (c) =>
+      c.charCodeAt(0),
+    );
+
+    // Act
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pubKey,
+      sigBytes,
+      signingInput,
+    );
+
+    // Assert
+    expect(valid).toBe(false);
+  });
+
+  it("deleting the signing step (zeroed signature) makes verify return false — negative guard test", async () => {
+    // Arrange — build the header.payload manually but use a zeroed-out 256-byte signature
+    const headerB64url = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const payloadB64url = btoa(JSON.stringify({ iss: "123456", iat: 1_699_999_940, exp: 1_700_000_540 }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const signingInput = new TextEncoder().encode(`${headerB64url}.${payloadB64url}`);
+    const zeroedSig = new Uint8Array(256); // all zeros — not a real RSA signature
+
+    // Act
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pubKey,
+      zeroedSig,
+      signingInput,
+    );
+
+    // Assert — a zeroed signature must NOT verify (confirms guard is meaningful)
+    expect(valid).toBe(false);
+  });
+});

--- a/worker/src/auth/jwt.ts
+++ b/worker/src/auth/jwt.ts
@@ -1,0 +1,64 @@
+/**
+ * GitHub App JWT signing — RS256 / RSASSA-PKCS1-v1_5 via Web Crypto.
+ *
+ * Uses only ambient globals (crypto.subtle, TextEncoder, btoa, atob) —
+ * no Node.js imports, compatible with both the Cloudflare Workers runtime
+ * and the vitest test environment.
+ */
+
+/**
+ * Encode a string or ArrayBuffer as base64url (no padding, URL-safe chars).
+ * - Strings are encoded directly via btoa.
+ * - ArrayBuffers are converted to binary string first.
+ */
+function b64url(input: string | ArrayBuffer): string {
+  let b64: string;
+  if (typeof input === "string") {
+    b64 = btoa(input);
+  } else {
+    b64 = btoa(String.fromCharCode(...new Uint8Array(input)));
+  }
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Import a base64-encoded PKCS#8 DER private key for use with RS256.
+ *
+ * @param b64Pkcs8Der - base64 (standard, not base64url) encoding of the PKCS#8 DER bytes.
+ * @returns A non-extractable CryptoKey with the "sign" usage.
+ */
+export async function importAppPrivateKey(b64Pkcs8Der: string): Promise<CryptoKey> {
+  const derBytes = Uint8Array.from(atob(b64Pkcs8Der), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "pkcs8",
+    derBytes,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+/**
+ * Sign a GitHub App JWT using RS256.
+ *
+ * @param appId  - GitHub App numeric ID (becomes the `iss` claim).
+ * @param key    - Private CryptoKey returned by importAppPrivateKey.
+ * @param nowSec - Unix timestamp in seconds (defaults to current time).
+ * @returns Compact serialized JWT: `<header>.<payload>.<signature>` (all base64url).
+ */
+export async function signAppJwt(
+  appId: string,
+  key: CryptoKey,
+  nowSec?: number,
+): Promise<string> {
+  const now = nowSec ?? Math.floor(Date.now() / 1000);
+
+  const headerB64 = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payloadB64 = b64url(JSON.stringify({ iss: appId, iat: now - 60, exp: now + 540 }));
+
+  const signingInput = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+  const sigBuffer = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, signingInput);
+  const sigB64 = b64url(sigBuffer);
+
+  return `${headerB64}.${payloadB64}.${sigB64}`;
+}

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -1,0 +1,1044 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { loginRoute, callbackRoute } from "./oauth";
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from src/webhook/mutations.test.ts
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements produced via bind() calls on the FakeDb. */
+function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/**
+ * Build a FakeD1 whose prepare().bind().first() returns the given row the first
+ * time it is called, then null thereafter. Used to model single-use state lookup.
+ */
+function captureDbWithFirstRow(
+  firstRowBySql: Map<string, FakeResult | null>,
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const callCounts = new Map<string, number>();
+  const db = makeFakeDb((sql, args) => {
+    const count = callCounts.get(sql) ?? 0;
+    callCounts.set(sql, count + 1);
+    const rowForSql = firstRowBySql.get(sql);
+    // Return the configured row only on the first call with this SQL.
+    const row = count === 0 ? (rowForSql ?? null) : null;
+    const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
+    // Override first() to return the per-call row.
+    (stmt as { first: <T>() => Promise<T | null> }).first = vi
+      .fn()
+      .mockResolvedValue(row);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal Env stub — only the fields needed for OAuth routes. */
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: {} as Fetcher,
+    GITHUB_TOKEN: "gh-token",
+    GITHUB_ORG: "Roxabi",
+    GITHUB_WEBHOOK_SECRET: "webhook-secret",
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_CLIENT_ID: "Iv1.abc123",
+    GITHUB_APP_CLIENT_SECRET: "secret-xyz",
+    GITHUB_APP_PRIVATE_KEY: "base64privkey",
+    GITHUB_APP_WEBHOOK_SECRET: "app-webhook-secret",
+  } as unknown as Env;
+}
+
+/** Mount the login and callback routes on a throwaway Hono app. */
+function makeApp(db: D1Database) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.get("/login", loginRoute);
+  app.get("/oauth/callback", callbackRoute);
+  const env = makeEnv(db);
+  return { app, env };
+}
+
+// ---------------------------------------------------------------------------
+// loginRoute
+// ---------------------------------------------------------------------------
+
+describe("loginRoute", () => {
+  describe("GET /login", () => {
+    it("returns 302 redirect", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(302);
+    });
+
+    it("Location starts with https://github.com/login/oauth/authorize", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      expect(location).toMatch(/^https:\/\/github\.com\/login\/oauth\/authorize/);
+    });
+
+    it("Location query includes client_id matching env", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      const url = new URL(location);
+      expect(url.searchParams.get("client_id")).toBe("Iv1.abc123");
+    });
+
+    it("Location query includes state as 32 hex chars", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      const url = new URL(location);
+      const state = url.searchParams.get("state") ?? "";
+      expect(state).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("Location redirect_uri ends with /oauth/callback derived from request origin", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://myapp.example.com/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      const url = new URL(location);
+      const redirectUri = url.searchParams.get("redirect_uri") ?? "";
+      expect(redirectUri).toMatch(/\/oauth\/callback$/);
+      expect(redirectUri).toContain("myapp.example.com");
+    });
+
+    it("oauth_state INSERT SQL contains '+10 minutes' for expiry", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request("http://localhost/login", { method: "GET" }, env);
+
+      // Assert — state row has datetime('now', '+10 minutes')
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.sql).toContain("+10 minutes");
+    });
+
+    it("oauth_state INSERT binds [state, redirectAfter] in that order", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request("http://localhost/login", { method: "GET" }, env);
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      // args[0] = state (32 hex), args[1] = redirectAfter
+      expect(insertStmt!.args[0]).toMatch(/^[0-9a-f]{32}$/);
+      expect(insertStmt!.args[1]).toBe("/"); // default when no ?redirect param
+    });
+
+    it("?redirect=/dash stores '/dash' as redirect_after", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=/dash",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/dash");
+    });
+
+    it("?redirect=//evil stores '/' (open-redirect guard)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=//evil",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+
+    it("?redirect=https://evil stores '/' (absolute URL guard)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=https://evil",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// callbackRoute
+// ---------------------------------------------------------------------------
+
+describe("callbackRoute", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("missing parameters", () => {
+    it("returns 400 when code is missing", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?state=abc123",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when state is missing", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?code=somecode",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when both code and state are missing", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("unknown or expired state", () => {
+    it("returns 400 when state lookup returns null (unknown state)", async () => {
+      // Arrange — FakeD1 first() returns null for oauth_state lookup
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?code=code1&state=unknownstate000000000000000000",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("happy path — user has installations", () => {
+    function stubFetchSequence(
+      accessToken: string,
+      user: { id: number; login: string },
+      installations: Array<{ id: number; account: { login: string; type: string } }>,
+    ) {
+      let callCount = 0;
+      const mockFetch = vi.fn(async (url: string, _init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          // Token exchange
+          return new Response(
+            JSON.stringify({ access_token: accessToken }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        } else if (callCount === 2) {
+          // /user
+          return new Response(JSON.stringify(user), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        } else {
+          // /user/installations
+          return new Response(JSON.stringify({ installations }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      });
+      vi.stubGlobal("fetch", mockFetch);
+      return mockFetch;
+    }
+
+    it("issues DELETE FROM oauth_state to consume state single-use", async () => {
+      // Arrange
+      const stateValue = "a".repeat(32);
+      const stateRowBySql = new Map<string, FakeResult | null>([
+        [
+          // The SELECT that looks up the state row — matched via substring
+          "SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')",
+          { redirect_after: "/" } as FakeResult,
+        ],
+      ]);
+      // Use a flexible factory so ANY sql with oauth_state SELECT returns the row
+      const captured: FakeStmt[] = [];
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+
+        // For users RETURNING id, return a row with id
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        // For tenants RETURNING id
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        // For sessions INSERT
+        const isSessionInsert =
+          sql.toLowerCase().includes("sessions") &&
+          sql.toLowerCase().includes("insert");
+
+        const rows = isOauthSelect
+          ? (row ? [row] : [])
+          : isUsersInsert
+            ? (usersRow ? [usersRow] : [])
+            : isTenantsInsert
+              ? (tenantsRow ? [tenantsRow] : [])
+              : [];
+
+        const stmt = makeFakeStmt(sql, args, rows, 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — a DELETE FROM oauth_state statement was issued
+      const deleteStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("delete") &&
+          s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(deleteStmt).toBeDefined();
+    });
+
+    it("issues users upsert with ON CONFLICT(github_id)", async () => {
+      // Arrange
+      const stateValue = "b".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const usersStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("users") &&
+          s.sql.toUpperCase().includes("ON CONFLICT(github_id)".toUpperCase()),
+      );
+      expect(usersStmt).toBeDefined();
+      expect(usersStmt!.sql).toContain("ON CONFLICT(github_id)");
+    });
+
+    it("issues tenants upsert with ON CONFLICT(installation_id)", async () => {
+      // Arrange
+      const stateValue = "c".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const tenantsStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("tenants") &&
+          s.sql.toUpperCase().includes("ON CONFLICT(installation_id)".toUpperCase()),
+      );
+      expect(tenantsStmt).toBeDefined();
+      expect(tenantsStmt!.sql).toContain("ON CONFLICT(installation_id)");
+    });
+
+    it("issues user_installations INSERT", async () => {
+      // Arrange
+      const stateValue = "d".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const uiStmt = captured.find((s) =>
+        s.sql.toLowerCase().includes("user_installations"),
+      );
+      expect(uiStmt).toBeDefined();
+    });
+
+    it("returns 302 with Set-Cookie __Host-session containing HttpOnly Secure SameSite=Strict Path=/ and NO Domain", async () => {
+      // Arrange
+      const stateValue = "e".repeat(32);
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, _args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, _args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(302);
+      const cookie = res.headers.get("Set-Cookie") ?? "";
+      expect(cookie).toContain("__Host-session=");
+      expect(cookie).toContain("HttpOnly");
+      expect(cookie).toContain("Secure");
+      expect(cookie).toContain("SameSite=Strict");
+      expect(cookie).toContain("Path=/");
+      expect(cookie).not.toContain("Domain");
+    });
+  });
+
+  describe("replay attack — state already consumed (first()→null on 2nd call)", () => {
+    it("returns 400 on replay (state gone after first use)", async () => {
+      // Arrange — state row returns null (simulating already-consumed state)
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+      // captureDb returns null for first() by default — models "state not found"
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?code=replaycode&state=aaaa0000bbbb1111cccc2222dddd3333",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — state is unknown (null row) → 400
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("zero installations", () => {
+    it("returns 302 to GitHub app install page when installations is empty", async () => {
+      // Arrange
+      const stateValue = "f".repeat(32);
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, _args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, _args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        return stmt;
+      });
+
+      // Stub fetch with empty installations
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok" }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          } else if (fetchCallCount === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [] }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location") ?? "";
+      expect(location).toContain("github.com/apps/");
+      expect(location).toContain("installations/new");
+    });
+
+    it("does NOT set a session cookie when installations is empty", async () => {
+      // Arrange
+      const stateValue = "0".repeat(32);
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, _args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, _args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        return stmt;
+      });
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (fetchCallCount === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [] }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — no Set-Cookie header when no installations
+      expect(res.headers.get("Set-Cookie")).toBeNull();
+    });
+
+    it("does NOT insert a session row when installations is empty", async () => {
+      // Arrange
+      const stateValue = "1".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (fetchCallCount === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [] }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — no INSERT INTO sessions statement
+      const sessionsInsert = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("sessions") &&
+          s.sql.toLowerCase().includes("insert"),
+      );
+      expect(sessionsInsert).toBeUndefined();
+    });
+  });
+});

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -86,32 +86,6 @@ function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
   return { db, stmts: () => captured };
 }
 
-/**
- * Build a FakeD1 whose prepare().bind().first() returns the given row the first
- * time it is called, then null thereafter. Used to model single-use state lookup.
- */
-function captureDbWithFirstRow(
-  firstRowBySql: Map<string, FakeResult | null>,
-): { db: D1Database; stmts: () => FakeStmt[] } {
-  const captured: FakeStmt[] = [];
-  const callCounts = new Map<string, number>();
-  const db = makeFakeDb((sql, args) => {
-    const count = callCounts.get(sql) ?? 0;
-    callCounts.set(sql, count + 1);
-    const rowForSql = firstRowBySql.get(sql);
-    // Return the configured row only on the first call with this SQL.
-    const row = count === 0 ? (rowForSql ?? null) : null;
-    const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
-    // Override first() to return the per-call row.
-    (stmt as { first: <T>() => Promise<T | null> }).first = vi
-      .fn()
-      .mockResolvedValue(row);
-    captured.push(stmt);
-    return stmt;
-  });
-  return { db, stmts: () => captured };
-}
-
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -330,6 +304,66 @@ describe("loginRoute", () => {
       expect(insertStmt).toBeDefined();
       expect(insertStmt!.args[1]).toBe("/");
     });
+
+    it("?redirect=/\\evil stores '/' (backslash bypass guard)", async () => {
+      // Arrange — backslash-prefixed path; sanitizeRedirect regex (?![/\\]) rejects it
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=/\\evil",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the /[/\\]/ check in sanitizeRedirect would let "/\evil" pass
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+
+    it("?redirect=/ok\\r\\nX-Injected:x stores '/' (CRLF injection guard)", async () => {
+      // Arrange — CRLF chars smuggled in the redirect param; sanitizeRedirect rejects via /[\r\n\0]/
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act — encodeURIComponent so the URL parser doesn't strip the special chars
+      await app.request(
+        "http://localhost/login?redirect=" + encodeURIComponent("/ok\r\nX-Injected: x"),
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the /[\r\n\0]/ check in sanitizeRedirect would let the injection through
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+
+    it("?redirect=/ok\\0null stores '/' (NUL injection guard)", async () => {
+      // Arrange — NUL byte smuggled in the redirect param; sanitizeRedirect rejects via /[\r\n\0]/
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act — encodeURIComponent so the URL parser doesn't strip the NUL byte
+      await app.request(
+        "http://localhost/login?redirect=" + encodeURIComponent("/ok\0null"),
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the /[\r\n\0]/ check in sanitizeRedirect would let the NUL through
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
   });
 });
 
@@ -450,7 +484,7 @@ describe("callbackRoute", () => {
      * Build a FakeD1 for happy-path callback tests.
      * State consumption is now a DELETE...RETURNING (detected via "delete" + "oauth_state").
      */
-    function makeHappyPathDb(captured: FakeStmt[]): D1Database {
+    function makeHappyPathDb(captured: FakeStmt[], redirectAfter = "/"): D1Database {
       let oauthDeleteCallCount = 0;
       return makeFakeDb((sql, args) => {
         const isOauthDelete =
@@ -459,7 +493,7 @@ describe("callbackRoute", () => {
         oauthDeleteCallCount += isOauthDelete ? 1 : 0;
         const row =
           isOauthDelete && oauthDeleteCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
+            ? ({ redirect_after: redirectAfter } as FakeResult)
             : null;
 
         // For users RETURNING id, return a row with id
@@ -653,6 +687,34 @@ describe("callbackRoute", () => {
       expect(cookie).toContain("SameSite=Strict");
       expect(cookie).toContain("Path=/");
       expect(cookie).not.toContain("Domain");
+    });
+
+    it("redirects to redirect_after from state row when it is '/dashboard'", async () => {
+      // Arrange — state row returns redirect_after: "/dashboard"
+      const stateValue = "f".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured, "/dashboard");
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — Location must reflect the stored redirect_after, not the hardcoded "/"
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard");
+      const cookie = res.headers.get("Set-Cookie") ?? "";
+      expect(cookie).toContain("__Host-session=");
     });
   });
 
@@ -848,6 +910,47 @@ describe("callbackRoute", () => {
       );
 
       // Assert
+      expect(res.status).toBe(502);
+    });
+
+    it("returns 502 when /user/installations fetch returns non-ok status", async () => {
+      // Arrange — token exchange + /user succeed but /user/installations returns 500
+      const { db } = makeStateOnlyDb();
+      const stateValue = "a".repeat(32);
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            // Token exchange succeeds
+            return new Response(
+              JSON.stringify({ access_token: "tok-abc" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (fetchCallCount === 2) {
+            // /user succeeds
+            return new Response(
+              JSON.stringify({ id: 1, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          // /user/installations returns 500
+          return new Response("Internal Server Error", { status: 500 });
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=goodcode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the if (!installRes.ok) guard would let the route parse a 500 body
       expect(res.status).toBe(502);
     });
   });

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -394,7 +394,7 @@ describe("callbackRoute", () => {
 
   describe("unknown or expired state", () => {
     it("returns 400 when state lookup returns null (unknown state)", async () => {
-      // Arrange — FakeD1 first() returns null for oauth_state lookup
+      // Arrange — FakeD1 first() returns null for oauth_state DELETE...RETURNING
       const { db } = captureDb();
       const { app, env } = makeApp(db);
 
@@ -446,26 +446,19 @@ describe("callbackRoute", () => {
       return mockFetch;
     }
 
-    it("issues DELETE FROM oauth_state to consume state single-use", async () => {
-      // Arrange
-      const stateValue = "a".repeat(32);
-      const stateRowBySql = new Map<string, FakeResult | null>([
-        [
-          // The SELECT that looks up the state row — matched via substring
-          "SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')",
-          { redirect_after: "/" } as FakeResult,
-        ],
-      ]);
-      // Use a flexible factory so ANY sql with oauth_state SELECT returns the row
-      const captured: FakeStmt[] = [];
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
+    /**
+     * Build a FakeD1 for happy-path callback tests.
+     * State consumption is now a DELETE...RETURNING (detected via "delete" + "oauth_state").
+     */
+    function makeHappyPathDb(captured: FakeStmt[]): D1Database {
+      let oauthDeleteCallCount = 0;
+      return makeFakeDb((sql, args) => {
+        const isOauthDelete =
           sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+          sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
         const row =
-          isOauthSelect && oauthSelectCallCount === 1
+          isOauthDelete && oauthDeleteCallCount === 1
             ? ({ redirect_after: "/" } as FakeResult)
             : null;
 
@@ -481,12 +474,7 @@ describe("callbackRoute", () => {
           sql.toLowerCase().includes("returning");
         const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
 
-        // For sessions INSERT
-        const isSessionInsert =
-          sql.toLowerCase().includes("sessions") &&
-          sql.toLowerCase().includes("insert");
-
-        const rows = isOauthSelect
+        const rows = isOauthDelete
           ? (row ? [row] : [])
           : isUsersInsert
             ? (usersRow ? [usersRow] : [])
@@ -495,7 +483,7 @@ describe("callbackRoute", () => {
               : [];
 
         const stmt = makeFakeStmt(sql, args, rows, 0);
-        if (isOauthSelect) {
+        if (isOauthDelete) {
           (stmt as { first: <T>() => Promise<T | null> }).first = vi
             .fn()
             .mockResolvedValue(row);
@@ -511,6 +499,13 @@ describe("callbackRoute", () => {
         captured.push(stmt);
         return stmt;
       });
+    }
+
+    it("uses atomic DELETE...RETURNING to consume state (closes TOCTOU)", async () => {
+      // Arrange
+      const stateValue = "a".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -527,55 +522,22 @@ describe("callbackRoute", () => {
         env,
       );
 
-      // Assert — a DELETE FROM oauth_state statement was issued
+      // Assert — a DELETE FROM oauth_state statement was issued (the atomic consume)
       const deleteStmt = captured.find(
         (s) =>
           s.sql.toLowerCase().includes("delete") &&
           s.sql.toLowerCase().includes("oauth_state"),
       );
       expect(deleteStmt).toBeDefined();
+      // It must also have RETURNING (atomic, not a separate DELETE)
+      expect(deleteStmt!.sql.toUpperCase()).toContain("RETURNING");
     });
 
     it("issues users upsert with ON CONFLICT(github_id)", async () => {
       // Arrange
       const stateValue = "b".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -605,43 +567,8 @@ describe("callbackRoute", () => {
     it("issues tenants upsert with ON CONFLICT(installation_id)", async () => {
       // Arrange
       const stateValue = "c".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -671,43 +598,8 @@ describe("callbackRoute", () => {
     it("issues user_installations INSERT", async () => {
       // Arrange
       const stateValue = "d".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -734,41 +626,8 @@ describe("callbackRoute", () => {
     it("returns 302 with Set-Cookie __Host-session containing HttpOnly Secure SameSite=Strict Path=/ and NO Domain", async () => {
       // Arrange
       const stateValue = "e".repeat(32);
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, _args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, _args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        return stmt;
-      });
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -797,37 +656,216 @@ describe("callbackRoute", () => {
     });
   });
 
-  describe("replay attack — state already consumed (first()→null on 2nd call)", () => {
-    it("returns 400 on replay (state gone after first use)", async () => {
-      // Arrange — state row returns null (simulating already-consumed state)
-      const { db } = captureDb();
-      const { app, env } = makeApp(db);
-      // captureDb returns null for first() by default — models "state not found"
+  describe("replay attack — behavioral single-use enforcement", () => {
+    it("first request mints session (302 + Set-Cookie); second with same state returns 400", async () => {
+      // Arrange — FakeD1 whose state-consume DELETE...RETURNING returns a row
+      // on the first call and null on the second (simulating row deleted by first request).
+      const stateValue = "aaaa0000bbbb1111cccc2222dddd3333";
+      const atomicDeleteSql =
+        `DELETE FROM oauth_state WHERE state = ? AND expires_at > datetime('now') RETURNING redirect_after`;
 
-      // Act
-      const res = await app.request(
-        "http://localhost/oauth/callback?code=replaycode&state=aaaa0000bbbb1111cccc2222dddd3333",
+      let atomicDeleteCallCount = 0;
+
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isAtomicDelete = sql.trim() === atomicDeleteSql.trim() ||
+          (sql.toLowerCase().includes("delete") &&
+            sql.toLowerCase().includes("oauth_state") &&
+            sql.toLowerCase().includes("returning"));
+
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+
+        let row: FakeResult | null = null;
+        if (isAtomicDelete) {
+          atomicDeleteCallCount++;
+          row = atomicDeleteCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        } else if (isUsersInsert) {
+          row = { id: 1 } as FakeResult;
+        } else if (isTenantsInsert) {
+          row = { id: 10 } as FakeResult;
+        }
+
+        const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
+        (stmt as { first: <T>() => Promise<T | null> }).first = vi
+          .fn()
+          .mockResolvedValue(row);
+        captured.push(stmt);
+        return stmt;
+      });
+
+      // Stub fetch so both calls hit GitHub APIs successfully
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          // Cycle through token → user → installations for each OAuth callback
+          const pos = ((fetchCallCount - 1) % 3) + 1;
+          if (pos === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok-abc" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (pos === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [{ id: 9, account: { login: "Roxabi", type: "Organization" } }] }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act — first call
+      const res1 = await app.request(
+        `http://localhost/oauth/callback?code=code1&state=${stateValue}`,
         { method: "GET" },
         env,
       );
 
-      // Assert — state is unknown (null row) → 400
+      // Act — second call with the same state (simulates replay)
+      const res2 = await app.request(
+        `http://localhost/oauth/callback?code=code2&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — first request succeeds with session cookie
+      expect(res1.status).toBe(302);
+      expect(res1.headers.get("Set-Cookie")).toContain("__Host-session=");
+
+      // Assert — second request fails (state row gone after first consume)
+      expect(res2.status).toBe(400);
+    });
+  });
+
+  describe("F1 — GitHub token / API error handling", () => {
+    /**
+     * Build a FakeD1 that successfully returns a state row (for state consume)
+     * but returns null for all other first() calls (sessions, etc.).
+     */
+    function makeStateOnlyDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+      const captured: FakeStmt[] = [];
+      let oauthDeleteCallCount = 0;
+      const db = makeFakeDb((sql, args) => {
+        const isOauthDelete =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
+        const row =
+          isOauthDelete && oauthDeleteCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+
+        const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
+        (stmt as { first: <T>() => Promise<T | null> }).first = vi
+          .fn()
+          .mockResolvedValue(row);
+        captured.push(stmt);
+        return stmt;
+      });
+      return { db, stmts: () => captured };
+    }
+
+    it("returns 400 when token endpoint returns {error} with no access_token", async () => {
+      // Arrange — GitHub returns HTTP 200 with error body (standard OAuth error shape)
+      const { db, stmts } = makeStateOnlyDb();
+      const stateValue = "e".repeat(32);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(
+            JSON.stringify({ error: "bad_verification_code" }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=badcode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
       expect(res.status).toBe(400);
+
+      // No INSERT INTO sessions should have been executed
+      const sessionsInsert = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("sessions") &&
+          s.sql.toLowerCase().includes("insert"),
+      );
+      expect(sessionsInsert).toBeUndefined();
+    });
+
+    it("returns 502 when /user fetch returns non-ok status", async () => {
+      // Arrange — token exchange succeeds but /user returns 401
+      const { db } = makeStateOnlyDb();
+      const stateValue = "f".repeat(32);
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            // Token exchange succeeds
+            return new Response(
+              JSON.stringify({ access_token: "tok-xyz" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          // /user returns 401
+          return new Response("Unauthorized", { status: 401 });
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=goodcode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(502);
     });
   });
 
   describe("zero installations", () => {
-    it("returns 302 to GitHub app install page when installations is empty", async () => {
-      // Arrange
-      const stateValue = "f".repeat(32);
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, _args) => {
-        const isOauthSelect =
+    /**
+     * Build a FakeD1 for zero-installation tests.
+     * Tracks whether INSERT INTO users was ever called.
+     */
+    function makeZeroInstallDb(captured: FakeStmt[]): D1Database {
+      let oauthDeleteCallCount = 0;
+      return makeFakeDb((sql, args) => {
+        const isOauthDelete =
           sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+          sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
         const row =
-          isOauthSelect && oauthSelectCallCount === 1
+          isOauthDelete && oauthDeleteCallCount === 1
             ? ({ redirect_after: "/" } as FakeResult)
             : null;
         const isUsersInsert =
@@ -835,8 +873,8 @@ describe("callbackRoute", () => {
           sql.toLowerCase().includes("returning");
         const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
 
-        const stmt = makeFakeStmt(sql, _args, [], 0);
-        if (isOauthSelect) {
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthDelete) {
           (stmt as { first: <T>() => Promise<T | null> }).first = vi
             .fn()
             .mockResolvedValue(row);
@@ -845,10 +883,12 @@ describe("callbackRoute", () => {
             .fn()
             .mockResolvedValue(usersRow);
         }
+        captured.push(stmt);
         return stmt;
       });
+    }
 
-      // Stub fetch with empty installations
+    function stubZeroInstallFetch() {
       let fetchCallCount = 0;
       vi.stubGlobal(
         "fetch",
@@ -881,7 +921,14 @@ describe("callbackRoute", () => {
           }
         }),
       );
+    }
 
+    it("returns 302 to GitHub app install page when installations is empty", async () => {
+      // Arrange
+      const stateValue = "f".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
       const { app, env } = makeApp(db);
 
       // Act
@@ -901,58 +948,9 @@ describe("callbackRoute", () => {
     it("does NOT set a session cookie when installations is empty", async () => {
       // Arrange
       const stateValue = "0".repeat(32);
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, _args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, _args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        }
-        return stmt;
-      });
-
-      let fetchCallCount = 0;
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (_url: string) => {
-          fetchCallCount++;
-          if (fetchCallCount === 1) {
-            return new Response(
-              JSON.stringify({ access_token: "tok" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else if (fetchCallCount === 2) {
-            return new Response(
-              JSON.stringify({ id: 42, login: "alice" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else {
-            return new Response(
-              JSON.stringify({ installations: [] }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          }
-        }),
-      );
-
+      const captured: FakeStmt[] = [];
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
       const { app, env } = makeApp(db);
 
       // Act
@@ -969,60 +967,9 @@ describe("callbackRoute", () => {
     it("does NOT insert a session row when installations is empty", async () => {
       // Arrange
       const stateValue = "1".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
-
-      let fetchCallCount = 0;
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (_url: string) => {
-          fetchCallCount++;
-          if (fetchCallCount === 1) {
-            return new Response(
-              JSON.stringify({ access_token: "tok" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else if (fetchCallCount === 2) {
-            return new Response(
-              JSON.stringify({ id: 42, login: "alice" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else {
-            return new Response(
-              JSON.stringify({ installations: [] }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          }
-        }),
-      );
-
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
       const { app, env } = makeApp(db);
 
       // Act
@@ -1039,6 +986,31 @@ describe("callbackRoute", () => {
           s.sql.toLowerCase().includes("insert"),
       );
       expect(sessionsInsert).toBeUndefined();
+    });
+
+    it("F4 — does NOT insert a user row when installations is empty (no ghost users)", async () => {
+      // Arrange — F4: user upsert must happen AFTER the install check, so zero
+      // installations must never produce an INSERT INTO users.
+      const stateValue = "2".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — no INSERT INTO users statement was executed
+      const usersInsert = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("insert") &&
+          s.sql.toLowerCase().includes("users"),
+      );
+      expect(usersInsert).toBeUndefined();
     });
   });
 });

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -19,10 +19,11 @@ import { mintSession, sessionCookie } from "./session";
 /**
  * Validate a `redirect` query parameter as a safe relative path.
  * Accepts paths starting with "/" but not "//" (open-redirect via protocol-
- * relative URLs) and rejects anything that is not a plain relative path.
+ * relative URLs), not starting with "/\" (backslash bypass), and rejects
+ * CRLF / NUL injection.
  */
 function sanitizeRedirect(raw: string | undefined): string {
-  if (raw && /^\/(?!\/)/.test(raw)) return raw;
+  if (raw && /^\/(?![/\\])/.test(raw) && !/[\r\n\0]/.test(raw)) return raw;
   return "/";
 }
 
@@ -90,11 +91,11 @@ export async function loginRoute(
  * GitHub redirects here after the user authorises (or denies) the app.
  * Flow:
  *   1. Validate code + state params.
- *   2. Consume state single-use (SELECT then DELETE).
+ *   2. Consume state — atomic single-use DELETE ... RETURNING (closes TOCTOU).
  *   3. Exchange code for access_token.
  *   4. Fetch /user and /user/installations.
- *   5. Upsert user → tenants → user_installations.
- *   6. If no installations → redirect to app install page (no session).
+ *   5. If no installations → redirect to app install page (no DB write, no session).
+ *   6. Upsert user → tenants → user_installations.
  *   7. Mint session tied to first installation, set __Host-session cookie.
  */
 export async function callbackRoute(
@@ -107,9 +108,9 @@ export async function callbackRoute(
     return c.json({ error: "bad_request" }, 400);
   }
 
-  // Consume state — single-use: SELECT (with expiry guard) then DELETE
+  // Consume state — single-use + expiry guard in one atomic statement (closes TOCTOU)
   const stateRow = await c.env.DB.prepare(
-    `SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')`,
+    `DELETE FROM oauth_state WHERE state = ? AND expires_at > datetime('now') RETURNING redirect_after`,
   )
     .bind(state)
     .first<{ redirect_after: string | null }>();
@@ -117,10 +118,6 @@ export async function callbackRoute(
   if (!stateRow) {
     return c.json({ error: "bad_request" }, 400);
   }
-
-  await c.env.DB.prepare(`DELETE FROM oauth_state WHERE state = ?`)
-    .bind(state)
-    .run();
 
   const redirectAfter = stateRow.redirect_after ?? "/";
 
@@ -146,9 +143,15 @@ export async function callbackRoute(
       }),
     },
   );
-  const { access_token } = (await tokenRes.json()) as {
-    access_token: string;
-  };
+
+  if (!tokenRes.ok) {
+    return c.json({ error: "oauth_failed" }, 502);
+  }
+  const tokenBody = (await tokenRes.json()) as { access_token?: string; error?: string };
+  if (tokenBody.error || !tokenBody.access_token) {
+    return c.json({ error: "oauth_failed" }, 400);
+  }
+  const access_token = tokenBody.access_token;
 
   const ghHeaders = {
     Authorization: `Bearer ${access_token}`,
@@ -160,6 +163,9 @@ export async function callbackRoute(
   const userRes = await fetch("https://api.github.com/user", {
     headers: ghHeaders,
   });
+  if (!userRes.ok) {
+    return c.json({ error: "github_unavailable" }, 502);
+  }
   const ghUser = (await userRes.json()) as { id: number; login: string };
 
   // Fetch user installations
@@ -167,12 +173,25 @@ export async function callbackRoute(
     "https://api.github.com/user/installations",
     { headers: ghHeaders },
   );
+  if (!installRes.ok) {
+    return c.json({ error: "github_unavailable" }, 502);
+  }
   const { installations } = (await installRes.json()) as {
     installations: Array<{
       id: number;
       account: { login: string; type: string };
     }>;
   };
+
+  // No installations — redirect to app install page, no session, no DB write
+  if (installations.length === 0) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: "https://github.com/apps/roxabi-live/installations/new",
+      },
+    });
+  }
 
   // Upsert user — get internal id
   const userRow = await c.env.DB.prepare(
@@ -183,17 +202,10 @@ export async function callbackRoute(
     .bind(ghUser.id, ghUser.login)
     .first<{ id: number }>();
 
-  const userId = userRow!.id;
-
-  // No installations — redirect to app install page, no session
-  if (installations.length === 0) {
-    return new Response(null, {
-      status: 302,
-      headers: {
-        Location: "https://github.com/apps/roxabi-live/installations/new",
-      },
-    });
+  if (!userRow) {
+    return c.json({ error: "db_error" }, 500);
   }
+  const userId = userRow.id;
 
   // Upsert each installation as a tenant and link to user
   let firstTenantId: number | null = null;
@@ -208,7 +220,10 @@ export async function callbackRoute(
       .bind(inst.id, inst.account.login, inst.account.type)
       .first<{ id: number }>();
 
-    const tenantId = tenantRow!.id;
+    if (!tenantRow) {
+      return c.json({ error: "db_error" }, 500);
+    }
+    const tenantId = tenantRow.id;
 
     await c.env.DB.prepare(
       `INSERT OR IGNORE INTO user_installations (user_id, tenant_id) VALUES (?, ?)`,
@@ -221,8 +236,12 @@ export async function callbackRoute(
     }
   }
 
+  if (firstTenantId === null) {
+    return c.json({ error: "db_error" }, 500);
+  }
+
   // Mint session tied to the first installation's tenant
-  const rawToken = await mintSession(c.env.DB, userId, firstTenantId!);
+  const rawToken = await mintSession(c.env.DB, userId, firstTenantId);
 
   return new Response(null, {
     status: 302,

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -1,0 +1,234 @@
+/**
+ * GitHub App OAuth routes.
+ *
+ * loginRoute    — initiates the OAuth flow (stores state, redirects to GitHub).
+ * callbackRoute — handles the GitHub callback (exchanges code, upserts user +
+ *                 tenants, mints session).
+ *
+ * Never logs tokens, client_secret, or raw session tokens.
+ */
+
+import type { Context } from "hono";
+import type { Env } from "../types";
+import { mintSession, sessionCookie } from "./session";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a `redirect` query parameter as a safe relative path.
+ * Accepts paths starting with "/" but not "//" (open-redirect via protocol-
+ * relative URLs) and rejects anything that is not a plain relative path.
+ */
+function sanitizeRedirect(raw: string | undefined): string {
+  if (raw && /^\/(?!\/)/.test(raw)) return raw;
+  return "/";
+}
+
+/**
+ * Encode a Uint8Array of random bytes as a lowercase hex string.
+ */
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// loginRoute
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /login
+ *
+ * Generates a random state token, persists it in D1 oauth_state with a
+ * 10-minute expiry, then redirects the browser to GitHub's OAuth authorize
+ * endpoint.  The redirect_uri is derived from the request origin — never from
+ * a query parameter — to prevent redirect-uri injection (D-6).
+ */
+export async function loginRoute(
+  c: Context<{ Bindings: Env }>,
+): Promise<Response> {
+  const redirectAfter = sanitizeRedirect(c.req.query("redirect") ?? undefined);
+
+  // 16 random bytes → 32 hex chars
+  const stateBytes = new Uint8Array(16);
+  crypto.getRandomValues(stateBytes);
+  const state = bytesToHex(stateBytes);
+
+  // Store state in D1 — single-use, expires in 10 minutes
+  await c.env.DB.prepare(
+    `INSERT INTO oauth_state (state, redirect_after, expires_at)
+     VALUES (?, ?, datetime('now', '+10 minutes'))`,
+  )
+    .bind(state, redirectAfter)
+    .run();
+
+  // Build GitHub authorize URL — redirect_uri derived from origin only (D-6)
+  const origin = new URL(c.req.url).origin;
+  const redirectUri = `${origin}/oauth/callback`;
+
+  const dest = new URL("https://github.com/login/oauth/authorize");
+  dest.searchParams.set("client_id", c.env.GITHUB_APP_CLIENT_ID);
+  dest.searchParams.set("redirect_uri", redirectUri);
+  dest.searchParams.set("state", state);
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: dest.toString() },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// callbackRoute
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /oauth/callback
+ *
+ * GitHub redirects here after the user authorises (or denies) the app.
+ * Flow:
+ *   1. Validate code + state params.
+ *   2. Consume state single-use (SELECT then DELETE).
+ *   3. Exchange code for access_token.
+ *   4. Fetch /user and /user/installations.
+ *   5. Upsert user → tenants → user_installations.
+ *   6. If no installations → redirect to app install page (no session).
+ *   7. Mint session tied to first installation, set __Host-session cookie.
+ */
+export async function callbackRoute(
+  c: Context<{ Bindings: Env }>,
+): Promise<Response> {
+  const code = c.req.query("code");
+  const state = c.req.query("state");
+
+  if (!code || !state) {
+    return c.json({ error: "bad_request" }, 400);
+  }
+
+  // Consume state — single-use: SELECT (with expiry guard) then DELETE
+  const stateRow = await c.env.DB.prepare(
+    `SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')`,
+  )
+    .bind(state)
+    .first<{ redirect_after: string | null }>();
+
+  if (!stateRow) {
+    return c.json({ error: "bad_request" }, 400);
+  }
+
+  await c.env.DB.prepare(`DELETE FROM oauth_state WHERE state = ?`)
+    .bind(state)
+    .run();
+
+  const redirectAfter = stateRow.redirect_after ?? "/";
+
+  // Build redirect_uri from origin (D-6)
+  const origin = new URL(c.req.url).origin;
+  const redirectUri = `${origin}/oauth/callback`;
+
+  // Exchange code for access_token
+  const tokenRes = await fetch(
+    "https://github.com/login/oauth/access_token",
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "roxabi-live",
+      },
+      body: JSON.stringify({
+        client_id: c.env.GITHUB_APP_CLIENT_ID,
+        client_secret: c.env.GITHUB_APP_CLIENT_SECRET,
+        code,
+        redirect_uri: redirectUri,
+      }),
+    },
+  );
+  const { access_token } = (await tokenRes.json()) as {
+    access_token: string;
+  };
+
+  const ghHeaders = {
+    Authorization: `Bearer ${access_token}`,
+    "User-Agent": "roxabi-live",
+    Accept: "application/vnd.github+json",
+  };
+
+  // Fetch authenticated user
+  const userRes = await fetch("https://api.github.com/user", {
+    headers: ghHeaders,
+  });
+  const ghUser = (await userRes.json()) as { id: number; login: string };
+
+  // Fetch user installations
+  const installRes = await fetch(
+    "https://api.github.com/user/installations",
+    { headers: ghHeaders },
+  );
+  const { installations } = (await installRes.json()) as {
+    installations: Array<{
+      id: number;
+      account: { login: string; type: string };
+    }>;
+  };
+
+  // Upsert user — get internal id
+  const userRow = await c.env.DB.prepare(
+    `INSERT INTO users (github_id, github_login) VALUES (?, ?)
+     ON CONFLICT(github_id) DO UPDATE SET github_login=excluded.github_login, updated_at=datetime('now')
+     RETURNING id`,
+  )
+    .bind(ghUser.id, ghUser.login)
+    .first<{ id: number }>();
+
+  const userId = userRow!.id;
+
+  // No installations — redirect to app install page, no session
+  if (installations.length === 0) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: "https://github.com/apps/roxabi-live/installations/new",
+      },
+    });
+  }
+
+  // Upsert each installation as a tenant and link to user
+  let firstTenantId: number | null = null;
+
+  for (const inst of installations) {
+    const tenantRow = await c.env.DB.prepare(
+      `INSERT INTO tenants (installation_id, account_login, account_type) VALUES (?, ?, ?)
+       ON CONFLICT(installation_id) DO UPDATE SET account_login=excluded.account_login,
+         account_type=excluded.account_type, updated_at=datetime('now')
+       RETURNING id`,
+    )
+      .bind(inst.id, inst.account.login, inst.account.type)
+      .first<{ id: number }>();
+
+    const tenantId = tenantRow!.id;
+
+    await c.env.DB.prepare(
+      `INSERT OR IGNORE INTO user_installations (user_id, tenant_id) VALUES (?, ?)`,
+    )
+      .bind(userId, tenantId)
+      .run();
+
+    if (firstTenantId === null) {
+      firstTenantId = tenantId;
+    }
+  }
+
+  // Mint session tied to the first installation's tenant
+  const rawToken = await mintSession(c.env.DB, userId, firstTenantId!);
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: redirectAfter,
+      "Set-Cookie": sessionCookie(rawToken),
+    },
+  });
+}

--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -1,0 +1,538 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+// ---------------------------------------------------------------------------
+// NOTE: session.ts does not exist yet — these tests are intentionally RED.
+// They define the contract that session.ts must satisfy (T6 task).
+// ---------------------------------------------------------------------------
+
+import {
+  mintSession,
+  validateSession,
+  deleteSession,
+  requireSession,
+  sessionCookie,
+  clearSessionCookie,
+  SESSION_COOKIE,
+  SESSION_TTL_SECONDS,
+} from "./session";
+import type { AuthEnv, SessionContext } from "./session";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from src/webhook/mutations.test.ts (captureDb pattern)
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements produced via bind() calls on the FakeDb. */
+function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/**
+ * Build a FakeD1 where `first()` always resolves with the provided row.
+ * Used to test the "found" path of validateSession.
+ */
+function fixedFirstDb(row: FakeResult | null): D1Database {
+  return makeFakeDb((sql, args) =>
+    makeFakeStmt(sql, args, row !== null ? [row] : [], 0),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const HEX64_RE = /^[0-9a-f]{64}$/;
+
+// ---------------------------------------------------------------------------
+// mintSession
+// ---------------------------------------------------------------------------
+
+describe("mintSession", () => {
+  it("INSERT SQL contains datetime('now', '+8 hours') for expires_at", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await mintSession(db, 7, 9);
+    // Assert
+    expect(stmts()[0].sql).toContain("datetime('now', '+8 hours')");
+  });
+
+  it("binds exactly 3 args: [userId, tenantId, token_hash]", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await mintSession(db, 7, 9);
+    // Assert
+    expect(stmts()[0].args).toHaveLength(3);
+    expect(stmts()[0].args[0]).toBe(7);
+    expect(stmts()[0].args[1]).toBe(9);
+  });
+
+  it("arg[2] (token_hash) is a 64-char lowercase hex string", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await mintSession(db, 7, 9);
+    // Assert
+    const hash = stmts()[0].args[2];
+    expect(typeof hash).toBe("string");
+    expect(hash).toMatch(HEX64_RE);
+  });
+
+  it("returned raw token is a 64-char lowercase hex string", async () => {
+    // Arrange
+    const { db } = captureDb();
+    // Act
+    const raw = await mintSession(db, 7, 9);
+    // Assert
+    expect(raw).toMatch(HEX64_RE);
+  });
+
+  it("returned raw token is NOT the stored token_hash (raw ≠ sha256(raw))", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    const raw = await mintSession(db, 7, 9);
+    // Assert — the raw token must differ from its own hash stored in arg[2]
+    const storedHash = stmts()[0].args[2];
+    expect(raw).not.toBe(storedHash);
+  });
+
+  it("two consecutive calls produce different raw tokens (randomness)", async () => {
+    // Arrange
+    const { db: db1 } = captureDb();
+    const { db: db2 } = captureDb();
+    // Act
+    const raw1 = await mintSession(db1, 1, 1);
+    const raw2 = await mintSession(db2, 1, 1);
+    // Assert
+    expect(raw1).not.toBe(raw2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSession — SQL guard clauses
+// ---------------------------------------------------------------------------
+
+describe("validateSession — SQL guard clauses", () => {
+  it("SQL contains token_hash = ? clause", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "a".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("token_hash = ?");
+  });
+
+  it("SQL contains expires_at > datetime('now') guard", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "b".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("expires_at > datetime('now')");
+  });
+
+  it("SQL contains revoked_at IS NULL guard", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "c".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("revoked_at IS NULL");
+  });
+
+  it("SQL contains NOT EXISTS subquery for tenant suspension", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "d".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("NOT EXISTS");
+  });
+
+  it("SQL contains suspended_at IS NOT NULL guard inside NOT EXISTS", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "e".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("suspended_at IS NOT NULL");
+  });
+
+  it("passes the hash of rawToken as the bound arg (¬raw token itself)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const raw = "f".repeat(64);
+    // Act
+    await validateSession(db, raw);
+    // Assert — bound arg must be a different value (the hash), not the raw token
+    expect(stmts()[0].args[0]).not.toBe(raw);
+    // The hash should itself be a 64-char hex string
+    expect(stmts()[0].args[0]).toMatch(HEX64_RE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSession — behaviour with FakeD1 rows
+// ---------------------------------------------------------------------------
+
+describe("validateSession — return value", () => {
+  const SESSION_ROW: FakeResult = {
+    userId: 7,
+    tenantId: 9,
+    githubId: 42,
+    githubLogin: "alice",
+  };
+
+  it("returns the SessionContext when first() resolves with a row", async () => {
+    // Arrange
+    const db = fixedFirstDb(SESSION_ROW);
+    // Act
+    const result = await validateSession(db, "rawtoken");
+    // Assert
+    expect(result).toEqual({
+      userId: 7,
+      tenantId: 9,
+      githubId: 42,
+      githubLogin: "alice",
+    });
+  });
+
+  it("returns null when first() resolves with null (expired/revoked/unknown)", async () => {
+    // Arrange
+    const db = fixedFirstDb(null);
+    // Act
+    const result = await validateSession(db, "rawtoken");
+    // Assert
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteSession
+// ---------------------------------------------------------------------------
+
+describe("deleteSession", () => {
+  it("issues DELETE FROM sessions WHERE token_hash = ?", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await deleteSession(db, "rawtoken");
+    // Assert
+    expect(stmts()[0].sql).toContain("DELETE FROM sessions");
+    expect(stmts()[0].sql).toContain("token_hash = ?");
+  });
+
+  it("binds the SHA-256 hash of the raw token, not the raw token itself", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const raw = "myrawtoken";
+    // Act
+    await deleteSession(db, raw);
+    // Assert
+    const bound = stmts()[0].args[0];
+    expect(bound).not.toBe(raw);
+    expect(bound).toMatch(HEX64_RE);
+  });
+
+  it("consistent hashing: same raw token → same hash in both deleteSession and mintSession", async () => {
+    // Arrange — capture hash from mintSession, then verify deleteSession uses same hash
+    const { db: mintDb, stmts: mintStmts } = captureDb();
+    const raw = await mintSession(mintDb, 1, 1);
+    const mintedHash = mintStmts()[0].args[2] as string;
+
+    const { db: delDb, stmts: delStmts } = captureDb();
+    // Act
+    await deleteSession(delDb, raw);
+    // Assert
+    expect(delStmts()[0].args[0]).toBe(mintedHash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireSession middleware
+// ---------------------------------------------------------------------------
+
+describe("requireSession", () => {
+  function buildApp(
+    db: D1Database,
+    probeHandler: (session: SessionContext) => Response = (s) =>
+      new Response(JSON.stringify(s), { status: 200 }),
+  ) {
+    const app = new Hono<AuthEnv>();
+
+    app.use("/protected", requireSession);
+    app.get("/protected", (c) => {
+      const session = c.get("session");
+      return probeHandler(session);
+    });
+
+    return app;
+  }
+
+  const VALID_SESSION: SessionContext = {
+    userId: 7,
+    tenantId: 9,
+    githubId: 42,
+    githubLogin: "alice",
+  };
+
+  it("returns 401 JSON {error:'unauthorized'} when no Cookie header is present", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    // Act
+    const res = await app.request("/protected", { method: "GET" }, env);
+    // Assert
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "unauthorized" });
+  });
+
+  it("returns 401 when Cookie is present but validateSession returns null (bad/expired token)", async () => {
+    // Arrange — DB always returns null for first()
+    const db = fixedFirstDb(null);
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    const cookieValue = `${SESSION_COOKIE}=badtoken`;
+    // Act
+    const res = await app.request(
+      "/protected",
+      { method: "GET", headers: { Cookie: cookieValue } },
+      env,
+    );
+    // Assert
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "unauthorized" });
+  });
+
+  it("calls next and sets session context when token is valid", async () => {
+    // Arrange — DB returns a valid session row
+    const db = fixedFirstDb(VALID_SESSION as unknown as FakeResult);
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    // mintSession to get a valid raw token format (64-char hex)
+    const { db: mintDb } = captureDb();
+    const raw = await mintSession(mintDb, 7, 9);
+    const cookieValue = `${SESSION_COOKIE}=${raw}`;
+    // Act
+    const res = await app.request(
+      "/protected",
+      { method: "GET", headers: { Cookie: cookieValue } },
+      env,
+    );
+    // Assert — next handler ran, session was set
+    expect(res.status).toBe(200);
+    const body = await res.json<SessionContext>();
+    expect(body.userId).toBe(7);
+    expect(body.tenantId).toBe(9);
+    expect(body.githubId).toBe(42);
+    expect(body.githubLogin).toBe("alice");
+  });
+
+  it("returns 401 when Cookie header has wrong cookie name", async () => {
+    // Arrange
+    const db = fixedFirstDb(VALID_SESSION as unknown as FakeResult);
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    const cookieValue = `wrong-name=sometoken`;
+    // Act
+    const res = await app.request(
+      "/protected",
+      { method: "GET", headers: { Cookie: cookieValue } },
+      env,
+    );
+    // Assert — no __Host-session cookie → 401
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionCookie
+// ---------------------------------------------------------------------------
+
+describe("sessionCookie", () => {
+  it("contains __Host-session=<rawToken>", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("abc123");
+    // Assert
+    expect(cookie).toContain("__Host-session=abc123");
+  });
+
+  it("contains HttpOnly flag", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("HttpOnly");
+  });
+
+  it("contains Secure flag", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("Secure");
+  });
+
+  it("contains SameSite=Strict", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("SameSite=Strict");
+  });
+
+  it("contains Path=/", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("Path=/");
+  });
+
+  it("contains Max-Age=28800 (8 hours)", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("Max-Age=28800");
+    // Verify SESSION_TTL_SECONDS export matches
+    expect(SESSION_TTL_SECONDS).toBe(28800);
+  });
+
+  it("does NOT contain Domain attribute (__Host- prefix requires omission)", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert — __Host- prefix mandates no Domain attribute
+    expect(cookie).not.toContain("Domain");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearSessionCookie
+// ---------------------------------------------------------------------------
+
+describe("clearSessionCookie", () => {
+  it("contains __Host-session= (empty value)", () => {
+    // Arrange + Act
+    const cookie = clearSessionCookie();
+    // Assert
+    expect(cookie).toContain("__Host-session=");
+  });
+
+  it("contains Max-Age=0 to expire the cookie immediately", () => {
+    // Arrange + Act
+    const cookie = clearSessionCookie();
+    // Assert
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("contains HttpOnly flag", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("HttpOnly");
+  });
+
+  it("contains Secure flag", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("Secure");
+  });
+
+  it("contains SameSite=Strict", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("SameSite=Strict");
+  });
+
+  it("contains Path=/", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("Path=/");
+  });
+
+  it("does NOT contain Domain attribute", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).not.toContain("Domain");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SESSION_COOKIE constant
+// ---------------------------------------------------------------------------
+
+describe("SESSION_COOKIE constant", () => {
+  it("equals '__Host-session'", () => {
+    expect(SESSION_COOKIE).toBe("__Host-session");
+  });
+});

--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -285,6 +285,47 @@ describe("validateSession — return value", () => {
 });
 
 // ---------------------------------------------------------------------------
+// validateSession — suspended-tenant behavioral guard (mutation-catching)
+// ---------------------------------------------------------------------------
+
+describe("validateSession — suspended-tenant behavioral guard", () => {
+  /**
+   * SQL-discriminating FakeD1: if the executed SQL contains the
+   * suspended_at IS NOT NULL guard (i.e. the guard is present in source),
+   * first() returns null — correctly filtering out the suspended tenant.
+   * If the guard is ABSENT from the SQL, first() returns a valid row —
+   * which would make validateSession return non-null and break toBeNull().
+   *
+   * This test FAILS if the suspended-tenant guard is removed from
+   * validateSession's SQL, because the fake would then return a row
+   * and validateSession would return non-null instead of null.
+   */
+  it("returns null for a suspended tenant (guard is mutation-catching)", async () => {
+    // Arrange — a valid session row that would be returned if the guard is absent
+    const validRow: FakeResult = {
+      userId: 7,
+      tenantId: 9,
+      githubId: 42,
+      githubLogin: "alice",
+    };
+
+    const db = makeFakeDb((sql, args) => {
+      // If the suspended-tenant guard is present in the SQL, simulate the DB
+      // filtering out the row (suspended tenant → no result).
+      // If the guard is absent, the DB returns a valid row — causing toBeNull() to fail.
+      const guardPresent = sql.includes("suspended_at IS NOT NULL");
+      return makeFakeStmt(sql, args, guardPresent ? [] : [validRow], 0);
+    });
+
+    // Act
+    const result = await validateSession(db, "a".repeat(64));
+
+    // Assert — suspended tenant session must be filtered out → null
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // deleteSession
 // ---------------------------------------------------------------------------
 
@@ -339,7 +380,9 @@ describe("requireSession", () => {
 
     app.use("/protected", requireSession);
     app.get("/protected", (c) => {
-      const session = c.get("session");
+      // requireSession guarantees session is set before next() is called;
+      // the non-null assertion is safe here (the middleware returns 401 otherwise).
+      const session = c.get("session")!;
       return probeHandler(session);
     });
 

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -21,7 +21,7 @@ export interface SessionContext {
 
 export type AuthEnv = {
   Bindings: Env;
-  Variables: { session: SessionContext };
+  Variables: { session?: SessionContext };
 };
 
 // ---------------------------------------------------------------------------

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -1,0 +1,188 @@
+/**
+ * Session management for GitHub App OAuth sessions.
+ *
+ * Tokens are stored as SHA-256 hashes (never raw). The __Host- cookie prefix
+ * mandates Secure + Path=/ + no Domain — enforced by sessionCookie().
+ */
+
+import type { MiddlewareHandler, Context } from "hono";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SessionContext {
+  userId: number;
+  tenantId: number;
+  githubId: number;
+  githubLogin: string;
+}
+
+export type AuthEnv = {
+  Bindings: Env;
+  Variables: { session: SessionContext };
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const SESSION_COOKIE = "__Host-session";
+export const SESSION_TTL_SECONDS = 28800; // 8 hours
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * SHA-256 digest of a UTF-8 string, returned as lowercase hex.
+ * Uses the ambient crypto.subtle (Cloudflare Workers / Vitest Node env).
+ */
+async function sha256hex(s: string): Promise<string> {
+  const bytes = new TextEncoder().encode(s);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Cookie helpers (pure, synchronous)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Set-Cookie header value for the session token.
+ * __Host- prefix requires: Secure, Path=/, no Domain.
+ */
+export function sessionCookie(rawToken: string): string {
+  return `${SESSION_COOKIE}=${rawToken}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${SESSION_TTL_SECONDS}`;
+}
+
+/**
+ * Build a Set-Cookie header value that immediately expires the session cookie.
+ */
+export function clearSessionCookie(): string {
+  return `${SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0`;
+}
+
+// ---------------------------------------------------------------------------
+// Token reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the __Host-session cookie value from the Cookie header.
+ * Returns null if the cookie is absent or the header is missing.
+ */
+export function readSessionToken(c: Context): string | null {
+  const cookieHeader = c.req.header("Cookie");
+  if (!cookieHeader) return null;
+
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const name = trimmed.slice(0, eqIdx).trim();
+    if (name === SESSION_COOKIE) {
+      return trimmed.slice(eqIdx + 1).trim() || null;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// D1 operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a new session: generate 32 random bytes as a 64-char hex token,
+ * store its SHA-256 hash in D1, and return the raw token (once, never stored).
+ */
+export async function mintSession(
+  db: D1Database,
+  userId: number,
+  tenantId: number,
+): Promise<string> {
+  const randomBytes = new Uint8Array(32);
+  crypto.getRandomValues(randomBytes);
+  const rawToken = Array.from(randomBytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  const hash = await sha256hex(rawToken);
+
+  await db
+    .prepare(
+      `INSERT INTO sessions (user_id, tenant_id, token_hash, expires_at)
+       VALUES (?, ?, ?, datetime('now', '+8 hours'))`,
+    )
+    .bind(userId, tenantId, hash)
+    .run();
+
+  return rawToken;
+}
+
+/**
+ * Validate a raw session token.
+ * Returns the SessionContext if the session is valid (not expired, not revoked,
+ * tenant not suspended), or null otherwise.
+ */
+export async function validateSession(
+  db: D1Database,
+  rawToken: string,
+): Promise<SessionContext | null> {
+  const hash = await sha256hex(rawToken);
+
+  const row = await db
+    .prepare(
+      `SELECT s.user_id AS userId, s.tenant_id AS tenantId, u.github_id AS githubId, u.github_login AS githubLogin
+       FROM sessions s JOIN users u ON u.id = s.user_id
+       WHERE s.token_hash = ?
+         AND s.expires_at > datetime('now')
+         AND s.revoked_at IS NULL
+         AND NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL)`,
+    )
+    .bind(hash)
+    .first<SessionContext>();
+
+  return row ?? null;
+}
+
+/**
+ * Delete a session by raw token (hashes before querying).
+ */
+export async function deleteSession(
+  db: D1Database,
+  rawToken: string,
+): Promise<void> {
+  const hash = await sha256hex(rawToken);
+
+  await db
+    .prepare(`DELETE FROM sessions WHERE token_hash = ?`)
+    .bind(hash)
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Fail-closed session middleware. Reads the __Host-session cookie, validates
+ * against D1, and sets the session context on the Hono context. Returns 401
+ * JSON if the token is absent or invalid.
+ */
+export const requireSession: MiddlewareHandler<AuthEnv> = async (c, next) => {
+  const token = readSessionToken(c);
+  if (!token) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const ctx = await validateSession(c.env.DB, token);
+  if (!ctx) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  c.set("session", ctx);
+  await next();
+};

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -64,7 +64,8 @@ app.get("/login", loginRoute);
 app.get("/oauth/callback", callbackRoute);
 app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
-app.use("/logout", requireSession);
+// /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
+// blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);
 
 // ── Static-assets fallback — last resort (frontend populated in S7, #99) ────

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -6,8 +6,11 @@ import { listIssuesRoute, getIssueRoute } from "./api/issues";
 import { adminSyncRoute } from "./api/admin";
 import { webhookRoute } from "./webhook/handlers";
 import { checkAdminAuth } from "./api/auth";
+import { loginRoute, callbackRoute } from "./auth/oauth";
+import { meRoute, logoutRoute } from "./api/me";
+import { requireSession, type AuthEnv } from "./auth/session";
 
-const app = new Hono<{ Bindings: Env }>();
+const app = new Hono<AuthEnv>();
 
 // ── API routes — evaluated BEFORE the ASSETS fallback ───────────────────────
 // S1 scaffold wires /health + /api/version. S5 (#97) adds POST /webhook/github.
@@ -55,6 +58,14 @@ app.get("/health", async (c) => {
   }
   return c.json({ status: "ok", db_reachable: dbReachable, issue_count: issueCount });
 });
+
+// ── Auth routes (#145, S2) ───────────────────────────────────────────────────
+app.get("/login", loginRoute);
+app.get("/oauth/callback", callbackRoute);
+app.use("/api/me", requireSession);
+app.get("/api/me", meRoute);
+app.use("/logout", requireSession);
+app.post("/logout", logoutRoute);
 
 // ── Static-assets fallback — last resort (frontend populated in S7, #99) ────
 app.all("*", (c) => c.env.ASSETS.fetch(c.req.raw));

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -32,4 +32,14 @@ export interface Env {
    * only guard). Set via `wrangler secret put ADMIN_TOKEN` to enable the gate.
    */
   ADMIN_TOKEN?: string;
+  // numeric App ID (App-JWT iss) — S3 consumes
+  GITHUB_APP_ID: string;
+  // OAuth client_id (login redirect)
+  GITHUB_APP_CLIENT_ID: string;
+  // OAuth client_secret (token exchange) — never logged
+  GITHUB_APP_CLIENT_SECRET: string;
+  // base64(PKCS#8 DER) of the App RSA key — importKey('pkcs8')
+  GITHUB_APP_PRIVATE_KEY: string;
+  // App webhook HMAC secret (distinct from org GITHUB_WEBHOOK_SECRET)
+  GITHUB_APP_WEBHOOK_SECRET: string;
 }

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -168,6 +168,11 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_ORG: "Roxabi",
     GITHUB_WEBHOOK_SECRET: "test-secret",
     ASSETS: {} as Fetcher,
+    GITHUB_APP_ID: "0",
+    GITHUB_APP_CLIENT_ID: "placeholder",
+    GITHUB_APP_CLIENT_SECRET: "placeholder",
+    GITHUB_APP_PRIVATE_KEY: "placeholder",
+    GITHUB_APP_WEBHOOK_SECRET: "placeholder",
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
Identity layer for the multi-tenant GitHub App auth epic (#141), slice **S2** (repo-canonical model). Builds on S1's migration 0004 (auth tables, live on staging).

- **`auth/jwt.ts`** — RS256 App-JWT signer: `importAppPrivateKey` (base64 PKCS#8 DER → `importKey('pkcs8')`, non-extractable) + `signAppJwt` (`iat-60`/`exp+540`). Permanent vitest RS256 sign/verify guard (SC-6). Consumed by S3.
- **`auth/session.ts`** — D1-backed sessions: SHA-256 `token_hash` at rest (raw returned once), `datetime('now','+8 hours')` expiry, fail-closed `requireSession` middleware with the suspended-tenant `NOT EXISTS` guard (SC-4), host-only `__Host-session` cookie (`HttpOnly; Secure; SameSite=Strict; Path=/`, **no Domain** — D-2).
- **`auth/oauth.ts`** — `GET /login` (single-use `state`, 10-min TTL, open-redirect guard) + `GET /oauth/callback` (verify+**DELETE** state → `code`→token → `/user`+`/user/installations` → upserts → mint session). `redirect_uri` derived from request origin only, never query (D-6). **D-1**: callback re-checks installations and upserts `tenants` + `user_installations` (the `sessions.tenant_id` FK requires it before S3's webhook exists); 0 installations → 302 to the App install page, no session.
- **`api/me.ts`** — `GET /api/me` (identity + installations) + `POST /logout` (DELETE session row, clear cookie).
- **`router.ts`** — `Hono<AuthEnv>`, 4 auth routes before the ASSETS fallback. `/api/issues` + `/api/graph` stay open (D-4 — gating all reads is S5/#148). **`types.ts`**: 5 `GITHUB_APP_*` Env fields.
- **`ci.yml`** — app-secrets guard repointed `secrets.GITHUB_APP_*` → `secrets.GH_APP_*` (GitHub 422s `GITHUB_`-prefixed Actions secret names — D-5).

RS256 was confirmed in **real workerd** (one-shot `wrangler dev` smoke) before any implementation code.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #145: feat(auth): GitHub App + OAuth login + sessions (Phase 1 S2) | OPEN |
| Analysis | — (epic-level, #141) | Absent (F-lite) |
| Spec | [145-github-app-oauth-sessions-spec.mdx](artifacts/specs/145-github-app-oauth-sessions-spec.mdx) | Present |
| Plan | [145-github-app-oauth-sessions-plan.mdx](artifacts/plans/145-github-app-oauth-sessions-plan.mdx) | Present |
| Implementation | 2 code commits on `feat/145-github-app-oauth-sessions` | Complete |
| Verification | Typecheck ✅ · Tests ✅ 349 pass (+84 new, 5 files) · secret-leak grep ✅ | Passed |

## Test Plan
- [ ] CI green (includes the now-correctly-wired app-secrets guard).
- [ ] **e2e on staging** (`roxabi-live-staging.mickael-b5e.workers.dev`, not Access-gated): install the App on the Roxabi org, hit `/login` → GitHub authorize → `/oauth/callback` mints `__Host-session` → `GET /api/me` returns identity + installations → `POST /logout` → `/api/me` 401.
- [ ] Replay a consumed `state` → 400; user with 0 installations → 302 to install page, no session.
- [ ] Suspended tenant (`tenants.suspended_at` set) → session validation returns 401.

Fixes #145

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
