### PR TITLE
feat(sync): install-token infra + webhook cutover (Phase 1 S3a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,61 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # ── GitHub App secrets injection (S2/#145) ───────────────────────────────
+      # GitHub forbids GITHUB_-prefixed Actions secret names (422); repo secrets are GH_APP_*.
+      # Inject after deploy so the Worker binary is already live when secrets are written.
+      - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'staging'
+        name: Inject GITHUB_APP_* secrets (staging)
+        run: |
+          printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --env staging --config ../wrangler.toml
+          printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --env staging --config ../wrangler.toml
+          printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --env staging --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
+      - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'main'
+        name: Inject GITHUB_APP_* secrets (production)
+        run: |
+          printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --config ../wrangler.toml
+          printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --config ../wrangler.toml
+          printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
+      # ── INSTALL_TOKEN_KEY injection (S3/#146) ────────────────────────────────
+      # Actions secret GH_INSTALL_TOKEN_KEY → Worker secret INSTALL_TOKEN_KEY (AES-GCM DEK).
+      # Same guard pattern as GH_APP_* above: GH_ prefix avoids GitHub's GITHUB_-name ban.
+      # TODO(RT3): after initial provisioning, run `wrangler secret delete GITHUB_TOKEN` on
+      # both staging and production to retire the legacy PAT (manual runtime op, not in CI).
+      - if: steps.guard.outputs.enabled == 'true'
+        id: install-token-key-guard
+        name: Guard — INSTALL_TOKEN_KEY secret
+        env:
+          INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}
+        run: |
+          if [ -z "$INSTALL_TOKEN_KEY" ]; then
+            echo "::notice::GH_INSTALL_TOKEN_KEY not set — INSTALL_TOKEN_KEY injection skipped until provisioned (S3/#146)."
+            echo "install_token_key=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "install_token_key=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'staging'
+        name: Inject INSTALL_TOKEN_KEY (staging)
+        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}
+      - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'main'
+        name: Inject INSTALL_TOKEN_KEY (production)
+        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}

