### PR TITLE
fix(ci): cd into worker/ before wrangler secret put (deploy hotfix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
       - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'staging'
         name: Inject GITHUB_APP_* secrets (staging)
         run: |
+          cd worker
           printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --env staging --config ../wrangler.toml
           printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --env staging --config ../wrangler.toml
           printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --env staging --config ../wrangler.toml
@@ -164,6 +165,7 @@ jobs:
       - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'main'
         name: Inject GITHUB_APP_* secrets (production)
         run: |
+          cd worker
           printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --config ../wrangler.toml
           printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --config ../wrangler.toml
           printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --config ../wrangler.toml
@@ -192,14 +194,14 @@ jobs:
           fi
       - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'staging'
         name: Inject INSTALL_TOKEN_KEY (staging)
-        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
+        run: cd worker && printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}
       - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'main'
         name: Inject INSTALL_TOKEN_KEY (production)
-        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
+        run: cd worker && printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Problem

The `#146` (S3a) staging deploy ([run 27416611235](https://github.com/Roxabi/roxabi-live/actions/runs/27416611235)) was the **first** deploy where the `GITHUB_APP_*` secret guard passed (App secrets now provisioned). That made the inject step actually execute for the first time — and it failed:

```
✘ [ERROR] Could not read file: ../wrangler.toml
  ENOENT: no such file or directory, open '/home/runner/work/roxabi-live/wrangler.toml'
```

The four `wrangler secret put` inject steps (`GITHUB_APP_*` + `INSTALL_TOKEN_KEY`, staging + production) pass `--config ../wrangler.toml` but run from the **repo root**, unlike every other wrangler step (`Deploy`, `Migrate D1`) which `cd worker &&` first. So `../` climbs one level above the repo → ENOENT. `bash -e` then aborted the job, so **`Inject INSTALL_TOKEN_KEY (staging)` never ran**.

### Impact on staging (current state)
- `Deploy (staging)` ✓ — S3a Worker binary **is live**
- `Migrate D1 (staging)` ✓
- `Inject GITHUB_APP_* (staging)` ✗ — aborted
- `Inject INSTALL_TOKEN_KEY (staging)` — skipped (job already dead) → **`INSTALL_TOKEN_KEY` not provisioned on the staging Worker**

## Fix

Prepend `cd worker` to all four inject steps so `../wrangler.toml` resolves to the repo-root config — matching the `Deploy`/`Migrate D1` steps. No other change.

## Verify after merge

Push to `staging` re-runs the deploy job; the inject steps should now go green and provision `GITHUB_APP_*` + `INSTALL_TOKEN_KEY` on the staging Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)