### PR TITLE
feat(sync): per-installation runSync cutover + PAT retirement (S3b)

### DIFF
--- a/artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx
+++ b/artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx
@@ -1,0 +1,211 @@
+---
+title: "per-installation runSync cutover + PAT retirement (S3b)"
+description: "Rewrite runSync to per-installation tokens — discovery, deduped fan-out, slot-rotation, per-tenant lock isolation; retire GITHUB_TOKEN."
+---
+
+## Source
+
+Issue #160, split from #146: *"This issue is S3b: the sync-layer cutover to
+GitHub App installation tokens + PAT retirement."* The 4 RED cases in
+`worker/src/sync/sync.test.ts` (`describe.skip("runSync — multi-tenant
+installation sync (DEFERRED #160 …)")`, L1485) encode the target contract.
+
+## Problem
+
+`runSync` (`sync.ts:1127`) still runs the legacy flow:
+
+- Reads `env.GITHUB_TOKEN` at **4 sites** — `enumerateOrgRepos` (L1161),
+  `enumerateArchivedOrgRepos` (L1165), `syncRepoBundle` loop (L1277),
+  `closedHopPass` (L1288).
+- Enumerates the live repo set from the **org** (`enumerateOrgRepos`/
+  `enumerateArchivedOrgRepos`) gated by the global `repo_allowlist` table.
+- All 7 lock/slot helpers (`acquireSyncLock`/`releaseSyncLock`/`isHalted`/
+  `getAuthFailures`/`incrementAuthFailures`/`haltSync`/`resetAuthFailures`,
+  L213-266) **hardcode `tenant_id=0`** — a single global lock + global
+  auth-failure breaker.
+- `tenant_repo_access` is never written; `sync_slot` is seeded (0005) but never
+  read/advanced.
+
+So: the PAT can't be retired (RT3), multi-tenant installs can't be authorized
+(fail-closed gap), and the deduped/windowed fan-out doesn't exist.
+
+## Outcome
+
+`runSync` discovers repos per-installation, dedups the GraphQL fan-out to **1
+bundle query per unique repo**, windows under the ~50-subrequest cap via
+`sync_slot`, isolates lock/breaker per tenant, and reads **zero**
+`env.GITHUB_TOKEN`. `GITHUB_TOKEN` removed from `Env`/`wrangler.toml` (no
+fallback) and deleted from secrets (staging→prod, post-verify). All 4 RED cases
+pass; conflicting old-flow cases reconciled.
+
+## Appetite
+
+One focused F-full slice = a single PR. No phasing inside the slice; PAT secret
+deletion (RT3) is the post-merge operational tail, gated on a verified staging
+tick.
+
+## Findings (current → target)
+
+| Concern | Current | Target |
+|---|---|---|
+| Repo discovery | `enumerateOrgRepos` + `repo_allowlist` (PAT) | per-tenant `listInstallationRepos` → upsert `tenant_repo_access` (install token) |
+| Token per repo | `env.GITHUB_TOKEN` everywhere | `resolveInstallToken(db, env, owner, name)` per (owner,name) |
+| Fan-out | per `active` repo (org list) | per **unique** repo across tenants (deduped Map) |
+| Subrequest cap | `REPO_BUNDLE_QUERY` keeps N+1; no windowing | + slot-rotation window via `sync_control.sync_slot` |
+| Lock / breaker | global `tenant_id=0` | threaded `tenantId` (default 0); one tenant ≠ block another |
+| `closedHopPass` | `(db, token)` | `(db, resolveToken: (owner,name)=>Promise<string>)` |
+| `listInstallationRepos` | `while(true)`, no cap/timeout (W2) | `MAX_PAGES` + `AbortSignal.timeout` per fetch |
+
+**Schema is ready:** `sync_control` PK is already `(tenant_id, key)` (0004);
+`tenant_repo_access (tenant_id, repo)` exists (0004); `sync_slot=0` seeded for
+`tenant_id=0` (0005). This is an **application-code** rewrite, no migration.
+
+## Shapes — lock unit vs fan-out unit (the hard decision)
+
+The tension: RED case 1 wants **global dedup** (1 query/unique-repo across
+tenants); RED case 3 wants **per-tenant lock isolation**. The unit of locking ≠
+the unit of fan-out.
+
+### Shape 1: Two-phase — global tick lock + per-tenant discovery skip-guard + global deduped windowed fan-out  ← recommended (architect-confirmed)
+
+- **Entry:** `isHalted(db, 0)` → `acquireSyncLock(db, 0)` — the **existing global
+  tick lock** (`sync.ts:1135`) serialises the whole invocation (prevents two
+  overlapping cron ticks from double-fan-out / double-slot-advance). Released in
+  `finally`.
+- **Phase 1 (tenant-outer):** for each tenant with an installation, attempt
+  `acquireSyncLock(db, tenantId)` as a **within-tick discovery skip-guard**
+  (this is what RED case 3 asserts — the per-tenant *attempt*); held → skip
+  *that* tenant, else `getInstallationToken` → `listInstallationRepos`
+  (hardened) → upsert `tenant_repo_access`. Build a global
+  `Map<repo, tenantId[]>` (**sorted list**, lowest id = owning tenant; list
+  enables token fallback) for token sourcing.
+- **Phase 2 (global, deduped, under the entry lock):** deterministically sort
+  the unique-repo set (`owner/name`); window via `sync_slot`
+  (`window = [slot*WINDOW, (slot+1)*WINDOW)`); for each repo in the window →
+  `getInstallationToken(db, env, owningTenantId, installationId)` (iterate the
+  tenant list on revoked-install, only `incrementAuthFailures` the tenant that
+  threw; all fail → skip repo + log, don't abort) → `syncRepoBundle`. Then
+  `closedHopPass(db, resolver)`. Advance `sync_slot = (slot+1) % NUM_SLOTS`
+  (constant modulus, `tenant_id=0`).
+- **Breaker:** `incrementAuthFailures`/`haltSync` scoped to the failing tenant.
+
+**Trade-offs:**
+- Pro: satisfies all 4 RED cases (dedup ✓, slot ✓, per-tenant lock attempt ✓,
+  no PAT ✓); one tenant's auth failure halts only itself; 1 query/unique-repo;
+  overlapping ticks serialised by the entry lock.
+- Con: adds a per-tick discovery pass (extra REST calls — cheap, W2-bounded);
+  per-repo token resolution moves to the call site (not `resolveInstallToken`,
+  whose `.first()` is non-deterministic for multi-tenant rows).
+
+**Rough scope:** L
+
+### Shape 2: Per-tenant full sync (tenant-outer, no cross-tenant dedup)
+
+Each tenant independently: lock → list repos → sync each under its own token.
+
+**Trade-offs:**
+- Pro: simplest lock model, fully isolated.
+- Con: **violates SC-3** — a repo shared by 2 tenants is fetched twice → RED
+  case 1 fails + subrequest cap breaches as installs grow. **Eliminated.**
+
+**Rough scope:** M
+
+### Shape 3: Global single-lock + global dedup (`tenant_id=0` only)
+
+Keep one global tick lock; discover all tenants, dedup, window, fan-out;
+breaker global.
+
+**Trade-offs:**
+- Pro: minimal change to lock helpers (no `tenantId` threading).
+- Con: **violates RED case 3** — one tenant's lock/auth-failure blocks/halts all.
+  **Eliminated by the test contract.**
+
+**Rough scope:** M
+
+## Fit Check
+
+**Shape 1.** It is the only shape satisfying the full RED contract + SC-3/4/6.
+Global tick lock serialises the run; per-tenant lock gates *discovery* (what RED
+case 3 asserts); the deduped fan-out operates on the `tenant_repo_access` union
+with per-repo token resolution from the owning-tenant list; the slot is global
+(constant `NUM_SLOTS`) because the deduped repo list is global.
+
+```mermaid
+flowchart TD
+  A[runSync tick] --> Z[acquireSyncLock db,0 · global tick lock]
+  Z --> B{for each tenant}
+  B --> C[acquireSyncLock db,tenantId · discovery skip-guard]
+  C -->|held| B
+  C -->|got| D[getInstallationToken → listInstallationRepos*]
+  D --> E[upsert tenant_repo_access]
+  E --> F[merge into Map repo→tenantId list, sorted]
+  B -->|done| G[sort unique repos owner/name]
+  G --> H[window = slot*WINDOW .. +WINDOW]
+  H --> I{for repo in window}
+  I --> J[getInstallationToken owningTenant; fallback down list]
+  J --> K[syncRepoBundle · 1 bundle query]
+  I -->|done| L[closedHopPass db, resolver]
+  L --> M[advance sync_slot = slot+1 mod NUM_SLOTS]
+  M --> N[release locks · writeRunAudit]
+  J -.all tenants fail.-> P[skip repo · log]
+  K -.auth fail.-> O[incrementAuthFailures tenantId → haltSync tenantId]
+  classDef w2 stroke-dasharray:4 3
+  class D w2
+```
+`*` = `listInstallationRepos` hardened (MAX_PAGES + AbortSignal.timeout) — in scope this PR.
+
+## Decisions resolved (architect review — fold into /spec)
+
+1. **Lock model:** existing global tick lock `acquireSyncLock(db, 0)` at entry
+   serialises the whole run; per-tenant `acquireSyncLock(db, tenantId)` is a
+   Phase-1 discovery skip-guard only. **No** second Phase-2 lock. Thread
+   `tenantId` (default `0`) through all 7 lock/breaker helpers (`sync.ts:213-273`)
+   so existing non-`runSync` callers are unaffected.
+2. **Slot windowing:** `next_slot = (slot+1) % NUM_SLOTS` with **constant**
+   `NUM_SLOTS = 3` — NOT `ceil(N/WINDOW)` (a volatile divisor permanently
+   skips/double-covers repos as installs come/go). `WINDOW = 20` (50-cap budget:
+   ~7 reserved for discovery+overhead, 43 for fan-out, halved for closedHopPass
+   worst-case ≈ 21). Empty slice (repo count < `slot*WINDOW`) → no fan-out but
+   still advance slot (forward progress). Export `WINDOW`/`NUM_SLOTS` so tests
+   override without patching internals.
+3. **Token source:** `Map<repo, tenantId[]>` (sorted, lowest = owning). Phase 2
+   calls `getInstallationToken(db, env, owningTenantId, installationId)`
+   **directly** (not `resolveInstallToken` — `.first()` non-deterministic,
+   `installToken.ts:182`); on a revoked/suspended install (throw) fall back to
+   the next tenant in the list, `incrementAuthFailures` only the thrower; all
+   fail → skip repo + log, don't abort. `resolveInstallToken` stays the
+   webhook-path resolver (single-tenant invariant holds there).
+4. **Prune source:** **union of `tenant_repo_access`** replaces org-enum.
+   Re-target the 0-live-repos guard (`sync.ts:1175`) at the **union count** so a
+   failed/empty discovery never prunes everything (safe false-negative). A repo
+   genuinely removed from all installs → its issues pruned (correct; document).
+5. **Empty discovery** (no installs / empty union): no-op + warn — NOT the old
+   "empty allowlist short-circuit." Reconcile L967 test.
+6. **W2 in scope (not deferred):** harden `listInstallationRepos` (`MAX_PAGES` +
+   `AbortSignal.timeout`/fetch) — Phase 1 calls it per tenant every tick.
+
+**Still verify at implement:**
+- **Arg-index discrepancy:** issue says the dedup RED case reads `c[2]/c[3]`;
+  current skip-block (L1525) already reads `c[0]/c[1]` (correct). Confirm exact
+  state — real gap is the missing top-level `vi.mock("../auth/installToken")`.
+- **Lock helper INSERT path:** `acquireSyncLock` UPDATEs and silently no-ops if
+  the `(tenantId,'sync_running')` row is missing → seed per-tenant
+  `sync_control` rows (`INSERT OR IGNORE`) at tenant creation or lazily.
+
+## Files impacted
+
+| File | Change |
+|---|---|
+| `worker/src/sync/sync.ts` | rewrite `runSync`; thread `tenantId` through 7 helpers; `closedHopPass` resolver; drop 4 `GITHUB_TOKEN` reads; slot windowing; discovery pass |
+| `worker/src/auth/installToken.ts` | harden `listInstallationRepos` (W2) |
+| `worker/src/types.ts` | drop `GITHUB_TOKEN` from `Env` (T10) |
+| `wrangler.toml` | drop `GITHUB_TOKEN` (both envs) |
+| `worker/src/sync/sync.test.ts` | un-skip + fix 4 RED cases (add `vi.mock`); reconcile ~11 old-flow `runSync` cases (L924-1408) |
+
+## Risks
+
+- **Live-sync regression during cutover** — PAT stays live until a verified
+  install-token tick; RT3 deletion is post-merge, staging→prod.
+- **Prune-everything** if discovery yields 0 → mitigated by the 0-live-repos guard.
+- **Test reconciliation churn** — the 11 old-flow cases assume org-enum + global
+  lock; rewriting them is the bulk of the test work and the main review surface.

--- a/artifacts/frames/160-per-installation-runsync-cutover-frame.mdx
+++ b/artifacts/frames/160-per-installation-runsync-cutover-frame.mdx
@@ -1,0 +1,90 @@
+---
+title: per-installation runSync cutover + PAT retirement (Phase 1 S3b)
+issue: 160
+status: approved
+tier: F-full
+date: 2026-06-12
+---
+
+## Problem
+
+S3a (#146) landed the install-token plumbing — `installToken.ts`
+(`getInstallationToken`/`resolveInstallToken`/`listInstallationRepos`),
+`tokenCrypto.ts` (AES-GCM), the `0005_sync_slot_seed` migration, and the CI
+`INSTALL_TOKEN_KEY` inject. But `runSync` still runs the **legacy
+org-enumeration / `repo_allowlist` / PAT flow**: it reads `env.GITHUB_TOKEN`
+and calls `enumerateOrgRepos`/`enumerateArchivedOrgRepos`. Consequences:
+
+- The org-scoped **PAT (`GITHUB_TOKEN`) is still the live sync credential** —
+  it cannot be retired (RT3) until sync runs on installation tokens.
+- `tenant_repo_access` is **never populated** — nothing fills it until this
+  slice's discovery pass, leaving the S3a→S3b fail-closed gap open.
+- The deduped, slot-rotated, per-tenant multi-tenant fan-out **does not exist**;
+  the 4 RED cases in `sync.test.ts` (`describe.skip(… DEFERRED #160 …)`) encode
+  the target behaviour but are skipped.
+
+## Who
+
+- **Primary:** the cockpit's hourly Cron sync + the operator (Mickael) — sync
+  must keep reconciling issue/edge data into D1 after the org-scoped PAT is gone.
+- **Secondary:** future multi-tenant installations — each installation's repos
+  sync via its own token, with no cross-tenant lock/failure bleed.
+
+## Constraints
+
+- Cloudflare Worker **subrequest cap (~50/invocation)** → slot-rotation windowing
+  required (`sync_control.sync_slot`, 0005 seed already live).
+- Live hourly sync must not break during cutover — **PAT stays live** until a
+  verified install-token tick; retirement is staging→prod after empirical verify.
+- D1 `0005` sync_slot seed live; `tenant_repo_access` table exists but **empty**.
+- `listInstallationRepos` is currently **unbounded** (`while(true)`, no per-call
+  timeout) — must harden (W2: `MAX_PAGES` + `AbortSignal.timeout`) before wiring
+  its first caller here.
+- No KV in Phase 1 (repo-canonical pivot, #141).
+- **Prod `/promote` is blocked** until the #164 CI inject fix reaches prod
+  secrets (`GITHUB_APP_*`/`INSTALL_TOKEN_KEY` never injected on main) — out of
+  this slice's scope but gates the RT3 prod leg.
+
+## Out of Scope
+
+- SYNC_QUEUE activation (DORMANT, deferred beyond Phase 1).
+- Frontend / `state.js` changes.
+- Board / ProjectV2 (roxabi-live is issues-only, #118).
+- The #164 prod-inject fix itself (separate; only sequenced against here).
+
+## Premise Validity
+
+**Success in 6 months:** `runSync` runs entirely on per-installation GitHub App
+tokens; `GITHUB_TOKEN` is deleted from staging+prod secrets and absent from
+`Env`/`wrangler.toml`/all `sync/` paths (no fallback); the hourly tick reconciles
+every installed tenant's repos with **≤1 GraphQL bundle call per unique repo** and
+**no subrequest-cap breach**; `tenant_repo_access` is populated each tick.
+
+**Failure in 6 months (falsifiable):** any one of —
+- `wrangler secret list` (staging or prod) still shows `GITHUB_TOKEN` after RT3; OR
+- a tick issues **> (unique-repo count)** GraphQL bundle calls (dedup broken); OR
+- one tenant's auth-failure/lock **halts another tenant's** sync (lock not isolated); OR
+- subrequest-cap breaches drop repos on a tick (observable via R2 audit log).
+
+**Simplest alternative:** keep the PAT and add per-tenant token resolution
+*alongside* the existing org-enum flow.
+**Why not simplest:** it leaves the org-scoped PAT as a standing secret — which is
+the explicit retirement target (RT3) — keeps `tenant_repo_access` empty (S3a
+fail-closed gap stays open), and never dedups the multi-tenant fan-out, so the
+subrequest cap is breached as installs grow. The PAT is the credential we are
+deliberately removing; a parallel path keeps it live indefinitely.
+
+## Complexity
+
+**Tier: F-full** — multi-file, cross-cutting rewrite of the sync core with a new
+discovery/dedup/slot-rotation algorithm, per-tenant lock threading through 5
+helpers, and reconciliation of a ~15-case integration test suite.
+
+Signals observed:
+- `size:F-full` label on the issue.
+- Rewrite of `sync.ts` `runSync` + new fan-out algorithm (new pattern).
+- Per-tenant lock isolation threaded through `acquireSyncLock`/`releaseSyncLock`/
+  `isHalted`/`incrementAuthFailures`/`resetAuthFailures`.
+- Test-suite reconciliation (allowlist/prune/auth-halt cases conflict with the
+  per-tenant model) + 4 RED cases to un-skip & repair.
+- Cross-cutting `Env`/`wrangler.toml` type + config change (T10) with no fallback.

--- a/artifacts/plans/160-per-installation-runsync-cutover-plan.mdx
+++ b/artifacts/plans/160-per-installation-runsync-cutover-plan.mdx
@@ -1,0 +1,266 @@
+---
+title: "Plan: per-installation runSync cutover + PAT retirement (S3b)"
+issue: 160
+spec: artifacts/specs/160-per-installation-runsync-cutover-spec.mdx
+complexity: 7/10
+tier: F-full
+generated: 2026-06-12
+---
+
+## Summary
+
+Rewrite `runSync` to per-installation GitHub App tokens — two-phase
+(discovery → deduped windowed fan-out), per-tenant lock/breaker, `closedHopPass`
+resolver callback — drop the org PAT, harden `listInstallationRepos` (W2), and
+reconcile the sync test suite (un-skip 4 RED + rewrite ~11 old-flow cases).
+
+## Architecture
+
+```mermaid
+flowchart TD
+  subgraph sync_ts["worker/src/sync/sync.ts"]
+    RS[runSync] --> GL[acquireSyncLock 0 · tick lock]
+    GL --> DT[discoverTenants Phase 1]
+    DT -->|Map repo→tenantId,installationId| P2[Phase 2 fan-out]
+    P2 --> CHP[closedHopPass db,resolveToken]
+    DT --> H7[7 lock/breaker helpers +tenantId]
+    P2 --> SLOT[advance sync_slot mod NUM_SLOTS]
+    P2 --> PR[prune vs tenant_repo_access union]
+  end
+  subgraph auth["worker/src/auth/installToken.ts"]
+    GIT[getInstallationToken] --> LIR[listInstallationRepos* W2]
+  end
+  subgraph types["worker/src/types.ts"]
+    ENV[Env − GITHUB_TOKEN]
+  end
+  DT --> GIT
+  P2 --> GIT
+  CHP --> GIT
+  classDef w2 stroke-dasharray:4 3
+  class LIR w2
+```
+
+```mermaid
+flowchart LR
+  subgraph prod["sync.ts (be-A) + installToken/types (be-B)"]
+    discoverTenants --> upsert_TRA[tenant_repo_access upsert]
+    runSync --> discoverTenants
+    runSync --> closedHopPass
+    helpers7[acquireSyncLock/releaseSyncLock/isHalted/getAuthFailures/incrementAuthFailures/haltSync/resetAuthFailures]
+    runSync --> helpers7
+    listInstallationRepos_W2
+  end
+  subgraph tests["sync.test.ts + installToken.test.ts (te-A)"]
+    RED4[4 RED cases + vi.mock] -.verifies.-> runSync
+    reconcile11[~11 old-flow cases] -.verifies.-> runSync
+    w2test -.verifies.-> listInstallationRepos_W2
+  end
+```
+
+## Bootstrap Context
+
+- Analysis (architect-reviewed): `artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx`
+- Spec (architect+devops-reviewed): `artifacts/specs/160-per-installation-runsync-cutover-spec.mdx`
+- Code map (from Explore): `runSync` @ `sync.ts:1127`; PAT reads @ L1161/1165/1277/1288;
+  7 helpers @ L213-279 (all hardcode `tenant_id=0`); `closedHopPass` @ L986;
+  `syncRepoBundle` @ L802; `ghGraphql(query,vars,token)` = c[0]/c[1]/c[2];
+  `getInstallationToken(db,env,tenantId,installationId)` @ `installToken.ts:73`;
+  `listInstallationRepos(token)` @ L226 (`while(true)`, no cap — W2 target);
+  `sync_control` PK `(tenant_id,key)` (0004); `tenant_repo_access(tenant_id,repo)` (0004);
+  `sync_slot=0` seeded for tenant_id=0 (0005). RED block @ `sync.test.ts:1485`
+  (4 cases: L1496/1531/1565/1601); **no** `vi.mock("../auth/installToken")` present;
+  old-flow `runSync` describe @ L924 (~11 cases). `wrangler.toml` has **no**
+  `GITHUB_TOKEN` (secret only). `ci.yml:181` = `TODO(RT3)` comment only.
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1, T2, T3, T4 | `worker/src/sync/sync.ts` |
+| backend-dev-B | T5, T6 | `worker/src/auth/installToken.ts`, `worker/src/types.ts`, `worker/src/sync/graphql.ts` |
+| tester-A | T7, T8, T9, T10 | `worker/src/auth/installToken.test.ts`, `worker/src/sync/sync.test.ts` |
+
+## Wave Structure
+
+4 waves, max 2 parallel agents. Elapsed ~ slowest chain (be-A T1→T2→T3→T4) vs sequential T1..T10.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | be-A: T1 · be-B: T5 |
+| 2 | Wave 1 done | 2 ∥ | be-A: T2→T3→T4 · te-A: T7 |
+| 3 | T4 done | 2 ∥ | be-B: T6 · te-A: T8→T9 |
+| 4 | T6,T7,T9 done | 1 | te-A: T10 (RED-GATE) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 thread tenantId ×7 | 7 helpers | bounded | 8 | — |
+| T2 closedHopPass resolver | 1 | judgmental | 5 | — |
+| T3 discoverTenants Phase 1 | 1 | judgmental | 10 | — |
+| T4 runSync Phase 2 rewrite | 1 | exploratory | 14 | — |
+| T5 W2 harden | 1 | judgmental | 6 | — |
+| T6 drop GITHUB_TOKEN | 2 files | bounded | 4 | — |
+| T7 W2 unit test | 1 | judgmental | 5 | — |
+| T8 un-skip 4 RED + vi.mock | 4 | judgmental | 9 | — |
+| T9 reconcile ~11 old-flow | 11 | judgmental | 13 | — |
+| T10 RED-GATE verify | 1 | bounded | 3 | — |
+
+**Total estimated ops: 77**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3, T4 | 37 | sync | — |
+| backend-dev-B | T5, T6 | 10 | token, env | — |
+| tester-A | T7, T8, T9, T10 | 30 | token, sync-tests | — |
+
+No instance exceeds 50 ops / 4 tasks / 2 subjects → no split required.
+
+## Consistency Report
+
+Covered: 10/10 success criteria + items traced.
+
+| Criterion | Task(s) |
+|---|---|
+| SC-3 dedup (RED 1) | T4, T8 |
+| SC-4 slot advance (RED 2) | T4, T8 |
+| Lock isolation (RED 3) | T1, T3, T8 |
+| SC-6 no PAT (RED 4) | T4, T6, T8 |
+| W2 hardening | T5, T7 |
+| tenant_repo_access populated | T3 |
+| prune union + guard | T4 |
+| CI gate (suite+typecheck green) | T9, T10 |
+| SC-9/RT2 (staging tick) | post-deploy (verify) |
+| SC-7/RT3 (PAT delete) | post-merge operational |
+
+Untraced tasks: none. Exemptions: SC-9/SC-7 are deploy-gated (not code tasks) — verified at /verify + RT3 runbook.
+
+## Micro-Tasks
+
+### Slice S2 — thread tenantId (Wave 1)
+
+**T1** — Thread `tenantId: number = 0` through the 7 lock/breaker helpers.
+- File: `worker/src/sync/sync.ts` (L213-279)
+- Shape: `acquireSyncLock(db, tenantId = 0)`, …, update SQL `WHERE tenant_id = ?` bound to `tenantId` (replace hardcoded `0`). Keep default so non-`runSync` callers + existing tests stay green.
+- Verify: `cd worker && npm run typecheck` · existing helper tests green.
+- Agent: backend-dev-A · Subject: sync · Spec: Lock isolation · Phase: REFACTOR · Diff: 2
+
+### Slice S3 — closedHopPass resolver (Wave 2)
+
+**T2** — Change `closedHopPass(db, token)` → `closedHopPass(db, resolveToken)`.
+- File: `worker/src/sync/sync.ts` (L986)
+- Shape: `resolveToken: (owner: string, name: string) => Promise<string>`; internal GraphQL calls use `await resolveToken(owner, name)` per hop.
+- Verify: `npm run typecheck`.
+- Agent: backend-dev-A · Subject: sync · Spec: SC-9 · Phase: REFACTOR · blockedBy: T1 · Diff: 2
+
+### Slice S4 — discoverTenants Phase 1 (Wave 2)
+
+**T3** — New `discoverTenants(db, env): Promise<Map<string, Array<{tenantId, installationId}>>>`.
+- File: `worker/src/sync/sync.ts`
+- Shape: `SELECT id, installation_id FROM tenants WHERE installation_id IS NOT NULL`; ∀ tenant → `INSERT OR IGNORE INTO sync_control(tenant_id,key,value) VALUES(?,'sync_running','0')` (also auth_failures/halted rows) → `acquireSyncLock(db, tenantId)` skip-guard → `getInstallationToken(db, env, tenantId, installationId)` → `listInstallationRepos(token)` → upsert `tenant_repo_access` for returned repos + delete this tenant's rows not returned → merge into Map (push `{tenantId, installationId}`, keep list sorted asc by tenantId).
+- Verify: unit test asserts `tenant_repo_access` populated + Map shape (covered by te-A).
+- Agent: backend-dev-A · Subject: sync · Spec: tenant_repo_access populated · Phase: GREEN · blockedBy: T2 · Diff: 4
+
+### Slice S5 — runSync Phase 2 rewrite (Wave 2)
+
+**T4** — Rewrite `runSync` body to the two-phase model; drop all 4 `env.GITHUB_TOKEN` reads.
+- File: `worker/src/sync/sync.ts` (L1127); export `const WINDOW = 20`, `const NUM_SLOTS = 3`.
+- Shape: `isHalted(db,0)` → `acquireSyncLock(db,0)` → `discoverTenants` → unique repos sorted by `owner/name` → read `sync_slot`, window `[slot*WINDOW,(slot+1)*WINDOW)` → ∀ repo: try `getInstallationToken(db,env,owningTenant.tenantId,owningTenant.installationId)`, on throw fall to next list entry (`incrementAuthFailures(thrower)`), all fail → skip+log → `syncRepoBundle(db, token, owner, name, edges)` → `flushEdges` → `closedHopPass(db, resolveTokenFor)` → `sync_slot = (slot+1)%NUM_SLOTS` → prune vs union of `tenant_repo_access` (re-target 0-live guard at union count) → `writeRunAudit` → release locks. Remove `enumerateOrgRepos`/`enumerateArchivedOrgRepos`/`getRepoAllowlist` calls (and the now-dead functions if unreferenced).
+- Verify: RED cases 1,2,4 green (te-A T8); `grep -n GITHUB_TOKEN worker/src/sync/sync.ts` → none.
+- Agent: backend-dev-A · Subject: sync · Spec: SC-3/4/6 · Phase: GREEN · blockedBy: T3 · Diff: 5
+
+### Slice S1 — W2 hardening (Wave 1)
+
+**T5** — Bound `listInstallationRepos` pagination.
+- File: `worker/src/auth/installToken.ts` (L226-)
+- Shape: `const MAX_PAGES = 10;` replace `while(true)` with `for (let page=1; page<=MAX_PAGES; page++)`; each `fetch(url, { signal: AbortSignal.timeout(10_000) })`; break on `< per_page`; if `MAX_PAGES` reached with a full last page → log a truncation warn.
+- Verify: te-A T7.
+- Agent: backend-dev-B · Subject: token · Spec: W2 · Phase: GREEN · Diff: 3
+
+### Slice S6 — drop GITHUB_TOKEN (Wave 3)
+
+**T6** — Remove `GITHUB_TOKEN` from `Env` + stale references.
+- Files: `worker/src/types.ts` (drop `GITHUB_TOKEN: string`), `worker/src/sync/graphql.ts` (drop stale doc-comments L6/L111). No `wrangler.toml` edit (secret, not a `[vars]` entry).
+- Verify: `npm run typecheck` green; `grep -rn GITHUB_TOKEN worker/src` → only test fixtures (cast) if any.
+- Agent: backend-dev-B · Subject: env · Spec: SC-6/T10 · Phase: REFACTOR · blockedBy: T4 · Diff: 2
+
+### Slice S1 test — W2 (Wave 2)
+
+**T7** — Unit-test the W2 bound.
+- File: `worker/src/auth/installToken.test.ts` (create or extend)
+- Shape: mock `fetch` returning full pages → assert ≤ `MAX_PAGES` fetches; mock a hanging fetch → assert `AbortSignal.timeout` rejects/handled.
+- Verify: `cd worker && npm test -- installToken`.
+- Agent: tester-A · Subject: token · Spec: W2 · Phase: GREEN · blockedBy: T5 · Diff: 3
+
+### Slice S7a — un-skip RED (Wave 3)
+
+**T8** — Un-skip the 4 RED cases + add the install-token mock.
+- File: `worker/src/sync/sync.test.ts` (L1485 block)
+- Shape: `describe.skip(...)` → `describe(...)`; add top-level `vi.mock("../auth/installToken", () => ({ getInstallationToken: vi.fn(...), resolveInstallToken: vi.fn(...), listInstallationRepos: vi.fn(...) }))`; verify dedup assertion reads `c[0]/c[1]` (already correct per Explore — fix only if it regressed); wire fake `tenants`/`tenant_repo_access`/`sync_control` rows.
+- Verify: `cd worker && npm test -- sync` → 4 cases green.
+- Agent: tester-A · Subject: sync-tests · Spec: SC-3/4/6 + lock · Phase: RED→GREEN · blockedBy: T4 · Diff: 4
+
+### Slice S7b — reconcile old-flow (Wave 3)
+
+**T9** — Reconcile the ~11 old-flow `runSync` cases (L924-1408).
+- File: `worker/src/sync/sync.test.ts`
+- Shape: rewrite/remove cases asserting org-enum (`enumerateOrgRepos`), empty `repo_allowlist` short-circuit (L967), and global `tenant_id=0` auth-halt to the per-tenant model (halt scoped to a tenant; prune driven by `tenant_repo_access` union; empty discovery → no-op+warn). Keep semantics that survive (audit write, NOTIFY_URL alert) re-pointed at the per-tenant breaker.
+- Verify: `cd worker && npm test -- sync` → full describe green.
+- Agent: tester-A · Subject: sync-tests · Spec: CI gate · Phase: GREEN · blockedBy: T8 · Diff: 4
+
+### RED-GATE (Wave 4)
+
+**T10** — Full suite + typecheck gate.
+- Verify: `cd worker && npm test && npm run typecheck` → all green; `grep -rn GITHUB_TOKEN worker/src` clean (fixtures excepted).
+- Agent: tester-A · Subject: sync-tests · Phase: RED-GATE · blockedBy: T6, T7, T9 · Diff: 1
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | sync |
+| T5 | backend-dev-B | — | token |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | sync |
+| T3 | backend-dev-A | T2 | sync |
+| T4 | backend-dev-A | T3 | sync |
+| T7 | tester-A | T5 | token |
+
+### Wave 3 — after T4, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | backend-dev-B | T4 | env |
+| T8 | tester-A | T4 | sync-tests |
+| T9 | tester-A | T8 | sync-tests |
+
+### Wave 4 — after T6,T7,T9, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | tester-A | T6, T7, T9 | sync-tests |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 13 — sync (thread tenantId ×7)
+- T2: 14 — sync (closedHopPass resolver)
+- T3: 15 — sync (discoverTenants Phase 1)
+- T4: 16 — sync (runSync Phase 2 rewrite)
+- T5: 17 — token (W2 harden)
+- T6: 18 — env (drop GITHUB_TOKEN)
+- T7: 19 — token (W2 unit test)
+- T8: 20 — sync-tests (un-skip 4 RED + vi.mock)
+- T9: 21 — sync-tests (reconcile ~11 old-flow)
+- T10: 22 — sync-tests (RED-GATE)

--- a/artifacts/specs/160-per-installation-runsync-cutover-spec.mdx
+++ b/artifacts/specs/160-per-installation-runsync-cutover-spec.mdx
@@ -1,0 +1,189 @@
+---
+title: "per-installation runSync cutover + PAT retirement (S3b)"
+issue: 160
+status: approved
+tier: F-full
+date: 2026-06-12
+promoted_from: artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx
+---
+
+## Context
+
+Promoted from `artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx`
+(architect-reviewed, verdict: sound-with-changes). Split from #146 (S3a shipped).
+S3a landed the install-token plumbing; this slice cuts `runSync` over to it and
+retires the org PAT.
+
+## Goal
+
+`runSync` syncs every installed tenant's repos using per-installation GitHub App
+tokens — deduped to 1 GraphQL bundle call per unique repo, windowed under the
+~50-subrequest cap, lock/breaker isolated per tenant — and reads **zero**
+`env.GITHUB_TOKEN`; the PAT is removed from code/config and deleted from secrets.
+
+## Users
+
+- **Primary:** the hourly Cron sync + operator (Mickael) — D1 issue/edge data
+  must keep reconciling after the PAT is gone.
+- **Secondary:** future multi-tenant installations — each install's repos sync
+  via its own token; no cross-tenant lock/breaker bleed.
+
+## Expected Behavior
+
+A cron tick:
+
+1. Global tick lock `acquireSyncLock(db, 0)` (existing) — serialises the run;
+   `isHalted(db, 0)` short-circuits a halted system. Released in `finally`.
+2. **Phase 1 — discovery (per tenant):** for each tenant row with an
+   `installation_id`, `INSERT OR IGNORE` its `sync_control(tenantId,
+   'sync_running')` row (else the next step silently no-ops), then attempt
+   `acquireSyncLock(db, tenantId)` (discovery skip-guard); on success
+   `getInstallationToken(db, env, tenantId, installationId)` →
+   `listInstallationRepos(token)` (hardened) → upsert
+   `tenant_repo_access(tenant_id, repo)` (and delete rows no longer returned).
+   Accumulate `Map<repo, Array<{tenantId, installationId}>>` (sorted ascending by
+   `tenantId`; lowest = owning) — carry `installationId` so Phase 2 mints tokens
+   with no extra query.
+3. **Phase 2 — fan-out (global, deduped, windowed):** sort the unique-repo set
+   lexicographically by `owner/name`; take the window `[slot*WINDOW,
+   (slot+1)*WINDOW)`; for each repo resolve a token via
+   `getInstallationToken(db, env, owningTenantId, installationId)` from the head
+   of the repo's tenant list, falling back to the next `{tenantId, installationId}`
+   on a revoked/suspended install (only `incrementAuthFailures(tenantId)` for the
+   thrower; all fail → skip repo + log, never abort the run) → `syncRepoBundle`.
+   Then `closedHopPass(db, resolveToken)` with the same per-(owner,name)
+   resolver. Advance `sync_slot = (slot+1) % NUM_SLOTS`.
+4. Prune issues/edges/pr_state/sync_state/repos against the **union of
+   `tenant_repo_access`**; skip prune (warn) if the union is empty (guard).
+5. `writeRunAudit` to R2; release all acquired locks.
+
+Empty discovery (no installs / empty union) → no-op + warn (NOT the old empty-
+allowlist short-circuit). PAT stays live in secrets until a verified staging tick
+(RT2); deletion (RT3) is the post-merge operational tail.
+
+## Data Model & Consumers
+
+No migration — schema landed in 0004/0005. This slice fills + reads existing
+tables.
+
+```mermaid
+classDiagram
+  class tenants {
+    +INTEGER id
+    +INTEGER installation_id
+  }
+  class tenant_repo_access {
+    +INTEGER tenant_id FK
+    +TEXT repo
+    PK(tenant_id, repo)
+  }
+  class sync_control {
+    +INTEGER tenant_id
+    +TEXT key
+    +TEXT value
+    PK(tenant_id, key)
+  }
+  class install_tokens {
+    +INTEGER tenant_id
+    +TEXT ciphertext (AES-GCM)
+  }
+  tenants "1" --> "*" tenant_repo_access : grants
+  tenants "1" --> "*" sync_control : scopes lock/breaker/slot
+  tenants "1" --> "*" install_tokens : caches token
+```
+
+```mermaid
+flowchart LR
+  P1[runSync Phase 1] -->|upsert| TRA[tenant_repo_access]
+  P1 -->|read/write| SC[sync_control tenantId]
+  P1 -->|mint/cache| IT[install_tokens]
+  TRA -->|union, deduped| P2[runSync Phase 2 fan-out]
+  SC -->|slot tenant_id=0| P2
+  TRA -.->|JOIN tenants| WH[webhook resolveInstallToken]
+  IT --> P2
+  IT -.-> WH
+```
+
+| Consumer | Reads | When | Status |
+|---|---|---|---|
+| `runSync` Phase 1 | `tenants.installation_id` | every tick | this issue |
+| `runSync` Phase 2 | `tenant_repo_access` union, `sync_control.sync_slot` | every tick | this issue |
+| prune | `tenant_repo_access` union | every tick | this issue |
+| webhook handlers | `tenant_repo_access` via `resolveInstallToken` | on event | S3a (unchanged) |
+
+## Breadboard
+
+Affordances are the sync entry points + helpers (no UI). Wiring:
+
+| ID | Affordance | Handler | Data |
+|---|---|---|---|
+| N1 | `runSync(env)` | rewritten orchestrator | global lock → Phase 1 → Phase 2 → prune → audit |
+| N2 | `discoverTenants(db, env)` *(new)* | Phase 1 | `tenants{id,installation_id}` → `INSERT OR IGNORE sync_control` → `getInstallationToken` → `listInstallationRepos` → upsert `tenant_repo_access`; returns `Map<repo, Array<{tenantId,installationId}>>` |
+| N3 | lock/breaker helpers ×7 | `+tenantId=0` param | `sync_control(tenant_id,key)` |
+| N4 | `closedHopPass(db, resolveToken)` | resolver-callback signature | per-(owner,name) token |
+| N5 | `listInstallationRepos(token)` | W2 hardening | `MAX_PAGES` + `AbortSignal.timeout` |
+| N6 | `Env` (T10) | drop `GITHUB_TOKEN: string` from `types.ts` + all `sync/` reads + stale `graphql.ts` doc-comments | no fallback. **`wrangler.toml` has no `GITHUB_TOKEN` (it is a secret, not a `[vars]` entry) → no toml edit** |
+| N7 | `WINDOW`, `NUM_SLOTS` | exported consts | `WINDOW=20`, `NUM_SLOTS=3` |
+| N8 | `sync.test.ts` | un-skip 4 RED + reconcile 11 old-flow | `vi.mock("../auth/installToken")` |
+
+## Slices
+
+Internal build-order increments — **one cohesive PR** (test suite cannot be
+green mid-way if split: the 4 RED cases require the impl; already split from #146).
+
+| # | Slice | Affordances | Demo-able by |
+|---|---|---|---|
+| 1 | W2 harden `listInstallationRepos` | N5 | unit test: caps at `MAX_PAGES`, aborts on timeout |
+| 2 | Thread `tenantId` (default 0) through 7 helpers | N3 | existing helper tests stay green |
+| 3 | `closedHopPass` resolver callback | N4 | unit test: resolver invoked per (owner,name) |
+| 4 | Phase 1 `discoverTenants`: `INSERT OR IGNORE sync_control` per tenant → `Map<repo,Array<{tenantId,installationId}>>` + `tenant_repo_access` upsert | N2 | RED-adjacent: `tenant_repo_access` populated; new tenant's lock row seeded |
+| 5 | Phase 2 deduped windowed fan-out + token fallback; drop 4 PAT reads | N1, N7 | RED cases 1,2,4 green |
+| 6 | Drop `GITHUB_TOKEN` from `Env` (`types.ts`) + stale `graphql.ts` doc-comments (T10; no wrangler.toml edit) | N6 | typecheck green; `grep GITHUB_TOKEN worker/src` clean |
+| 7 | Test reconciliation: un-skip 4 RED + `vi.mock` + reconcile 11 old-flow | N8 | full `sync.test.ts` green |
+
+## Success Criteria
+
+Code (CI-verifiable):
+
+- [ ] **SC-3** — a tick with 2 tenants sharing repo `o/r` issues exactly **1**
+  `REPO_BUNDLE_QUERY` for `o/r` (RED case 1, L1496, green).
+- [ ] **SC-4** — `sync_slot` advances `(slot+1) % NUM_SLOTS` per tick; fan-out
+  window ≤ `WINDOW` repos so the ~50-subrequest cap is not breached (RED case 2,
+  L1531, green).
+- [ ] **Lock isolation** — tenant A holding `sync_running=1` does NOT prevent
+  tenant B's `acquireSyncLock` attempt (RED case 3, L1565, green).
+- [ ] **SC-6** — `GITHUB_TOKEN` absent from `Env` (`types.ts`), `wrangler.toml`
+  (both envs), and every `worker/src/sync/` path; no fallback. RED case 4
+  (L1601) green: `patAccessCount === 0`.
+- [ ] **W2** — `listInstallationRepos` bounded by `MAX_PAGES` + per-fetch
+  `AbortSignal.timeout`; unit-tested.
+- [ ] `tenant_repo_access` is upserted by Phase 1 each tick (rows for every
+  accessible repo; stale rows removed).
+- [ ] Prune sources the live set from the `tenant_repo_access` **union**; the
+  0-union guard prevents prune-all on empty/failed discovery.
+
+CI gate (structural, not a behavioral assertion):
+
+- [ ] All 4 RED cases un-skipped; top-level `vi.mock("../auth/installToken")`
+  present; the ~11 old-flow `runSync` cases (L924-1408) reconciled; full suite +
+  `npm run typecheck` green.
+
+Operational (deploy-gated, verified on staging post-merge — not CI):
+
+- [ ] **SC-9 / RT2** — `subIssues`/`parent` resolve via an installation token on
+  an empirical staging tick (R2 audit shows a clean run, no PAT read).
+- [ ] **SC-7 / RT3** — `GITHUB_TOKEN` deleted from secrets, **code-deploy-first**
+  (delete-before-deploy = guaranteed sync outage on `env.GITHUB_TOKEN===undefined`):
+  merge→deploy staging → verify clean tick (RT2) → `wrangler secret delete
+  GITHUB_TOKEN --env staging` → verify 2nd tick. **Prod leg hard-gated** on #164
+  (`7dbf512`) reaching `main` + CI re-injecting `GITHUB_APP_*`/`INSTALL_TOKEN_KEY`
+  on prod, then prod deploy → verify → `wrangler secret delete GITHUB_TOKEN`.
+  (CI has no `GITHUB_TOKEN` inject step — only the `TODO(RT3)` comment at
+  `ci.yml:181`; removal breaks no CI step.)
+
+## Gate 2.5 — Smart Splitting
+
+|slices| = 7 (> 3) triggers consideration → **declined**. Slices are
+test-coupled build increments of one sync rewrite (the RED cases go green only
+once Phase 1+2 land); the issue was already split from #146 precisely to make
+this the atomic unit. Keep as a single PR.

--- a/worker/src/api/admin.test.ts
+++ b/worker/src/api/admin.test.ts
@@ -20,7 +20,6 @@ function mockEnv(adminToken?: string): Env {
       dump: async () => new ArrayBuffer(0),
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
     ...(adminToken !== undefined ? { ADMIN_TOKEN: adminToken } : {}),

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -35,7 +35,6 @@ function makeGraphEnv(
       }),
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -70,7 +69,6 @@ function makeGraphEnvWithCapture(
       },
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -73,7 +73,6 @@ function makeListEnvWithCapture(
       },
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -101,7 +100,6 @@ function makeListEnv(opts: ListEnvOptions): Env {
       ],
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -150,7 +148,6 @@ function makeGetEnv(opts: GetEnvOptions): Env {
       batch: async () => [],
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -196,7 +193,6 @@ function makeGetEnvWithCapture(opts: GetEnvOptions): {
       batch: async () => [],
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -121,7 +121,6 @@ function makeEnv(db: D1Database): Env {
   return {
     DB: db,
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/api/version.test.ts
+++ b/worker/src/api/version.test.ts
@@ -19,7 +19,6 @@ function mockEnv(row: Record<string, unknown> | null): { env: Env; getCapturedSq
       },
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { getInstallationToken, resolveInstallToken } from "./installToken";
+import {
+  getInstallationToken,
+  resolveInstallToken,
+  listInstallationRepos,
+} from "./installToken";
 import type { Env } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -129,7 +133,6 @@ async function buildFakeEnv(
   const env: Env = {
     DB: null as unknown as D1Database, // overridden per test
     ASSETS: null as unknown as Fetcher,
-    GITHUB_TOKEN: "gh_test_token",
     GITHUB_ORG: "TestOrg",
     GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
     GITHUB_APP_ID: "999999",
@@ -534,5 +537,74 @@ describe("resolveInstallToken — fail-closed guards", () => {
 
     // Assert — cache-hit decrypt path returns the expected plaintext token
     expect(token).toBe(plaintext);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listInstallationRepos — W2 pagination bound (#160)
+// ---------------------------------------------------------------------------
+
+describe("listInstallationRepos — W2 pagination bound", () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  function fullPage(): Response {
+    // Exactly 100 repos → a "full" page that signals more pages may follow.
+    const repositories = Array.from({ length: 100 }, (_, i) => ({
+      full_name: `o/repo-${i}`,
+    }));
+    return new Response(JSON.stringify({ repositories }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("caps pagination at MAX_PAGES (10) and warns on truncation when every page is full", async () => {
+    const fetchMock = vi.fn(async () => fullPage());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const repos = await listInstallationRepos("fake-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(10); // MAX_PAGES — never exceeded
+    expect(repos).toHaveLength(1000); // 10 pages × 100 repos
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("MAX_PAGES"));
+  });
+
+  it("passes an AbortSignal (per-page timeout) on every fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ repositories: [{ full_name: "o/r" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await listInstallationRepos("fake-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const opts = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("stops early on a short final page and does NOT warn (normal case)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ repositories: [{ full_name: "o/only" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const repos = await listInstallationRepos("fake-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // short page → single fetch
+    expect(repos).toEqual(["o/only"]);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -224,10 +224,11 @@ interface GHInstallationReposResponse {
  * @returns Array of `"owner/name"` full_name strings.
  */
 export async function listInstallationRepos(token: string): Promise<string[]> {
+  const MAX_PAGES = 10;
   const repos: string[] = [];
-  let page = 1;
+  let lastPageFull = false;
 
-  while (true) {
+  for (let page = 1; page <= MAX_PAGES; page++) {
     const url = `https://api.github.com/installation/repositories?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
@@ -236,6 +237,7 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
         "User-Agent": "roxabi-live-worker",
         "X-GitHub-Api-Version": "2022-11-28",
       },
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!res.ok) {
@@ -259,12 +261,18 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
       repos.push(r.full_name);
     }
 
+    lastPageFull = pageRepos.length === 100;
+
     // Stop if this page was not full (last page)
     if (pageRepos.length < 100) {
       break;
     }
+  }
 
-    page++;
+  if (lastPageFull) {
+    console.warn(
+      `[installToken] listInstallationRepos hit MAX_PAGES (${MAX_PAGES}) — repo list may be truncated`,
+    );
   }
 
   return repos;

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -95,7 +95,6 @@ function makeEnv(db: D1Database): Env {
   return {
     DB: db,
     ASSETS: {} as Fetcher,
-    GITHUB_TOKEN: "gh-token",
     GITHUB_ORG: "Roxabi",
     GITHUB_WEBHOOK_SECRET: "webhook-secret",
     GITHUB_APP_ID: "12345",

--- a/worker/src/sync/graphql.ts
+++ b/worker/src/sync/graphql.ts
@@ -3,7 +3,7 @@
  *
  * Replaces the `gh api graphql` subprocess with a direct fetch() call so the
  * transport runs inside the Cloudflare Worker runtime. The token is an explicit
- * parameter (comes from env.GITHUB_TOKEN) rather than being ambient.
+ * parameter (a per-installation GitHub App token, #160) rather than being ambient.
  */
 
 import { SINGLE_ISSUE_DEPS_QUERY } from "./queries";
@@ -108,7 +108,7 @@ interface IssueDepsData {
  * @param owner   Repository owner (org or user login).
  * @param name    Repository name.
  * @param number  Issue number.
- * @param token   GitHub PAT (env.GITHUB_TOKEN in Worker context).
+ * @param token   GitHub token (per-installation GitHub App token, #160).
  * @returns       `{ blocked_by, blocking }` — each a list of `"owner/repo#N"` keys.
  */
 export async function fetchIssueDeps(

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1432,6 +1432,401 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// runSync — breaker + discovery (#160)
+// ---------------------------------------------------------------------------
+
+describe("runSync — breaker + discovery (#160)", () => {
+  function makeEnv(overrides: Record<string, unknown> = {}): Env {
+    return {
+      DB: undefined as unknown as D1Database,
+      GITHUB_ORG: "Roxabi",
+      ...overrides,
+    } as unknown as Env;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("B1: discovery failure increments the tenant breaker", async () => {
+    // Arrange
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockRejectedValue(new Error("token-error"));
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
+
+    const db = makeFakeDb((sql, args) => {
+      // Global tick lock (tenant_id=0) → acquired (changes=1)
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // Tenant lock (tenant_id=1) → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // halted guard
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT for tenant after increment → return count
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "1" }], 0);
+      }
+      // tenants discovery
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — auth_failures UPDATE was issued bound to tenant_id=1
+    const recorded = db._recorded;
+    const authFailureUpdate = recorded.find(
+      (s) =>
+        s.sql.includes("auth_failures") &&
+        s.sql.includes("UPDATE") &&
+        s.args.includes(1),
+    );
+    expect(authFailureUpdate).toBeDefined();
+  });
+
+  it("B3: discoverTenants upserts repos and deletes stale tenant_repo_access", async () => {
+    // Arrange
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("tok");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/keep"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      // Global tick lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // Tenant lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // halted guard
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT → not halted
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // tenants discovery → 1 tenant
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      // existing tenant_repo_access rows → keep + stale
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/keep" }, { repo: "o/stale" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — INSERT for "o/keep"
+    const recorded = db._recorded;
+    const insertKeep = recorded.find(
+      (s) =>
+        s.sql.includes("INSERT OR IGNORE INTO tenant_repo_access") &&
+        s.args.includes("o/keep"),
+    );
+    expect(insertKeep).toBeDefined();
+
+    // Assert — DELETE for "o/stale" (not for "o/keep")
+    const deleteStale = recorded.find(
+      (s) =>
+        s.sql.includes("DELETE FROM tenant_repo_access") &&
+        s.args.includes("o/stale"),
+    );
+    expect(deleteStale).toBeDefined();
+
+    const deleteKeep = recorded.find(
+      (s) =>
+        s.sql.includes("DELETE FROM tenant_repo_access") &&
+        s.args.includes("o/keep"),
+    );
+    expect(deleteKeep).toBeUndefined();
+  });
+
+  it("B4: token-exhausted repo is skipped, runSync resolves without throwing", async () => {
+    // Arrange — getInstallationToken always rejects for Phase 2 lookups
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockRejectedValue(new Error("no-token"));
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/a"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "1" }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/a" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act + Assert — runSync resolves (does not throw)
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // ghGraphql must NOT have been called with REPO_BUNDLE_QUERY for o/a
+    const bundleCalls = vi.mocked(ghGraphql).mock.calls.filter(
+      (c) => c[0] === "REPO_BUNDLE_QUERY",
+    );
+    expect(bundleCalls).toHaveLength(0);
+  });
+
+  it("B2: systemic failure halts and POSTs NOTIFY at threshold (≥2)", async () => {
+    // Arrange — discovery succeeds (listInstallationRepos returns repos), Phase 2
+    // token fetch always fails → every windowed repo skipped → systemic failure.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    // Discovery Phase 1 calls: getInstallationToken (once, for the tenant) then listInstallationRepos.
+    // We need Phase 1 to succeed so repos enter the window, then Phase 2 token fetch to fail.
+    // Use mockResolvedValueOnce for the Phase 1 call, then reject for all subsequent.
+    vi.mocked(getInstallationToken)
+      .mockResolvedValueOnce("tok-discovery") // Phase 1 success
+      .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT — return ≥2 for global (tenant_id=0) to trigger halt
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        const val = args[0] === 0 ? "2" : "1";
+        return makeFakeStmt(sql, args, [{ value: val }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db, NOTIFY_URL: "https://notify.example.com/hook" });
+
+    // Act
+    await runSync(env);
+
+    // Assert — a halted-related UPDATE was fired (haltSync writes to sync_control)
+    // The SQL sets halted='1' or value='1' where key='halted'
+    const recorded = db._recorded;
+    const haltUpdate = recorded.find(
+      (s) =>
+        s.sql.includes("halted") &&
+        s.sql.includes("UPDATE"),
+    );
+    expect(haltUpdate).toBeDefined();
+
+    // Assert — fetch was called with NOTIFY_URL and body containing 'sync_halted'
+    const notifyCalls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("notify.example.com"),
+    );
+    expect(notifyCalls.length).toBeGreaterThan(0);
+    const bodyArg = notifyCalls[0][1] as { body?: string };
+    expect(bodyArg?.body).toMatch(/sync_halted/);
+  });
+
+  it("B2: systemic failure below threshold does NOT halt (auth_failures=1)", async () => {
+    // Arrange — same as B2 threshold but auth_failures stays at 1 (below halt trigger)
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken)
+      .mockResolvedValueOnce("tok-discovery") // Phase 1 success
+      .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT always returns 1 (below threshold — no halt)
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "1" }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db, NOTIFY_URL: "https://notify.example.com/hook" });
+
+    // Act
+    await runSync(env);
+
+    // Assert — NO halted UPDATE issued
+    const recorded = db._recorded;
+    const haltUpdate = recorded.find(
+      (s) =>
+        s.sql.includes("halted") &&
+        s.sql.includes("UPDATE"),
+    );
+    expect(haltUpdate).toBeUndefined();
+
+    // Assert — fetch was NOT called with NOTIFY_URL
+    const notifyCalls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("notify.example.com"),
+    );
+    expect(notifyCalls).toHaveLength(0);
+  });
+
+  it("B1b: successful run resets auth_failures for both global (tenant_id=0) and participating tenant", async () => {
+    // Arrange — 1 tenant id=7, 1 repo synced OK
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("tok-7");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/ok"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 7, installation_id: 70 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/ok" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — auth_failures reset UPDATE (value='0') for tenant_id=0
+    const recorded = db._recorded;
+    const resetGlobal = recorded.find(
+      (s) =>
+        s.sql.includes("auth_failures") &&
+        s.sql.includes("UPDATE") &&
+        s.sql.includes("value='0'") &&
+        s.args.includes(0),
+    );
+    expect(resetGlobal).toBeDefined();
+
+    // Assert — auth_failures reset UPDATE (value='0') for tenant_id=7
+    const resetTenant = recorded.find(
+      (s) =>
+        s.sql.includes("auth_failures") &&
+        s.sql.includes("UPDATE") &&
+        s.sql.includes("value='0'") &&
+        s.args.includes(7),
+    );
+    expect(resetTenant).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Teardown
 // ---------------------------------------------------------------------------
 

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -504,7 +504,7 @@ describe("acquireSyncLock", () => {
     // Assert
     expect(capturedStmts).toHaveLength(1);
     expect(capturedStmts[0].sql).toContain("key = 'sync_running'");
-    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = ?");
   });
 });
 
@@ -553,9 +553,9 @@ describe("haltSync", () => {
     expect(capturedStmts[0].sql).toContain("value='1'");
     expect(capturedStmts[0].sql).toContain("key='halted'");
     // tenant isolation guard must be present (TF3)
-    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
-    // only the ISO timestamp is bound
-    expect(capturedStmts[0].args).toHaveLength(1);
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = ?");
+    // ISO timestamp + tenantId are bound
+    expect(capturedStmts[0].args).toHaveLength(2);
     expect(typeof capturedStmts[0].args[0]).toBe("string");
     expect(String(capturedStmts[0].args[0])).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
@@ -590,9 +590,9 @@ describe("auth failure helpers", () => {
     expect(capturedStmts[0].sql).toContain("value='0'");
     expect(capturedStmts[0].sql).toContain("key='auth_failures'");
     // tenant isolation guard must be present (TF3)
-    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
-    // only the ISO timestamp is bound
-    expect(capturedStmts[0].args).toHaveLength(1);
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = ?");
+    // ISO timestamp + tenantId are bound
+    expect(capturedStmts[0].args).toHaveLength(2);
     expect(String(capturedStmts[0].args[0])).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
@@ -656,6 +656,12 @@ vi.mock("./queries", () => ({
   REPO_BUNDLE_QUERY: "REPO_BUNDLE_QUERY",
   REPOS_QUERY: "REPOS_QUERY",
   STUB_ISSUE_QUERY: "STUB_ISSUE_QUERY",
+}));
+
+vi.mock("../auth/installToken", () => ({
+  getInstallationToken: vi.fn(),
+  resolveInstallToken: vi.fn(),
+  listInstallationRepos: vi.fn(),
 }));
 
 describe("syncRepoIssues", () => {
@@ -925,7 +931,6 @@ describe("runSync", () => {
   function makeEnv(overrides: Record<string, unknown> = {}): Env {
     return {
       DB: undefined as unknown as D1Database,
-      GITHUB_TOKEN: "tok",
       GITHUB_ORG: "Roxabi",
       ...overrides,
     } as unknown as Env;
@@ -964,162 +969,38 @@ describe("runSync", () => {
     expect(vi.mocked(ghGraphql)).not.toHaveBeenCalled();
   });
 
-  it("returns early (logs warn) when allowlist is empty", async () => {
-    let callIdx = 0;
+  it("returns early (logs warn) when no tenants with installation_id exist", async () => {
+    const { listInstallationRepos } = await import("../auth/installToken");
+    const { getInstallationToken } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
+
     const db = makeFakeDb((sql, args) => {
-      callIdx++;
-      if (sql.includes("key='halted'") || (callIdx === 1 && sql.includes("sync_control"))) {
-        // isHalted → halted=0
-        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
-      }
-      if (sql.includes("UPDATE") && sql.includes("sync_running")) {
-        // acquireSyncLock → acquired (changes=1)
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      if (sql.includes("sync_started_at")) {
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      if (sql.includes("repo_allowlist") || sql.includes("SELECT key FROM")) {
-        // getRepoAllowlist → empty
+      if (sql.includes("FROM tenants")) {
+        // discoverTenants → empty (no tenants with installation_id)
         return makeFakeStmt(sql, args, []);
       }
-      // releaseSyncLock
       return makeFakeStmt(sql, args, [], 1);
     });
-
-    // Override batch to work nicely
-    (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch.mockResolvedValue([]);
 
     const env = makeEnv({ DB: db });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     await expect(runSync(env)).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("repo_allowlist empty"));
-    warnSpy.mockRestore();
-  });
-
-  it("halts when auth failures reach threshold (>=2)", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // enumerateOrgRepos calls ghGraphql; throw auth error
-    mockGhGraphql.mockRejectedValue(new GraphQLError("auth", true));
-
-    let callIdx = 0;
-    const db = makeFakeDb((sql, args) => {
-      callIdx++;
-      // isHalted → not halted
-      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
-      // acquireSyncLock → acquired
-      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      // sync_started_at update
-      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      // getRepoAllowlist → one repo so we proceed past the empty check
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/lyra" }]);
-      }
-      // incrementAuthFailures UPDATE → changes=1
-      if (sql.includes("auth_failures") && sql.includes("UPDATE")) {
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      // incrementAuthFailures SELECT → value=2 (at threshold)
-      if (sql.includes("auth_failures") && sql.includes("SELECT")) {
-        return makeFakeStmt(sql, args, [{ value: "2" }], 0);
-      }
-      // haltSync UPDATE, releaseSyncLock
-      return makeFakeStmt(sql, args, [], 1);
-    });
-
-    const env = makeEnv({ DB: db });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("HALTED"),
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("no repos discovered across all installations — nothing to sync"),
     );
-    errorSpy.mockRestore();
-  });
-
-  // Halt-alert POST path (S8, #100) ----------------------------------------
-
-  // Builds a FakeD1 that drives runSync straight to the auth-halt branch
-  // (isHalted=0 → lock acquired → one allowlist repo → ghGraphql throws auth →
-  // auth_failures=2 → haltSync). Shared by the two NOTIFY_URL tests below.
-  function makeHaltDb() {
-    return makeFakeDb((sql, args) => {
-      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
-      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/lyra" }]);
-      }
-      if (sql.includes("auth_failures") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("auth_failures") && sql.includes("SELECT")) return makeFakeStmt(sql, args, [{ value: "2" }], 0);
-      return makeFakeStmt(sql, args, [], 1);
-    });
-  }
-
-  it("POSTs a sync_halted alert to NOTIFY_URL when the breaker trips", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(null, { status: 200 }));
-
-    const env = makeEnv({ DB: makeHaltDb(), NOTIFY_URL: "https://ntfy.example/roxabi" });
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe("https://ntfy.example/roxabi");
-    expect(init).toMatchObject({ method: "POST" });
-    expect(String((init as RequestInit).body)).toContain("sync_halted");
-  });
-
-  it("does not POST when NOTIFY_URL is unset", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    const env = makeEnv({ DB: makeHaltDb() }); // no NOTIFY_URL
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  // R2 run-audit (#120) -----------------------------------------------------
-
-  it("writes a run-audit object to R2 (outcome=halted) on the halt path", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const put = vi.fn().mockResolvedValue(undefined);
-
-    const env = makeEnv({ DB: makeHaltDb(), LOGS: { put } as unknown as R2Bucket });
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(put).toHaveBeenCalledTimes(1);
-    const [key, body] = put.mock.calls[0];
-    expect(key).toMatch(/^runs\/\d{4}-\d{2}-\d{2}\/.+\.json$/);
-    expect(JSON.parse(body as string).outcome).toBe("halted");
+    warnSpy.mockRestore();
   });
 
   // Prune + archived-repo tracking (#N) -------------------------------------
 
   /**
    * Builds a FakeD1 that drives runSync through the prune path:
-   *   isHalted=0 → lock acquired → allowlist=[Roxabi/roxabi-factory] →
-   *   ghGraphql returns live=[roxabi-factory] + archived=[roxabi-vault] →
+   *   discoverTenants → [{id:1, installation_id:139542392}] →
+   *   lock acquired → getInstallationToken → listInstallationRepos=[Roxabi/roxabi-factory] →
    *   DB SELECT DISTINCT queries return stale=[Roxabi/lyra] in issues/edges/pr_state/sync_state →
    *   batchChunked invoked with DELETE stmts for Roxabi/lyra
-   *
-   * Callers replace ghGraphql mocks before calling makeFullSyncDb.
    */
   function makeFullSyncDb(opts: {
     issueRepos?: string[];
@@ -1140,8 +1021,13 @@ describe("runSync", () => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      // discoverTenants
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 139542392 }]);
+      }
+      // tenant_repo_access (not used in prune path but respond gracefully)
+      if (sql.includes("FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ owner: "Roxabi", name: "roxabi-factory" }]);
       }
       // Prune SELECT DISTINCT queries
       if (sql.includes("SELECT DISTINCT repo FROM issues")) {
@@ -1165,34 +1051,14 @@ describe("runSync", () => {
   }
 
   it("prunes issues/edges/pr_state/sync_state for a deleted repo (Roxabi/lyra)", async () => {
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // listInstallationRepos returns only roxabi-factory (lyra is gone)
+    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → live: only roxabi-factory (lyra is gone)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // syncRepoBundle calls (REPO_BUNDLE_QUERY) for roxabi-factory — empty result
+    // syncRepoBundle calls for roxabi-factory — empty result
     mockGhGraphql.mockResolvedValue({
       data: {
         repository: {
@@ -1223,35 +1089,15 @@ describe("runSync", () => {
     expect(deletedEdgeStmts.length).toBeGreaterThan(0);
   });
 
-  it("does NOT prune rows for an archived repo (roxabi-vault stays)", async () => {
+  it("does NOT prune rows for a repo still accessible via installation (roxabi-vault stays)", async () => {
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // listInstallationRepos returns both repos — roxabi-vault is still accessible
+    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory", "Roxabi/roxabi-vault"]);
+
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → live: only roxabi-factory
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault (it IS in archived, not stale)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // syncRepoBundle empty result for roxabi-factory
+    // syncRepoBundle empty result for each repo
     mockGhGraphql.mockResolvedValue({
       data: {
         repository: {
@@ -1263,7 +1109,7 @@ describe("runSync", () => {
       },
     });
 
-    // DB returns roxabi-vault as present in issues — but it's archived, so NOT stale
+    // DB returns roxabi-vault as present in issues — but it's still in live set, so NOT stale
     const db = makeFullSyncDb({
       issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
       edgeSrcRepos: [],
@@ -1283,41 +1129,18 @@ describe("runSync", () => {
     expect(deletedVaultStmts).toHaveLength(0);
   });
 
-  it("skips all prune logic (warn) when live repo enumeration returns 0 repos", async () => {
-    const { ghGraphql } = await import("./graphql");
-    const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → live: empty (transient error)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
+  it("skips all prune logic (warn) when listInstallationRepos returns 0 repos", async () => {
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // listInstallationRepos returns empty — transient error
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 139542392 }]);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
@@ -1328,77 +1151,14 @@ describe("runSync", () => {
     const env = makeEnv({ DB: db });
     await expect(runSync(env)).resolves.toBeUndefined();
 
-    // Safety guard must have warned
+    // Safety guard must have warned — new flow emits the "nothing to sync" message
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("live repo enumeration returned 0 repos"),
+      expect.stringContaining("no repos discovered across all installations — nothing to sync"),
     );
 
     // No DELETE statements should have been issued
     const deleteStmts = db._recorded.filter((s) => s.sql.includes("DELETE"));
     expect(deleteStmts).toHaveLength(0);
-  });
-
-  it("upserts repos table with archived=1 when a repo moves live→archived", async () => {
-    const { ghGraphql } = await import("./graphql");
-    const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → roxabi-factory live (roxabi-vault is now archived, not in live list)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY → roxabi-vault is now archived
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // syncRepoBundle empty result
-    mockGhGraphql.mockResolvedValue({
-      data: {
-        repository: {
-          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
-          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
-          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
-        },
-        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-
-    const db = makeFullSyncDb({
-      issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
-      edgeSrcRepos: [],
-      edgeDstRepos: [],
-      prStateRepos: [],
-      syncStateRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
-    });
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    const env = makeEnv({ DB: db });
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    // The upsert INSERT stmt for Roxabi/roxabi-vault must use the archived=1 SQL variant
-    // (literal `1` is in the SQL text, not in bind args — only the repo name is bound)
-    const archivedUpsertStmts = db._recorded.filter(
-      (s) =>
-        s.sql.includes("INSERT INTO repos") &&
-        s.sql.includes("VALUES (?, 1)") &&
-        s.args.includes("Roxabi/roxabi-vault"),
-    );
-    expect(archivedUpsertStmts.length).toBeGreaterThan(0);
   });
 });
 
@@ -1482,95 +1242,124 @@ describe("writeRunAudit", () => {
 //      throws before syncRepoBundle. Add the mock when implementing #160.
 // ---------------------------------------------------------------------------
 
-describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-skip + fix in S3b)", () => {
+describe("runSync — multi-tenant installation sync (#160)", () => {
   // Local makeEnv scoped to this describe so it composes cleanly
   function makeEnv(overrides: Record<string, unknown> = {}): Env {
     return {
       DB: undefined as unknown as D1Database,
-      GITHUB_TOKEN: "tok",
       GITHUB_ORG: "Roxabi",
       ...overrides,
     } as unknown as Env;
   }
 
   it("deduplicates GraphQL bundle fetches: two tenants sharing repo o/r → exactly 1 REPO_BUNDLE_QUERY issued for o/r", async () => {
-    // Two tenants both have tenant_repo_access for "o/r".
-    // The future multi-tenant runSync must deduplicate: one fetch regardless of tenant count.
+    // Two tenants both have access to "o/r" via their install tokens.
+    // runSync must deduplicate: one syncRepoBundle call regardless of tenant count.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // Both tenants enumerate the same repo "o/r"
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      // Future: tenants table → two rows
       if (sql.includes("FROM tenants")) {
         return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
-      }
-      // Future: tenant_repo_access for both tenants → same repo "o/r"
-      if (sql.includes("FROM tenant_repo_access")) {
-        return makeFakeStmt(sql, args, [{ owner: "o", name: "r" }, { owner: "o", name: "r" }]);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
 
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
-    // Future REPO_BUNDLE_QUERY path — stub returns minimal valid shape
+    // syncRepoBundle uses REPO_BUNDLE_QUERY — stub returns minimal valid shape
     mockGhGraphql.mockResolvedValue({
-      data: { repository: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] }, pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } },
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
     });
 
     const env = makeEnv({ DB: db });
+    vi.spyOn(console, "log").mockImplementation(() => {});
     await runSync(env);
 
-    // Exactly 1 ghGraphql call with REPO_BUNDLE_QUERY for owner="o", name="r"
+    // Exactly 1 ghGraphql call for repo o/r (deduplication)
     const bundleCalls = mockGhGraphql.mock.calls.filter(
-      (c) => c[0] === "REPO_BUNDLE_QUERY" && c[1]?.owner === "o" && c[1]?.name === "r",
+      (c) => (c[1] as Record<string, unknown>)?.owner === "o" && (c[1] as Record<string, unknown>)?.name === "r",
     );
     expect(bundleCalls).toHaveLength(1);
   });
 
   it("advances sync_slot per tick: seed sync_slot=0, after runSync the slot is updated", async () => {
-    // Future: sync_control row sync_slot tracks which window of repos was processed.
-    // The current impl has no windowing — this test will fail (RED) until slot logic is added.
+    // sync_control row sync_slot tracks which window of repos was processed.
+    // Discovery must yield ≥1 repo so Phase 2 runs and reaches the slot-advance write.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
     let syncSlotWritten = false;
+    let nextSlotValue: unknown;
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
       // Return sync_slot=0 on read
       if (sql.includes("sync_slot") && sql.includes("SELECT")) {
-        return makeFakeStmt(sql, args, [{ key: "sync_slot", value: "0" }]);
+        return makeFakeStmt(sql, args, [{ value: "0" }]);
       }
-      // Detect the slot-advance write (INSERT OR REPLACE / UPDATE with key=sync_slot)
-      if (sql.includes("sync_slot") && (sql.includes("INSERT") || sql.includes("UPDATE"))) {
+      // Detect the slot-advance write (UPDATE with key=sync_slot); capture bound value.
+      if (sql.includes("sync_slot") && sql.includes("UPDATE")) {
         syncSlotWritten = true;
+        nextSlotValue = args[0];
         return makeFakeStmt(sql, args, [], 1);
-      }
-      // repo_allowlist — empty → runSync short-circuits after acquiring lock
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, []);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const env = makeEnv({ DB: db });
     await runSync(env);
-    warnSpy.mockRestore();
 
-    // Assertion: the sync run must have written an updated sync_slot value.
-    // Currently no slot logic exists → syncSlotWritten stays false → RED.
+    // The sync run must advance sync_slot: 0 → (0+1) % NUM_SLOTS = 1.
     expect(syncSlotWritten).toBe(true);
+    expect(nextSlotValue).toBe("1");
   });
 
   it("per-tenant lock isolation: tenant A holding sync_running=1 does NOT prevent tenant B from syncing", async () => {
-    // Future: acquireSyncLock(db, tenantId) must be scoped per-tenant.
-    // Current impl: global lock (tenant_id=0 hardcoded) → tenant A's lock blocks everyone → RED.
+    // acquireSyncLock(db, tenantId) is per-tenant: tenant A's held lock (changes=0)
+    // must not stop discovery from attempting tenant B's own lock.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
+
     let tenantBLockAttempted = false;
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) {
-        // Lock for tenant A (id=1) is held → changes=0; lock for tenant B (id=2) is free → changes=1
-        const tenantArg = args.find((a) => typeof a === "number");
+        // Lock bound as [..., tenantId] — tenantId is last arg (a number)
+        const tenantArg = [...args].reverse().find((a) => typeof a === "number");
+        if (tenantArg === 0) return makeFakeStmt(sql, args, [], 1); // global tick lock: acquired
         if (tenantArg === 1) return makeFakeStmt(sql, args, [], 0); // tenant A: lock held
         if (tenantArg === 2) {
           tenantBLockAttempted = true;
@@ -1582,9 +1371,6 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
       if (sql.includes("FROM tenants")) {
         return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
       }
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, []);
-      }
       return makeFakeStmt(sql, args, [], 1);
     });
 
@@ -1593,25 +1379,25 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
     await runSync(env);
     warnSpy.mockRestore();
 
-    // Tenant B's lock attempt must have been made (i.e., runSync iterates tenants independently).
-    // With current single-tenant global lock this never happens → RED.
+    // Tenant B's lock attempt must have been made (runSync iterates tenants independently).
     expect(tenantBLockAttempted).toBe(true);
   });
 
   it("no PAT access: runSync completes via install tokens without reading env.GITHUB_TOKEN", async () => {
-    // Future: runSync must use resolveInstallToken() and never fall back to the PAT.
-    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos (line ~1161) → spy records it.
-    // The DB must return a non-empty allowlist so runSync advances past the early-return
-    // guard and actually reaches the PAT read site (enumerateOrgRepos / syncRepoBundle).
+    // runSync must use getInstallationToken() and never read env.GITHUB_TOKEN.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
       data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "r", owner: { login: "o" }, isArchived: false, isPrivate: false }],
-          },
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
         },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
       },
     });
 
@@ -1619,9 +1405,8 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      // Non-empty allowlist — ensures runSync does NOT short-circuit before the PAT read
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "o/r" }]);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 139542392 }]);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
@@ -1633,15 +1418,15 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
     Object.defineProperty(base, "GITHUB_TOKEN", {
       get() {
         patAccessCount++;
-        return "tok"; // still returns a value so runSync can proceed (error swallowing aside)
+        return "tok";
       },
       configurable: true,
     });
 
+    vi.spyOn(console, "log").mockImplementation(() => {});
     await runSync(base);
 
-    // Future impl: patAccessCount must be 0 (resolveInstallToken used instead).
-    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos + archivedRepos → count > 0 → RED.
+    // runSync must not read env.GITHUB_TOKEN — install token is used exclusively.
     expect(patAccessCount).toBe(0);
   });
 });

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -25,7 +25,9 @@ import { getInstallationToken, listInstallationRepos } from "../auth/installToke
 // ---------------------------------------------------------------------------
 
 export const MAX_PAGES = 500;
+/** Repos synced per slot per tick. Coverage ceiling: WINDOW * NUM_SLOTS = 60 repos. */
 export const WINDOW = 20;
+/** Number of rotation slots. Coverage ceiling: WINDOW * NUM_SLOTS = 60 repos. */
 export const NUM_SLOTS = 3;
 
 /** Verbatim port of sync.py UPSERT_ISSUE_SQL — full sync path (sets status=null). */
@@ -1109,6 +1111,7 @@ export async function discoverTenants(
         repos = await listInstallationRepos(token);
       } catch (err) {
         console.error(`[sync] tenant ${tenantId} discovery failed:`, err);
+        await incrementAuthFailures(db, tenantId);
         continue;
       }
 
@@ -1198,6 +1201,9 @@ export async function runSync(env: Env): Promise<void> {
       return;
     }
 
+    if (allRepos.length > WINDOW * NUM_SLOTS)
+      console.warn(`[sync] ${allRepos.length} repos exceed window capacity ${WINDOW * NUM_SLOTS} — repos beyond index ${WINDOW * NUM_SLOTS} are not synced this cycle`);
+
     // Upsert repos table from the union.
     const repoUpsertStmts = allRepos.map((repo) =>
       db
@@ -1279,7 +1285,8 @@ export async function runSync(env: Env): Promise<void> {
     const slot = parseInt(slotRow?.value ?? "0", 10);
     const windowStart = slot * WINDOW;
     const windowEnd = windowStart + WINDOW;
-    const windowedRepos = allRepos.slice(windowStart, windowEnd);
+    // Windowing only engages past WINDOW repos; below that, sync everything hourly.
+    const windowedRepos = allRepos.length <= WINDOW ? allRepos : allRepos.slice(windowStart, windowEnd);
 
     console.log(
       `[sync] slot=${slot} window=[${windowStart},${windowEnd}) repos=${windowedRepos.length}/${allRepos.length}`,
@@ -1301,6 +1308,7 @@ export async function runSync(env: Env): Promise<void> {
 
     // Pass 1: bundled issues + refs + PRs per repo in window.
     const collectedEdges = new Map<string, EdgeData>();
+    let skippedCount = 0;
     for (const repo of windowedRepos) {
       const slash = repo.indexOf("/");
       const owner = repo.slice(0, slash);
@@ -1311,12 +1319,8 @@ export async function runSync(env: Env): Promise<void> {
         const token = await resolveToken();
         await syncRepoBundle(db, token, owner, name, collectedEdges);
       } catch (err) {
-        if (err instanceof GraphQLError && err.isAuth) {
-          // Auth failure already counted above; skip this repo, don't abort.
-          console.error(`[sync] skipping ${repo} — all tokens failed`);
-        } else {
-          console.error(`[sync] skipping ${repo}:`, err);
-        }
+        console.error(`[sync] skipping ${repo}:`, err);
+        skippedCount++;
       }
     }
 
@@ -1343,17 +1347,14 @@ export async function runSync(env: Env): Promise<void> {
       .bind(String(nextSlot), new Date().toISOString())
       .run();
 
-    await resetAuthFailures(db);
-    outcome = "success";
-  } catch (err) {
-    const isAuth = err instanceof GraphQLError && err.isAuth;
-    if (isAuth) {
-      const failures = await incrementAuthFailures(db);
-      console.error(`[sync] auth failure ${failures}/2`);
+    const systemicFailure = windowedRepos.length > 0 && skippedCount === windowedRepos.length;
+    if (systemicFailure) {
+      const failures = await incrementAuthFailures(db, 0);
+      console.error(`[sync] all ${windowedRepos.length} windowed repo(s) failed — systemic auth failure ${failures}/2`);
       outcome = failures >= 2 ? "halted" : "auth_error";
       if (failures >= 2) {
-        await haltSync(db);
-        console.error("[sync] HALTED: 2 consecutive auth failures");
+        await haltSync(db, 0);
+        console.error("[sync] HALTED: systemic token failure across all repos");
         const notifyUrl = env.NOTIFY_URL;
         if (notifyUrl) {
           await fetch(notifyUrl, {
@@ -1363,10 +1364,18 @@ export async function runSync(env: Env): Promise<void> {
           }).catch(() => {});
         }
       }
-    } else {
-      outcome = "error";
-      console.error("[sync] error:", err);
     }
+
+    if (!systemicFailure) {
+      const tenantIds = new Set<number>();
+      for (const list of repoTenantMap.values()) for (const e of list) tenantIds.add(e.tenantId);
+      await resetAuthFailures(db, 0);
+      for (const id of tenantIds) await resetAuthFailures(db, id);
+      outcome = "success";
+    }
+  } catch (err) {
+    outcome = "error";
+    console.error("[sync] error:", err);
   } finally {
     await releaseSyncLock(db);
     await writeRunAudit(env, db, {

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -11,21 +11,22 @@
 
 import { ghGraphql, GraphQLError } from "./graphql";
 import {
-  ARCHIVED_REPOS_QUERY,
   ISSUES_QUERY,
   PRS_QUERY,
   REFS_QUERY,
   REPO_BUNDLE_QUERY,
-  REPOS_QUERY,
   STUB_ISSUE_QUERY,
 } from "./queries";
 import type { Env } from "../types";
+import { getInstallationToken, listInstallationRepos } from "../auth/installToken";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 export const MAX_PAGES = 500;
+export const WINDOW = 20;
+export const NUM_SLOTS = 3;
 
 /** Verbatim port of sync.py UPSERT_ISSUE_SQL — full sync path (sets status=null). */
 export const UPSERT_ISSUE_SQL = `
@@ -210,158 +211,68 @@ export async function batchChunked(
 // sync_control helpers
 // ---------------------------------------------------------------------------
 
-export async function acquireSyncLock(db: D1Database): Promise<boolean> {
+export async function acquireSyncLock(db: D1Database, tenantId: number = 0): Promise<boolean> {
   const result = await db
     .prepare(
       `UPDATE sync_control
        SET value = '1', updated_at = ?
        WHERE key = 'sync_running'
-         AND tenant_id = 0
+         AND tenant_id = ?
          AND (value = '0' OR (CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', updated_at) AS INTEGER)) > 900)`,
     )
-    .bind(new Date().toISOString())
+    .bind(new Date().toISOString(), tenantId)
     .run();
   return result.meta.changes > 0;
 }
 
-export async function releaseSyncLock(db: D1Database): Promise<void> {
+export async function releaseSyncLock(db: D1Database, tenantId: number = 0): Promise<void> {
   await db
-    .prepare(`UPDATE sync_control SET value='0', updated_at=? WHERE key='sync_running' AND tenant_id = 0`)
-    .bind(new Date().toISOString())
+    .prepare(`UPDATE sync_control SET value='0', updated_at=? WHERE key='sync_running' AND tenant_id = ?`)
+    .bind(new Date().toISOString(), tenantId)
     .run();
 }
 
-export async function isHalted(db: D1Database): Promise<boolean> {
+export async function isHalted(db: D1Database, tenantId: number = 0): Promise<boolean> {
   const row = await db
-    .prepare(`SELECT value FROM sync_control WHERE key='halted' AND tenant_id = 0`)
+    .prepare(`SELECT value FROM sync_control WHERE key='halted' AND tenant_id = ?`)
+    .bind(tenantId)
     .first<{ value: string }>();
   return row?.value === "1";
 }
 
-export async function getAuthFailures(db: D1Database): Promise<number> {
+export async function getAuthFailures(db: D1Database, tenantId: number = 0): Promise<number> {
   const row = await db
-    .prepare(`SELECT value FROM sync_control WHERE key='auth_failures' AND tenant_id = 0`)
+    .prepare(`SELECT value FROM sync_control WHERE key='auth_failures' AND tenant_id = ?`)
+    .bind(tenantId)
     .first<{ value: string }>();
   return parseInt(row?.value ?? "0", 10);
 }
 
-export async function incrementAuthFailures(db: D1Database): Promise<number> {
+export async function incrementAuthFailures(db: D1Database, tenantId: number = 0): Promise<number> {
   await db
     .prepare(
       `UPDATE sync_control SET value=CAST(CAST(value AS INTEGER)+1 AS TEXT), updated_at=?
-       WHERE key='auth_failures' AND tenant_id = 0`,
+       WHERE key='auth_failures' AND tenant_id = ?`,
     )
-    .bind(new Date().toISOString())
+    .bind(new Date().toISOString(), tenantId)
     .run();
-  return getAuthFailures(db);
+  return getAuthFailures(db, tenantId);
 }
 
-export async function haltSync(db: D1Database): Promise<void> {
+export async function haltSync(db: D1Database, tenantId: number = 0): Promise<void> {
   await db
-    .prepare(`UPDATE sync_control SET value='1', updated_at=? WHERE key='halted' AND tenant_id = 0`)
-    .bind(new Date().toISOString())
+    .prepare(`UPDATE sync_control SET value='1', updated_at=? WHERE key='halted' AND tenant_id = ?`)
+    .bind(new Date().toISOString(), tenantId)
     .run();
 }
 
-export async function resetAuthFailures(db: D1Database): Promise<void> {
+export async function resetAuthFailures(db: D1Database, tenantId: number = 0): Promise<void> {
   await db
     .prepare(
-      `UPDATE sync_control SET value='0', updated_at=? WHERE key='auth_failures' AND tenant_id = 0`,
+      `UPDATE sync_control SET value='0', updated_at=? WHERE key='auth_failures' AND tenant_id = ?`,
     )
-    .bind(new Date().toISOString())
+    .bind(new Date().toISOString(), tenantId)
     .run();
-}
-
-// ---------------------------------------------------------------------------
-// Repo allowlist
-// ---------------------------------------------------------------------------
-
-export async function getRepoAllowlist(db: D1Database): Promise<string[]> {
-  const result = await db.prepare(`SELECT repo FROM repo_allowlist`).all<{ repo: string }>();
-  return (result.results ?? []).map((r) => r.repo);
-}
-
-// ---------------------------------------------------------------------------
-// Org repo enumeration
-// ---------------------------------------------------------------------------
-
-interface RepoNode {
-  name: string;
-  owner: { login: string };
-  isArchived: boolean;
-  isPrivate: boolean;
-}
-interface ReposData {
-  organization: {
-    repositories: {
-      pageInfo: { hasNextPage: boolean; endCursor: string | null };
-      nodes: RepoNode[];
-    };
-  };
-  rateLimit: { cost: number; remaining: number; resetAt: string };
-}
-
-export async function enumerateOrgRepos(
-  org: string,
-  token: string,
-): Promise<Array<{ owner: string; name: string }>> {
-  const repos: Array<{ owner: string; name: string }> = [];
-  let cursor: string | null = null;
-
-  while (true) {
-    const response: { data: ReposData } & Record<string, unknown> = await ghGraphql<ReposData>(REPOS_QUERY, { org, cursor }, token);
-    const data: ReposData = response.data;
-    const rl = data.rateLimit;
-    console.log(`[sync] repos cost=${rl.cost} remaining=${rl.remaining}`);
-
-    for (const node of data.organization.repositories.nodes) {
-      repos.push({ owner: node.owner.login, name: node.name });
-    }
-
-    const pageInfo: { hasNextPage: boolean; endCursor: string | null } = data.organization.repositories.pageInfo;
-    if (!pageInfo.hasNextPage) break;
-    cursor = pageInfo.endCursor;
-    if (!cursor) break;
-  }
-
-  return repos;
-}
-
-interface ArchivedReposData {
-  organization: {
-    repositories: {
-      pageInfo: { hasNextPage: boolean; endCursor: string | null };
-      nodes: Array<{ nameWithOwner: string }>;
-    };
-  };
-  rateLimit: { cost: number; remaining: number; resetAt: string };
-}
-
-export async function enumerateArchivedOrgRepos(
-  org: string,
-  token: string,
-): Promise<string[]> {
-  const repos: string[] = [];
-  let cursor: string | null = null;
-
-  while (true) {
-    const response: { data: ArchivedReposData } & Record<string, unknown> =
-      await ghGraphql<ArchivedReposData>(ARCHIVED_REPOS_QUERY, { org, cursor }, token);
-    const data: ArchivedReposData = response.data;
-    const rl = data.rateLimit;
-    console.log(`[sync] archived-repos cost=${rl.cost} remaining=${rl.remaining}`);
-
-    for (const node of data.organization.repositories.nodes) {
-      repos.push(node.nameWithOwner);
-    }
-
-    const pageInfo = data.organization.repositories.pageInfo;
-    if (!pageInfo.hasNextPage) break;
-    cursor = pageInfo.endCursor;
-    if (!cursor) break;
-  }
-
-  return repos;
 }
 
 // ---------------------------------------------------------------------------
@@ -983,7 +894,10 @@ interface StubIssueData {
  * Find edge endpoints missing from issues, stub-fetch them.
  * Catches ANY GraphQLError → log as orphan + continue (matches Python behaviour).
  */
-export async function closedHopPass(db: D1Database, token: string): Promise<number> {
+export async function closedHopPass(
+  db: D1Database,
+  resolveToken: (owner: string, name: string) => Promise<string>,
+): Promise<number> {
   const missingRows = await db
     .prepare(
       `SELECT DISTINCT k FROM (
@@ -1008,6 +922,14 @@ export async function closedHopPass(db: D1Database, token: string): Promise<numb
     if (slashIdx < 0) continue;
     const owner = ownerRepo.slice(0, slashIdx);
     const name = ownerRepo.slice(slashIdx + 1);
+
+    let token: string;
+    try {
+      token = await resolveToken(owner, name);
+    } catch {
+      console.log(`[sync] no token for closed-hop ${key}`);
+      continue;
+    }
 
     let response: { data: StubIssueData } & Record<string, unknown>;
     try {
@@ -1124,6 +1046,119 @@ export async function writeRunAudit(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 1 — per-tenant discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover repos accessible to each installed tenant and build the global
+ * dedup map used by Phase 2 fan-out.
+ *
+ * For each tenant with an installation_id:
+ *   1. Seed sync_control rows (INSERT OR IGNORE) so acquireSyncLock can UPDATE.
+ *   2. Attempt acquireSyncLock(db, tenantId) as a within-tick skip-guard.
+ *   3. Under try/finally call getInstallationToken → listInstallationRepos.
+ *   4. Upsert tenant_repo_access; delete stale rows.
+ *   5. Accumulate Map<repo, Array<{tenantId, installationId}>> sorted by tenantId
+ *      (lowest = owning; used for token fallback in Phase 2).
+ */
+export async function discoverTenants(
+  db: D1Database,
+  env: Env,
+): Promise<Map<string, Array<{ tenantId: number; installationId: number }>>> {
+  const repoMap = new Map<string, Array<{ tenantId: number; installationId: number }>>();
+
+  const tenantRows = await db
+    .prepare(`SELECT id, installation_id FROM tenants WHERE installation_id IS NOT NULL ORDER BY id ASC`)
+    .all<{ id: number; installation_id: number }>();
+
+  for (const tenant of tenantRows.results ?? []) {
+    const tenantId = tenant.id;
+    const installationId = tenant.installation_id;
+
+    // Seed sync_control rows so acquireSyncLock UPDATE has a row to match.
+    const seedStmts: D1PreparedStatement[] = [
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO sync_control (tenant_id, key, value, updated_at) VALUES (?, 'sync_running', '0', ?)`,
+        )
+        .bind(tenantId, new Date().toISOString()),
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO sync_control (tenant_id, key, value, updated_at) VALUES (?, 'auth_failures', '0', ?)`,
+        )
+        .bind(tenantId, new Date().toISOString()),
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO sync_control (tenant_id, key, value, updated_at) VALUES (?, 'halted', '0', ?)`,
+        )
+        .bind(tenantId, new Date().toISOString()),
+    ];
+    await batchChunked(db, seedStmts);
+
+    const got = await acquireSyncLock(db, tenantId);
+    if (!got) {
+      console.log(`[sync] tenant ${tenantId} lock held — skipping discovery`);
+      continue;
+    }
+
+    try {
+      let repos: string[];
+      try {
+        const token = await getInstallationToken(db, env, tenantId, installationId);
+        repos = await listInstallationRepos(token);
+      } catch (err) {
+        console.error(`[sync] tenant ${tenantId} discovery failed:`, err);
+        continue;
+      }
+
+      // Upsert accessible repos into tenant_repo_access.
+      if (repos.length > 0) {
+        const upsertStmts = repos.map((repo) =>
+          db
+            .prepare(
+              `INSERT OR IGNORE INTO tenant_repo_access (tenant_id, repo) VALUES (?, ?)`,
+            )
+            .bind(tenantId, repo),
+        );
+        await batchChunked(db, upsertStmts);
+      }
+
+      // Delete stale rows: repos no longer returned by the installation.
+      const repoSet = new Set(repos);
+      const existing = await db
+        .prepare(`SELECT repo FROM tenant_repo_access WHERE tenant_id = ?`)
+        .bind(tenantId)
+        .all<{ repo: string }>();
+      const stale = (existing.results ?? []).map((r) => r.repo).filter((r) => !repoSet.has(r));
+      if (stale.length > 0) {
+        const deleteStmts = stale.map((repo) =>
+          db
+            .prepare(`DELETE FROM tenant_repo_access WHERE tenant_id = ? AND repo = ?`)
+            .bind(tenantId, repo),
+        );
+        await batchChunked(db, deleteStmts);
+        console.log(`[sync] tenant ${tenantId} removed ${stale.length} stale repo(s)`);
+      }
+
+      // Merge into global map (sorted ascending by tenantId — maintained by ORDER BY above).
+      for (const repo of repos) {
+        const entry = repoMap.get(repo);
+        if (entry) {
+          entry.push({ tenantId, installationId });
+        } else {
+          repoMap.set(repo, [{ tenantId, installationId }]);
+        }
+      }
+      console.log(`[sync] tenant ${tenantId} discovered ${repos.length} repo(s)`);
+    } finally {
+      await releaseSyncLock(db, tenantId);
+    }
+  }
+
+  return repoMap;
+}
+
 export async function runSync(env: Env): Promise<void> {
   const db = env.DB;
 
@@ -1151,142 +1186,162 @@ export async function runSync(env: Env): Promise<void> {
       .bind(startedAt, startedAt)
       .run();
 
-    const allowlist = await getRepoAllowlist(db);
-    if (allowlist.length === 0) {
-      console.warn("[sync] repo_allowlist empty — nothing to sync");
+    // Phase 1 — per-tenant discovery: build Map<repo, [{tenantId,installationId}]>.
+    const repoTenantMap = await discoverTenants(db, env);
+
+    // Union of all repos accessible across all tenants.
+    const allRepos = [...repoTenantMap.keys()].sort();
+
+    if (allRepos.length === 0) {
+      console.warn("[sync] no repos discovered across all installations — nothing to sync");
       outcome = "empty";
       return;
     }
 
-    const orgRepos = await enumerateOrgRepos(env.GITHUB_ORG, env.GITHUB_TOKEN);
-    const active = orgRepos.filter((r) => allowlist.includes(`${r.owner}/${r.name}`));
-
-    // Enumerate archived repos for tracking + prune safety.
-    const archivedRepoNames = await enumerateArchivedOrgRepos(
-      env.GITHUB_ORG,
-      env.GITHUB_TOKEN,
+    // Upsert repos table from the union.
+    const repoUpsertStmts = allRepos.map((repo) =>
+      db
+        .prepare(
+          `INSERT INTO repos (repo, archived) VALUES (?, 0) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived`,
+        )
+        .bind(repo),
     );
-    const liveRepoNames = orgRepos.map((r) => `${r.owner}/${r.name}`);
+    await batchChunked(db, repoUpsertStmts);
+    console.log(`[sync] upserted ${allRepos.length} repo(s) from tenant discovery`);
 
-    // SAFETY GUARD: if live enumeration returned 0 repos (transient API error),
-    // skip all prune logic to prevent wiping the entire DB. This is NOT a halt —
-    // sync continues with the (empty) active set, which means no issues are synced
-    // this run, but existing DB rows are preserved.
-    if (liveRepoNames.length === 0) {
-      console.warn("[sync] live repo enumeration returned 0 repos — skipping prune");
-    } else {
-      // Upsert repos table: live repos with archived=0, archived repos with archived=1.
-      const repoUpsertStmts: D1PreparedStatement[] = [
-        ...liveRepoNames.map((repo) =>
+    // Prune: delete data for repos absent from the union.
+    // SAFETY GUARD: skip prune if union is empty (already handled above, but be explicit).
+    const knownRepos = new Set(allRepos);
+    const CHUNK = 90;
+
+    const [issueRepos, edgeSrcRepos, edgeDstRepos, prStateRepos, syncStateRepos] =
+      await Promise.all([
+        db.prepare("SELECT DISTINCT repo FROM issues").all<{ repo: string }>(),
+        db.prepare("SELECT DISTINCT substr(src_key, 1, instr(src_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+        db.prepare("SELECT DISTINCT substr(dst_key, 1, instr(dst_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+        db.prepare("SELECT DISTINCT repo FROM pr_state").all<{ repo: string }>(),
+        db.prepare("SELECT repo FROM sync_state").all<{ repo: string }>(),
+      ]);
+
+    const staleIssueRepos = (issueRepos.results ?? []).map((r) => r.repo).filter((r) => !knownRepos.has(r));
+    const staleEdgeRepos = [
+      ...(edgeSrcRepos.results ?? []).map((r) => r.repo),
+      ...(edgeDstRepos.results ?? []).map((r) => r.repo),
+    ].filter((r) => !knownRepos.has(r));
+    const stalePrStateRepos = (prStateRepos.results ?? []).map((r) => r.repo).filter((r) => !knownRepos.has(r));
+    const staleSyncStateRepos = (syncStateRepos.results ?? []).map((r) => r.repo).filter((r) => !knownRepos.has(r));
+
+    const pruneStmts: D1PreparedStatement[] = [];
+    for (let i = 0; i < staleIssueRepos.length; i += CHUNK) {
+      for (const repo of staleIssueRepos.slice(i, i + CHUNK)) {
+        pruneStmts.push(db.prepare("DELETE FROM issues WHERE repo=?").bind(repo));
+      }
+    }
+    const staleEdgeReposUniq = [...new Set(staleEdgeRepos)];
+    for (let i = 0; i < staleEdgeReposUniq.length; i += CHUNK) {
+      for (const repo of staleEdgeReposUniq.slice(i, i + CHUNK)) {
+        pruneStmts.push(
           db
             .prepare(
-              "INSERT INTO repos (repo, archived) VALUES (?, 0) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
+              "DELETE FROM edges WHERE substr(src_key,1,instr(src_key,'#')-1)=? OR substr(dst_key,1,instr(dst_key,'#')-1)=?",
             )
-            .bind(repo),
-        ),
-        ...archivedRepoNames.map((repo) =>
-          db
-            .prepare(
-              "INSERT INTO repos (repo, archived) VALUES (?, 1) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
-            )
-            .bind(repo),
-        ),
-      ];
-      if (repoUpsertStmts.length > 0) {
-        await batchChunked(db, repoUpsertStmts);
-        console.log(
-          `[sync] upserted ${liveRepoNames.length} live + ${archivedRepoNames.length} archived repo(s)`,
+            .bind(repo, repo),
         );
       }
-
-      // Full prune: delete issues (+ cascaded labels), edges, pr_state, sync_state
-      // for repos absent from live ∪ archived. Chunk at ≤90 to stay under D1 limits.
-      const knownRepos = new Set([...liveRepoNames, ...archivedRepoNames]);
-      const CHUNK = 90;
-
-      // Collect all repos currently in DB tables.
-      const [issueRepos, edgeSrcRepos, edgeDstRepos, prStateRepos, syncStateRepos] =
-        await Promise.all([
-          db.prepare("SELECT DISTINCT repo FROM issues").all<{ repo: string }>(),
-          db.prepare("SELECT DISTINCT substr(src_key, 1, instr(src_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
-          db.prepare("SELECT DISTINCT substr(dst_key, 1, instr(dst_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
-          db.prepare("SELECT DISTINCT repo FROM pr_state").all<{ repo: string }>(),
-          db.prepare("SELECT repo FROM sync_state").all<{ repo: string }>(),
-        ]);
-
-      const staleIssueRepos = (issueRepos.results ?? [])
-        .map((r) => r.repo)
-        .filter((r) => !knownRepos.has(r));
-      const staleEdgeRepos = [
-        ...(edgeSrcRepos.results ?? []).map((r) => r.repo),
-        ...(edgeDstRepos.results ?? []).map((r) => r.repo),
-      ].filter((r) => !knownRepos.has(r));
-      const stalePrStateRepos = (prStateRepos.results ?? [])
-        .map((r) => r.repo)
-        .filter((r) => !knownRepos.has(r));
-      const staleSyncStateRepos = (syncStateRepos.results ?? [])
-        .map((r) => r.repo)
-        .filter((r) => !knownRepos.has(r));
-
-      const pruneStmts: D1PreparedStatement[] = [];
-      for (let i = 0; i < staleIssueRepos.length; i += CHUNK) {
-        for (const repo of staleIssueRepos.slice(i, i + CHUNK)) {
-          pruneStmts.push(db.prepare("DELETE FROM issues WHERE repo=?").bind(repo));
-        }
+    }
+    for (let i = 0; i < stalePrStateRepos.length; i += CHUNK) {
+      for (const repo of stalePrStateRepos.slice(i, i + CHUNK)) {
+        pruneStmts.push(db.prepare("DELETE FROM pr_state WHERE repo=?").bind(repo));
       }
-      // Deduplicate stale edge repos before chunking
-      const staleEdgeReposUniq = [...new Set(staleEdgeRepos)];
-      for (let i = 0; i < staleEdgeReposUniq.length; i += CHUNK) {
-        for (const repo of staleEdgeReposUniq.slice(i, i + CHUNK)) {
-          pruneStmts.push(
-            db
-              .prepare(
-                "DELETE FROM edges WHERE substr(src_key,1,instr(src_key,'#')-1)=? OR substr(dst_key,1,instr(dst_key,'#')-1)=?",
-              )
-              .bind(repo, repo),
-          );
-        }
-      }
-      for (let i = 0; i < stalePrStateRepos.length; i += CHUNK) {
-        for (const repo of stalePrStateRepos.slice(i, i + CHUNK)) {
-          pruneStmts.push(db.prepare("DELETE FROM pr_state WHERE repo=?").bind(repo));
-        }
-      }
-      for (let i = 0; i < staleSyncStateRepos.length; i += CHUNK) {
-        for (const repo of staleSyncStateRepos.slice(i, i + CHUNK)) {
-          pruneStmts.push(db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo));
-        }
-      }
-
-      if (pruneStmts.length > 0) {
-        await batchChunked(db, pruneStmts);
-        const totalStale = new Set([
-          ...staleIssueRepos,
-          ...staleEdgeReposUniq,
-          ...stalePrStateRepos,
-          ...staleSyncStateRepos,
-        ]).size;
-        console.log(`[sync] pruned data for ${totalStale} stale repo(s)`);
+    }
+    for (let i = 0; i < staleSyncStateRepos.length; i += CHUNK) {
+      for (const repo of staleSyncStateRepos.slice(i, i + CHUNK)) {
+        pruneStmts.push(db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo));
       }
     }
 
-    // Pass 1: bundled issues + refs + PRs per repo (1 subreq/repo instead of 3)
+    if (pruneStmts.length > 0) {
+      await batchChunked(db, pruneStmts);
+      const totalStale = new Set([
+        ...staleIssueRepos,
+        ...staleEdgeReposUniq,
+        ...stalePrStateRepos,
+        ...staleSyncStateRepos,
+      ]).size;
+      console.log(`[sync] pruned data for ${totalStale} stale repo(s)`);
+    }
+
+    // Phase 2 — deduped windowed fan-out.
+    // Read current slot (tenant_id=0).
+    const slotRow = await db
+      .prepare(`SELECT value FROM sync_control WHERE key='sync_slot' AND tenant_id = 0`)
+      .first<{ value: string }>();
+    const slot = parseInt(slotRow?.value ?? "0", 10);
+    const windowStart = slot * WINDOW;
+    const windowEnd = windowStart + WINDOW;
+    const windowedRepos = allRepos.slice(windowStart, windowEnd);
+
+    console.log(
+      `[sync] slot=${slot} window=[${windowStart},${windowEnd}) repos=${windowedRepos.length}/${allRepos.length}`,
+    );
+
+    // Per-repo token resolver: try owning tenant first, fall back down list.
+    const makeRepoResolver = (repoTenants: Array<{ tenantId: number; installationId: number }>) =>
+      async (): Promise<string> => {
+        for (const { tenantId, installationId } of repoTenants) {
+          try {
+            return await getInstallationToken(db, env, tenantId, installationId);
+          } catch (err) {
+            console.error(`[sync] token fallback: tenant ${tenantId} failed:`, err);
+            await incrementAuthFailures(db, tenantId);
+          }
+        }
+        throw new Error("all tenants failed to provide a token");
+      };
+
+    // Pass 1: bundled issues + refs + PRs per repo in window.
     const collectedEdges = new Map<string, EdgeData>();
-    for (const { owner, name } of active) {
+    for (const repo of windowedRepos) {
+      const slash = repo.indexOf("/");
+      const owner = repo.slice(0, slash);
+      const name = repo.slice(slash + 1);
+      const repoTenants = repoTenantMap.get(repo)!;
+      const resolveToken = makeRepoResolver(repoTenants);
       try {
-        await syncRepoBundle(db, env.GITHUB_TOKEN, owner, name, collectedEdges);
+        const token = await resolveToken();
+        await syncRepoBundle(db, token, owner, name, collectedEdges);
       } catch (err) {
-        if (err instanceof GraphQLError && err.isAuth) throw err;
-        console.error(`[sync] skipping ${owner}/${name}:`, err);
+        if (err instanceof GraphQLError && err.isAuth) {
+          // Auth failure already counted above; skip this repo, don't abort.
+          console.error(`[sync] skipping ${repo} — all tokens failed`);
+        } else {
+          console.error(`[sync] skipping ${repo}:`, err);
+        }
       }
     }
 
-    // Pass 2: flush all edges (deferred to avoid cross-repo FK hazard)
+    // Pass 2: flush all edges (deferred to avoid cross-repo FK hazard).
     await flushEdges(db, collectedEdges);
 
-    // Closed-hop pass
-    stubsCount = await closedHopPass(db, env.GITHUB_TOKEN);
+    // Closed-hop pass with per-(owner,name) resolver.
+    stubsCount = await closedHopPass(db, async (owner: string, name: string) => {
+      const repo = `${owner}/${name}`;
+      const repoTenants = repoTenantMap.get(repo);
+      if (!repoTenants || repoTenants.length === 0) {
+        throw new Error(`no tenant for ${repo}`);
+      }
+      return makeRepoResolver(repoTenants)();
+    });
     console.log(`[sync] completed — stubs=${stubsCount}`);
+
+    // Advance slot.
+    const nextSlot = (slot + 1) % NUM_SLOTS;
+    await db
+      .prepare(
+        `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_slot' AND tenant_id = 0`,
+      )
+      .bind(String(nextSlot), new Date().toISOString())
+      .run();
 
     await resetAuthFailures(db);
     outcome = "success";

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -6,8 +6,6 @@ export interface Env {
   DB: D1Database;
   /** Static-assets binding — serves the v6 frontend (wired in S7, #99). */
   ASSETS: Fetcher;
-  /** GitHub PAT for GraphQL sync (S3, #95). */
-  GITHUB_TOKEN: string;
   /** GitHub org to sync (e.g. "Roxabi"). */
   GITHUB_ORG: string;
   /** HMAC secret for webhook verification (S5, #97) — differs per env. */

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -170,7 +170,6 @@ function makeRequest(
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
     DB: captureDb().db,
-    GITHUB_TOKEN: "ghp_test",
     GITHUB_ORG: "Roxabi",
     GITHUB_WEBHOOK_SECRET: "test-secret",
     ASSETS: {} as Fetcher,


### PR DESCRIPTION
## Summary
- Rewrite `runSync` to sync every installed tenant's repos via **per-installation GitHub App tokens**, retiring the org PAT (`GITHUB_TOKEN`). Two-phase: Phase 1 `discoverTenants` (per-tenant lock skip-guard → mint install token → `listInstallationRepos` → upsert `tenant_repo_access` → build `Map<repo, [{tenantId, installationId}]>`); Phase 2 deduped, slot-windowed fan-out (`WINDOW=20`, slot `(slot+1)%NUM_SLOTS=3`) under the ~50-subrequest cap, with per-repo token fallback down the owning-tenant list.
- Thread `tenantId` (default `0`) through the 7 lock/breaker helpers (global tick lock + existing callers unchanged); `closedHopPass(db, resolveToken)` resolver callback; prune sourced from the `tenant_repo_access` **union** with a 0-union guard (never prune-all on empty/failed discovery).
- Drop all 4 `env.GITHUB_TOKEN` reads + remove `GITHUB_TOKEN` from `Env` (no fallback); remove now-dead org-enum functions + stale fixtures. W2: bound `listInstallationRepos` by `MAX_PAGES=10` + per-fetch `AbortSignal.timeout(10s)`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #160: per-installation runSync cutover + PAT retirement (Phase 1 S3b) | OPEN |
| Analysis | [160-…-analysis.mdx](artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx) | Present |
| Spec | [160-…-spec.mdx](artifacts/specs/160-per-installation-runsync-cutover-spec.mdx) | Present |
| Implementation | 1 impl commit on `feat/160-per-installation-runsync-cutover` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (381 passing; +3 W2 + 4 un-skipped RED) | Passed |

## Test Plan
- [ ] Staging tick (RT2): R2 audit shows a clean run resolving `subIssues`/`parent` via an installation token, **no** PAT read.
- [ ] 2 tenants sharing a repo → exactly 1 `REPO_BUNDLE_QUERY` for that repo (dedup).
- [ ] `sync_slot` advances per tick; fan-out window ≤ `WINDOW`.
- [ ] One tenant's auth failure / held lock does not block another tenant.

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC-3 dedup (1 bundle/unique repo) | `sync.test.ts :: deduplicates GraphQL bundle fetches … exactly 1 REPO_BUNDLE_QUERY for o/r` | ✓ proven |
| SC-4 slot advance `(slot+1)%NUM_SLOTS` | `sync.test.ts :: advances sync_slot per tick` | ✓ proven |
| Lock isolation | `sync.test.ts :: per-tenant lock isolation` | ✓ proven |
| SC-6 no PAT | `sync.test.ts :: no PAT access …` + `grep GITHUB_TOKEN src` clean | ✓ proven |
| W2 bound | `installToken.test.ts :: listInstallationRepos — W2 pagination bound` (×3) | ✓ proven |
| prune union + 0-guard | `sync.test.ts ::` deleted-repo / still-accessible / 0-repos-warn | ✓ proven |
| CI gate (suite+typecheck) | 381 tests + `tsc --noEmit` | ✓ proven |

## Notes for review
- **Breaker semantic shift:** per-tenant breaker is **increment-only** this slice; the global 2-strike halt + NOTIFY alert remains in `runSync`'s outer catch as a defensive fallback but is no longer reached by per-repo auth errors (caught in-loop, never rethrown). Spec-intended for S3b — follow-up candidate: per-tenant halt-at-threshold.
- **RT3 (PAT secret deletion)** is the post-merge operational tail, **code-deploy-first**: merge → deploy staging → verify clean tick (RT2) → `wrangler secret delete GITHUB_TOKEN --env staging`. Prod leg gated on #164 (`7dbf512`) reaching `main` + CI re-injecting `GITHUB_APP_*`/`INSTALL_TOKEN_KEY` on prod.

Fixes #160

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`