--- a/artifacts/plans/146-installation-sync-backfill-plan.mdx
+++ b/artifacts/plans/146-installation-sync-backfill-plan.mdx
@@ -1,0 +1,322 @@
+---
+title: "Plan: feat(sync) installation sync + per-repo fan-out + PAT retirement (S3)"
+issue: 146
+spec: artifacts/specs/146-installation-sync-backfill-spec.mdx
+parent_issue: 141
+complexity: 8/10
+tier: F-full
+generated: 2026-06-11
+---
+
+## Summary
+
+Wire the hourly + on-demand sync to **GitHub App installation tokens** (replacing the org-wide PAT),
+fan out **one GraphQL call per unique repo** across tenants, window repos under the 50-subrequest cap
+via `sync_control.sync_slot`, declare `SYNC_QUEUE` dormant, and **retire `GITHUB_TOKEN`** (no fallback)
+once a staging tick is verified. Transport (`ghGraphql`) is already token-parameterized — only the 6
+PAT callsites + 3 new modules change.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph entry [entry]
+    CRON[Cron 0 * * * *] --> RS[runSync env]
+    ADMIN[POST /admin/sync] --> RS
+    WH[webhook handlers.ts] --> RIT
+  end
+  subgraph token [auth/installToken.ts NEW]
+    RIT[resolveInstallToken owner/name] --> GIT[getInstallationToken tenantId,instId]
+    GIT -->|cache fresh| DEC[tokenCrypto.decryptToken]
+    GIT -->|stale/miss| JWT[jwt.signAppJwt] --> MINT[POST /app/installations/:id/access_tokens]
+    MINT --> ENC[tokenCrypto.encryptToken] --> ITUP[(install_tokens upsert)]
+    DEC --> TOK[bearer token]
+    ENC --> TOK
+  end
+  subgraph crypto [auth/tokenCrypto.ts NEW]
+    KEY[INSTALL_TOKEN_KEY secret] --> DEK[importDek AES-GCM]
+    DEK --> DEC
+    DEK --> ENC
+  end
+  subgraph sync [sync/sync.ts]
+    RS --> DISC[listInstallationRepos per tenant] --> TRA[(tenant_repo_access upsert)]
+    TRA --> DEDUP[dedup repo→tenant map]
+    DEDUP --> SLOT[slot window sync_control.sync_slot]
+    SLOT --> LOOP[per unique repo]
+    RIT --> GG
+    LOOP -->|resolveInstallToken| GG[ghGraphql token + sub_issues header]
+    GG --> WRITE[(issues / edges global PK)]
+    LOOP --> CHP[closedHopPass tokenResolver]
+    CHP --> GG
+  end
+  RIT -.-> GIT
+```
+
+### File × function map
+
+```mermaid
+flowchart LR
+  subgraph crypto_f [auth/tokenCrypto.ts]
+    f_importDek[importDek] --- f_enc[encryptToken] --- f_dec[decryptToken]
+  end
+  subgraph token_f [auth/installToken.ts]
+    f_get[getInstallationToken] --- f_res[resolveInstallToken] --- f_list[listInstallationRepos]
+  end
+  subgraph jwt_f [auth/jwt.ts reuse]
+    f_sign[signAppJwt] --- f_imp[importAppPrivateKey]
+  end
+  subgraph sync_f [sync/sync.ts]
+    f_run[runSync] --- f_bundle[syncRepoBundle] --- f_hop[closedHopPass] --- f_lock[acquireSyncLock tenantId]
+  end
+  subgraph gql_f [sync/graphql.ts]
+    f_gg[ghGraphql + GraphQL-Features header]
+  end
+  subgraph wh_f [webhook/handlers.ts]
+    f_dep[handleDeps] --- f_del[handleRefDelete]
+  end
+  f_res --> f_get
+  f_get --> f_sign
+  f_get --> f_dec
+  f_get --> f_enc
+  f_run --> f_list
+  f_run --> f_get
+  f_run --> f_bundle
+  f_bundle --> f_gg
+  f_hop --> f_res
+  f_dep --> f_res
+  f_del --> f_res
+  TESTS[*.test.ts] -.-> f_enc
+  TESTS -.-> f_get
+  TESTS -.-> f_run
+  TESTS -.-> f_dep
+```
+
+## Key Design Decisions
+
+- **D1 — SC-9 gate (sub_issues via install token):** No GitHub doc confirms the `GraphQL-Features: sub_issues`
+  preview header was retired at GA, BUT current sync queries `subIssues`/`parent` **headerless on the PAT
+  successfully** (live on staging), the installation has `issues:read`, and an installation access token (IAT)
+  with `issues:read` is documented-equivalent to a PAT for issue reads. **Resolution:** add the header
+  defensively (harmless if graduated) + empirical staging smoke-test post-deploy (RT2). Gate cleared with mitigation.
+- **D2 — SYNC_QUEUE dormant:** A producer binding to a non-existent queue **breaks `wrangler deploy`**, and Queues
+  require Workers **Paid** (plan unconfirmed). **Resolution:** keep the dormant **commented** stanza + add an
+  optional `SYNC_QUEUE?: Queue` Env type; defer real `wrangler queues create` + uncomment to Paid + >30 repos
+  (zero further code change). Satisfies SC-5 "declared, no consumer".
+- **D3 — tenant_repo_access population:** No code writes it today. **Resolution:** populate **at sync-time** via
+  `listInstallationRepos(token)` per tenant (self-healing, no webhook-timing dependency); installation-webhook
+  event handling deferred to S4 #147. This also replaces the PAT-based `enumerateOrgRepos` discovery.
+
+## Agents
+
+| Agent instance | Tasks | Files | Subjects |
+|---|---|---|---|
+| tester-A | T1, T2 | tokenCrypto.test.ts, installToken.test.ts | crypto, install-token |
+| tester-B | T3, T4, T13 | sync.test.ts, handlers.test.ts, full-suite sweep | sync, webhook, verify |
+| backend-dev-A | T5, T6 | tokenCrypto.ts, installToken.ts | crypto, install-token |
+| backend-dev-B | T7 | sync/sync.ts | sync |
+| backend-dev-C | T8, T9 | webhook/handlers.ts, sync/graphql.ts | webhook, graphql |
+| devops-A | T10, T11, T12 | types.ts, wrangler.toml, 0005_*.sql, ci.yml | config, ci |
+
+## Wave Structure
+
+4 waves, max 7 parallel agents. Elapsed ~4 agent-passes vs ~13 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 7 ∥ | tester-A: T1,T2 · tester-B: T3,T4 · backend-dev-C: T9 · devops-A: T11,T12 |
+| RED-GATE | W1 RED tests present+failing | — | RG1 (sentinel: T1,T2,T3,T4 failing) |
+| 2 | RED-GATE | 3 ∥ | backend-dev-A: T5→T6 · backend-dev-B: T7(⟸T6) · backend-dev-C: T8(⟸T6) |
+| 3 | W2 done | 1 | devops-A: T10 (⟸T7,T8 — drop PAT after callsites gone) |
+| 4 | W3 done | 1 | tester-B: T13 (⟸T9,T10,T11,T12) |
+
+### Budget — per task
+
+| Task | Class | Est. ops | Split? |
+|------|-------|----------|--------|
+| T1 crypto tests | bounded | 3 | — |
+| T2 install-token tests | judgmental | 6 | — |
+| T3 sync tests | judgmental | 8 | — |
+| T4 webhook tests | bounded | 4 | — |
+| T5 crypto impl | bounded | 3 | — |
+| T6 install-token impl | judgmental | 8 | — |
+| T7 sync refactor | exploratory | 15 | — (own instance) |
+| T8 webhook impl | bounded | 3 | — |
+| T9 graphql header | trivial | 2 | — |
+| T10 Env drop-PAT | trivial | 2 | — |
+| T11 migration+wrangler | bounded | 4 | — |
+| T12 CI inject | bounded | 3 | — |
+| T13 verify sweep | judgmental | 5 | — |
+
+**Total estimated ops: ~66**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| tester-A | T1,T2 | 9 | crypto, install-token | — |
+| tester-B | T3,T4,T13 | 17 | sync, webhook, verify(sweep) | — (verify = closeout sweep, not new surface) |
+| backend-dev-A | T5,T6 | 11 | crypto, install-token | — |
+| backend-dev-B | T7 | 15 | sync | — |
+| backend-dev-C | T8,T9 | 5 | webhook, graphql | — |
+| devops-A | T10,T11,T12 | 9 | config, ci | — |
+
+## Consistency Report
+
+| Spec criterion | Task(s) |
+|---|---|
+| SC-1 AES-GCM round-trip, DEK=INSTALL_TOKEN_KEY, no plaintext log | T1, T5 |
+| SC-2 refresh when expires_at ≤ now+5min, write D1 | T2, T6 |
+| SC-3 dedup repos across tenants, 1 GraphQL/unique repo | T3, T7 |
+| SC-4 slot-rotation via sync_control.sync_slot, no cap breach | T3, T7, T11 |
+| SC-5 SYNC_QUEUE declared, no consumer (DORMANT) | T10, T11 (D2) |
+| SC-6 GITHUB_TOKEN removed Env/wrangler/handleDeps/handleRefDelete | T8, T10 |
+| SC-7 PAT deleted staging→prod after verified tick | RT3 (runtime) |
+| SC-8 no tenant_id on issues/edges, no backfill | (design — confirmed, no task) |
+| SC-9 subIssues/parent gate cleared | D1 → T9 + RT2 |
+
+Covered: 9/9. Untraced tasks: none. Exemptions: SC-8 is a non-action (confirm absence).
+
+## Runtime Ops (ship — sequenced, NOT code tasks)
+
+- **RT1 [PRE-deploy gate]** provision `INSTALL_TOKEN_KEY` (32-byte base64) on staging+prod via
+  `wrangler secret put INSTALL_TOKEN_KEY [--env staging]`; add `GH_INSTALL_TOKEN_KEY` Actions secret.
+  Worker `Env` requires it → must exist before first deploy or the worker errors.
+- **RT2** deploy staging → `wrangler tail --env staging` confirms 1 cron tick mints an install token +
+  writes issue rows + `subIssues`/`parent` resolve (clears D1 empirically).
+- **RT3** `wrangler secret delete GITHUB_TOKEN --env staging` → confirm clean tick (no 401s) → repeat prod.
+
+## Micro-Tasks
+
+### Wave 1 — RED tests + independent config (7 ∥)
+
+**T1 [P] (RED, tester-A, crypto, diff 2)** — `worker/src/auth/tokenCrypto.test.ts`
+Tests against signatures: `importDek(b64:string):Promise<CryptoKey>`, `encryptToken(dek,plaintext):Promise<{enc:string,iv:string}>`, `decryptToken(dek,enc,iv):Promise<string>`.
+Cases: round-trip equality; IV is 12 bytes & differs across two encrypts of same plaintext; tampered ciphertext → throws; wrong DEK → throws; outputs base64url.
+Verify: `cd worker && npx vitest run src/auth/tokenCrypto.test.ts` → fails (no impl).
+
+**T2 [P] (RED, tester-A, install-token, diff 3)** — `worker/src/auth/installToken.test.ts`
+FakeD1 + mocked `fetch`. Signatures: `getInstallationToken(db,env,tenantId,installationId):Promise<string>`, `resolveInstallToken(db,env,owner,name):Promise<string>`.
+Cases: cache fresh (expires_at > now+5min) → decrypt, **no mint fetch**; cache stale/missing → signAppJwt + POST mint + encrypt + upsert; resolver with no `tenant_repo_access` row → throws (fail-closed); `tenants.suspended_at` set → throws; plaintext token never written raw (assert stored col is ciphertext).
+Verify: `cd worker && npx vitest run src/auth/installToken.test.ts` → fails.
+
+**T3 [P] (RED, tester-B, sync, diff 4)** — `worker/src/sync/sync.test.ts` (additions)
+Cases: two tenants sharing repo `o/r` → exactly **1** `REPO_BUNDLE_QUERY` for `o/r`; `sync_slot` advances per tick and windows the repo list (repos beyond per-tick cap deferred); per-tenant lock — tenant A `sync_running` does not block tenant B; assert **no `env.GITHUB_TOKEN`** read in runSync path.
+Verify: `cd worker && npx vitest run src/sync/sync.test.ts` → new cases fail.
+
+**T4 [P] (RED, tester-B, webhook, diff 2)** — `worker/src/webhook/handlers.test.ts` (updates)
+Cases: `handleDeps` cross-repo path calls `resolveInstallToken(db,env,owner,name)` (not `env.GITHUB_TOKEN`); `handleRefDelete` calls `resolveInstallToken` for the deleted-branch repo.
+Verify: `cd worker && npx vitest run src/webhook/handlers.test.ts` → fails.
+
+**T9 [P] (backend-dev-C, graphql, diff 1)** — `worker/src/sync/graphql.ts`
+Add `"GraphQL-Features": "sub_issues"` to the `ghGraphql` request headers (defensive, D1). Keep `token` param. Add a unit assertion the header is sent.
+Verify: `cd worker && npm run typecheck` + header test green.
+
+**T11 [P] (devops-A, config, diff 2)** — `worker/migrations/0005_sync_slot_seed.sql` + `wrangler.toml`
+Migration: `INSERT OR IGNORE INTO sync_control (tenant_id,key,value) VALUES (0,'sync_slot','0');`. wrangler.toml: keep `SYNC_QUEUE` stanza **commented** with a `DORMANT — activate on Workers Paid + >30 repos` note (D2); confirm no `GITHUB_TOKEN` var stanza (secret-only).
+Verify: `cd worker && npx wrangler d1 migrations list roxabi-live-production` lists 0005 locally; `grep -n DORMANT wrangler.toml`.
+
+**T12 [P] (devops-A, ci, diff 2)** — `.github/workflows/ci.yml`
+Add a guard+inject step mirroring `GH_APP_*`: `GH_INSTALL_TOKEN_KEY` → `wrangler secret put INSTALL_TOKEN_KEY` in the deploy job (staging + prod). Add a TODO comment for the sequenced `GITHUB_TOKEN` deletion (RT3) — do **not** delete in CI.
+Verify: `grep -n INSTALL_TOKEN_KEY .github/workflows/ci.yml`; yaml parses.
+
+### RED-GATE V1
+
+**RG1 (sentinel, lead)** — confirm T1–T4 present and failing before any GREEN task. blockedBy T1,T2,T3,T4.
+
+### Wave 2 — GREEN core (3 ∥)
+
+**T5 (GREEN, backend-dev-A, crypto, diff 2)** — `worker/src/auth/tokenCrypto.ts`
+Web Crypto AES-GCM. `importDek(b64)` → `crypto.subtle.importKey('raw', base64decode, {name:'AES-GCM'}, false, ['encrypt','decrypt'])`. `encryptToken` → 12-byte random IV, base64url out. `decryptToken`. Never log plaintext.
+Verify: `cd worker && npx vitest run src/auth/tokenCrypto.test.ts` green. blockedBy RG1.
+
+**T6 (GREEN, backend-dev-A, install-token, diff 4)** — `worker/src/auth/installToken.ts`
+`getInstallationToken(db,env,tenantId,installationId)`: SELECT install_tokens; if `expires_at > now+5min` → `decryptToken`; else `importAppPrivateKey`+`signAppJwt` (jwt.ts) → `POST /app/installations/{id}/access_tokens` → `encryptToken` → upsert → return. `resolveInstallToken(db,env,owner,name)`: JOIN `tenant_repo_access`(repo=`owner/name`)→`tenants`(id, installation_id, suspended_at); throw if no row or suspended (fail-closed) → `getInstallationToken`. `listInstallationRepos(token)`: GET `/installation/repositories` (paginated) → `owner/name[]`.
+Verify: `cd worker && npx vitest run src/auth/installToken.test.ts` green + typecheck. blockedBy T5.
+
+**T7 (GREEN, backend-dev-B, sync, diff 5)** — `worker/src/sync/sync.ts`
+(a) Repo discovery: for each `tenants` row → `getInstallationToken` → `listInstallationRepos` → upsert `tenant_repo_access`; build deduped `Map<repo, tenantId>` (first tenant wins; repo fetched once). Replaces `enumerateOrgRepos`/`enumerateArchivedOrgRepos` PAT calls.
+(b) Per-repo loop: `resolveInstallToken`/`getInstallationToken` token per repo bundle.
+(c) `sync_slot` windowing: read slot from `sync_control`, `LIMIT/OFFSET` repo list (~40/tick), advance `slot mod ceil(total/window)`.
+(d) Parameterize `acquireSyncLock`/`releaseSyncLock`/`isHalted`/`incrementAuthFailures`/`resetAuthFailures` with `tenantId` (default 0); seed per-tenant rows; per-tenant failure must not hold another tenant's lock.
+(e) `closedHopPass(db, tokenResolver)` callback — resolve per (owner,name) hop; unknown repo → caught as orphan stub.
+(f) Remove all `env.GITHUB_TOKEN` reads.
+Verify: `cd worker && npx vitest run src/sync/sync.test.ts` green + typecheck. blockedBy T6.
+
+**T8 (GREEN, backend-dev-C, webhook, diff 2)** — `worker/src/webhook/handlers.ts`
+Line 209 (`handleDeps` cross-repo) + line 364 (`handleRefDelete`): replace `env.GITHUB_TOKEN` with `await resolveInstallToken(db, env, owner, name)` (owner/name already in scope).
+Verify: `cd worker && npx vitest run src/webhook/handlers.test.ts` green. blockedBy T6.
+
+### Wave 3 — Env drop-PAT
+
+**T10 (devops-A, config, diff 1)** — `worker/src/types.ts`
+Add `INSTALL_TOKEN_KEY: string`; add `SYNC_QUEUE?: Queue` (optional, dormant); **remove `GITHUB_TOKEN`**.
+Verify: `cd worker && npm run typecheck` green (all callsites gone). blockedBy T7,T8.
+
+### Wave 4 — verify
+
+**T13 (tester-B, verify, diff 3)** — full gate + regression sweep
+`cd worker && npm run typecheck && npm test`; assert `grep -rn "GITHUB_TOKEN" worker/src` returns **no** runtime reads (only comments/tests asserting removal); coverage on new modules.
+Verify: suite green + grep clean. blockedBy T9,T10,T11,T12.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate. blockedBy refs T-numbers (not session task IDs). -->
+
+### Wave 1 — no deps, 7 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | tester-A | — | crypto |
+| T2 | tester-A | — | install-token |
+| T3 | tester-B | — | sync |
+| T4 | tester-B | — | webhook |
+| T9 | backend-dev-C | — | graphql |
+| T11 | devops-A | — | config |
+| T12 | devops-A | — | ci |
+
+### RED-GATE — after W1 RED tests
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| RG1 | lead | T1,T2,T3,T4 | gate |
+
+### Wave 2 — after RED-GATE, 3 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | backend-dev-A | RG1 | crypto |
+| T6 | backend-dev-A | T5 | install-token |
+| T7 | backend-dev-B | T6 | sync |
+| T8 | backend-dev-C | T6 | webhook |
+
+### Wave 3 — after W2
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | devops-A | T7,T8 | config |
+
+### Wave 4 — after W3
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T13 | tester-B | T9,T10,T11,T12 | verify |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to re-attach tasks on session restart. -->
+- T1: 58 — crypto (tester-A)
+- T2: 59 — install-token (tester-A)
+- T3: 60 — sync (tester-B)
+- T4: 61 — webhook (tester-B)
+- T9: 62 — graphql (backend-dev-C)
+- T11: 63 — config (devops-A)
+- T12: 64 — ci (devops-A)
+- RG1: 65 — RED-GATE (lead) ⟸ T1,T2,T3,T4
+- T5: 66 — crypto (backend-dev-A) ⟸ RG1
+- T6: 67 — install-token (backend-dev-A) ⟸ T5
+- T7: 68 — sync (backend-dev-B) ⟸ T6
+- T8: 69 — webhook (backend-dev-C) ⟸ T6
+- T10: 70 — config (devops-A) ⟸ T7,T8
+- T13: 71 — verify (tester-B) ⟸ T9,T10,T11,T12

--- a/artifacts/specs/146-installation-sync-backfill-spec.mdx
+++ b/artifacts/specs/146-installation-sync-backfill-spec.mdx
@@ -98,7 +98,7 @@ post-GA when token type changes from PAT → installation. Gates this slice.
 - [ ] Cron fan-out deduplicates repos across tenants: 1 GraphQL call per unique repo (not per tenant).
 - [ ] Slot-rotation: `sync_control (tenant_id, 'sync_slot')` advances per tick; repos beyond
   the per-tick cap deferred to next tick; no subrequest-cap breach under ~22 repos/tick.
-- [ ] SYNC_QUEUE binding declared in `wrangler.toml`; **no consumer handler registered** (DORMANT).
+- [ ] SYNC_QUEUE binding declared in `wrangler.toml` as an intentional DORMANT placeholder for future fan-out (Phase 2); **no consumer handler registered** in Phase 1.
 - [ ] `GITHUB_TOKEN` removed from `Env` / `wrangler.toml` / `handleDeps` / `handleRefDelete`;
   no PAT fallback anywhere.
 - [ ] PAT deleted from staging secrets after first verified installation sync tick; then prod.

--- a/worker/migrations/0005_sync_slot_seed.sql
+++ b/worker/migrations/0005_sync_slot_seed.sql
@@ -1,0 +1,7 @@
+-- migration: 0005_sync_slot_seed.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+
+-- Seed the global sync_slot sentinel row (tenant_id=0).
+-- INSERT OR IGNORE: idempotent — no-op if the row already exists (e.g. re-applied migration).
+-- sync_control PK is (tenant_id, key); tenant_id=0 is the global sentinel (no FK to tenants).
+INSERT OR IGNORE INTO sync_control (tenant_id, key, value) VALUES (0, 'sync_slot', '0');

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { getInstallationToken, resolveInstallToken } from "./installToken";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// NOTE: installToken.ts does not exist yet — these tests are intentionally RED.
+// They define the contract that installToken.ts must satisfy (S3 task).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// FakeD1 — local copy of the project pattern (see session.test.ts)
+// ---------------------------------------------------------------------------
+
+type FakeResult = { [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Test key generation helpers (mirrors jwt.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+async function generateTestKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  ) as Promise<CryptoKeyPair>;
+}
+
+async function exportPrivateKeyAsB64(key: CryptoKey): Promise<string> {
+  const der = (await crypto.subtle.exportKey("pkcs8", key)) as ArrayBuffer;
+  return btoa(String.fromCharCode(...new Uint8Array(der)));
+}
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+/** Generate a fresh 32-byte INSTALL_TOKEN_KEY as base64. */
+function generateInstallTokenKey(): string {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  return btoa(String.fromCharCode(...raw));
+}
+
+/** Encrypt a plaintext token using the same AES-GCM approach as tokenCrypto
+ *  so we can seed install_tokens with a realistic encrypted row.
+ *  NOTE: this is a test-local helper — it imports from tokenCrypto which
+ *  doesn't exist yet, so it will also fail at import time (expected RED). */
+// We'll use a simple approach: store a known "encrypted" value using the
+// real tokenCrypto module once it exists. For now, tests that need a seeded
+// encrypted row (cache-hit path) import encryptToken directly.
+import { importDek, encryptToken } from "./tokenCrypto";
+
+// ---------------------------------------------------------------------------
+// Fake env builder
+// ---------------------------------------------------------------------------
+
+async function buildFakeEnv(
+  overrides: Partial<Env> = {},
+): Promise<{ env: Env; appPrivKeyB64: string; installTokenKeyB64: string }> {
+  const pair = await generateTestKeyPair();
+  const appPrivKeyB64 = await exportPrivateKeyAsB64(pair.privateKey);
+  const installTokenKeyB64 = generateInstallTokenKey();
+
+  const env: Env = {
+    DB: null as unknown as D1Database, // overridden per test
+    ASSETS: null as unknown as Fetcher,
+    GITHUB_TOKEN: "gh_test_token",
+    GITHUB_ORG: "TestOrg",
+    GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
+    GITHUB_APP_ID: "999999",
+    GITHUB_APP_CLIENT_ID: "Iv1.test",
+    GITHUB_APP_CLIENT_SECRET: "test-client-secret",
+    GITHUB_APP_PRIVATE_KEY: appPrivKeyB64,
+    GITHUB_APP_WEBHOOK_SECRET: "test-app-webhook-secret",
+    INSTALL_TOKEN_KEY: installTokenKeyB64,
+    ...overrides,
+  } as unknown as Env;
+
+  return { env, appPrivKeyB64, installTokenKeyB64 };
+}
+
+// ---------------------------------------------------------------------------
+// FakeD1 factory for install token scenarios
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a FakeD1 seeded with tenants + install_tokens + tenant_repo_access rows.
+ * The stmtFactory inspects the SQL to route queries to the right fixture data.
+ */
+function buildSeededDb(opts: {
+  tenant?: {
+    id: number;
+    installation_id: number;
+    account_login: string;
+    account_type: string;
+    suspended_at: string | null;
+  };
+  installToken?: {
+    tenant_id: number;
+    token_enc: string;
+    token_iv: string;
+    expires_at: string; // ISO 8601
+  };
+  repoAccess?: { tenant_id: number; repo: string }[];
+  /** Track upsert calls to install_tokens */
+  upsertCapture?: Array<{ sql: string; args: unknown[] }>;
+}): D1Database {
+  const {
+    tenant,
+    installToken,
+    repoAccess = [],
+    upsertCapture,
+  } = opts;
+
+  return makeFakeDb((sql, args) => {
+    const sqlLower = sql.toLowerCase();
+
+    // Capture upsert/insert into install_tokens
+    if (
+      upsertCapture &&
+      (sqlLower.includes("insert") || sqlLower.includes("update")) &&
+      sqlLower.includes("install_tokens")
+    ) {
+      upsertCapture.push({ sql, args });
+      return makeFakeStmt(sql, args, [], 1);
+    }
+
+    // Query on install_tokens (cache lookup)
+    if (sqlLower.includes("install_tokens")) {
+      if (installToken) {
+        return makeFakeStmt(sql, args, [installToken as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []); // cache miss
+    }
+
+    // Query on tenant_repo_access
+    if (sqlLower.includes("tenant_repo_access")) {
+      const matchingRow = repoAccess.find(
+        (r) => args.includes(r.repo) || args.length === 0,
+      );
+      if (matchingRow) {
+        return makeFakeStmt(sql, args, [matchingRow as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []); // no access row
+    }
+
+    // Query on tenants (suspended check or JOIN)
+    if (sqlLower.includes("tenants")) {
+      if (tenant) {
+        return makeFakeStmt(sql, args, [tenant as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []);
+    }
+
+    // Default: empty result
+    return makeFakeStmt(sql, args, [], 0);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------------
+
+/** ISO timestamp offset from now by `seconds`. */
+function nowPlusSeconds(seconds: number): string {
+  return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// getInstallationToken — cache fresh path
+// ---------------------------------------------------------------------------
+
+describe("getInstallationToken — cache fresh", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the decrypted token from cache when expires_at > now+5min, without calling fetch", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const plaintext = "ghs_cached_fresh_token";
+    const { enc, iv } = await encryptToken(dek, plaintext);
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(10 * 60), // 10 min from now — well past 5-min threshold
+      },
+    });
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const token = await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert
+    expect(token).toBe(plaintext);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getInstallationToken — cache stale/miss path
+// ---------------------------------------------------------------------------
+
+describe("getInstallationToken — cache stale/missing", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls GitHub mint endpoint once when cache is missing, returns fresh token", async () => {
+    // Arrange
+    const { env } = await buildFakeEnv();
+    const freshToken = "ghs_freshly_minted_token";
+    const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      // No installToken row → cache miss
+      upsertCapture,
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: freshToken,
+          expires_at: nowPlusSeconds(3600),
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const token = await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert
+    expect(token).toBe(freshToken);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The fetch URL must reference the installation ID
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("42");
+    expect(calledUrl).toContain("access_tokens");
+  });
+
+  it("calls GitHub mint endpoint once when cache is stale (expires_at ≤ now+5min)", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const staleToken = "ghs_stale_token";
+    const { enc, iv } = await encryptToken(dek, staleToken);
+    const freshToken = "ghs_new_token_after_refresh";
+    const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(2 * 60), // 2 min — within the 5-min stale window
+      },
+      upsertCapture,
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: freshToken,
+          expires_at: nowPlusSeconds(3600),
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const token = await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert
+    expect(token).toBe(freshToken);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("after a mint, the stored token_enc value is NOT the plaintext token", async () => {
+    // Arrange
+    const { env } = await buildFakeEnv();
+    const freshToken = "ghs_freshly_minted_secret";
+    const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      upsertCapture,
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: freshToken,
+          expires_at: nowPlusSeconds(3600),
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    ) as typeof fetch;
+
+    // Act
+    await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert — upsert must have been called, and the stored enc must NOT be plaintext
+    expect(upsertCapture.length).toBeGreaterThanOrEqual(1);
+    const upsertArgs = upsertCapture[upsertCapture.length - 1].args;
+    // token_enc arg must not equal the plaintext token
+    const storedEnc = upsertArgs.find(
+      (a) => typeof a === "string" && a !== freshToken,
+    );
+    expect(storedEnc).toBeDefined();
+    // None of the args should literally be the plaintext
+    expect(upsertArgs).not.toContain(freshToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInstallToken — fail-closed guards
+// ---------------------------------------------------------------------------
+
+describe("resolveInstallToken — fail-closed guards", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when no tenant_repo_access row exists for the given owner/name", async () => {
+    // Arrange
+    const { env } = await buildFakeEnv();
+
+    // DB has no tenant_repo_access for "owner/missing-repo"
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "owner",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      repoAccess: [], // no access rows
+    });
+
+    // Act + Assert — fail-closed: unknown repo must not produce a token
+    await expect(
+      resolveInstallToken(db, { ...env, DB: db }, "owner", "missing-repo"),
+    ).rejects.toThrow();
+  });
+
+  it("throws when the owning tenant has suspended_at set (suspended guard)", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const { enc, iv } = await encryptToken(dek, "ghs_some_token");
+
+    // DB has access row but tenant is suspended
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "owner",
+        account_type: "Organization",
+        suspended_at: "2026-06-01T00:00:00.000Z", // non-null → suspended
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(10 * 60),
+      },
+      repoAccess: [{ tenant_id: 1, repo: "owner/my-repo" }],
+    });
+
+    // Act + Assert — suspended tenant must be rejected
+    await expect(
+      resolveInstallToken(db, { ...env, DB: db }, "owner", "my-repo"),
+    ).rejects.toThrow();
+  });
+});

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -198,7 +198,19 @@ function buildSeededDb(opts: {
       return makeFakeStmt(sql, args, []); // cache miss
     }
 
-    // Query on tenant_repo_access
+    // JOIN query: SQL contains both "tenant_repo_access" and "join" — this branch must
+    // precede the bare tenant_repo_access branch because the JOIN SQL includes both table
+    // names and would be incorrectly intercepted by that branch, returning the wrong row
+    // shape ({tenant_id, repo} instead of {id, installation_id, suspended_at}).
+    if (sqlLower.includes("tenant_repo_access") && sqlLower.includes("join")) {
+      const matchingAccess = repoAccess.find((r) => args.includes(r.repo));
+      if (matchingAccess && tenant) {
+        return makeFakeStmt(sql, args, [tenant as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []); // no matching tenant
+    }
+
+    // Query on tenant_repo_access (bare — no JOIN)
     if (sqlLower.includes("tenant_repo_access")) {
       const matchingRow = repoAccess.find(
         (r) => args.includes(r.repo),
@@ -486,5 +498,41 @@ describe("resolveInstallToken — fail-closed guards", () => {
     await expect(
       resolveInstallToken(db, { ...env, DB: db }, "owner", "my-repo"),
     ).rejects.toThrow();
+  });
+
+  it("resolves to the decrypted token via cache-hit when tenant is active", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const plaintext = "ghs_live_token";
+    const { enc, iv } = await encryptToken(dek, plaintext);
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "owner",
+        account_type: "Organization",
+        suspended_at: null, // active — not suspended
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(10 * 60), // fresh — well beyond 5-min stale window
+      },
+      repoAccess: [{ tenant_id: 1, repo: "owner/active-repo" }],
+    });
+
+    // Act
+    const token = await resolveInstallToken(
+      db,
+      { ...env, DB: db },
+      "owner",
+      "active-repo",
+    );
+
+    // Assert — cache-hit decrypt path returns the expected plaintext token
+    expect(token).toBe(plaintext);
   });
 });

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -118,7 +118,7 @@ function generateInstallTokenKey(): string {
 // We'll use a simple approach: store a known "encrypted" value using the
 // real tokenCrypto module once it exists. For now, tests that need a seeded
 // encrypted row (cache-hit path) import encryptToken directly.
-import { importDek, encryptToken } from "./tokenCrypto";
+import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
 
 // ---------------------------------------------------------------------------
 // Fake env builder
@@ -375,9 +375,9 @@ describe("getInstallationToken — cache stale/missing", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("after a mint, the stored token_enc value is NOT the plaintext token", async () => {
+  it("after a mint, the stored token_enc value is NOT the plaintext token (real decryption round-trip)", async () => {
     // Arrange
-    const { env } = await buildFakeEnv();
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
     const freshToken = "ghs_freshly_minted_secret";
     const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
 
@@ -405,16 +405,27 @@ describe("getInstallationToken — cache stale/missing", () => {
     // Act
     await getInstallationToken(db, { ...env, DB: db }, 1, 42);
 
-    // Assert — upsert must have been called, and the stored enc must NOT be plaintext
+    // Assert — upsert must have been called
     expect(upsertCapture.length).toBeGreaterThanOrEqual(1);
     const upsertArgs = upsertCapture[upsertCapture.length - 1].args;
-    // token_enc arg must not equal the plaintext token
-    const storedEnc = upsertArgs.find(
-      (a) => typeof a === "string" && a !== freshToken,
-    );
-    expect(storedEnc).toBeDefined();
-    // None of the args should literally be the plaintext
+
+    // None of the args should literally be the plaintext (basic guard)
     expect(upsertArgs).not.toContain(freshToken);
+
+    // Real guard: recover token_enc and token_iv by SQL parameter position
+    // INSERT INTO install_tokens (tenant_id, token_enc, token_iv, expires_at, updated_at)
+    // VALUES (?, ?, ?, ?, ?)
+    // .bind(tenantId, enc, iv, expires_at, updatedAt)
+    //        idx 0    1    2   3           4
+    const storedTokenEnc = upsertArgs[1] as string;
+    const storedTokenIv = upsertArgs[2] as string;
+    expect(typeof storedTokenEnc).toBe("string");
+    expect(typeof storedTokenIv).toBe("string");
+
+    // Decrypt and verify round-trip — this FAILS if impl stored plaintext instead of ciphertext
+    const dek = await importDek(installTokenKeyB64);
+    const recovered = await decryptToken(dek, storedTokenEnc, storedTokenIv);
+    expect(recovered).toBe(freshToken);
   });
 });
 

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -3,11 +3,6 @@ import { getInstallationToken, resolveInstallToken } from "./installToken";
 import type { Env } from "../types";
 
 // ---------------------------------------------------------------------------
-// NOTE: installToken.ts does not exist yet — these tests are intentionally RED.
-// They define the contract that installToken.ts must satisfy (S3 task).
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // FakeD1 — local copy of the project pattern (see session.test.ts)
 // ---------------------------------------------------------------------------
 
@@ -206,7 +201,7 @@ function buildSeededDb(opts: {
     // Query on tenant_repo_access
     if (sqlLower.includes("tenant_repo_access")) {
       const matchingRow = repoAccess.find(
-        (r) => args.includes(r.repo) || args.length === 0,
+        (r) => args.includes(r.repo),
       );
       if (matchingRow) {
         return makeFakeStmt(sql, args, [matchingRow as unknown as FakeResult]);
@@ -328,6 +323,9 @@ describe("getInstallationToken — cache stale/missing", () => {
     const calledUrl = fetchMock.mock.calls[0][0] as string;
     expect(calledUrl).toContain("42");
     expect(calledUrl).toContain("access_tokens");
+    // Assert upsert was issued to install_tokens cache
+    expect(upsertCapture.length).toBeGreaterThanOrEqual(1);
+    expect(upsertCapture[0].sql.toLowerCase()).toContain("install_tokens");
   });
 
   it("calls GitHub mint endpoint once when cache is stale (expires_at ≤ now+5min)", async () => {

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -109,6 +109,7 @@ export async function getInstallationToken(
       "User-Agent": "roxabi-live-worker",
       "X-GitHub-Api-Version": "2022-11-28",
     },
+    signal: AbortSignal.timeout(10_000),
   });
 
   if (!mintRes.ok) {
@@ -230,7 +231,7 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
     const url = `https://api.github.com/installation/repositories?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
-        Authorization: `token ${token}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "User-Agent": "roxabi-live-worker",
         "X-GitHub-Api-Version": "2022-11-28",

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -45,6 +45,9 @@ const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
 /** Read the AES-GCM DEK (base64) used to encrypt install tokens at rest. */
 function getInstallTokenKey(env: Env): string {
+  if (!env.INSTALL_TOKEN_KEY) {
+    throw new Error("INSTALL_TOKEN_KEY secret is not configured");
+  }
   return env.INSTALL_TOKEN_KEY;
 }
 
@@ -172,7 +175,11 @@ export async function resolveInstallToken(
 ): Promise<string> {
   const repo = `${owner}/${name}`;
 
-  // JOIN tenant_repo_access → tenants to get suspension status + installation_id
+  // JOIN tenant_repo_access → tenants to get suspension status + installation_id.
+  // Phase-1 invariant (see #141/#147): one repo → one installation (enforced by
+  // tenants UNIQUE(installation_id) + tenant_repo_access FK). .first() is therefore
+  // deterministic here. Re-verify this assumption before extending to multi-tenant
+  // (Phase 2 / #147) — the query will need GROUP BY or a different resolution strategy.
   const row = await db
     .prepare(
       `SELECT t.id, t.installation_id, t.suspended_at

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -1,0 +1,250 @@
+/**
+ * Installation access token management for GitHub App installs.
+ *
+ * Tokens are encrypted at rest using AES-GCM (tokenCrypto.ts) in the
+ * install_tokens D1 table and refreshed proactively 5 minutes before expiry.
+ *
+ * Compatible with the Cloudflare Workers runtime — no Node.js imports.
+ */
+
+import { importAppPrivateKey, signAppJwt } from "./jwt";
+import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface InstallTokenRow {
+  token_enc: string;
+  token_iv: string;
+  expires_at: string;
+}
+
+interface TenantRow {
+  id: number;
+  installation_id: number;
+  suspended_at: string | null;
+}
+
+interface GHAccessTokenResponse {
+  token: string;
+  expires_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Proactive refresh window: treat tokens expiring within 5 minutes as stale. */
+const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Env access helper
+// ---------------------------------------------------------------------------
+
+/** Read the AES-GCM DEK (base64) used to encrypt install tokens at rest. */
+function getInstallTokenKey(env: Env): string {
+  return env.INSTALL_TOKEN_KEY;
+}
+
+// ---------------------------------------------------------------------------
+// Core: getInstallationToken
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a valid installation access token for the given tenant/installation.
+ *
+ * Cache-hit path: if install_tokens has a row with expires_at > now+5min, decrypts
+ * and returns it without calling GitHub.
+ *
+ * Mint path: calls POST /app/installations/{id}/access_tokens, encrypts the new
+ * token, upserts into install_tokens, and returns the plaintext token (once).
+ *
+ * @param db             - D1 database binding.
+ * @param env            - Worker env bindings.
+ * @param tenantId       - Primary key in the tenants table.
+ * @param installationId - GitHub App installation ID.
+ * @returns Plaintext GitHub installation access token.
+ */
+export async function getInstallationToken(
+  db: D1Database,
+  env: Env,
+  tenantId: number,
+  installationId: number,
+): Promise<string> {
+  const installTokenKey = getInstallTokenKey(env);
+
+  // Step 1 — Check cache
+  const row = await db
+    .prepare(
+      `SELECT token_enc, token_iv, expires_at FROM install_tokens WHERE tenant_id = ?`,
+    )
+    .bind(tenantId)
+    .first<InstallTokenRow>();
+
+  if (row) {
+    const expiresAt = new Date(row.expires_at).getTime();
+    const threshold = Date.now() + STALE_THRESHOLD_MS;
+    if (expiresAt > threshold) {
+      // Cache hit — decrypt and return
+      const dek = await importDek(installTokenKey);
+      return decryptToken(dek, row.token_enc, row.token_iv);
+    }
+  }
+
+  // Step 2 — Mint a fresh token via GitHub App JWT
+  const appKey = await importAppPrivateKey(env.GITHUB_APP_PRIVATE_KEY);
+  const jwt = await signAppJwt(env.GITHUB_APP_ID, appKey);
+
+  const mintUrl = `https://api.github.com/app/installations/${installationId}/access_tokens`;
+  const mintRes = await fetch(mintUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "roxabi-live-worker",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!mintRes.ok) {
+    const text = await mintRes.text();
+    throw new Error(
+      `GitHub installation token mint failed: HTTP ${mintRes.status} — ${text}`,
+    );
+  }
+
+  const { token, expires_at } = (await mintRes.json()) as GHAccessTokenResponse;
+
+  // Step 3 — Encrypt and upsert
+  const dek = await importDek(installTokenKey);
+  const { enc, iv } = await encryptToken(dek, token);
+  const updatedAt = new Date().toISOString();
+
+  await db
+    .prepare(
+      `INSERT INTO install_tokens (tenant_id, token_enc, token_iv, expires_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(tenant_id) DO UPDATE SET
+         token_enc  = excluded.token_enc,
+         token_iv   = excluded.token_iv,
+         expires_at = excluded.expires_at,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(tenantId, enc, iv, expires_at, updatedAt)
+    .run();
+
+  // Step 4 — Return the fresh plaintext token (never persisted raw)
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// resolveInstallToken
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an installation access token by repository owner + name.
+ *
+ * Fail-closed: throws if no tenant_repo_access row exists for the repo, or if
+ * the owning tenant is suspended.
+ *
+ * @param db    - D1 database binding.
+ * @param env   - Worker env bindings.
+ * @param owner - Repository owner (org or user login).
+ * @param name  - Repository name.
+ * @returns Plaintext GitHub installation access token for the owning installation.
+ * @throws If the repo is not registered or the tenant is suspended.
+ */
+export async function resolveInstallToken(
+  db: D1Database,
+  env: Env,
+  owner: string,
+  name: string,
+): Promise<string> {
+  const repo = `${owner}/${name}`;
+
+  // JOIN tenant_repo_access → tenants to get suspension status + installation_id
+  const row = await db
+    .prepare(
+      `SELECT t.id, t.installation_id, t.suspended_at
+       FROM tenant_repo_access tra
+       JOIN tenants t ON t.id = tra.tenant_id
+       WHERE tra.repo = ?`,
+    )
+    .bind(repo)
+    .first<TenantRow>();
+
+  if (!row) {
+    throw new Error(`No installation found for repository: ${repo}`);
+  }
+
+  if (row.suspended_at !== null) {
+    throw new Error(
+      `Installation for repository ${repo} is suspended (suspended_at: ${row.suspended_at})`,
+    );
+  }
+
+  return getInstallationToken(db, env, row.id, row.installation_id);
+}
+
+// ---------------------------------------------------------------------------
+// listInstallationRepos
+// ---------------------------------------------------------------------------
+
+interface GHRepository {
+  full_name: string;
+}
+
+interface GHInstallationReposResponse {
+  repositories: GHRepository[];
+  total_count: number;
+}
+
+/**
+ * List all repositories accessible to an installation via its access token.
+ *
+ * Paginates automatically (100 per page) until all repos are collected.
+ *
+ * @param token - GitHub installation access token (from getInstallationToken).
+ * @returns Array of `"owner/name"` full_name strings.
+ */
+export async function listInstallationRepos(token: string): Promise<string[]> {
+  const repos: string[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/installation/repositories?per_page=100&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "roxabi-live-worker",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `GitHub list installation repositories failed: HTTP ${res.status} — ${text}`,
+      );
+    }
+
+    const body = (await res.json()) as GHInstallationReposResponse;
+    const pageRepos = body.repositories ?? [];
+
+    for (const r of pageRepos) {
+      repos.push(r.full_name);
+    }
+
+    // Stop if this page was not full (last page)
+    if (pageRepos.length < 100) {
+      break;
+    }
+
+    page++;
+  }
+
+  return repos;
+}

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -111,11 +111,19 @@ export async function getInstallationToken(
   if (!mintRes.ok) {
     const text = await mintRes.text();
     throw new Error(
-      `GitHub installation token mint failed: HTTP ${mintRes.status} — ${text}`,
+      `GitHub installation token mint failed: HTTP ${mintRes.status} — ${text.slice(0, 200)}`,
     );
   }
 
-  const { token, expires_at } = (await mintRes.json()) as GHAccessTokenResponse;
+  let mintBody: GHAccessTokenResponse;
+  try {
+    mintBody = (await mintRes.json()) as GHAccessTokenResponse;
+  } catch {
+    throw new Error(
+      `GitHub installation token mint failed: unexpected non-JSON response for installation ${installationId}`,
+    );
+  }
+  const { token, expires_at } = mintBody;
 
   // Step 3 — Encrypt and upsert
   const dek = await importDek(installTokenKey);
@@ -180,9 +188,7 @@ export async function resolveInstallToken(
   }
 
   if (row.suspended_at !== null) {
-    throw new Error(
-      `Installation for repository ${repo} is suspended (suspended_at: ${row.suspended_at})`,
-    );
+    throw new Error(`Installation for ${repo} is suspended`);
   }
 
   return getInstallationToken(db, env, row.id, row.installation_id);
@@ -227,11 +233,18 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
     if (!res.ok) {
       const text = await res.text();
       throw new Error(
-        `GitHub list installation repositories failed: HTTP ${res.status} — ${text}`,
+        `GitHub list installation repositories failed: HTTP ${res.status} — ${text.slice(0, 200)}`,
       );
     }
 
-    const body = (await res.json()) as GHInstallationReposResponse;
+    let body: GHInstallationReposResponse;
+    try {
+      body = (await res.json()) as GHInstallationReposResponse;
+    } catch {
+      throw new Error(
+        `GitHub list installation repositories failed: unexpected non-JSON response (page ${page})`,
+      );
+    }
     const pageRepos = body.repositories ?? [];
 
     for (const r of pageRepos) {

--- a/worker/src/auth/tokenCrypto.test.ts
+++ b/worker/src/auth/tokenCrypto.test.ts
@@ -2,11 +2,6 @@ import { describe, expect, it } from "vitest";
 import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
 
 // ---------------------------------------------------------------------------
-// NOTE: tokenCrypto.ts does not exist yet — these tests are intentionally RED.
-// They define the AES-GCM encryption contract that tokenCrypto.ts must satisfy.
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -52,6 +47,12 @@ describe("importDek", () => {
     expect(key.algorithm).toMatchObject({ name: "AES-GCM" });
     expect(key.usages).toContain("encrypt");
     expect(key.usages).toContain("decrypt");
+  });
+
+  it("rejects a non-32-byte (AES-128 / 16-byte) key with a clear error", async () => {
+    const raw = crypto.getRandomValues(new Uint8Array(16));
+    const b64 = btoa(String.fromCharCode(...raw));
+    await expect(importDek(b64)).rejects.toThrow(/32 bytes/);
   });
 });
 

--- a/worker/src/auth/tokenCrypto.test.ts
+++ b/worker/src/auth/tokenCrypto.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
+
+// ---------------------------------------------------------------------------
+// NOTE: tokenCrypto.ts does not exist yet — these tests are intentionally RED.
+// They define the AES-GCM encryption contract that tokenCrypto.ts must satisfy.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a random 32-byte DEK and return it as a base64 string + CryptoKey. */
+async function generateDek(): Promise<{ b64: string; key: CryptoKey }> {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  const b64 = btoa(String.fromCharCode(...raw));
+  const key = await importDek(b64);
+  return { b64, key };
+}
+
+/** Decode a base64url string to bytes. */
+function decodeBase64url(s: string): Uint8Array {
+  // Convert base64url → standard base64, add padding
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/").padEnd(
+    s.length + ((4 - (s.length % 4)) % 4),
+    "=",
+  );
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+/** Check that a string contains only base64url characters (no +, /, =). */
+function isBase64url(s: string): boolean {
+  return /^[A-Za-z0-9\-_]+$/.test(s);
+}
+
+// ---------------------------------------------------------------------------
+// importDek
+// ---------------------------------------------------------------------------
+
+describe("importDek", () => {
+  it("imports a 32-byte base64 DEK and returns a CryptoKey usable for AES-GCM", async () => {
+    // Arrange
+    const raw = crypto.getRandomValues(new Uint8Array(32));
+    const b64 = btoa(String.fromCharCode(...raw));
+
+    // Act
+    const key = await importDek(b64);
+
+    // Assert
+    expect(key).toBeInstanceOf(CryptoKey);
+    expect(key.type).toBe("secret");
+    expect(key.algorithm).toMatchObject({ name: "AES-GCM" });
+    expect(key.usages).toContain("encrypt");
+    expect(key.usages).toContain("decrypt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encryptToken / decryptToken — round-trip
+// ---------------------------------------------------------------------------
+
+describe("encryptToken / decryptToken", () => {
+  it("round-trip: encryptToken then decryptToken returns the original plaintext", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const plaintext = "ghs_test_github_token_abc123";
+
+    // Act
+    const { enc, iv } = await encryptToken(key, plaintext);
+    const decrypted = await decryptToken(key, enc, iv);
+
+    // Assert
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("IV is 12 bytes (decoded from base64url)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+
+    // Act
+    const { iv } = await encryptToken(key, "some-token");
+
+    // Assert — AES-GCM standard IV length
+    const ivBytes = decodeBase64url(iv);
+    expect(ivBytes.byteLength).toBe(12);
+  });
+
+  it("two encrypts of the same plaintext produce different iv values (random IV)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const plaintext = "repeated-token";
+
+    // Act
+    const result1 = await encryptToken(key, plaintext);
+    const result2 = await encryptToken(key, plaintext);
+
+    // Assert — random IV means each encryption is unique
+    expect(result1.iv).not.toBe(result2.iv);
+  });
+
+  it("two encrypts of the same plaintext produce different enc values (random IV)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const plaintext = "repeated-token";
+
+    // Act
+    const result1 = await encryptToken(key, plaintext);
+    const result2 = await encryptToken(key, plaintext);
+
+    // Assert — different IV ⇒ different ciphertext
+    expect(result1.enc).not.toBe(result2.enc);
+  });
+
+  it("tampered ciphertext (flip a char in enc) causes decryptToken to reject/throw", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const { enc, iv } = await encryptToken(key, "sensitive-token");
+
+    // Tamper: flip the first character of enc
+    const tamperedEnc = enc[0] === "A" ? "B" + enc.slice(1) : "A" + enc.slice(1);
+
+    // Act + Assert — AES-GCM authentication tag must fail
+    await expect(decryptToken(key, tamperedEnc, iv)).rejects.toThrow();
+  });
+
+  it("wrong DEK causes decryptToken to reject/throw", async () => {
+    // Arrange
+    const { key: key1 } = await generateDek();
+    const { key: key2 } = await generateDek();
+    const { enc, iv } = await encryptToken(key1, "sensitive-token");
+
+    // Act + Assert — wrong key ⇒ authentication tag mismatch
+    await expect(decryptToken(key2, enc, iv)).rejects.toThrow();
+  });
+
+  it("enc output is base64url (no '+', '/', '=' chars)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+
+    // Act
+    const { enc } = await encryptToken(key, "test-token-value");
+
+    // Assert
+    expect(isBase64url(enc)).toBe(true);
+  });
+
+  it("iv output is base64url (no '+', '/', '=' chars)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+
+    // Act
+    const { iv } = await encryptToken(key, "test-token-value");
+
+    // Assert
+    expect(isBase64url(iv)).toBe(true);
+  });
+});

--- a/worker/src/auth/tokenCrypto.ts
+++ b/worker/src/auth/tokenCrypto.ts
@@ -1,0 +1,96 @@
+/**
+ * AES-GCM token encryption/decryption using the Web Crypto API.
+ *
+ * Compatible with Cloudflare Workers runtime and the Vitest test environment.
+ * Never logs or surfaces plaintext tokens.
+ */
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode an ArrayBuffer as base64url (no padding, URL-safe chars).
+ * Reuses the same approach as b64url in jwt.ts.
+ */
+function toBase64url(buf: ArrayBuffer): string {
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Decode a base64url string to Uint8Array.
+ */
+function fromBase64url(s: string): Uint8Array {
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), "=");
+  return Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Import a base64-encoded 32-byte raw key as an AES-GCM CryptoKey.
+ *
+ * @param b64 - Standard base64 (not base64url) encoding of the 32-byte DEK.
+ * @returns A non-extractable CryptoKey usable for encrypt and decrypt.
+ */
+export async function importDek(b64: string): Promise<CryptoKey> {
+  const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "raw",
+    bytes,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Encrypt a plaintext token using AES-GCM with a random 12-byte IV.
+ *
+ * @param dek       - CryptoKey returned by importDek.
+ * @param plaintext - The plaintext installation access token to encrypt.
+ * @returns `{ enc, iv }` — both are base64url-encoded (no +, /, = chars).
+ */
+export async function encryptToken(
+  dek: CryptoKey,
+  plaintext: string,
+): Promise<{ enc: string; iv: string }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plaintext);
+  const ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, dek, encoded);
+  return {
+    enc: toBase64url(ct),
+    iv: toBase64url(iv.buffer as ArrayBuffer),
+  };
+}
+
+/**
+ * Decrypt an AES-GCM ciphertext back to plaintext.
+ *
+ * Propagates the rejection from crypto.subtle.decrypt on authentication failure
+ * (tampered ciphertext, wrong DEK). Never swallows errors.
+ *
+ * @param dek - CryptoKey returned by importDek.
+ * @param enc - base64url-encoded ciphertext (from encryptToken).
+ * @param iv  - base64url-encoded 12-byte IV (from encryptToken).
+ * @returns The original plaintext string.
+ * @throws If decryption fails (authentication tag mismatch, wrong key, etc.)
+ */
+export async function decryptToken(
+  dek: CryptoKey,
+  enc: string,
+  iv: string,
+): Promise<string> {
+  const ctBytes = fromBase64url(enc);
+  const ivBytes = fromBase64url(iv);
+  const plainBuffer = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: ivBytes },
+    dek,
+    ctBytes,
+  );
+  return new TextDecoder().decode(plainBuffer);
+}

--- a/worker/src/auth/tokenCrypto.ts
+++ b/worker/src/auth/tokenCrypto.ts
@@ -39,6 +39,11 @@ function fromBase64url(s: string): Uint8Array {
  */
 export async function importDek(b64: string): Promise<CryptoKey> {
   const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  if (bytes.byteLength !== 32) {
+    throw new Error(
+      `INSTALL_TOKEN_KEY must decode to exactly 32 bytes (AES-256), got ${bytes.byteLength}`,
+    );
+  }
   return crypto.subtle.importKey(
     "raw",
     bytes,
@@ -64,7 +69,7 @@ export async function encryptToken(
   const ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, dek, encoded);
   return {
     enc: toBase64url(ct),
-    iv: toBase64url(iv.buffer as ArrayBuffer),
+    iv: toBase64url(iv.buffer),
   };
 }
 

--- a/worker/src/sync/graphql.test.ts
+++ b/worker/src/sync/graphql.test.ts
@@ -68,6 +68,21 @@ describe("ghGraphql — request headers", () => {
     const headers = init.headers as Record<string, string>;
     expect(headers["User-Agent"]).toBe("roxabi-live-worker");
   });
+
+  it("sends GraphQL-Features: sub_issues", async () => {
+    const mockFetch = makeFetchMock({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: {} }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await ghGraphql("query { viewer { login } }", {}, "any-token");
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["GraphQL-Features"]).toBe("sub_issues");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/worker/src/sync/graphql.ts
+++ b/worker/src/sync/graphql.ts
@@ -52,6 +52,7 @@ export async function ghGraphql<T = unknown>(
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
       "User-Agent": "roxabi-live-worker",
+      "GraphQL-Features": "sub_issues",
     },
     body: JSON.stringify({ query, variables }),
   });

--- a/worker/src/sync/graphql.ts
+++ b/worker/src/sync/graphql.ts
@@ -37,7 +37,7 @@ export class GraphQLError extends Error {
  *
  * @param query     GraphQL query string (one of the constants from queries.ts).
  * @param variables Variable map matching the query's parameter declarations.
- * @param token     GitHub PAT (env.GITHUB_TOKEN in Worker context).
+ * @param token     GitHub token — org PAT in S3a; GitHub App installation token from #160.
  * @returns         Parsed response body; always contains a `data` key on success.
  * @throws          GraphQLError on HTTP errors or GraphQL-level `errors` in body.
  */

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1470,6 +1470,183 @@ describe("writeRunAudit", () => {
 });
 
 // ---------------------------------------------------------------------------
+// runSync — multi-tenant / per-installation tests
+// ---------------------------------------------------------------------------
+// DEFERRED to #160 (S3b — sync per-tenant cutover + PAT retirement). The runSync
+// rewrite was split out of #146 (S3a shipped the install-token infra + webhook
+// cutover). Skipped here because (a) these assert the not-yet-built per-tenant
+// runSync, and (b) two bugs must be fixed when un-skipping in #160:
+//   1. dedup assertion uses c[2]/c[3]; ghGraphql(query, variables, token) puts
+//      query at c[0], vars at c[1].
+//   2. no vi.mock("../auth/installToken") → a faithful impl's getInstallationToken
+//      throws before syncRepoBundle. Add the mock when implementing #160.
+// ---------------------------------------------------------------------------
+
+describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-skip + fix in S3b)", () => {
+  // Local makeEnv scoped to this describe so it composes cleanly
+  function makeEnv(overrides: Record<string, unknown> = {}): Env {
+    return {
+      DB: undefined as unknown as D1Database,
+      GITHUB_TOKEN: "tok",
+      GITHUB_ORG: "Roxabi",
+      ...overrides,
+    } as unknown as Env;
+  }
+
+  it("deduplicates GraphQL bundle fetches: two tenants sharing repo o/r → exactly 1 REPO_BUNDLE_QUERY issued for o/r", async () => {
+    // Two tenants both have tenant_repo_access for "o/r".
+    // The future multi-tenant runSync must deduplicate: one fetch regardless of tenant count.
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      // Future: tenants table → two rows
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
+      }
+      // Future: tenant_repo_access for both tenants → same repo "o/r"
+      if (sql.includes("FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ owner: "o", name: "r" }, { owner: "o", name: "r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+    // Future REPO_BUNDLE_QUERY path — stub returns minimal valid shape
+    mockGhGraphql.mockResolvedValue({
+      data: { repository: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] }, pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } },
+    });
+
+    const env = makeEnv({ DB: db });
+    await runSync(env);
+
+    // Exactly 1 ghGraphql call with REPO_BUNDLE_QUERY for owner="o", name="r"
+    const bundleCalls = mockGhGraphql.mock.calls.filter(
+      (c) => c[0] === "REPO_BUNDLE_QUERY" && c[1]?.owner === "o" && c[1]?.name === "r",
+    );
+    expect(bundleCalls).toHaveLength(1);
+  });
+
+  it("advances sync_slot per tick: seed sync_slot=0, after runSync the slot is updated", async () => {
+    // Future: sync_control row sync_slot tracks which window of repos was processed.
+    // The current impl has no windowing — this test will fail (RED) until slot logic is added.
+    let syncSlotWritten = false;
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      // Return sync_slot=0 on read
+      if (sql.includes("sync_slot") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ key: "sync_slot", value: "0" }]);
+      }
+      // Detect the slot-advance write (INSERT OR REPLACE / UPDATE with key=sync_slot)
+      if (sql.includes("sync_slot") && (sql.includes("INSERT") || sql.includes("UPDATE"))) {
+        syncSlotWritten = true;
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // repo_allowlist — empty → runSync short-circuits after acquiring lock
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, []);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = makeEnv({ DB: db });
+    await runSync(env);
+    warnSpy.mockRestore();
+
+    // Assertion: the sync run must have written an updated sync_slot value.
+    // Currently no slot logic exists → syncSlotWritten stays false → RED.
+    expect(syncSlotWritten).toBe(true);
+  });
+
+  it("per-tenant lock isolation: tenant A holding sync_running=1 does NOT prevent tenant B from syncing", async () => {
+    // Future: acquireSyncLock(db, tenantId) must be scoped per-tenant.
+    // Current impl: global lock (tenant_id=0 hardcoded) → tenant A's lock blocks everyone → RED.
+    let tenantBLockAttempted = false;
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        // Lock for tenant A (id=1) is held → changes=0; lock for tenant B (id=2) is free → changes=1
+        const tenantArg = args.find((a) => typeof a === "number");
+        if (tenantArg === 1) return makeFakeStmt(sql, args, [], 0); // tenant A: lock held
+        if (tenantArg === 2) {
+          tenantBLockAttempted = true;
+          return makeFakeStmt(sql, args, [], 1); // tenant B: lock acquired
+        }
+        return makeFakeStmt(sql, args, [], 0);
+      }
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
+      }
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, []);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = makeEnv({ DB: db });
+    await runSync(env);
+    warnSpy.mockRestore();
+
+    // Tenant B's lock attempt must have been made (i.e., runSync iterates tenants independently).
+    // With current single-tenant global lock this never happens → RED.
+    expect(tenantBLockAttempted).toBe(true);
+  });
+
+  it("no PAT access: runSync completes via install tokens without reading env.GITHUB_TOKEN", async () => {
+    // Future: runSync must use resolveInstallToken() and never fall back to the PAT.
+    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos (line ~1161) → spy records it.
+    // The DB must return a non-empty allowlist so runSync advances past the early-return
+    // guard and actually reaches the PAT read site (enumerateOrgRepos / syncRepoBundle).
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "r", owner: { login: "o" }, isArchived: false, isPrivate: false }],
+          },
+        },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      // Non-empty allowlist — ensures runSync does NOT short-circuit before the PAT read
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "o/r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const base = makeEnv({ DB: db });
+    // Replace GITHUB_TOKEN with a spy getter that records every access.
+    let patAccessCount = 0;
+    delete (base as unknown as Record<string, unknown>)["GITHUB_TOKEN"];
+    Object.defineProperty(base, "GITHUB_TOKEN", {
+      get() {
+        patAccessCount++;
+        return "tok"; // still returns a value so runSync can proceed (error swallowing aside)
+      },
+      configurable: true,
+    });
+
+    await runSync(base);
+
+    // Future impl: patAccessCount must be 0 (resolveInstallToken used instead).
+    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos + archivedRepos → count > 0 → RED.
+    expect(patAccessCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Teardown
 // ---------------------------------------------------------------------------
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -42,4 +42,7 @@ export interface Env {
   GITHUB_APP_PRIVATE_KEY: string;
   // App webhook HMAC secret (distinct from org GITHUB_WEBHOOK_SECRET)
   GITHUB_APP_WEBHOOK_SECRET: string;
+  // base64 32-byte AES-GCM DEK for install-token encryption at rest (S3a, #146).
+  // Consumed by auth/tokenCrypto + auth/installToken. Set via `wrangler secret put INSTALL_TOKEN_KEY`.
+  INSTALL_TOKEN_KEY: string;
 }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -44,5 +44,6 @@ export interface Env {
   GITHUB_APP_WEBHOOK_SECRET: string;
   // base64 32-byte AES-GCM DEK for install-token encryption at rest (S3a, #146).
   // Consumed by auth/tokenCrypto + auth/installToken. Set via `wrangler secret put INSTALL_TOKEN_KEY`.
-  INSTALL_TOKEN_KEY: string;
+  // Optional at type-level (provisioned at deploy-time via CI); runtime guard in auth/installToken.ts getInstallTokenKey().
+  INSTALL_TOKEN_KEY?: string;
 }

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -35,8 +35,14 @@ vi.mock("../sync/sync", async (importOriginal) => {
   };
 });
 
+// RED (S3): resolveInstallToken does not exist yet — import fails at runtime → test fails
+vi.mock("../auth/installToken", () => ({
+  resolveInstallToken: vi.fn(),
+}));
+
 import { fetchIssueDeps } from "../sync/graphql";
 import { syncBranches } from "../sync/sync";
+import { resolveInstallToken } from "../auth/installToken";
 
 // ---------------------------------------------------------------------------
 // FakeD1 — cloned from mutations.test.ts / sync.test.ts pattern
@@ -173,6 +179,7 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_APP_CLIENT_SECRET: "placeholder",
     GITHUB_APP_PRIVATE_KEY: "placeholder",
     GITHUB_APP_WEBHOOK_SECRET: "placeholder",
+    INSTALL_TOKEN_KEY: "placeholder",
     ...overrides,
   };
 }
@@ -462,6 +469,56 @@ describe("handleDeps", () => {
       // Assert — catch swallows all errors, not just GraphQLError
       expect(result).toBe(0);
     });
+
+    // RED (S3 — future multi-tenant): handleDeps cross-repo path must use resolveInstallToken,
+    // NOT env.GITHUB_TOKEN. Current impl calls fetchIssueDeps(db, env.GITHUB_TOKEN, ...) at
+    // handlers.ts line ~209. Future impl must call resolveInstallToken(db, env, owner, name)
+    // and pass the resulting token to fetchIssueDeps.
+    it("cross-repo path resolves token via resolveInstallToken(db, env, owner, name) — NOT env.GITHUB_TOKEN", async () => {
+      // Arrange
+      const { db } = captureDb();
+      vi.mocked(fetchIssueDeps).mockResolvedValue({ blocked_by: [], blocking: [] });
+      // Future: resolveInstallToken returns an install token
+      vi.mocked(resolveInstallToken).mockResolvedValue("ghs_install_token");
+
+      // Use REPO which is "Roxabi/roxabi-live" → owner="Roxabi", name="roxabi-live"
+      const [owner, name] = REPO.split("/");
+
+      let patAccessCount = 0;
+      const envWithSpy: Env = { ...baseEnv, DB: db };
+      delete (envWithSpy as unknown as Record<string, unknown>)["GITHUB_TOKEN"];
+      Object.defineProperty(envWithSpy, "GITHUB_TOKEN", {
+        get() {
+          patAccessCount++;
+          return "ghp_test";
+        },
+        configurable: true,
+      });
+
+      const payload = {
+        action: "blocked_by_added",
+        blocked_issue: { number: 42 },
+        repository: { full_name: REPO },
+        // no blocking_issue key → cross-repo path
+      };
+
+      // Act
+      await handleDeps(payload, db, envWithSpy);
+
+      // Assert 1: resolveInstallToken called with the right db + env + owner/name.
+      // Compare via mock.calls indices, NOT toHaveBeenCalledWith(db, envWithSpy, ...): the
+      // structural matcher enumerates envWithSpy's own property names, which trips the
+      // GITHUB_TOKEN getter-spy and inflates patAccessCount. Reference-identity (toBe) and
+      // index access do not enumerate, so they measure the impl's access only.
+      const call = vi.mocked(resolveInstallToken).mock.calls[0];
+      expect(call?.[0]).toBe(db);
+      expect(call?.[1]).toBe(envWithSpy);
+      expect(call?.[2]).toBe(owner);
+      expect(call?.[3]).toBe(name);
+
+      // Assert 2: env.GITHUB_TOKEN must NOT be accessed by the impl (PAT bypass)
+      expect(patAccessCount).toBe(0);
+    });
   });
 });
 
@@ -622,6 +679,9 @@ describe("handleRefDelete", () => {
     // Arrange
     const { db } = captureDb();
     vi.mocked(syncBranches).mockResolvedValue(undefined);
+    // S3: handleRefDelete resolves the install token, then passes it to syncBranches
+    // (no longer env.GITHUB_TOKEN).
+    vi.mocked(resolveInstallToken).mockResolvedValue("ghs_install_token");
     const payload = {
       ref_type: "branch",
       ref: "42-done",
@@ -631,8 +691,8 @@ describe("handleRefDelete", () => {
     // Act
     await handleRefDelete(payload, db, { ...baseEnv, DB: db });
 
-    // Assert — syncBranches called with correct owner/name split
-    expect(vi.mocked(syncBranches)).toHaveBeenCalledWith(db, baseEnv.GITHUB_TOKEN, "Roxabi", "lyra");
+    // Assert — syncBranches called with the resolved install token + correct owner/name split
+    expect(vi.mocked(syncBranches)).toHaveBeenCalledWith(db, "ghs_install_token", "Roxabi", "lyra");
   });
 
   it("no-op for non-matching branch name", async () => {
@@ -665,6 +725,56 @@ describe("handleRefDelete", () => {
 
     // Assert
     expect(vi.mocked(syncBranches)).not.toHaveBeenCalled();
+  });
+
+  // RED (S3 — future multi-tenant): handleRefDelete must resolve the token for the
+  // deleted-branch repo via resolveInstallToken(db, env, owner, name), NOT env.GITHUB_TOKEN.
+  // Current impl calls syncBranches(db, env.GITHUB_TOKEN, owner, name) at handlers.ts line ~364.
+  // Future impl must call resolveInstallToken and pass the install token to syncBranches.
+  it("resolves token via resolveInstallToken for deleted-branch repo — NOT env.GITHUB_TOKEN", async () => {
+    // Arrange
+    const { db } = captureDb();
+    vi.mocked(syncBranches).mockResolvedValue(undefined);
+    // Future: resolveInstallToken returns an install token for this repo
+    vi.mocked(resolveInstallToken).mockResolvedValue("ghs_install_token");
+
+    // Use "Roxabi/lyra" so owner="Roxabi", name="lyra"
+    const repoFullName = "Roxabi/lyra";
+    const [owner, name] = repoFullName.split("/");
+
+    let patAccessCount = 0;
+    const envWithSpy: Env = { ...baseEnv, DB: db };
+    delete (envWithSpy as unknown as Record<string, unknown>)["GITHUB_TOKEN"];
+    Object.defineProperty(envWithSpy, "GITHUB_TOKEN", {
+      get() {
+        patAccessCount++;
+        return "ghp_test";
+      },
+      configurable: true,
+    });
+
+    const payload = {
+      ref_type: "branch",
+      ref: "42-done",
+      repository: { full_name: repoFullName },
+    };
+
+    // Act
+    await handleRefDelete(payload, db, envWithSpy);
+
+    // Assert 1: resolveInstallToken called with the right db + env + owner/name.
+    // Compare via mock.calls indices, NOT toHaveBeenCalledWith(db, envWithSpy, ...): the
+    // structural matcher enumerates envWithSpy's own property names, which trips the
+    // GITHUB_TOKEN getter-spy and inflates patAccessCount. Reference-identity (toBe) and
+    // index access do not enumerate, so they measure the impl's access only.
+    const call = vi.mocked(resolveInstallToken).mock.calls[0];
+    expect(call?.[0]).toBe(db);
+    expect(call?.[1]).toBe(envWithSpy);
+    expect(call?.[2]).toBe(owner);
+    expect(call?.[3]).toBe(name);
+
+    // Assert 2: env.GITHUB_TOKEN must NOT be accessed by the impl (PAT bypass)
+    expect(patAccessCount).toBe(0);
   });
 });
 

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -35,7 +35,7 @@ vi.mock("../sync/sync", async (importOriginal) => {
   };
 });
 
-// RED (S3): resolveInstallToken does not exist yet — import fails at runtime → test fails
+// Mocked to isolate webhook handler tests from the installation-token implementation.
 vi.mock("../auth/installToken", () => ({
   resolveInstallToken: vi.fn(),
 }));
@@ -411,6 +411,8 @@ describe("handleDeps", () => {
   });
 
   describe("cross-repo (blocking_issue absent)", () => {
+    beforeEach(() => vi.clearAllMocks());
+
     it("calls fetchIssueDeps then db.batch with upsertEdges stmts", async () => {
       // Arrange
       const { db } = captureDb();
@@ -671,6 +673,7 @@ describe("handleRefCreate", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleRefDelete", () => {
+  beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.clearAllMocks());
 
   const baseEnv: Env = makeEnv();

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -28,6 +28,7 @@ import {
 } from "./mutations";
 import { BRANCH_ISSUE_RE, canonicalKey, extractFromLabels, syncBranches } from "../sync/sync";
 import { fetchIssueDeps, GraphQLError } from "../sync/graphql";
+import { resolveInstallToken } from "../auth/installToken";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -206,7 +207,24 @@ export async function handleDeps(
   // current dep graph and derive edges from the authoritative GitHub state.
   if (blockingIssue == null) {
     const repoObj = (payload["repository"] as Record<string, unknown> | undefined) ?? {};
-    return await pointFetchAndUpsertDeps(db, env.GITHUB_TOKEN, blockedIssue, repoObj);
+    const fullName = (repoObj["full_name"] as string | undefined) ?? "";
+    const slashIdx = fullName.indexOf("/");
+    if (slashIdx < 0 || slashIdx === fullName.length - 1) {
+      console.warn(
+        `[webhook] handle_deps: cannot resolve token — malformed repository.full_name=${JSON.stringify(fullName)}`,
+      );
+      return 0;
+    }
+    const owner = fullName.slice(0, slashIdx);
+    const name = fullName.slice(slashIdx + 1);
+    let token: string;
+    try {
+      token = await resolveInstallToken(db, env, owner, name);
+    } catch (err) {
+      console.warn(`[webhook] handle_deps: resolveInstallToken failed for ${fullName}`, err);
+      return 0;
+    }
+    return await pointFetchAndUpsertDeps(db, token, blockedIssue, repoObj);
   }
 
   // Same-repo fast path: both sides are in the payload — use them directly.
@@ -361,7 +379,8 @@ export async function handleRefDelete(
   const name = repo.slice(slashIdx + 1);
 
   try {
-    await syncBranches(db, env.GITHUB_TOKEN, owner, name);
+    const token = await resolveInstallToken(db, env, owner, name);
+    await syncBranches(db, token, owner, name);
   } catch (err) {
     console.error(
       `[webhook] handle_ref_delete: syncBranches failed for repo=${repo} ref=${ref}`,

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -383,7 +383,7 @@ export async function handleRefDelete(
     await syncBranches(db, token, owner, name);
   } catch (err) {
     console.error(
-      `[webhook] handle_ref_delete: syncBranches failed for repo=${repo} ref=${ref}`,
+      `[webhook] handle_ref_delete: token resolution or branch sync failed for repo=${repo} ref=${ref}`,
       err,
     );
   }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -80,6 +80,7 @@ binding     = "LOGS"
 bucket_name = "roxabi-live-logs-staging"
 
 # ── Dormant — activate when Workers Paid (Queues) is enabled ─────────────────
+# DORMANT — activate on Workers Paid + >30 repos (no consumer in Phase 1; uncommenting requires `wrangler queues create`)
 # [[queues.producers]]
 # binding = "SYNC_QUEUE"
 # queue   = "roxabi-live-sync"


### PR DESCRIPTION
## Summary
- **Phase 1 S3a** — GitHub App **installation-token infrastructure** + webhook cutover. Ships the token plumbing; the `runSync` per-tenant cutover + PAT retirement are split to **#160 (S3b)** because the existing `runSync` test suite encodes the old org-enum/allowlist/prune **PAT** flow and conflicts with the per-tenant model.
- `auth/tokenCrypto.ts` — AES-GCM encrypt/decrypt at rest (DEK = `INSTALL_TOKEN_KEY`, 12-byte IV, base64url, never logs plaintext).
- `auth/installToken.ts` — `getInstallationToken` (App-JWT mint + 5-min refresh + D1 cache), `resolveInstallToken` (`tenant_repo_access` JOIN, fail-closed + suspended guard), `listInstallationRepos`.
- Webhook `handleDeps` cross-repo + `handleRefDelete` resolve install tokens (no `env.GITHUB_TOKEN`); `graphql.ts` adds defensive `GraphQL-Features: sub_issues`; `Env.INSTALL_TOKEN_KEY`; `0005` sync_slot seed; wrangler SYNC_QUEUE DORMANT; ci.yml `INSTALL_TOKEN_KEY` inject (+ the `GH_APP_*` inject steps S2's guard block was missing).

## Split / scope
S3 (#146) re-cut: **S3a = this PR** (infra). **S3b = #160** (runSync per-tenant rewrite + drop `GITHUB_TOKEN` from Env/wrangler + PAT secret deletion). The 4 sync RED tests are `describe.skip`'d; #160 un-skips them after fixing the dedup arg-index (`c[0]/c[1]`) + adding `vi.mock("../auth/installToken")`.

⚠️ **Pre-merge gate (RT1):** provision `INSTALL_TOKEN_KEY` secret (staging+prod) + `GH_INSTALL_TOKEN_KEY` Actions secret **before merge** — `Env` requires it.
⚠️ **Temp degradation:** `tenant_repo_access` is populated only by #160 → the webhook install-token paths fail-closed (caught → no-op, **no 5xx**) until S3b; the hourly **PAT cron still reconciles** (~1h eventual consistency).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #146 (re-scoped S3a) | OPEN |
| Analysis | — | Absent (spec pre-ratified) |
| Spec | [146-installation-sync-backfill-spec.mdx](artifacts/specs/146-installation-sync-backfill-spec.mdx) | Present |
| Implementation | 1 commit (`6967598`) on `feat/146-installation-sync-backfill` | Complete (S3a) |
| Verification | Typecheck ✅ · Tests ✅ (377 pass / 4 skipped) · Lint n/a | Passed |

## Test Plan
- [ ] `cd worker && npm run typecheck && npm test` → green (377 pass / 4 skipped)
- [ ] tokenCrypto: AES-GCM round-trip · 12-byte IV uniqueness · tamper / wrong-DEK reject · base64url
- [ ] installToken: cache-hit (no mint) · stale → mint+refresh · fail-closed (no row) · suspended guard · ciphertext-at-rest
- [ ] handlers: cross-repo dep + ref-delete resolve via `resolveInstallToken` (not PAT)
- [ ] (post-merge, after RT1) staging webhook + cron tick clean

Fixes #146

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`