### PR TITLE
chore: promote staging → main — Phase 1 (multi-tenant auth + install-token sync)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "roxabi-live-marketplace",
+  "version": "1.0.0",
+  "description": "Roxabi Live — issue management plugin (relocated from dev-core, labels + native relations, no Projects V2).",
+  "owner": {
+    "name": "Roxabi",
+    "url": "https://github.com/Roxabi"
+  },
+  "plugins": [
+    {
+      "name": "roxabi-issues",
+      "description": "Issue triage — set labels (size/priority/lane/type), manage blocked-by dependencies and parent/child sub-issues on GitHub issues. Labels + native relations, no Projects V2 board.",
+      "source": "./plugins/roxabi-issues",
+      "category": "development"
+    }
+  ]
+}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,13 +28,22 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reviewed')
     timeout-minutes: 5
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
   update-behind-prs:
@@ -43,6 +52,15 @@ jobs:
     if: github.event_name == 'push'
     timeout-minutes: 5
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -62,7 +80,7 @@ jobs:
               --method PUT -f expected_head_sha="$SHA" || true
           done
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
 
   close-linked-issues:
     name: Close linked issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
       - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'staging'
         name: Inject GITHUB_APP_* secrets (staging)
         run: |
+          cd worker
           printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --env staging --config ../wrangler.toml
           printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --env staging --config ../wrangler.toml
           printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --env staging --config ../wrangler.toml
@@ -164,6 +165,7 @@ jobs:
       - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'main'
         name: Inject GITHUB_APP_* secrets (production)
         run: |
+          cd worker
           printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --config ../wrangler.toml
           printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --config ../wrangler.toml
           printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --config ../wrangler.toml
@@ -192,14 +194,14 @@ jobs:
           fi
       - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'staging'
         name: Inject INSTALL_TOKEN_KEY (staging)
-        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
+        run: cd worker && printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}
       - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'main'
         name: Inject INSTALL_TOKEN_KEY (production)
-        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
+        run: cd worker && printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      - id: app-secrets-guard
+      # consumed by S2/#145 — gates GitHub App secret injection steps
+      - if: steps.guard.outputs.enabled == 'true'
+        id: app-secrets-guard
         name: Guard — GITHUB_APP_* secrets
         env:
           GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,20 @@ jobs:
       - name: Test (vitest)
         run: cd worker && npm test
 
+  plugin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install plugin deps
+        run: cd plugins/roxabi-issues && bun install --frozen-lockfile
+      - name: Typecheck (tsc)
+        run: cd plugins/roxabi-issues && bun run typecheck
+      - name: Test (vitest)
+        run: cd plugins/roxabi-issues && bun run test
+
   deploy:
     needs: [ci, worker]
     if: github.event_name == 'push' && (github.ref_name == 'staging' || github.ref_name == 'main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,11 @@ jobs:
       - if: steps.guard.outputs.enabled == 'true'
         id: app-secrets-guard
         name: Guard — GITHUB_APP_* secrets
+        # GitHub forbids GITHUB_-prefixed Actions secret names (422) — repo secrets are GH_APP_*
         env:
-          GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
-          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GITHUB_APP_WEBHOOK_SECRET }}
+          GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
         run: |
           missing=()
           [ -z "$GITHUB_APP_ID" ] && missing+=("GITHUB_APP_ID")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,61 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # ── GitHub App secrets injection (S2/#145) ───────────────────────────────
+      # GitHub forbids GITHUB_-prefixed Actions secret names (422); repo secrets are GH_APP_*.
+      # Inject after deploy so the Worker binary is already live when secrets are written.
+      - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'staging'
+        name: Inject GITHUB_APP_* secrets (staging)
+        run: |
+          printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --env staging --config ../wrangler.toml
+          printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --env staging --config ../wrangler.toml
+          printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --env staging --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
+      - if: steps.guard.outputs.enabled == 'true' && steps.app-secrets-guard.outputs.app_secrets == 'true' && github.ref_name == 'main'
+        name: Inject GITHUB_APP_* secrets (production)
+        run: |
+          printf %s "$GITHUB_APP_ID"             | npx wrangler secret put GITHUB_APP_ID             --config ../wrangler.toml
+          printf %s "$GITHUB_APP_PRIVATE_KEY"    | npx wrangler secret put GITHUB_APP_PRIVATE_KEY    --config ../wrangler.toml
+          printf %s "$GITHUB_APP_WEBHOOK_SECRET" | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}
+      # ── INSTALL_TOKEN_KEY injection (S3/#146) ────────────────────────────────
+      # Actions secret GH_INSTALL_TOKEN_KEY → Worker secret INSTALL_TOKEN_KEY (AES-GCM DEK).
+      # Same guard pattern as GH_APP_* above: GH_ prefix avoids GitHub's GITHUB_-name ban.
+      # TODO(RT3): after initial provisioning, run `wrangler secret delete GITHUB_TOKEN` on
+      # both staging and production to retire the legacy PAT (manual runtime op, not in CI).
+      - if: steps.guard.outputs.enabled == 'true'
+        id: install-token-key-guard
+        name: Guard — INSTALL_TOKEN_KEY secret
+        env:
+          INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}
+        run: |
+          if [ -z "$INSTALL_TOKEN_KEY" ]; then
+            echo "::notice::GH_INSTALL_TOKEN_KEY not set — INSTALL_TOKEN_KEY injection skipped until provisioned (S3/#146)."
+            echo "install_token_key=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "install_token_key=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'staging'
+        name: Inject INSTALL_TOKEN_KEY (staging)
+        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}
+      - if: steps.guard.outputs.enabled == 'true' && steps.install-token-key-guard.outputs.install_token_key == 'true' && github.ref_name == 'main'
+        name: Inject INSTALL_TOKEN_KEY (production)
+        run: printf %s "$INSTALL_TOKEN_KEY" | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          INSTALL_TOKEN_KEY: ${{ secrets.GH_INSTALL_TOKEN_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,35 @@ jobs:
         name: Install worker deps
         run: cd worker && npm ci
       - if: steps.guard.outputs.enabled == 'true' && github.ref_name == 'staging'
+        name: Migrate D1 (staging)
+        run: cd worker && npx wrangler d1 migrations apply DB --env staging --remote --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - if: steps.guard.outputs.enabled == 'true' && github.ref_name == 'main'
+        name: Migrate D1 (production)
+        run: cd worker && npx wrangler d1 migrations apply DB --remote --config ../wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - id: app-secrets-guard
+        name: Guard — GITHUB_APP_* secrets
+        env:
+          GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GITHUB_APP_WEBHOOK_SECRET }}
+        run: |
+          missing=()
+          [ -z "$GITHUB_APP_ID" ] && missing+=("GITHUB_APP_ID")
+          [ -z "$GITHUB_APP_PRIVATE_KEY" ] && missing+=("GITHUB_APP_PRIVATE_KEY")
+          [ -z "$GITHUB_APP_WEBHOOK_SECRET" ] && missing+=("GITHUB_APP_WEBHOOK_SECRET")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::notice::GITHUB_APP_* secrets not set (${missing[*]}) — GitHub App auth inactive until provisioned (S2/#145)."
+            echo "app_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "app_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.guard.outputs.enabled == 'true' && github.ref_name == 'staging'
         name: Deploy (staging)
         run: cd worker && npx wrangler deploy --env staging --config ../wrangler.toml
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app.outputs.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,9 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+      - id: worker-typecheck
+        name: worker typecheck (tsc)
+        entry: bash -c 'cd worker && npm run typecheck'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Let:
 
 → `docs/ARCHITECTURE.md` (to be created)
 
+## Plugins
+
+`plugins/roxabi-issues/` — Claude Code plugin (own `.claude-plugin/marketplace.json`), relocated from dev-core 2026-06-09. Skill `issue-triage` (invoked `roxabi-issues:issue-triage`): set labels (size/priority/lane/type) + manage blocked-by deps + parent/child sub-issues on GitHub issues. **Labels + native relations only — no ProjectV2 board** (board read is the cockpit's job). Self-contained bun project (`bun run typecheck|test`). Registered in `roxabi-plugins/.claude-plugin/external-registry.json`.
+
 ## TL;DR
 
 - Entry: `/dev #N` → tier (S/F-lite/F-full) → lifecycle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,13 @@ wrangler.toml       # repo root — binds both envs
 frontend/           # served via ASSETS binding
 ```
 
+**Plugin (issue mgmt — relocated from dev-core)**
+
+```
+.claude-plugin/marketplace.json   # single-plugin marketplace
+plugins/roxabi-issues/            # roxabi-issues:issue-triage (bun; labels + native relations)
+```
+
 **Legacy Python app (decommissioned 2026-06-08)**
 
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 |:---:|:---:|:---:|
 | ![Table](docs/images/table-view.png) | ![List](docs/images/list-view.png) | ![Graph](docs/images/graph-view.png) |
 
-Roxabi Live pulls GitHub issues from the entire org into a local SQLite corpus and serves a multi-view dashboard. It tracks parent/child relationships and blockers, updates in real time via webhooks, and runs an hourly reconciler to stay in sync.
+Roxabi Live pulls GitHub issues from the entire org into a [Cloudflare D1](https://developers.cloudflare.com/d1/) database and serves a multi-view dashboard at **[live.roxabi.dev](https://live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via a GitHub org webhook, and re-syncs hourly via a Cron Trigger — all on a single Cloudflare Worker.
 
 ## Why
 
@@ -18,45 +18,45 @@ GitHub Projects and the default issue list give no cross-repo dependency view. R
 
 ## Quick Start
 
+Roxabi Live runs as a **Cloudflare Worker** at **[live.roxabi.dev](https://live.roxabi.dev)** (behind Cloudflare Access) — nothing to install to use it.
+
+Local development:
+
 ```bash
-# 1. Install
 git clone https://github.com/Roxabi/roxabi-live.git
-cd roxabi-live
-make install
-
-# 2. Configure
-cp .env.example .env
-# Set CORPUS_DB_PATH and GITHUB_WEBHOOK_SECRET in .env
-
-# 3. Sync corpus
-make sync
-
-# 4. Start dev server
-uv run roxabi-live
-# → http://localhost:8000/v6/
+cd roxabi-live/worker
+npm ci
+npx wrangler dev          # local Worker + D1 → http://localhost:8787
 ```
+
+Deploys are CI-driven: push to `staging` → staging Worker; push to `main` → production (`live.roxabi.dev`).
 
 ## How It Works
 
 ```mermaid
 flowchart LR
+    CRON[Cron Trigger\n0 * * * *]
     GH[GitHub Org\nGraphQL API]
-    DB[(corpus.db\nSQLite)]
-    API[FastAPI\nroxabi-live]
-    FE[Dashboard\n/v6/]
+    W[CF Worker\nHono]
+    DB[(D1\nroxabi-live-production)]
+    R2[(R2\nroxabi-live-logs)]
+    FE[Dashboard\nlive.roxabi.dev]
     WH[GitHub Webhook\nPOST /webhook/github]
 
-    GH -->|GraphQL sync\nhourly + on-demand| DB
-    DB -->|aiosqlite| API
-    API -->|JSON| FE
-    WH -->|HMAC-gated events| DB
+    CRON -->|hourly scheduled| W
+    GH -->|GraphQL| W
+    W -->|upsert| DB
+    DB -->|read| W
+    W -->|JSON + static ASSETS| FE
+    WH -->|HMAC-gated events| W
+    W -->|per-run audit| R2
 ```
 
 **Sync flow:**
-1. `roxabi-corpus sync` fetches issues via GraphQL — `subIssues`, `parent`, `blockedBy`, `blocking` fields.
-2. Issues and edges land in `corpus.db` (tables: `issues`, `edges`, `repos`, `sync_state`).
-3. FastAPI serves the corpus over a REST API; the frontend builds the views client-side.
-4. Incoming webhooks trigger incremental updates; the reconciler runs every hour to catch drift.
+1. A Cron Trigger (`0 * * * *`) invokes the Worker's `scheduled` handler hourly; `POST /admin/sync` triggers it out-of-band.
+2. The Worker fetches issues via GitHub GraphQL — `subIssues`, `parent`, `blockedBy`, `blocking` fields — and upserts into D1 (tables: `issues`, `edges`, `repos`, `sync_state`).
+3. The Worker serves the corpus over a JSON API; the static frontend (ASSETS binding) builds the views client-side.
+4. The GitHub org webhook (`POST /webhook/github`, HMAC-verified) applies incremental updates in real time; each sync run writes a JSON audit to R2.
 
 ## Features
 
@@ -65,32 +65,43 @@ flowchart LR
 | **Views** | Pivot matrix (milestones x lanes), flat list, SVG dependency graph |
 | **Filters** | Multi-select: repo, milestone, priority, status; full-text search |
 | **Dependencies** | Parent/child edges + blocker edges; status propagation (blocked/ready/done) |
-| **Sync** | GitHub GraphQL corpus sync; hourly reconciler; real-time webhook updates |
+| **Sync** | GitHub GraphQL sync; hourly Cron Trigger; real-time webhook updates |
 | **Theme** | Light/dark toggle |
-| **Storage** | Single SQLite file — no external DB |
+| **Storage** | Cloudflare D1 (serverless SQLite) + R2 per-run audit log |
 
 ## API Reference
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/health` | GET | Health check + DB stats |
-| `/api/issues` | GET | List issues (supports `repo`, `milestone`, `status`, `priority`, `search` query params) |
+| `/health` | GET | DB reachability + issue count |
+| `/api/version` | GET | Build/version info |
+| `/api/issues` | GET | List issues (`repo`, `state`, `label`, `limit`, `offset` query params) |
 | `/api/issues/{key}` | GET | Single issue by key, e.g. `Roxabi/lyra#123` |
-| `/api/graph` | GET | Full dependency graph JSON |
-| `/api/repos` | GET | List synced repos |
+| `/api/graph` | GET | Full dependency graph JSON (nodes + edges) |
+| `/admin/sync` | POST | Out-of-band sync trigger (`Authorization: Bearer <ADMIN_TOKEN>`) |
 | `/webhook/github` | POST | GitHub webhook receiver (HMAC-verified) |
-| `/v6/` | Static | Dep-graph dashboard |
-| `/dep-graph/` | Static | Legacy v5 view |
+| `/` | Static | Dep-graph dashboard (served via ASSETS) |
 
 ## Configuration
 
-Copy `.env.example` to `.env` and set values.
+Bindings live in [`wrangler.toml`](wrangler.toml); secrets are set per-environment via `wrangler secret put`.
 
-| Variable | Default | Description |
+| Binding / Secret | Type | Description |
 |---|---|---|
-| `CORPUS_DB_PATH` | `~/.roxabi/corpus.db` | Path to corpus SQLite database |
-| `GITHUB_WEBHOOK_SECRET` | — | HMAC secret for webhook verification |
-| `CORPUS_SYNC_INTERVAL_SECONDS` | `3600` | Reconciler interval in seconds |
+| `DB` | D1 | Issue corpus (`roxabi-live-production` / `roxabi-live-staging`) |
+| `ASSETS` | Static | Serves `frontend/` |
+| `LOGS` | R2 | Per-run sync audit (`roxabi-live-logs`) |
+| `GITHUB_TOKEN` | secret | GitHub GraphQL auth |
+| `GITHUB_ORG` | var | Org to sync |
+| `GITHUB_WEBHOOK_SECRET` | secret | HMAC verification for `/webhook/github` |
+| `ADMIN_TOKEN` | secret (optional) | Bearer gate for `/admin/*` |
+| Cron | trigger | `0 * * * *` — hourly sync |
+
+```bash
+# set a secret (prod, then staging)
+printf %s '<value>' | wrangler secret put GITHUB_TOKEN
+printf %s '<value>' | wrangler secret put GITHUB_TOKEN --env staging
+```
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ Copy `.env.example` to `.env` and set values.
 | `GITHUB_WEBHOOK_SECRET` | — | HMAC secret for webhook verification |
 | `CORPUS_SYNC_INTERVAL_SECONDS` | `3600` | Reconciler interval in seconds |
 
+## Plugins
+
+This repo also hosts the **`roxabi-issues`** Claude Code plugin (`plugins/roxabi-issues/`), relocated from `dev-core` — issue triage that pairs with the cockpit.
+
+```bash
+claude plugin marketplace add Roxabi/roxabi-live
+claude plugin install roxabi-issues
+```
+
+The `issue-triage` skill (invoked `roxabi-issues:issue-triage`) sets labels (size / priority / lane / type) and manages blocked-by dependencies and parent/child sub-issues on GitHub issues — **labels + native relations only, no Projects V2 board** (the cockpit owns the read/dashboard side). Self-contained bun project.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+++ b/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
@@ -282,3 +282,86 @@ guards + staging URL + staging R2 (dec. 17–20), Access staging-gate (dec. 21),
 machine + honesty surface (dec. 22–23), payload/title/body product calls (dec. 24). RS256 +
 subIssues moved to pre-impl validation tasks. Mermaid corrected (install async; cron bidirectional);
 composite-PK duplication removed.
+
+---
+
+## Addendum (2026-06-10) — repo-canonical pivot
+
+### What changed and why
+
+Decisions 8, 9, and 10 in this analysis (lines above) specified the original **per-tenant**
+data model: composite PKs `(tenant_id, issue_key)` on `issues`/`edges`, a `tenant_id` column
+on data tables, a live-table PK recreation migration (M-a), and a backfill of `tenant_id` into
+existing rows. That model is **superseded** by the **repo-canonical** model ratified 2026-06-10.
+
+**The superseded decisions (preserved above as historical record):**
+- Dec. 8: composite PK `(tenant_id, key)` on `issues` — superseded
+- Dec. 9: live-table composite-PK recreation migration — superseded (eliminated)
+- Dec. 10: `COUNT(*) WHERE tenant_id IS NULL = 0` backfill gate — superseded (no backfill)
+
+### Repo-canonical model
+
+PKs on `issues` (`key = owner/repo#N`) and `edges` remain **unchanged** — globally unique,
+no `tenant_id` column added. Authorization is a JOIN at read time:
+
+```sql
+-- Superseded (stale):
+WHERE i.tenant_id = ?
+
+-- Current (repo-canonical):
+JOIN tenant_repo_access tra
+  ON tra.repo = i.repo
+  AND tra.tenant_id = ?
+```
+
+### Risk eliminated
+
+The riskiest migration step — recreating PKs on `issues`/`edges` live tables — is eliminated.
+No M-a migration. No M-b NOT NULL cutover on existing tables. S7 scope shrinks to: NOT NULL
+on **new tables only** + CF Access narrowed to `/admin/*`.
+
+### New tables (10 new + 2 ALTERs)
+
+New tables added by S1 migrations (#144): `tenants`, `users`, `user_installations`, `sessions`,
+`oauth_state`, `install_tokens`, `tenant_repo_access`, `user_repo_permission_cache`,
+`sync_control`, `zk_payloads`. Existing tables receive only:
+- `ALTER TABLE issues ADD COLUMN payload TEXT`
+- `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE`
+
+No `tenant_id` column on `issues`, `edges`, `labels`, or `pr_state`.
+
+### Corrections to prior synthesis
+
+| Item | Prior synthesis | Ratified (this addendum) |
+|---|---|---|
+| `zk_payloads` PK | `(tenant_id, issue_key)` | `(user_id, issue_key)` — ZK keys are per-user browser keys |
+| `installations` table | named `installations` | renamed `tenants` (has `installation_id` column) |
+| `sync_control` PK | `(tenant_id, key)` | confirmed `(tenant_id, key)` — unchanged |
+
+### Session SELECT (authoritative)
+
+```sql
+SELECT s.*, u.github_id, u.github_login
+FROM sessions s
+JOIN users u ON u.id = s.user_id
+WHERE s.token_hash = ?
+  AND s.expires_at > datetime('now')
+  AND s.revoked_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM tenants t
+    WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL
+  )
+```
+
+The NOT-EXISTS guard enforces suspended-tenant revocation without an immediate session flush.
+
+### Spec files updated (2026-06-10)
+
+All slice specs amended to reflect this pivot:
+- `141-multi-tenant-github-app-auth-spec.mdx` — pivot note + mermaid (repo-canonical)
+- `144-schema-tenant-migrations-spec.mdx` — full rewrite (10 tables + 2 ALTERs; no composite-PK recreation)
+- `145-github-app-oauth-sessions-spec.mdx` — `SameSite=Strict`; suspended-tenant guard; PKCS#8 contract; vitest RS256 CI guard
+- `146-installation-sync-backfill-spec.mdx` — per-repo fan-out; AES-GCM tokens; slot-rotation; SYNC_QUEUE DORMANT; PAT retirement; no backfill
+- `147-webhook-tenant-routing-spec.mdx` — lifecycle handlers; issue rows retained on `installation.deleted`; `user_repo_permission_cache` invalidation
+- `148-tenant-filtered-reads-spec.mdx` — JOIN `tenant_repo_access`; private-repo permission cache; no `tenant_id` in response shapes
+- `150-notnull-access-cutover-spec.mdx` — NOT NULL on new tables only; no backfill on old tables; CF Access → `/admin/*`

--- a/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+++ b/artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
@@ -1,0 +1,284 @@
+---
+title: "Multi-tenant GitHub App auth — Phase 1 implementation analysis (#141)"
+description: "Codebase-grounded, review-hardened shapes for Phase 1 of ADR Shape D: tenant model, sessions, schema/migration, sync+webhook isolation, deploy sequencing. Folds in architect/security/devops/product/doc review."
+---
+
+## Source
+
+> "On voulait étendre ça avec une authentification GitHub […] permettre aux utilisateurs de relier
+> leur compte GitHub à l'outil […] que ça devienne un outil pour tout le monde plutôt qu'un outil
+> que pour moi." — Phase 1 of `artifacts/analyses/zk-encryption-spike-analysis.mdx` (ADR → Shape D).
+
+The ADR settled the **archetype** (single GitHub App, server-centric, single D1 + `tenant_id`,
+phased toward an opt-in Phase-2 ZK mode). This analysis decides the **implementation shape** for
+Phase 1 — grounded in the *actual* current Worker — and locks the sub-decisions `/spec` will split
+into child issues. **Review-hardened**: 5 expert reviews (architect, security, devops, product, doc)
+folded in; see Review Log.
+
+## Problem
+
+The Worker is single-tenant to the bone (verified in `worker/src/`):
+
+- **One credential, one org:** sync reads a single `GITHUB_TOKEN` (**PAT**) + `GITHUB_ORG` var;
+  `runSync` syncs exactly one org per cron tick. No App, OAuth, installation tokens, or user identity.
+- **No identity layer:** no `users`/`sessions`/`tenants`/`installations`/`oauth_state` tables; the
+  Worker is blind to the user — Cloudflare Access at the edge is the *sole* guard except `/admin/*`.
+- **Globally-shared data:** `issues` (PK `key` = `owner/repo#N`), `edges` (PK `(src,dst,kind)`),
+  `labels`, `pr_state`, `repos`, `sync_state` — **none** carry a tenant column. Every read in
+  `api/issues.ts` + `api/graph.ts` is unfiltered; `GET /api/graph` dumps the entire corpus; and
+  `GET /api/issues/:key` returns any issue by key (a latent IDOR once multi-tenant).
+- **One webhook:** single `GITHUB_WEBHOOK_SECRET`, keys from `repository.full_name`, one org.
+
+So "let any GitHub user see their own issues" touches every layer: auth (new), schema (breaking),
+sync (per-tenant loop), webhook (tenant routing), reads (tenant filter, fail-closed), frontend (login).
+
+## Outcome
+
+A second GitHub user logs in, links their account, and sees **only their own** issues + dep-graph in
+prod, with tenant isolation verified, and no auth rewrite when Phase-2 ZK lands. (Frame #141.)
+
+## Appetite
+
+F-full epic; `/spec` smart-splits into child issues. Likely split: **(1)** schema migrations +
+auth tables · **(2)** App-JWT + OAuth + sessions module · **(3)** per-installation sync fan-out +
+PAT retirement · **(4)** webhook tenant routing + stub policy · **(5)** tenant-filtered reads +
+middleware · **(6)** login/account-link/consent UI · **(7)** CI migrate-step + staging URL + R2 +
+Access-policy deploy runbook.
+
+---
+
+## Current architecture (grounding)
+
+| Layer | Today | Phase-1 delta |
+|---|---|---|
+| Auth | CF Access (edge) + `ADMIN_TOKEN` on `/admin/*` | + app sessions (fail-closed) on public app; Access → `/admin/*` only |
+| GitHub creds | 1 PAT (`GITHUB_TOKEN`) + 1 `GITHUB_ORG` | GitHub App: App-JWT (RS256) → per-installation tokens; **PAT removed** |
+| Identity | none | `users` + `sessions` + `installations` + `user_installations` + `oauth_state` |
+| Schema | `issues` PK `key`; `edges` PK `(src,dst,kind)`; no tenant | `tenant_id` everywhere; **composite PKs** (table-recreation) |
+| Reads | all unfiltered | middleware-gated `/api/*`; every WHERE + every single-fetch `AND tenant_id=?` |
+| Writes | `sync.ts`, `webhook/mutations.ts` | every write carries `tenant_id`; stubs tenant-local + title-less |
+| Webhook | 1 org secret, keys from `repository.full_name` | 1 App secret; route by `installation.id`; unknown install → 200 no-write |
+| Frontend | no login; `app.js` → `/api/graph`,`/api/version` | login + account-link + consent UI |
+| Runtime | Hono on workerd; Web Crypto already used (HMAC) | + RS256 App-JWT + session crypto via Web Crypto |
+| Deploy/CI | `ci.yml`: `npm ci` + `wrangler deploy` (no migrate step) | + `wrangler d1 migrations apply` per-env; secret guards; staging URL + R2 |
+
+Bindings today = `DB` (D1), `ASSETS`, `LOGS` (R2, optional). **No KV, no DO, no Queues.**
+
+---
+
+## Core decision — what is a "tenant", and which credential syncs it?
+
+Everything downstream follows from this axis. Three mutually-exclusive shapes:
+
+**Shape 1 — Installation-as-tenant.** App installed on the user's account/org → `installation_id` =
+tenant + sync credential; OAuth only for identity. Sync mints installation tokens (App-JWT →
+`POST /app/installations/:id/access_tokens`). Webhooks routed by `payload.installation.id`.
+*Pro:* high rate limits, auto-rotation, **no broad user-token at rest**, native webhooks. *Con:*
+install step; multi-org user → N installations (needs membership). **Scope L.**
+
+**Shape 2 — User-token sync.** OAuth-only; **store user-to-server token server-side** and sync with it.
+`tenant_id` = user id. *Pro:* lightest onboarding. *Con:* token refresh machinery, **lower rate
+limits**, **large user-token-at-rest liability**, **no webhooks → polling** (kills the real-time
+model), stalls on expiry. **Weaker outcome, contradicts the ADR.** Scope L.
+
+**Shape 3 — Hybrid: installation for sync + OAuth for identity. ← adopt.** OAuth user-to-server =
+identity/session (token **discardable** after identity — minimal liability, reused live in Phase 2);
+App installation = data access + sync credential. Tables: `users`, `installations`,
+`user_installations` (membership). `tenant_id` = `installation_id` on data rows. One user → many
+installations; one installation → many authorized users (same-org colleagues share one tenant, **no
+data duplication**). *Con:* most moving parts; onboarding = authorize **and** install. **Scope L–XL.**
+
+### Fit Check
+
+| | Shape 1 | Shape 2 | **Shape 3** |
+|---|---|---|---|
+| Real-time webhooks (keep model) | ✓ | ✗ | **✓** |
+| Sync rate limits at scale | ✓ | ✗ | **✓** |
+| Token-at-rest liability | low | **high** | **low** |
+| Multi-org user supported | ✗ | ✓ | **✓** |
+| Phase-2 ZK seam ready | partial | ✓ | **✓** |
+| Matches ADR Shape A/D | ✓ | ✗ | **✓✓** |
+
+**Eliminated: Shape 2** (weaker outcome, contradicts ADR). **Shape 1 vs 3:** 3 = 1 + the membership
+join that "link your account and see your org's issues" requires. **Adopt Shape 3.** (Architect:
+shapes cover all viable combinations; Shape 3 is the only consistent option.)
+
+```mermaid
+flowchart LR
+  U[User] -. "App install (async, GitHub-side)" .-> GH[(GitHub)]
+  subgraph Browser
+    U -->|1. GET /login| W
+    W -->|2. set session cookie| U
+  end
+  subgraph Worker[CF Worker]
+    W[/login + /oauth/callback<br/>state single-use, client_secret/]
+    CRON[cron] <-->|App-JWT RS256 ⇄ install token| GH
+    CRON -->|write tenant_id=installation_id| D[(D1)]
+    WH[/webhook/github/] -->|installation.id → tenant_id| D
+    API[/api/* — middleware 401 if no session<br/>WHERE tenant_id = active tenant/] --> D
+  end
+  W <-->|code ⇄ token| GH
+  GH -->|webhook: 1 secret + installation.id| WH
+```
+
+---
+
+## Settled sub-decisions
+
+### Sessions & access enforcement
+1. **D1 `sessions` table** — opaque random token **hashed at rest** (store SHA-256 of token, compare
+   hash), FK→`users`, `tenant_id` of the **active** installation, `expires_at` (short TTL), index on
+   `tenant_id`. Transport: cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>` (**not** a
+   wildcard `.roxabi.dev`). *Rejected:* stateless JWT (can't revoke day-one), KV (no binding; D1 keeps
+   revocation transactional).
+2. **Revocation (mandatory, day-one):** logout → `DELETE FROM sessions WHERE token_hash=?`;
+   `installation.deleted` / user-removed webhook → `DELETE FROM sessions WHERE tenant_id=?`. TTL expiry
+   is **not** revocation — both paths required.
+3. **Session fixation:** mint a **new** token *after* OAuth completes; never reuse any pre-auth value.
+4. **Enforcement point:** a named session middleware on the **`/api/*` group** (mirrors the existing
+   `checkAdminAuth` Hono pattern). **Fail-closed:** absent/expired/invalid session → **401 before any
+   DB statement executes**. "Every WHERE gets `tenant_id`" is the data guard *behind* the gate, not the
+   gate itself.
+
+### OAuth code-exchange
+5. **Routes:** `GET /login` (redirect to GitHub authorize + `state`), `GET /oauth/callback` (verify
+   `state`, exchange `code`→token with `GITHUB_APP_CLIENT_SECRET`). No PKCE (we hold the secret).
+6. **`state` (CSRF):** stored in D1 `oauth_state` table, **single-use** (deleted atomically on first
+   successful verify), **TTL ≤ 10 min** enforced at verify, abandoned rows swept. **`redirect_uri` is
+   hard-coded in the Worker**, never caller-supplied. (`SameSite=Lax` is acceptable *only* because
+   `state` defends the GET callback — documented constraint for future route authors.)
+7. **Secrets:** `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`,
+   `GITHUB_APP_PRIVATE_KEY` (PEM), `GITHUB_APP_WEBHOOK_SECRET` — per-env via `wrangler secret put …
+   [--env staging]`. **Rotatable, never logged**; RS256 signing errors log message only, never key/JWT.
+   Private-key rotation = dual-key overlap (GitHub allows 2 active) + `wrangler secret put` + redeploy
+   (deploy-coupled, document in runbook).
+
+### Schema & migration
+8. **`tenant_id TEXT`** added to `issues`, `edges`, `labels`, `pr_state`, `sync_state`, `repos`,
+   `repo_allowlist`. New tables: `users`, `installations`, `user_installations`, `sessions`,
+   `oauth_state`.
+9. **Composite PKs (fail-closed isolation):** `issues` → `(tenant_id, key)`; `edges` →
+   `(tenant_id, src_key, dst_key, kind)`; same on `labels`/`pr_state`. **D1/SQLite has no
+   `ALTER TABLE … ADD PRIMARY KEY`** → each is a **table-recreation** migration
+   (`CREATE new → INSERT … SELECT → DROP old → ALTER … RENAME`), preserving all indexes/FKs, within one
+   migration file. The `tenant_id` predicate is the live guard; composite PK makes a missing predicate
+   fail-closed (no silent cross-tenant overwrite).
+10. **Migration sequence (non-transactional CF deploy):** **M-a** add `tenant_id` *nullable* + recreate
+    PKs + add auth tables → **backfill** → **M-b** set `tenant_id NOT NULL`. **Backfill is a runtime
+    op, not SQL-file-embeddable** (installation_id is a runtime value): after the App is installed on
+    the `Roxabi` org, set existing rows to that **real installation_id** (not a sentinel) via a
+    **chunked admin endpoint / `wrangler d1 execute … UPDATE … WHERE tenant_id IS NULL`** (mind D1
+    per-statement row caps; trivial at current data size but state the assumption + verify row-count =
+    0 NULLs before applying M-b). Define rollback for orphan rows.
+11. **`sync_control` per-tenant:** key-value bag becomes keyed by `(tenant_id, key)` (or a sibling
+    `tenant_sync_control`). Per-tenant: `auth_halt_count`, `last_auth_halt_at`, `sync_running`,
+    `sync_started_at`. Global: `data_version`. A per-installation failure must **not** hold another
+    tenant's lock or trip a global halt.
+
+### Sync & webhook isolation
+12. **Per-installation sync fan-out:** `runSync` loops installations → mint token → sync repos → write
+    scoped by `tenant_id`. Per-tenant auth-halt breaker (decision 11). **Remove `GITHUB_TOKEN` (PAT)**
+    from `Env` + `wrangler.toml` in the same child issue that ships installation tokens — **no PAT
+    fallback** (also retire its uses in `handleDeps`/`handleRefDelete`).
+13. **Webhook routing:** single App secret (reuse `webhook/hmac.ts`); after HMAC pass, **mandatory**
+    `payload.installation.id` → `installations` lookup → `tenant_id` **before any DB write**. Unknown/
+    deleted/suspended installation → **return 200 OK, perform no mutation** (so GitHub doesn't retry;
+    no orphan/wrong-tenant rows).
+14. **Cross-tenant edge / stub policy (security-critical):** stubs are **always written under the
+    requesting tenant's `tenant_id`**, `is_stub=1`, `title=NULL`, `body=NULL` — **never** populated with
+    content fetched under another installation's token. `closedHopPass` (currently a tenant-blind
+    `UNION` over all edges, `sync.ts:985`) is **scoped per-tenant** (walk only that tenant's edge
+    graph). Cross-tenant dep references therefore materialize as tenant-local title-less stubs, never as
+    another tenant's real data.
+
+### Reads & isolation
+15. **Every read tenant-scoped:** `listIssuesRoute` + `graphRoute` (5 queries) gain `WHERE tenant_id=?`;
+    **`getIssueRoute`** issue/labels/edges fetches gain **`AND tenant_id=?`** (closes the IDOR — keys
+    are public GitHub URLs). `tenant_id` always from the **validated session**, never a request param.
+16. **Multi-installation contract:** the **session encodes a single *active* `tenant_id`**. Login: if
+    the user has exactly one installation → use it; if >1 → **org-picker** sets the active tenant
+    (switchable later). **No UNION-across-tenants** queries (they would defeat composite-PK isolation
+    and complicate pagination). This makes every `/api/*` query single-tenant.
+
+### Deploy / CI (devops)
+17. **Add `wrangler d1 migrations apply` to `ci.yml`** per-env **before** each `wrangler deploy`
+    (`… apply DB --env staging` / `… apply DB`). It does **not** exist today → without it the
+    nullable→NOT-NULL sequence never runs.
+18. **Secret-presence guard** in CI for `GITHUB_APP_*` (a deploy with missing app secrets succeeds but
+    fails at first OAuth) — pre-deploy check or documented `wrangler secret put` pre-flight per env.
+19. **Staging needs a testable URL:** staging `route=[]` today → enable `workers_dev=true` (or a test
+    route) so the Access-boundary change can be validated end-to-end before prod.
+20. **Separate staging R2 bucket** `roxabi-live-logs-staging` (both envs currently point at prod
+    `roxabi-live-logs` → staging cron fan-out would pollute the prod audit trail).
+21. **CF Access boundary = explicit deployment gate (one-way):** session middleware deployed and
+    **verified returning 401** for unauthenticated callers **on staging** *before* the Access policy is
+    relaxed on any env. Order: staging smoke-test → Access policy update (Access → `/admin/*` only;
+    `/webhook/*` keeps its existing bypass) → prod. Rollback = re-enable the Access rule.
+
+### UX & honesty (product)
+22. **Onboarding state machine:** OAuth callback with **no installation for the user** → "authorized,
+    not installed" state → guided redirect to the App **install URL** with a clear CTA → re-check on
+    return. The acceptance path "logs in → sees issues" has no dead-end.
+23. **Operator-read honesty (concrete surface + AC):** a **consent step in the OAuth flow** (before
+    first data view) the user must **acknowledge**, plus a **persistent dashboard notice**. Copy warns
+    Phase-1 data is operator-readable and **not to paste secrets into issue bodies**. Binary AC: notice
+    acknowledged before any issue data renders.
+24. **`payload` shape (locked, product calls — see gate):** introduce `payload TEXT` JSON.
+    **`title` moves into `payload`** now (graph reads `JSON_EXTRACT(payload,'$.title')`; `state`/`edges`
+    stay structural/plaintext). **`body` deferred** (not synced in Phase 1 — broadens operator-readable
+    surface, no value to the Phase-1 graph; `payload` shape already accommodates it later). Phase 2 then
+    swaps **one** column to ciphertext.
+
+---
+
+## Key risks (beyond the settled mitigations)
+
+- **Composite-PK table-recreation** (dec. 9) is the riskiest migration: a partial failure leaves a
+  half-migrated table with no auto-rollback → must be a single, tested migration with a staging dry-run.
+- **CF Access one-way relax** (dec. 21): the window between relax and a working session = public data
+  exposure → the staging-gate is non-negotiable.
+- **Backfill correctness** (dec. 10): any row left `NULL` when M-b applies fails the migration; verify
+  `COUNT(*) WHERE tenant_id IS NULL = 0` first.
+
+## Pre-impl validation tasks (binary, do before writing the code they gate)
+
+- **RS256 in workerd:** confirm `crypto.subtle` `importKey(pkcs8, RSASSA-PKCS1-v1_5)` + `sign` works at
+  the App-JWT path (distinct from the ADR-verified RSA-OAEP). Fallback if not: re-evaluate App-JWT
+  approach. *Gates decision 7/12.*
+- **`subIssues`/`parent` via installation token:** one live call confirming no preview header needed
+  post-GA when the token type changes from PAT → installation. *Gates decision 12.*
+
+---
+
+## Files / surfaces impacted
+
+| Surface | Current file(s) | Phase-1 change |
+|---|---|---|
+| Auth (new) | `api/auth.ts` (`ADMIN_TOKEN` only) | `worker/src/auth/*`: App-JWT, OAuth exchange, sessions, middleware |
+| Schema | `migrations/0001..0003` | `000N_tenant_nullable+pks.sql` (recreate), `000N_auth_tables.sql`, `000N_tenant_not_null.sql` |
+| Env | `types.ts`, `wrangler.toml` (×2 envs) | + `GITHUB_APP_*`; **remove `GITHUB_TOKEN`**; staging URL + `roxabi-live-logs-staging` |
+| Sync | `sync/sync.ts`, `sync/graphql.ts` | per-installation loop + token mint; tenant-scoped writes; per-tenant `sync_control`; scoped `closedHopPass` |
+| Webhook | `webhook/handlers.ts`, `hmac.ts`, `mutations.ts` | `installation.id`→tenant routing; unknown→200 no-write; tenant-local title-less stubs |
+| Reads | `api/issues.ts`, `api/graph.ts` | middleware gate; `tenant_id`/`AND tenant_id=?` on all queries |
+| Routing | `router.ts` | `/login`, `/oauth/callback`; session middleware on `/api/*` |
+| Frontend | `frontend/app.js`, `index.html` | unauthenticated landing; login; account-link; org-picker; consent notice |
+| CI/deploy | `ci.yml`, `wrangler.toml`, CF Access policy | `d1 migrations apply` step; secret guards; Access→`/admin/*`; staging gate |
+
+## Open questions (genuinely open)
+
+- **Membership view evolution:** active-tenant + org-picker is the Phase-1 contract (dec. 16); a merged
+  cross-installation view is a possible later enhancement (out of Phase-1 scope).
+- **Private-key rotation runbook** detail (dual-key overlap mechanics) — documented at impl, not a gate.
+
+## Review Log
+
+5 parallel expert reviews (architect, security-auditor, devops, product-lead, doc-writer); all
+"needs improvement." Must-fixes folded into settled decisions: closedHopPass scoping (dec. 14),
+backfill procedure (dec. 10), composite-PK recreation (dec. 9), per-tenant `sync_control` (dec. 11),
+oauth_state single-use/TTL/redirect_uri (dec. 6), multi-installation contract (dec. 16), session
+revocation + fixation + cookie scope (dec. 1–3), `/api/*` middleware fail-closed + IDOR (dec. 4, 15),
+webhook unknown-installation no-write (dec. 13), PAT retirement (dec. 12), CI migrate-step + secret
+guards + staging URL + staging R2 (dec. 17–20), Access staging-gate (dec. 21), onboarding state
+machine + honesty surface (dec. 22–23), payload/title/body product calls (dec. 24). RS256 +
+subIssues moved to pre-impl validation tasks. Mermaid corrected (install async; cron bidirectional);
+composite-PK duplication removed.

--- a/artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx
+++ b/artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx
@@ -1,0 +1,211 @@
+---
+title: "per-installation runSync cutover + PAT retirement (S3b)"
+description: "Rewrite runSync to per-installation tokens — discovery, deduped fan-out, slot-rotation, per-tenant lock isolation; retire GITHUB_TOKEN."
+---
+
+## Source
+
+Issue #160, split from #146: *"This issue is S3b: the sync-layer cutover to
+GitHub App installation tokens + PAT retirement."* The 4 RED cases in
+`worker/src/sync/sync.test.ts` (`describe.skip("runSync — multi-tenant
+installation sync (DEFERRED #160 …)")`, L1485) encode the target contract.
+
+## Problem
+
+`runSync` (`sync.ts:1127`) still runs the legacy flow:
+
+- Reads `env.GITHUB_TOKEN` at **4 sites** — `enumerateOrgRepos` (L1161),
+  `enumerateArchivedOrgRepos` (L1165), `syncRepoBundle` loop (L1277),
+  `closedHopPass` (L1288).
+- Enumerates the live repo set from the **org** (`enumerateOrgRepos`/
+  `enumerateArchivedOrgRepos`) gated by the global `repo_allowlist` table.
+- All 7 lock/slot helpers (`acquireSyncLock`/`releaseSyncLock`/`isHalted`/
+  `getAuthFailures`/`incrementAuthFailures`/`haltSync`/`resetAuthFailures`,
+  L213-266) **hardcode `tenant_id=0`** — a single global lock + global
+  auth-failure breaker.
+- `tenant_repo_access` is never written; `sync_slot` is seeded (0005) but never
+  read/advanced.
+
+So: the PAT can't be retired (RT3), multi-tenant installs can't be authorized
+(fail-closed gap), and the deduped/windowed fan-out doesn't exist.
+
+## Outcome
+
+`runSync` discovers repos per-installation, dedups the GraphQL fan-out to **1
+bundle query per unique repo**, windows under the ~50-subrequest cap via
+`sync_slot`, isolates lock/breaker per tenant, and reads **zero**
+`env.GITHUB_TOKEN`. `GITHUB_TOKEN` removed from `Env`/`wrangler.toml` (no
+fallback) and deleted from secrets (staging→prod, post-verify). All 4 RED cases
+pass; conflicting old-flow cases reconciled.
+
+## Appetite
+
+One focused F-full slice = a single PR. No phasing inside the slice; PAT secret
+deletion (RT3) is the post-merge operational tail, gated on a verified staging
+tick.
+
+## Findings (current → target)
+
+| Concern | Current | Target |
+|---|---|---|
+| Repo discovery | `enumerateOrgRepos` + `repo_allowlist` (PAT) | per-tenant `listInstallationRepos` → upsert `tenant_repo_access` (install token) |
+| Token per repo | `env.GITHUB_TOKEN` everywhere | `resolveInstallToken(db, env, owner, name)` per (owner,name) |
+| Fan-out | per `active` repo (org list) | per **unique** repo across tenants (deduped Map) |
+| Subrequest cap | `REPO_BUNDLE_QUERY` keeps N+1; no windowing | + slot-rotation window via `sync_control.sync_slot` |
+| Lock / breaker | global `tenant_id=0` | threaded `tenantId` (default 0); one tenant ≠ block another |
+| `closedHopPass` | `(db, token)` | `(db, resolveToken: (owner,name)=>Promise<string>)` |
+| `listInstallationRepos` | `while(true)`, no cap/timeout (W2) | `MAX_PAGES` + `AbortSignal.timeout` per fetch |
+
+**Schema is ready:** `sync_control` PK is already `(tenant_id, key)` (0004);
+`tenant_repo_access (tenant_id, repo)` exists (0004); `sync_slot=0` seeded for
+`tenant_id=0` (0005). This is an **application-code** rewrite, no migration.
+
+## Shapes — lock unit vs fan-out unit (the hard decision)
+
+The tension: RED case 1 wants **global dedup** (1 query/unique-repo across
+tenants); RED case 3 wants **per-tenant lock isolation**. The unit of locking ≠
+the unit of fan-out.
+
+### Shape 1: Two-phase — global tick lock + per-tenant discovery skip-guard + global deduped windowed fan-out  ← recommended (architect-confirmed)
+
+- **Entry:** `isHalted(db, 0)` → `acquireSyncLock(db, 0)` — the **existing global
+  tick lock** (`sync.ts:1135`) serialises the whole invocation (prevents two
+  overlapping cron ticks from double-fan-out / double-slot-advance). Released in
+  `finally`.
+- **Phase 1 (tenant-outer):** for each tenant with an installation, attempt
+  `acquireSyncLock(db, tenantId)` as a **within-tick discovery skip-guard**
+  (this is what RED case 3 asserts — the per-tenant *attempt*); held → skip
+  *that* tenant, else `getInstallationToken` → `listInstallationRepos`
+  (hardened) → upsert `tenant_repo_access`. Build a global
+  `Map<repo, tenantId[]>` (**sorted list**, lowest id = owning tenant; list
+  enables token fallback) for token sourcing.
+- **Phase 2 (global, deduped, under the entry lock):** deterministically sort
+  the unique-repo set (`owner/name`); window via `sync_slot`
+  (`window = [slot*WINDOW, (slot+1)*WINDOW)`); for each repo in the window →
+  `getInstallationToken(db, env, owningTenantId, installationId)` (iterate the
+  tenant list on revoked-install, only `incrementAuthFailures` the tenant that
+  threw; all fail → skip repo + log, don't abort) → `syncRepoBundle`. Then
+  `closedHopPass(db, resolver)`. Advance `sync_slot = (slot+1) % NUM_SLOTS`
+  (constant modulus, `tenant_id=0`).
+- **Breaker:** `incrementAuthFailures`/`haltSync` scoped to the failing tenant.
+
+**Trade-offs:**
+- Pro: satisfies all 4 RED cases (dedup ✓, slot ✓, per-tenant lock attempt ✓,
+  no PAT ✓); one tenant's auth failure halts only itself; 1 query/unique-repo;
+  overlapping ticks serialised by the entry lock.
+- Con: adds a per-tick discovery pass (extra REST calls — cheap, W2-bounded);
+  per-repo token resolution moves to the call site (not `resolveInstallToken`,
+  whose `.first()` is non-deterministic for multi-tenant rows).
+
+**Rough scope:** L
+
+### Shape 2: Per-tenant full sync (tenant-outer, no cross-tenant dedup)
+
+Each tenant independently: lock → list repos → sync each under its own token.
+
+**Trade-offs:**
+- Pro: simplest lock model, fully isolated.
+- Con: **violates SC-3** — a repo shared by 2 tenants is fetched twice → RED
+  case 1 fails + subrequest cap breaches as installs grow. **Eliminated.**
+
+**Rough scope:** M
+
+### Shape 3: Global single-lock + global dedup (`tenant_id=0` only)
+
+Keep one global tick lock; discover all tenants, dedup, window, fan-out;
+breaker global.
+
+**Trade-offs:**
+- Pro: minimal change to lock helpers (no `tenantId` threading).
+- Con: **violates RED case 3** — one tenant's lock/auth-failure blocks/halts all.
+  **Eliminated by the test contract.**
+
+**Rough scope:** M
+
+## Fit Check
+
+**Shape 1.** It is the only shape satisfying the full RED contract + SC-3/4/6.
+Global tick lock serialises the run; per-tenant lock gates *discovery* (what RED
+case 3 asserts); the deduped fan-out operates on the `tenant_repo_access` union
+with per-repo token resolution from the owning-tenant list; the slot is global
+(constant `NUM_SLOTS`) because the deduped repo list is global.
+
+```mermaid
+flowchart TD
+  A[runSync tick] --> Z[acquireSyncLock db,0 · global tick lock]
+  Z --> B{for each tenant}
+  B --> C[acquireSyncLock db,tenantId · discovery skip-guard]
+  C -->|held| B
+  C -->|got| D[getInstallationToken → listInstallationRepos*]
+  D --> E[upsert tenant_repo_access]
+  E --> F[merge into Map repo→tenantId list, sorted]
+  B -->|done| G[sort unique repos owner/name]
+  G --> H[window = slot*WINDOW .. +WINDOW]
+  H --> I{for repo in window}
+  I --> J[getInstallationToken owningTenant; fallback down list]
+  J --> K[syncRepoBundle · 1 bundle query]
+  I -->|done| L[closedHopPass db, resolver]
+  L --> M[advance sync_slot = slot+1 mod NUM_SLOTS]
+  M --> N[release locks · writeRunAudit]
+  J -.all tenants fail.-> P[skip repo · log]
+  K -.auth fail.-> O[incrementAuthFailures tenantId → haltSync tenantId]
+  classDef w2 stroke-dasharray:4 3
+  class D w2
+```
+`*` = `listInstallationRepos` hardened (MAX_PAGES + AbortSignal.timeout) — in scope this PR.
+
+## Decisions resolved (architect review — fold into /spec)
+
+1. **Lock model:** existing global tick lock `acquireSyncLock(db, 0)` at entry
+   serialises the whole run; per-tenant `acquireSyncLock(db, tenantId)` is a
+   Phase-1 discovery skip-guard only. **No** second Phase-2 lock. Thread
+   `tenantId` (default `0`) through all 7 lock/breaker helpers (`sync.ts:213-273`)
+   so existing non-`runSync` callers are unaffected.
+2. **Slot windowing:** `next_slot = (slot+1) % NUM_SLOTS` with **constant**
+   `NUM_SLOTS = 3` — NOT `ceil(N/WINDOW)` (a volatile divisor permanently
+   skips/double-covers repos as installs come/go). `WINDOW = 20` (50-cap budget:
+   ~7 reserved for discovery+overhead, 43 for fan-out, halved for closedHopPass
+   worst-case ≈ 21). Empty slice (repo count < `slot*WINDOW`) → no fan-out but
+   still advance slot (forward progress). Export `WINDOW`/`NUM_SLOTS` so tests
+   override without patching internals.
+3. **Token source:** `Map<repo, tenantId[]>` (sorted, lowest = owning). Phase 2
+   calls `getInstallationToken(db, env, owningTenantId, installationId)`
+   **directly** (not `resolveInstallToken` — `.first()` non-deterministic,
+   `installToken.ts:182`); on a revoked/suspended install (throw) fall back to
+   the next tenant in the list, `incrementAuthFailures` only the thrower; all
+   fail → skip repo + log, don't abort. `resolveInstallToken` stays the
+   webhook-path resolver (single-tenant invariant holds there).
+4. **Prune source:** **union of `tenant_repo_access`** replaces org-enum.
+   Re-target the 0-live-repos guard (`sync.ts:1175`) at the **union count** so a
+   failed/empty discovery never prunes everything (safe false-negative). A repo
+   genuinely removed from all installs → its issues pruned (correct; document).
+5. **Empty discovery** (no installs / empty union): no-op + warn — NOT the old
+   "empty allowlist short-circuit." Reconcile L967 test.
+6. **W2 in scope (not deferred):** harden `listInstallationRepos` (`MAX_PAGES` +
+   `AbortSignal.timeout`/fetch) — Phase 1 calls it per tenant every tick.
+
+**Still verify at implement:**
+- **Arg-index discrepancy:** issue says the dedup RED case reads `c[2]/c[3]`;
+  current skip-block (L1525) already reads `c[0]/c[1]` (correct). Confirm exact
+  state — real gap is the missing top-level `vi.mock("../auth/installToken")`.
+- **Lock helper INSERT path:** `acquireSyncLock` UPDATEs and silently no-ops if
+  the `(tenantId,'sync_running')` row is missing → seed per-tenant
+  `sync_control` rows (`INSERT OR IGNORE`) at tenant creation or lazily.
+
+## Files impacted
+
+| File | Change |
+|---|---|
+| `worker/src/sync/sync.ts` | rewrite `runSync`; thread `tenantId` through 7 helpers; `closedHopPass` resolver; drop 4 `GITHUB_TOKEN` reads; slot windowing; discovery pass |
+| `worker/src/auth/installToken.ts` | harden `listInstallationRepos` (W2) |
+| `worker/src/types.ts` | drop `GITHUB_TOKEN` from `Env` (T10) |
+| `wrangler.toml` | drop `GITHUB_TOKEN` (both envs) |
+| `worker/src/sync/sync.test.ts` | un-skip + fix 4 RED cases (add `vi.mock`); reconcile ~11 old-flow `runSync` cases (L924-1408) |
+
+## Risks
+
+- **Live-sync regression during cutover** — PAT stays live until a verified
+  install-token tick; RT3 deletion is post-merge, staging→prod.
+- **Prune-everything** if discovery yields 0 → mitigated by the 0-live-repos guard.
+- **Test reconciliation churn** — the 11 old-flow cases assume org-enum + global
+  lock; rewriting them is the bulk of the test work and the main review surface.

--- a/artifacts/analyses/zk-encryption-spike-analysis.mdx
+++ b/artifacts/analyses/zk-encryption-spike-analysis.mdx
@@ -1,0 +1,163 @@
+---
+title: "Zero-knowledge encryption + multi-tenant GitHub auth — architecture spike"
+description: "Time-boxed spike: can roxabi-live become a multi-tenant tool where the operator provably cannot read user data? Decides between server-centric / client-centric / envelope-asymmetric, with the residual trust gap stated explicitly."
+status: proposed
+---
+
+## Source
+
+> "On sait que ça marche maintenant sur les workers et on voulait étendre ça avec une authentification GitHub […] permettre aux utilisateurs de relier leur compte GitHub à l'outil […] que ça devienne un outil pour tout le monde plutôt qu'un outil que pour moi. […] dans un second temps […] que les données soient cryptées directement dans les bases de données de manière à ce qu'on n'ait pas accès à cette donnée là via une clé qui serait stockée directement côté GitHub potentiellement et du coup seul l'utilisateur sur son navigateur local aurait accès à cette clé et moi j'aurais pas accès côté serveur — ça garantit une sécurité complète."
+
+## Problem
+
+`roxabi-live` is single-tenant: one CF Worker + one D1, behind CF Access for `mickael@bouly.io`. Server-side sync (cron + org webhook) reads plaintext issues via GraphQL and writes them to D1. Two extensions are wanted:
+
+1. **Multi-tenant** — any GitHub user links their account and sees *their* issues → "a tool for everyone."
+2. **Operator-blind data** ("sécurité complète") — D1 contents unreadable by the operator (me); key held only in the user's browser, possibly backed up on GitHub.
+
+These two goals **pull in opposite directions**: goal 1 (background sync, real-time, works-when-browser-closed) wants a *fat server*; goal 2 (operator can't read) wants a *thin server / fat client*. This spike resolves the tension and picks an auth primitive that doesn't have to be re-chosen later.
+
+## Outcome
+
+A decision (this ADR) that:
+- picks the storage/encryption archetype **honestly labelled** by the threat model it actually defends against;
+- picks a GitHub auth primitive that serves both the multi-tenant baseline *and* a future operator-blind mode without rework;
+- states the **residual trust gap** for the chosen option in plain language;
+- enumerates the issues to file.
+
+## Appetite
+
+Spike — research-only, no implementation. Informs issue creation for two epics (multi-tenant auth, encryption).
+
+---
+
+## Verified findings
+
+All claims below were verified against primary sources (Cloudflare docs, MDN, GitHub docs, OWASP) by two research agents; citations in the source notes at the bottom.
+
+### Crypto (workerd + browser) — envelope-asymmetric is cryptographically viable
+- workerd `crypto.subtle` supports AES-GCM, ECDH-P256, HKDF, PBKDF2, RSA-OAEP, `generateKey/importKey/exportKey/encrypt/decrypt/deriveKey/deriveBits`. Browser Web Crypto supports the full set incl. `wrapKey/unwrapKey`.
+- **ECIES (ephemeral ECDH-P256 → HKDF → AES-GCM) is preferred over RSA-OAEP** on workerd: it avoids the one unconfirmed primitive (`wrapKey` *with RSA-OAEP as the wrapping alg*) and uses only confirmed paths. Compact keys (P-256 pub ≈ 65 B).
+- KDF for any passphrase-wrapped key: native max is **PBKDF2-SHA256 @ ≥600k iters** (OWASP). **Argon2id is NOT in Web Crypto** — needs a WASM bundle. Implication: passphrase-derived protection is GPU-attackable at PBKDF2 strength unless WASM-Argon2 is added.
+
+### The hard tension — precisely characterized
+Envelope-asymmetric (Option C) makes **at-rest** D1 data unreadable, but the Worker **holds plaintext in memory** during each sync tick (GitHub fetch → encrypt). So:
+
+| Defends against | Does NOT defend against |
+|---|---|
+| D1 database breach / dump | The Worker **code author** (= me, today) |
+| CF account sub-user with D1 read-only | Anyone with CF Worker **deploy** access |
+| A *future* operator inheriting the DB | Cloudflare infra operator |
+| Accidental at-rest exposure | GitHub (source of plaintext) |
+
+→ **Option C is "operator-at-rest protection," NOT zero-knowledge.** It does **not** satisfy the literal ask ("moi j'aurais pas accès côté serveur"): because I control the Worker code, I *can* read plaintext during the sync tick. Only an architecture where **the server never sees plaintext** (client does the fetch + encrypt) delivers true operator-blindness.
+
+### GitHub auth — one primitive serves both modes
+- **A single GitHub App issues BOTH token types**: *installation tokens* (server-to-server: cron, webhooks, 1 h auto-rotated, `Issues:Read` covers `subIssues`/`parent`/`blockedBy`/`blocking` — all GA, no preview header) **and** *user-to-server tokens* (usable client-side). → Picking a GitHub App now does not lock out a future client-centric mode.
+- **GitHub PKCE does NOT remove `client_secret`.** Public-client PKCE is unsupported; the token-exchange `POST` always needs the secret. → Even a "browser-only / zero-knowledge" mode needs a **thin Worker endpoint** holding the secret to do `code → token`. The server can hand the token to the browser and **not persist it** — but the exchange touches the server. "Token never touches the server" is only *partially* achievable.
+
+### Key-on-GitHub idea — NOT operator-proof
+- The wrapped-key *blob* is cryptographically sound (useless without the passphrase).
+- But a **"secret" gist is not private** — it is URL-accessible without auth, forkable, and its **revision history persists** old key versions. Scope isolation stops the operator's *App token* from hitting the Gists API, **but** an operator-controlled Worker that sees the gist URL during the flow can fetch the blob out-of-band, no token needed.
+- → **Drop gist key storage.** Operator-blind key handling requires the key to stay in **browser-local storage** (IndexedDB/non-extractable CryptoKey), with any backup being a passphrase-wrapped export the **server never sees the location of** (e.g. user-downloaded file, or a store keyed by a secret the server never receives).
+
+### D1 multi-tenant ceiling
+- Single DB + `tenant_id` column viable to **10 GB / thousands of tenants** (Workers Paid). DB-per-tenant scales to **50,000 DBs** (hard isolation, provisioning overhead). Cron fan-out bounded by **10,000 subrequests/invocation + 15 min CPU** → hundreds of users per tick; beyond that → Cloudflare Queues / multi-tick batching.
+- **Server-side dep-graph survives encryption only if graph-relevant metadata (`state`, edges) stays plaintext** and only *content* (title/body) is encrypted. Full-field encryption forces graph computation **client-side** — which `frontend/state.js` **already does today**, so a client-decrypt model is compatible with the existing frontend.
+
+---
+
+## Shapes
+
+### Shape A — Server-centric (multi-tenant, NOT operator-blind)
+GitHub App · installation tokens · cron + per-install webhooks · single D1 + `tenant_id` · at-rest encryption optional. Operator **can** read.
+- **Pro:** simplest; best UX (works browser-closed, real-time); server computes graph; reuses ~all current code.
+- **Con:** does not meet the operator-blind goal at all.
+- **Scope:** M
+
+### Shape B — Client-centric (true zero-knowledge)
+GitHub App user-to-server token + thin exchange endpoint · browser fetches GitHub → encrypts → pushes ciphertext · server = opaque blob store · no content cron · graph computed client-side (already the case).
+- **Pro:** the only shape where the operator can't read **content**. Matches the literal ask — with one scope correction: **structural metadata still leaks** (see below).
+- **Con:** no background sync (browser must be open); no real-time webhook-driven content updates; GitHub token now lives in the browser (different threat model); more client complexity; loses server-side search/indexing. **Content-only privacy** — `state`/`edges`/counts/timing/sizes remain operator-visible (needed for the server-side graph); hiding those collapses back toward Shape A's UX. No forward secrecy with a static user key; XSS can still misuse an in-process key; multi-device bootstrap is unsolved (see residual gap).
+- **Scope:** L
+
+### Shape C — Envelope-asymmetric (operator-at-rest only)
+Server-centric like A, but sync encrypts each record to the user's **public** key (ECIES); only the browser's private key decrypts.
+- **Pro:** keeps cron/webhook/server-graph; protects against DB breach + future operator.
+- **Con:** **NOT zero-knowledge** (plaintext in Worker memory during sync); residual gap = me + CF + GitHub; extra complexity for a guarantee weaker than the ask implies.
+- **Scope:** L
+
+### Shape D — Hybrid, phased ← recommended
+- **Phase 1 (ship "tool for everyone"):** Shape A. GitHub App, single D1 + `tenant_id`, server-centric. No false privacy claims. GitHub issues are data the user already entrusts to GitHub; for public repos it isn't even secret.
+- **Phase 2 (opt-in operator-blind mode):** Shape B as an explicit per-user toggle. Same GitHub App (user-to-server token). Users who need "operator can't read" turn it on and accept the UX cost (browser-driven sync). Key stays browser-local; no gist.
+- **Pro:** unblocks the multi-tenant goal immediately; offers *real* zero-knowledge to those who want it, honestly, instead of baking a mislabeled weak guarantee into the default; **one** GitHub App covers both.
+- **Con:** two sync paths to maintain long-term.
+- **Scope:** XL (split across the two epics)
+
+## Fit Check
+
+| | A | B | C | **D (hybrid)** |
+|---|---|---|---|---|
+| "Tool for everyone" fast | ✓✓ | ✗ (UX cost) | ✓ | **✓✓ (Phase 1)** |
+| Operator truly can't read | ✗ | ✓✓ | ✗ (mislabeled) | **✓ (Phase 2 opt-in)** |
+| Works browser-closed / real-time | ✓✓ | ✗ | ✓✓ | **✓ default / ✗ ZK mode** |
+| Reuses current Worker/cron/graph | ✓✓ | ✗ | ✓ | **✓** |
+| Honest about its guarantee | ✓ | ✓ | ✗ | **✓✓** |
+
+**Eliminated: C as a standalone answer.** It costs L-effort for a guarantee that does not match the stated goal — its protection (anti-DB-breach) is better achieved by Phase-1 at-rest encryption inside Shape A/D without the client-key machinery. C only becomes interesting if the threat model is explicitly *narrowed* to "future DB breach," which is not what was asked.
+
+---
+
+## Decision (ADR)
+
+**Adopt Shape D (hybrid, phased), on a single GitHub App.**
+
+1. **Auth primitive: GitHub App** (not OAuth App). Reason: it issues installation tokens (Phase-1 server sync, webhooks, higher rate limits) *and* user-to-server tokens (Phase-2 client-side mode) — so the auth decision is **not** re-litigated when Phase 2 lands. `Issues:Read` covers all needed GraphQL fields. A thin Worker endpoint holds `client_secret` for the OAuth code-exchange (unavoidable — GitHub PKCE doesn't remove it).
+2. **Phase 1 — multi-tenant, server-centric (Shape A).** Single D1 + `tenant_id`; per-install webhooks; cron fan-out (move to Queues only past ~hundreds of users). At-rest encryption of *content* fields is a cheap optional add (anti-DB-breach) but **must not be advertised as operator-blind**.
+3. **Phase 2 — opt-in zero-knowledge (Shape B).** Per-user toggle: browser fetches GitHub with its user token, encrypts content client-side (ECIES via Web Crypto), pushes ciphertext; server stores blobs and serves them; graph computed client-side (already the case). Key stays browser-local (non-extractable CryptoKey / IndexedDB).
+4. **Reject gist key storage.** Not operator-proof (URL-accessible, history persists, Worker can intercept the URL). Backup = passphrase-wrapped export the server never locates; if a passphrase KDF is used, require WASM-Argon2id (PBKDF2-600k as floor).
+
+### Residual trust gap (stated explicitly)
+- **Phase 1 (default):** operator **can** read user data. This is acceptable *only* if communicated — it's the same trust users already place in GitHub for the same issues. At-rest encryption narrows it to "operator-with-code-access can read," nothing stronger.
+- **Phase 2 (ZK mode):** operator cannot read stored **content**. Irreducible residue:
+  - (a) the **OAuth code-exchange** touches a server endpoint holding `client_secret` (token can be returned to the browser unpersisted, but the exchange is server-side; `client_secret` leak = user impersonation → must be rotatable, never logged);
+  - (b) the user's GitHub token lives in the browser;
+  - (c) **served-JS integrity** — a malicious deploy can ship key-exfiltrating JS. *SRI does not help* when the operator controls the asset CDN (it can update hash + asset atomically); only external code-transparency would, and it's never fully closed for served JS;
+  - (d) **XSS = key theft** — a non-extractable CryptoKey blocks `exportKey()` but **not in-process misuse**: an XSS payload can call `decrypt()` directly. The ZK guarantee is therefore contingent on a strict CSP + XSS elimination;
+  - (e) **metadata leakage** — content is encrypted but `state`, `edges` (who-blocks-whom), per-tenant issue counts, sync timing, and record sizes stay plaintext (the server graph needs them). Significant org-structure leakage without decrypting a byte. The privacy claim must be scoped to *"content, not graph structure."*;
+  - (f) **no forward secrecy** — static user key ⇒ private-key compromise retroactively decrypts all historical D1 ciphertext. Mitigate with per-record ephemeral keys + key rotation if this matters;
+  - (g) **session tokens at rest in D1 are operator-readable** (Phase 1 too) → operator-level access to whatever the user's token reaches; sessions need short TTL + revocation.
+
+### How this constrains the multi-tenant auth epic
+- The auth epic **must register a GitHub App** (not an OAuth App) and provision a **server-side token-exchange endpoint** from day one, even though Phase 1 alone could run on installation tokens — otherwise Phase 2 forces an auth rewrite. `client_secret` must be rotatable and never logged.
+- D1 schema gets `tenant_id` **now** (Phase 1). The migration is **breaking** on the live DB (backfill existing rows to a seed tenant) and CF deploy+migration are **not transactional** → sequence: migration first, then code; define a rollback for orphaned rows.
+- Phase-1 schema must **already** separate the encryptable payload from structural metadata: store `title`/`body`/notes in a dedicated `payload` column (JSON), keep `state` + `edges` as plaintext structural columns. Phase 2 then swaps **one column** (`payload TEXT → encrypted BLOB`) instead of restructuring rows.
+- CF Access (current edge gate) is **replaced by app-level sessions** for the public app (Access stays only for `/admin/*`). Sessions need a **revocation/invalidation design from day one**: short TTL, server-side revocation, and a defined reaction to GitHub App un-installation — retrofitting this later is harder than the encryption work.
+- **Tenant isolation choice:** single D1 + `tenant_id` (chosen) over Durable-Object-per-tenant. DO-per-tenant would eliminate the cross-tenant `WHERE`-filter bug class but adds provisioning complexity not justified at expected scale; revisit only if a tenant-isolation incident or >10 GB pressure appears.
+- **Phase-2 lifecycle gate (avoid two forever-paths):** the ADR must set a graduation criterion up front — either ZK mode is time-boxed toward becoming the default, or it's an explicitly capped permanent minority path with a named maintenance budget. Otherwise the server cron path bitrots against the ciphertext schema.
+- **WASM-Argon2id is a Phase-2 go/no-go**, not a follow-up: if it can't run in workerd at target iterations, PBKDF2-600k is the floor for *every* exported/backed-up key blob → brute-force becomes realistic on weak passphrases.
+
+---
+
+## Files / surfaces impacted (for issue scoping)
+
+| Surface | Phase 1 | Phase 2 |
+|---|---|---|
+| `worker/src/auth/*` (new) | GitHub App install, OAuth exchange, sessions | user-token relay |
+| `worker/migrations/` | `tenant_id` on issues/edges; sessions table | `encrypted_payload` column shape |
+| `worker/src/sync/*` | per-install tokens, per-tenant scoping | (ZK: server stops fetching content) |
+| `worker/src/webhook/*` | per-install HMAC, tenant routing | — |
+| `worker/src/api/*` | tenant-filtered reads | serve ciphertext blobs |
+| `frontend/` | login, account-link UI | client crypto (ECIES), key mgmt, encrypt-on-push |
+
+## Open questions / not verified
+- **Multi-device key bootstrap (ZK mode)** — the most likely ZK-breaking user behavior, currently unsolved. Passphrase-wrapped export invites weak passphrases (defeats the KDF); a server-stored recovery key collapses ZK. Needs a real design before Phase 2 (candidates: device-to-device key transfer via QR/WebRTC, or accept "per-device, no sync" + re-link).
+- WASM-Argon2id inside workerd at target iteration count — **Phase-2 go/no-go** (see Decision), not a passive follow-up.
+- Live-token confirmation that `subIssues`/`parent` need no preview header post-GA (research said GA; recommend a smoke test).
+- D1 read-replica consistency lag (no published SLA).
+- Whether at-rest content encryption in Phase 1 is worth the complexity vs. plain D1 + "we can read your data" honesty — **product call**, not technical. Note: even encrypted, private-repo issue **bodies may contain pasted secrets** — Phase-1 honesty messaging should warn users not to treat the cockpit as a secret store.
+
+---
+
+## Source notes (citations)
+Crypto: Cloudflare Web Crypto docs + historical changelog; MDN SubtleCrypto/wrapKey/deriveKey; OWASP Password Storage; RSA-OAEP max-plaintext (Chilkat); ECIES-with-WebCrypto reference. Gist risk: TruffleSecurity, GitGuardian, GitHub 2025-11-25 changelog, GitHub "Creating gists" docs. Auth: GitHub "Differences between GitHub Apps and OAuth apps", "Rate limits for GitHub Apps", "Permissions required for GitHub Apps", "Dependencies on issues" GA changelog (2025-08-21), "Authorizing OAuth apps". D1: Cloudflare D1 Limits + Pricing, Workers Limits.

--- a/artifacts/frames/141-multi-tenant-github-app-auth-frame.mdx
+++ b/artifacts/frames/141-multi-tenant-github-app-auth-frame.mdx
@@ -1,0 +1,105 @@
+---
+title: "Multi-tenant GitHub App auth — make roxabi-live a multi-user tool (Phase 1)"
+issue: 141
+status: approved
+tier: F-full
+date: 2026-06-09
+---
+
+## Problem
+
+`roxabi-live` is single-tenant. One CF Worker + one D1 sit behind CF Access for a single
+identity (`mickael@bouly.io`). The corpus, the hourly cron sync, the GitHub org webhook, and
+the dep-graph all assume **one operator's org data**. There is no path for another GitHub user
+to authenticate and see *their own* issues — it is a personal cockpit, not a product.
+
+Now is the trigger: the CF Worker + D1 stack was validated in production (M₁ cutover complete
+2026-06-08, `live.roxabi.dev` fully independent), so the foundation is proven and ready to
+extend from one user to many.
+
+This is **Phase 1** of the decision recorded in
+`artifacts/analyses/zk-encryption-spike-analysis.mdx` (ADR → Shape D, hybrid/phased). Phase 1
+is the multi-tenant, **server-centric** baseline. It deliberately does **not** make data
+operator-blind — that is Phase 2 (epic #142, blocked-by this). The auth primitive is chosen
+here so Phase 2 needs no auth rewrite.
+
+## Who
+
+- **Primary:** any GitHub user who installs / links the GitHub App → authenticates and sees
+  **only their own** issues + dep-graph in the cockpit.
+- **Secondary:** the operator (mickael) — runs and maintains sync, holds the D1 database. Must
+  now (a) enforce tenant isolation on every read, and (b) communicate honestly that in Phase 1
+  the operator **can** read user data (same trust users already place in GitHub for the same
+  issues), warning users not to paste secrets into issue bodies.
+
+## Constraints
+
+- **Auth primitive = a single GitHub App** (not an OAuth App). Issues both *installation
+  tokens* (server-to-server: cron, webhooks; `Issues:Read` covers `subIssues`/`parent`/
+  `blockedBy`/`blocking`, all GA) and *user-to-server tokens* (reused by Phase 2). Picking it
+  now means Phase 2 does not re-litigate auth.
+- **Server-side OAuth code-exchange endpoint holding `client_secret`** — GitHub PKCE does not
+  remove the secret, so a thin Worker endpoint is unavoidable. Secret must be **rotatable** and
+  **never logged**.
+- **App-level sessions replace CF Access** for the public app; CF Access stays only on
+  `/admin/*`. From day one: short TTL, **server-side revocation**, and a defined reaction to
+  GitHub App **un-installation**. (Retrofitting session invalidation later is harder than the
+  rest.) NOTE: session tokens at rest in D1 are operator-readable.
+- **D1 schema: single DB + `tenant_id`** on issues/edges (Durable-Object-per-tenant explicitly
+  rejected at this scale). The migration is **breaking** on the live DB (backfill existing rows
+  to a seed tenant); CF deploy + migration are **not transactional** → sequence
+  **migration-before-code** with a rollback path for orphan rows.
+- **Isolate a `payload` column** (title/body/notes JSON) from structural metadata (`state`,
+  `edges` stay plaintext) — so Phase 2 swaps **one column** to ciphertext, not the row shape.
+- **Per-install webhooks + tenant routing**; per-tenant sync scoping; cron fan-out within the
+  workerd limits (10k subrequests / 15 min CPU per invocation) → fine for hundreds of users;
+  move to Cloudflare Queues only beyond that.
+- **Runtime:** Cloudflare Workers (workerd) — `fetch()` + Web Crypto + D1 binding only.
+
+## Out of Scope
+
+- **Phase 2 client-side zero-knowledge / operator-blind mode** → epic **#142** (blocked-by
+  this). No ECIES, no browser-local keys, no ciphertext storage in Phase 1.
+- **Cloudflare Queues** migration for cron fan-out — deferred until ~hundreds of users.
+- **At-rest content encryption in Phase 1** — optional, a *product call* per the ADR open
+  questions, not a hard requirement here. Default = honest "operator can read." (Can be added
+  later as anti-DB-breach without being advertised as operator-blind.)
+- **Billing, plans, quotas, rate-limit tiering.**
+- **Multi-device key bootstrap, WASM-Argon2id** — Phase-2 concerns.
+
+## Premise Validity
+
+**Success in 6 months:** ≥1 GitHub user *other than the operator* has logged in via the GitHub
+App, linked their account, and sees **only their own** issues + dep-graph in production; tenant
+isolation is verified (no cross-tenant leakage observed). The epic's acceptance criterion — "a
+second GitHub user can log in, link their account, and see only their own issues + graph" — is
+met live.
+
+**Failure in 6 months (falsifiable):** after ship, **either** (i) external-tenant count = **0**
+(no non-operator user has successfully linked and used the tool across the period) **or**
+(ii) **≥1 observed cross-tenant data-exposure incident** in production (one tenant's issues
+rendered to another). Both are observable boolean/threshold states on a 6-month horizon and
+would trigger redesign-or-abort.
+
+**Simplest alternative:** keep CF Access and expand its allow-list to multiple emails — one
+shared single-org corpus, no GitHub App, no `tenant_id`.
+
+**Why not simplest:** a multi-email CF Access list still shows every allowed user the **same**
+corpus (the operator's org data), not their *own* GitHub issues. No per-user GitHub data, no
+isolation, no user token — it cannot become "their" tool, and it cannot graduate to Phase-2
+zero-knowledge (no user-to-server token, no per-tenant payload column). It fails the core
+outcome ("a tool for everyone").
+
+## Complexity
+
+**Tier: F-full** — multi-domain, new architecture, and a breaking migration on a live database.
+
+Signals observed:
+- **Multi-domain:** auth (GitHub App + OAuth exchange + sessions) · DB (breaking `tenant_id`
+  migration + `payload` column) · sync/webhook (per-install tokens, tenant routing) · API
+  (tenant-filtered reads) · frontend (login + account-link UI).
+- **New architecture:** GitHub App as auth primitive; app-level session layer replacing edge
+  CF Access; tenant model across the whole data path.
+- **Unknowns:** session revocation / App-uninstall reaction design; breaking live-DB migration
+  sequencing (non-transactional deploy+migrate) + orphan-row rollback.
+- **Size label:** `size:F-full` (L/XL).

--- a/artifacts/frames/160-per-installation-runsync-cutover-frame.mdx
+++ b/artifacts/frames/160-per-installation-runsync-cutover-frame.mdx
@@ -1,0 +1,90 @@
+---
+title: per-installation runSync cutover + PAT retirement (Phase 1 S3b)
+issue: 160
+status: approved
+tier: F-full
+date: 2026-06-12
+---
+
+## Problem
+
+S3a (#146) landed the install-token plumbing — `installToken.ts`
+(`getInstallationToken`/`resolveInstallToken`/`listInstallationRepos`),
+`tokenCrypto.ts` (AES-GCM), the `0005_sync_slot_seed` migration, and the CI
+`INSTALL_TOKEN_KEY` inject. But `runSync` still runs the **legacy
+org-enumeration / `repo_allowlist` / PAT flow**: it reads `env.GITHUB_TOKEN`
+and calls `enumerateOrgRepos`/`enumerateArchivedOrgRepos`. Consequences:
+
+- The org-scoped **PAT (`GITHUB_TOKEN`) is still the live sync credential** —
+  it cannot be retired (RT3) until sync runs on installation tokens.
+- `tenant_repo_access` is **never populated** — nothing fills it until this
+  slice's discovery pass, leaving the S3a→S3b fail-closed gap open.
+- The deduped, slot-rotated, per-tenant multi-tenant fan-out **does not exist**;
+  the 4 RED cases in `sync.test.ts` (`describe.skip(… DEFERRED #160 …)`) encode
+  the target behaviour but are skipped.
+
+## Who
+
+- **Primary:** the cockpit's hourly Cron sync + the operator (Mickael) — sync
+  must keep reconciling issue/edge data into D1 after the org-scoped PAT is gone.
+- **Secondary:** future multi-tenant installations — each installation's repos
+  sync via its own token, with no cross-tenant lock/failure bleed.
+
+## Constraints
+
+- Cloudflare Worker **subrequest cap (~50/invocation)** → slot-rotation windowing
+  required (`sync_control.sync_slot`, 0005 seed already live).
+- Live hourly sync must not break during cutover — **PAT stays live** until a
+  verified install-token tick; retirement is staging→prod after empirical verify.
+- D1 `0005` sync_slot seed live; `tenant_repo_access` table exists but **empty**.
+- `listInstallationRepos` is currently **unbounded** (`while(true)`, no per-call
+  timeout) — must harden (W2: `MAX_PAGES` + `AbortSignal.timeout`) before wiring
+  its first caller here.
+- No KV in Phase 1 (repo-canonical pivot, #141).
+- **Prod `/promote` is blocked** until the #164 CI inject fix reaches prod
+  secrets (`GITHUB_APP_*`/`INSTALL_TOKEN_KEY` never injected on main) — out of
+  this slice's scope but gates the RT3 prod leg.
+
+## Out of Scope
+
+- SYNC_QUEUE activation (DORMANT, deferred beyond Phase 1).
+- Frontend / `state.js` changes.
+- Board / ProjectV2 (roxabi-live is issues-only, #118).
+- The #164 prod-inject fix itself (separate; only sequenced against here).
+
+## Premise Validity
+
+**Success in 6 months:** `runSync` runs entirely on per-installation GitHub App
+tokens; `GITHUB_TOKEN` is deleted from staging+prod secrets and absent from
+`Env`/`wrangler.toml`/all `sync/` paths (no fallback); the hourly tick reconciles
+every installed tenant's repos with **≤1 GraphQL bundle call per unique repo** and
+**no subrequest-cap breach**; `tenant_repo_access` is populated each tick.
+
+**Failure in 6 months (falsifiable):** any one of —
+- `wrangler secret list` (staging or prod) still shows `GITHUB_TOKEN` after RT3; OR
+- a tick issues **> (unique-repo count)** GraphQL bundle calls (dedup broken); OR
+- one tenant's auth-failure/lock **halts another tenant's** sync (lock not isolated); OR
+- subrequest-cap breaches drop repos on a tick (observable via R2 audit log).
+
+**Simplest alternative:** keep the PAT and add per-tenant token resolution
+*alongside* the existing org-enum flow.
+**Why not simplest:** it leaves the org-scoped PAT as a standing secret — which is
+the explicit retirement target (RT3) — keeps `tenant_repo_access` empty (S3a
+fail-closed gap stays open), and never dedups the multi-tenant fan-out, so the
+subrequest cap is breached as installs grow. The PAT is the credential we are
+deliberately removing; a parallel path keeps it live indefinitely.
+
+## Complexity
+
+**Tier: F-full** — multi-file, cross-cutting rewrite of the sync core with a new
+discovery/dedup/slot-rotation algorithm, per-tenant lock threading through 5
+helpers, and reconciliation of a ~15-case integration test suite.
+
+Signals observed:
+- `size:F-full` label on the issue.
+- Rewrite of `sync.ts` `runSync` + new fan-out algorithm (new pattern).
+- Per-tenant lock isolation threaded through `acquireSyncLock`/`releaseSyncLock`/
+  `isHalted`/`incrementAuthFailures`/`resetAuthFailures`.
+- Test-suite reconciliation (allowlist/prune/auth-halt cases conflict with the
+  per-tenant model) + 4 RED cases to un-skip & repair.
+- Cross-cutting `Env`/`wrangler.toml` type + config change (T10) with no fallback.

--- a/artifacts/plans/144-schema-tenant-migrations-plan.mdx
+++ b/artifacts/plans/144-schema-tenant-migrations-plan.mdx
@@ -1,0 +1,292 @@
+---
+title: "Plan: feat(schema): repo-canonical tenancy + auth-table migrations + CI/infra (Phase 1 S1)"
+issue: 144
+spec: artifacts/specs/144-schema-tenant-migrations-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-06-10T08:35:00Z
+---
+
+## Summary
+
+Single migration `0004_tenancy_auth.sql` (10 new tables, `title`→`payload` move incl. `DROP COLUMN`,
+`repo_node_id` anchor, `sync_control` rebuild), payload refactor across 4 worker src files (API JSON
+contract preserved — frontend untouched), CI migrate-step + `GITHUB_APP_*` guard, wrangler.toml
+staging R2 split + `workers_dev` + dormant `SYNC_QUEUE` placeholder.
+
+## Spec Deviations (implementation-level, documented)
+
+| # | Spec says | Plan does | Why |
+|---|-----------|-----------|-----|
+| D-1 | `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` | `ADD COLUMN repo_node_id TEXT` + `CREATE UNIQUE INDEX ux_repos_node_id` | SQLite forbids adding a UNIQUE column via ADD COLUMN. UNIQUE index on nullable col allows multiple NULLs (existing rows safe). |
+| D-2 | `sync_control.tenant_id INTEGER NOT NULL REFERENCES tenants(id)` | Rebuild with `tenant_id INTEGER NOT NULL DEFAULT 0`, **no FK** | Table already exists with 5 live global rows (lock, circuit-breaker, data_version) used by runtime SQL in sync.ts/mutations.ts/version.ts. FK to `tenants` would fail on sentinel 0; DEFAULT 0 keeps current INSERTs working. FK semantics arrive when rows become per-tenant (S3). Composite PK `(tenant_id,key)` delivered as specced. |
+| D-3 | `SYNC_QUEUE` binding "declared DORMANT" | Commented-out TOML placeholder block | Active Queues producer binding requires queue existence + Workers Paid (plan unconfirmed) — an active binding could fail deploy. Commented block is plan-agnostic. |
+
+## Architecture
+
+```mermaid
+flowchart TD
+  subgraph migrations["worker/migrations/0004_tenancy_auth.sql"]
+    NEW[10 new tables<br/>tenants users user_installations sessions<br/>oauth_state install_tokens tenant_repo_access<br/>user_repo_permission_cache zk_payloads]
+    SC[sync_control REBUILD<br/>PK key → PK tenant_id,key<br/>copy 5 rows tenant_id=0]
+    PAY[issues: ADD payload →<br/>backfill json_object title →<br/>DROP COLUMN title]
+    RNI[repos: ADD repo_node_id +<br/>UNIQUE INDEX]
+  end
+  subgraph write["write path"]
+    SYNC[sync/sync.ts upsert ×3] -->|"json_object('title',?)"| PAY
+    MUT[webhook/mutations.ts upsertIssue +<br/>BUMP ON CONFLICT tenant_id,key] --> PAY
+    MUT --> SC
+  end
+  subgraph read["read path (contract preserved)"]
+    API1[api/issues.ts ×2 SELECT] -->|"JSON_EXTRACT(payload,'$.title') AS title"| PAY
+    API2[api/graph.ts SELECT] -->|same alias| PAY
+    FE[frontend/*.js — UNTOUCHED] --> API1 & API2
+  end
+  subgraph infra["deploy plumbing"]
+    CI[ci.yml deploy job:<br/>migrate-step in CF_API_TOKEN guard<br/>+ GITHUB_APP_* guard] --> migrations
+    WT[wrangler.toml: R2 staging split,<br/>workers_dev, SYNC_QUEUE commented]
+    R2[CF: create bucket<br/>roxabi-live-logs-staging] -.pre-merge.-> WT
+  end
+  style PAY fill:#f96
+  style SC fill:#f96
+```
+
+```mermaid
+flowchart LR
+  subgraph m0004["0004_tenancy_auth.sql"]
+    ddl[10×CREATE TABLE + rebuild + ALTERs]
+  end
+  subgraph sync.ts
+    upsertSQL[UPSERT_ISSUES_SQL] --- ins1[insert site L445] --- ins2[L871] --- ins3[L1041]
+  end
+  subgraph mutations.ts
+    upsertIssue[UPSERT_ISSUE_SQL L23-31] --- bump[BUMP_DATA_VERSION_SQL L73]
+  end
+  subgraph issues.ts
+    sel1[SELECT L90] --- sel2[SELECT L155]
+  end
+  subgraph graph.ts
+    sel3[SELECT L157]
+  end
+  T5tests[issues.test.ts · graph.test.ts<br/>sync.test.ts · handlers.test.ts] -->|assert SQL strings + fixtures| sync.ts & mutations.ts & issues.ts & graph.ts
+  ddl -->|schema shape| sync.ts & mutations.ts & issues.ts & graph.ts
+```
+
+## Bootstrap Context
+
+- Ratified pivot (2026-06-10, PR #152): repo-canonical model — NO `tenant_id` on data tables; spec DDL is authoritative for the 10 new tables (see spec `## DDL`).
+- Existing migrations 0001–0003 are **idempotent** (`IF NOT EXISTS` / `INSERT OR IGNORE`) → first tracked `wrangler d1 migrations apply --remote` is safe even if they were originally applied via `d1 execute`. 0001 re-run executes against the pre-0004 shape (ordering safe).
+- Tests use **mocked D1** (captured SQL strings + fake row objects), not miniflare — fixture rows model SELECT output, so `title` keys in fake rows stay (alias preserves them); SQL-string assertions must be updated.
+- `wrangler d1 migrations apply DB --local` validates the full chain on a fresh local sqlite.
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1, T2, T3 | worker/migrations/0004_tenancy_auth.sql, worker/src/sync/sync.ts, worker/src/webhook/mutations.ts |
+| backend-dev-B | T4 | worker/src/api/issues.ts, worker/src/api/graph.ts |
+| devops-A | T6, T7, T8 | .github/workflows/ci.yml, wrangler.toml, CF R2 (ops) |
+| tester-A | T5, T9 | worker/src/**/*.test.ts, local D1 verify |
+
+## Wave Structure
+
+4 waves, max 3 parallel agents. Elapsed ~1 day vs ~2.5 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | backend-dev-A: T1 · devops-A: T6→T7→T8 |
+| 2 | T1 done | 2 ∥ | backend-dev-A: T2→T3 · backend-dev-B: T4 |
+| 3 | T2,T3,T4 done | 1 | tester-A: T5 |
+| 4 | T5,T6,T7 done | 1 | tester-A: T9 (RED-GATE) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 migration file | 1 file, ~14 DDL blocks | judgmental | 6 | — |
+| T2 sync.ts payload | 4 sites | bounded | 5 | — |
+| T3 mutations.ts | 2 SQL + 1 confirm | bounded | 4 | — |
+| T4 api payload | 3 SELECTs | bounded | 4 | — |
+| T5 test updates | 4 files | judgmental | 8 | — |
+| T6 ci.yml | 3 steps | judgmental | 5 | — |
+| T7 wrangler.toml | 3 edits | bounded | 3 | — |
+| T8 R2 bucket create | 1 cmd | trivial | 2 | — |
+| T9 RED-GATE | 6 checks | bounded | 4 | — |
+
+**Total estimated ops: 41**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3 | 15 | migrations, sync-payload | — |
+| backend-dev-B | T4 | 4 | api-payload | — |
+| devops-A | T6, T7, T8 | 10 | ci, wrangler-config | — |
+| tester-A | T5, T9 | 12 | payload-tests | — |
+
+## Consistency Report
+
+- Covered: **6/6** success criteria.
+- SC1 (M-a applies clean, 10 tables, 2 ALTERs, no tenant_id on data tables) → T1, T9
+- SC2 (no top-level `title`; `JSON_EXTRACT` reads) → T1, T2, T3, T4, T5, T9
+- SC3 (`zk_payloads` PK `(user_id,issue_key)`) → T1, T9
+- SC4 (`sync_control` PK `(tenant_id,key)`) → T1, T3, T9
+- SC5 (ci.yml migrate-step + GITHUB_APP_* guard) → T6
+- SC6 (wrangler.toml R2 staging + workers_dev + SYNC_QUEUE dormant) → T7, T8
+- Uncovered: none. Untraced tasks: none. Exemptions: M-b NOT-NULL draft = appendix only (committed in S7 per epic).
+
+## Micro-Tasks
+
+### Group SC1–SC4 — migration + payload refactor
+
+**T1 — Write `worker/migrations/0004_tenancy_auth.sql`** `[P]`
+- Agent: backend-dev-A · Subject: migrations · Slice: V1 · Phase: GREEN · Difficulty: 4 · Est: 10 min
+- File: `worker/migrations/0004_tenancy_auth.sql` (new)
+- Content order:
+  1. Header comment (applied via `wrangler d1 migrations apply DB [--env staging] --remote`) + `PRAGMA foreign_keys = ON;`
+  2. 9 `CREATE TABLE IF NOT EXISTS` from spec DDL **verbatim** (`tenants`, `users`, `user_installations`, `sessions`, `oauth_state`, `install_tokens`, `tenant_repo_access`, `user_repo_permission_cache`, `zk_payloads`)
+  3. `sync_control` rebuild (D-2): `CREATE TABLE sync_control_new (tenant_id INTEGER NOT NULL DEFAULT 0, key TEXT NOT NULL, value TEXT, updated_at TEXT NOT NULL DEFAULT (datetime('now')), PRIMARY KEY (tenant_id, key));` → `INSERT INTO sync_control_new (tenant_id, key, value, updated_at) SELECT 0, key, value, updated_at FROM sync_control;` → `DROP TABLE sync_control;` → `ALTER TABLE sync_control_new RENAME TO sync_control;`
+  4. `ALTER TABLE issues ADD COLUMN payload TEXT;` → `UPDATE issues SET payload = json_object('title', title) WHERE title IS NOT NULL;` → `ALTER TABLE issues DROP COLUMN title;`
+  5. `ALTER TABLE repos ADD COLUMN repo_node_id TEXT;` + `CREATE UNIQUE INDEX IF NOT EXISTS ux_repos_node_id ON repos(repo_node_id);` (D-1)
+- Verify: `cd worker && rm -rf .wrangler/state && npx wrangler d1 migrations apply DB --local --config ../wrangler.toml` exits 0; `npx wrangler d1 execute DB --local --config ../wrangler.toml --command "PRAGMA table_info(issues)"` shows `payload`, no `title`; `--command "SELECT tenant_id, key FROM sync_control ORDER BY key"` shows 4 seeded keys at tenant_id=0.
+- Expected: clean apply, 10 tables exist, data preserved.
+- Spec trace: SC1, SC2, SC3, SC4
+
+**T2 — sync.ts: write `payload` instead of `title`** (blockedBy T1)
+- Agent: backend-dev-A · Subject: sync-payload · Slice: V1 · Phase: GREEN · Difficulty: 3 · Est: 8 min
+- File: `worker/src/sync/sync.ts`
+- Upsert SQL (~L33–41): replace `title` column with `payload`, value `json_object('title', ?)`, conflict-update `payload = excluded.payload`. Bind sites L445, L871, L1041 keep passing `node.title` (it feeds the `json_object` placeholder). GraphQL types (`title: string`) unchanged.
+- Verify: `cd worker && npm run typecheck` clean; `grep -n "json_object" src/sync/sync.ts` ≥1; `grep -cn "title\s*=" src/sync/sync.ts` shows no `title =` column assignment in SQL.
+- Spec trace: SC2
+
+**T3 — mutations.ts: payload upsert + composite-PK bump** (blockedBy T1)
+- Agent: backend-dev-A · Subject: sync-payload · Slice: V1 · Phase: GREEN · Difficulty: 3 · Est: 8 min
+- File: `worker/src/webhook/mutations.ts`
+- Upsert issue SQL (L23–31): `title` col → `payload` with `json_object('title', ?)`; input type keeps `title: string` (handlers.ts L98 keeps extracting from webhook payload — no change there, confirm only).
+- `BUMP_DATA_VERSION_SQL` (L73): `INSERT INTO sync_control (tenant_id, key, value, updated_at) VALUES (0, 'data_version', ?, ?) ON CONFLICT(tenant_id, key) DO UPDATE …` (D-2: old `ON CONFLICT(key)` no longer matches a unique index after rebuild).
+- Verify: `cd worker && npm run typecheck`; `grep -n "ON CONFLICT(tenant_id, key)" src/webhook/mutations.ts` hits.
+- Spec trace: SC2, SC4
+
+**T4 — api/issues.ts + api/graph.ts: read title via JSON_EXTRACT** `[P]` (blockedBy T1)
+- Agent: backend-dev-B · Subject: api-payload · Slice: V1 · Phase: GREEN · Difficulty: 2 · Est: 8 min
+- Files: `worker/src/api/issues.ts` (L90, L155), `worker/src/api/graph.ts` (L157)
+- Replace `title` in SELECT lists with `JSON_EXTRACT(issues.payload,'$.title') AS title` (issues.ts L90 uses `issues.`-prefixed cols; L155 + graph.ts L157 bare cols → `JSON_EXTRACT(payload,'$.title') AS title`). Row mappings (`row.title`) and response JSON shape unchanged → frontend untouched.
+- Verify: `cd worker && npm run typecheck`; `grep -c "JSON_EXTRACT" src/api/issues.ts` == 2; `grep -c "JSON_EXTRACT" src/api/graph.ts` == 1.
+- Spec trace: SC2
+
+**T5 — Update tests for payload schema** (blockedBy T2, T3, T4)
+- Agent: tester-A · Subject: payload-tests · Slice: V1 · Phase: GREEN · Difficulty: 3 · Est: 15 min
+- Files: `worker/src/api/issues.test.ts`, `worker/src/api/graph.test.ts`, `worker/src/sync/sync.test.ts`, `worker/src/webhook/handlers.test.ts`
+- Tests mock D1 (captured SQL + fake rows): fake SELECT rows keep `title` keys (alias preserved). Update: assertions matching SQL strings (`title` column lists → `payload`/`json_object`/`JSON_EXTRACT`; `ON CONFLICT(tenant_id, key)`), insert-bind expectations, any fixture asserting `title` column in upserts.
+- Verify: `cd worker && npm test` green (all suites).
+- Spec trace: SC2, SC4
+
+### Group SC5–SC6 — CI + wrangler config
+
+**T6 — ci.yml: migrate-step + GITHUB_APP_* guard** `[P]`
+- Agent: devops-A · Subject: ci · Slice: V1 · Phase: GREEN · Difficulty: 3 · Est: 10 min
+- File: `.github/workflows/ci.yml` (deploy job, L78–116)
+- Add inside `steps.guard.outputs.enabled == 'true'`, **after `npm ci`, before the deploy steps**:
+  - `Migrate D1 (staging)` — `if: …enabled == 'true' && github.ref_name == 'staging'` → `cd worker && npx wrangler d1 migrations apply DB --env staging --remote --config ../wrangler.toml` with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` env (same as deploy steps)
+  - `Migrate D1 (production)` — same for `main`, no `--env`
+  - `Guard — GITHUB_APP_* secrets` step (notice-only, same pattern as CF guard): checks `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY`/`GITHUB_APP_WEBHOOK_SECRET`; missing → `::notice::` (no failure — secrets land in S2); sets `app_secrets=true|false` output for future use.
+- Verify: `actionlint .github/workflows/ci.yml` (if installed, else `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))"`); grep ordering: migrate steps appear between `npm ci` and `wrangler deploy`.
+- Spec trace: SC5
+
+**T7 — wrangler.toml: staging R2 split + workers_dev + dormant SYNC_QUEUE** (blockedBy T6 — same instance, sequential)
+- Agent: devops-A · Subject: wrangler-config · Slice: V1 · Phase: GREEN · Difficulty: 2 · Est: 5 min
+- File: `wrangler.toml`
+- `[[env.staging.r2_buckets]] bucket_name` → `"roxabi-live-logs-staging"` (comment: staging/prod audit-log isolation); add `workers_dev = true` under `[env.staging]`; append commented `# [[queues.producers]] … SYNC_QUEUE` placeholder block (D-3) with note "dormant — activate with Queues (Workers Paid) for fan-out, see #146".
+- Verify: `cd worker && npx wrangler deploy --dry-run --env staging --config ../wrangler.toml` parses config (dry-run, no deploy).
+- Spec trace: SC6
+
+**T8 — Create staging R2 bucket (CF ops, pre-merge)** (blockedBy T7)
+- Agent: devops-A · Subject: wrangler-config · Slice: V1 · Phase: GREEN · Difficulty: 1 · Est: 2 min
+- Command: `cd worker && CLOUDFLARE_ACCOUNT_ID=b5e90be971920ce406f7b679c4f1cd33 npx wrangler r2 bucket create roxabi-live-logs-staging`
+- Verify: `… npx wrangler r2 bucket list | grep roxabi-live-logs-staging`
+- Fallback: auth failure → escalate to lead (user runs it); merge blocked until bucket exists (staging deploy would fail).
+- Spec trace: SC6
+
+**T9 — RED-GATE: full verification sweep** (blockedBy T5, T6, T7)
+- Agent: tester-A · Subject: payload-tests · Slice: V1 · Phase: RED-GATE · Difficulty: 2 · Est: 10 min
+- Checks (all must pass, run from `worker/`):
+  1. `npm test` green
+  2. `npm run typecheck` clean
+  3. Fresh local apply: `rm -rf .wrangler/state && npx wrangler d1 migrations apply DB --local --config ../wrangler.toml` exits 0
+  4. `npx wrangler d1 execute DB --local --config ../wrangler.toml --command "PRAGMA table_info(issues)"` → `payload` present, `title` absent, no `tenant_id`
+  5. `--command "SELECT name FROM pragma_table_info('zk_payloads') WHERE pk > 0 ORDER BY pk"` → `user_id, issue_key`; same for `sync_control` → `tenant_id, key`; `pragma_table_info('edges'|'labels'|'pr_state')` → no `tenant_id`
+  6. `--command "SELECT count(*) FROM sync_control WHERE tenant_id = 0"` ≥ 4
+- Expected: all 6 green → slice done, ready for /pr.
+- Spec trace: SC1, SC2, SC3, SC4
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs).
+     Seed in wave order; within a wave all rows are parallel (∥). -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | migrations |
+| T6 | devops-A | — | ci |
+
+### Wave 1 (devops chain, same instance)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | devops-A | T6 | wrangler-config |
+| T8 | devops-A | T7 | wrangler-config |
+
+### Wave 2 — after T1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | sync-payload |
+| T3 | backend-dev-A | T2 | sync-payload |
+| T4 | backend-dev-B | T1 | api-payload |
+
+### Wave 3 — after Wave 2
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | tester-A | T2, T3, T4 | payload-tests |
+
+### Wave 4 — RED-GATE
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T9 | tester-A | T5, T6, T7 | payload-tests |
+
+## Appendix — M-b NOT-NULL draft (authored in S1, committed in S7/#150)
+
+Per epic #141: this file is **designed here but NOT committed to `worker/migrations/`** until S7,
+so CI never applies it before backfill. S7 commits it as `000N_tenant_not_null.sql` after
+`COUNT(*) WHERE … IS NULL = 0` re-verification.
+
+```sql
+-- 000N_tenant_not_null.sql — S7 (#150) ONLY. Pre-req: backfill verified
+-- (no NULL rows). Scope: NEW tables only — data tables keep global PKs.
+-- New tables were created with NOT NULL constraints already in 0004;
+-- this migration only tightens what was intentionally left nullable in Phase 1:
+--   issues.payload stays NULLABLE (stub rows are title-less by design);
+--   repos.repo_node_id stays NULLABLE (filled lazily by sync/webhooks).
+-- If S2–S6 add any temporarily-nullable columns to the new auth tables,
+-- enumerate their NOT NULL rebuilds here. As of S1 design: NO-OP candidate —
+-- re-evaluate at S7 entry; if still empty, close #150 with this rationale.
+```
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — migrations
+- T2: 13 — sync-payload
+- T3: 14 — sync-payload
+- T4: 15 — api-payload
+- T5: 16 — payload-tests
+- T6: 17 — ci
+- T7: 18 — wrangler-config
+- T8: 19 — wrangler-config
+- T9: 20 — payload-tests

--- a/artifacts/plans/144-schema-tenant-migrations-plan.mdx
+++ b/artifacts/plans/144-schema-tenant-migrations-plan.mdx
@@ -19,8 +19,10 @@ staging R2 split + `workers_dev` + dormant `SYNC_QUEUE` placeholder.
 | # | Spec says | Plan does | Why |
 |---|-----------|-----------|-----|
 | D-1 | `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` | `ADD COLUMN repo_node_id TEXT` + `CREATE UNIQUE INDEX ux_repos_node_id` | SQLite forbids adding a UNIQUE column via ADD COLUMN. UNIQUE index on nullable col allows multiple NULLs (existing rows safe). |
-| D-2 | `sync_control.tenant_id INTEGER NOT NULL REFERENCES tenants(id)` | Rebuild with `tenant_id INTEGER NOT NULL DEFAULT 0`, **no FK** | Table already exists with 5 live global rows (lock, circuit-breaker, data_version) used by runtime SQL in sync.ts/mutations.ts/version.ts. FK to `tenants` would fail on sentinel 0; DEFAULT 0 keeps current INSERTs working. FK semantics arrive when rows become per-tenant (S3). Composite PK `(tenant_id,key)` delivered as specced. |
+| D-2 | `sync_control.tenant_id INTEGER NOT NULL REFERENCES tenants(id)` | Rebuild with `tenant_id INTEGER NOT NULL DEFAULT 0`, **no FK** | Table already exists with 5 live global rows (lock, circuit-breaker, data_version) used by runtime SQL in sync.ts/mutations.ts/version.ts. FK to `tenants` would fail on sentinel 0; DEFAULT 0 keeps current INSERTs working. FK semantics arrive when rows become per-tenant (S3). Composite PK `(tenant_id,key)` delivered as specced. Rebuild finalized as rename-swap (old→sync_control_old, new→sync_control, drop old) so data survives any crash point — post-review refinement. |
 | D-3 | `SYNC_QUEUE` binding "declared DORMANT" | Commented-out TOML placeholder block | Active Queues producer binding requires queue existence + Workers Paid (plan unconfirmed) — an active binding could fail deploy. Commented block is plan-agnostic. |
+| D-4 | spec: `redirect_after TEXT` (no constraint) | `CHECK` same-origin relative path (`LIKE '/%' AND NOT LIKE '//%'`) | review hardening — open-redirect defense-in-depth for S2; S2 callback still validates |
+| D-5 | spec: `sessions` table DDL (no secondary indexes) | + `ix_sessions_user_id`, `ix_sessions_expires_at` | review hardening — S2 revocation (`WHERE user_id`) + expiry sweep need them |
 
 ## Architecture
 

--- a/artifacts/plans/145-github-app-oauth-sessions-plan.mdx
+++ b/artifacts/plans/145-github-app-oauth-sessions-plan.mdx
@@ -1,0 +1,330 @@
+---
+title: "Plan: feat(auth): GitHub App + OAuth login + sessions (Phase 1 S2)"
+issue: 145
+spec: artifacts/specs/145-github-app-oauth-sessions-spec.mdx
+complexity: 6/10
+tier: F-lite
+generated: 2026-06-10T00:00:00Z
+---
+
+## Summary
+
+Identity layer for the multi-tenant pivot (#141 S2): RS256 App-JWT signer util (+ permanent CI
+guard), `GET /login` / `GET /oauth/callback` OAuth flow with single-use `state`, D1-backed
+sessions (SHA-256 at rest, fail-closed middleware with suspended-tenant guard), `GET /api/me` +
+`POST /logout`. GitHub App registered + all 10 Worker secrets provisioned out-of-band 2026-06-10.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph secrets["Worker secrets (provisioned 2026-06-10)"]
+    SK["GITHUB_APP_{ID,CLIENT_ID,CLIENT_SECRET,PRIVATE_KEY,WEBHOOK_SECRET}"]
+  end
+
+  subgraph oauth["worker/src/auth/oauth.ts"]
+    LOGIN["loginRoute: mint state → 302 authorize"]
+    CB["callbackRoute: verify+delete state → code→token → upserts → mint session"]
+  end
+
+  subgraph session["worker/src/auth/session.ts"]
+    MINT["mintSession: raw token → SHA-256 → INSERT sessions"]
+    VAL["validateSession: SELECT + suspended-tenant NOT EXISTS guard"]
+    MW["requireSession middleware (fail-closed 401)"]
+  end
+
+  subgraph jwt["worker/src/auth/jwt.ts (consumed by S3)"]
+    IMP["importAppPrivateKey: b64(PKCS#8 DER) → CryptoKey"]
+    SIGN["signAppJwt: RS256 {iss:app_id, iat-60, exp+540}"]
+  end
+
+  subgraph d1["D1 (migration 0004)"]
+    OS[(oauth_state)]
+    US[(users)]
+    TN[(tenants)]
+    UI[(user_installations)]
+    SS[(sessions)]
+  end
+
+  subgraph api["worker/src/api/me.ts"]
+    ME["meRoute: identity + installations"]
+    OUT["logoutRoute: DELETE session + clear cookie"]
+  end
+
+  LOGIN -->|INSERT state, TTL 10min| OS
+  CB -->|SELECT+DELETE single-use| OS
+  CB -->|"github.com/login/oauth/access_token (client_secret)"| GH["GitHub API"]
+  CB -->|"/user + /user/installations (user token)"| GH
+  CB -->|upsert| US
+  CB -->|"re-check upsert (D-1)"| TN
+  CB -->|"re-check upsert (D-1)"| UI
+  CB --> MINT --> SS
+  MW --> VAL --> SS
+  MW --> ME
+  MW --> OUT
+  SK --> CB
+  SK --> IMP --> SIGN
+  ME --> UI
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph jwt.ts["auth/jwt.ts"]
+    f1["importAppPrivateKey()"]
+    f2["signAppJwt()"]
+    f3["b64url()"]
+  end
+  subgraph oauth.ts["auth/oauth.ts"]
+    f4["loginRoute()"]
+    f5["callbackRoute()"]
+    f6["mintState()/consumeState()"]
+  end
+  subgraph session.ts["auth/session.ts"]
+    f7["mintSession()"]
+    f8["validateSession()"]
+    f9["requireSession()"]
+    f10["sessionCookie()/clearCookie()"]
+  end
+  subgraph me.ts["api/me.ts"]
+    f11["meRoute()"]
+    f12["logoutRoute()"]
+  end
+  subgraph router.ts
+    r1["app.get /login"]
+    r2["app.get /oauth/callback"]
+    r3["app.get /api/me (gated)"]
+    r4["app.post /logout (gated)"]
+  end
+  t1["auth/jwt.test.ts"] --> jwt.ts
+  t2["auth/oauth.test.ts"] --> oauth.ts
+  t3["auth/session.test.ts"] --> session.ts
+  t4["api/me.test.ts"] --> me.ts
+  f5 --> f6
+  f5 --> f7
+  f11 --> f9
+  f12 --> f9
+  r1 --> f4
+  r2 --> f5
+  r3 --> f11
+  r4 --> f12
+```
+
+## Bootstrap Context
+
+- Hono app (`worker/src/router.ts`), routes registered before ASSETS fallback.
+- Middleware pattern: `app.use("/admin/*", …)` + `checkAdminAuth` (`worker/src/api/auth.ts`) —
+  fail-closed, returns `Response` on deny, `null` on pass. `requireSession` mirrors this.
+- Test pattern: colocated `*.test.ts`, FakeD1 with captured SQL strings + fixture rows
+  (ref: `worker/src/webhook/mutations.test.ts`, `worker/src/api/issues.test.ts`).
+- crypto.subtle usage ref: `worker/src/webhook/hmac.ts` (HMAC import/verify).
+- Schema: migration `worker/migrations/0004_tenancy_auth.sql` (S1, live on staging).
+
+## Spec Deviations / Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D-1 | `callbackRoute` **re-check**: fetches `/user/installations` with the user token and upserts `tenants` + `user_installations` before minting the session | `sessions.tenant_id NOT NULL REFERENCES tenants` — without tenant rows (S3 webhook not built yet) no session can ever be minted. Parent spec flow §3 explicitly allows "installation webhook **(or callback re-check)**". User with 0 installations → no session, 302 to the App install page (full CTA UI = S6). |
+| D-2 | Session cookie is **host-only**: `Domain` attribute omitted; name `__Host-session` (requires Secure + Path=/ + no Domain, browser-enforced) | Spec says `Domain=<exact host>`, but per RFC 6265 an explicit Domain attribute ENABLES subdomains; omitting it is strictly tighter (exact host only). `__Host-` prefix makes the contract self-enforcing. |
+| D-3 | RS256 CI guard runs in plain vitest (node env, `globalThis.crypto.subtle`) — not `@cloudflare/vitest-pool-workers` | Suite is plain vitest (mocked D1); webcrypto API surface is identical. The *real-workerd* check is T1: one-shot smoke via `wrangler dev` (local = workerd runtime) before any GREEN code. Adding the workers pool = infra churn deferred. |
+| D-4 | Only `/api/me` + `/logout` are session-gated; existing `/api/issues`, `/api/graph` stay open | Gating all `/api/*` reads is S5 (#148) scope — needs tenant-filtered queries first. |
+| D-5 | ci.yml app-secrets-guard mapping fixed to `secrets.GH_APP_*` | GitHub rejects Actions secret names with `GITHUB_` prefix (HTTP 422, verified 2026-06-10) — guard as written in S1 could never pass. Env var names inside the step keep `GITHUB_APP_*`. |
+| D-6 | `redirect_uri` derived from `new URL(req.url).origin + "/oauth/callback"` | "Worker-hard-coded" = not attacker-suppliable (never read from query/body). Origin differs per env (live.roxabi.dev / workers.dev) — deriving from the CF-edge-trusted request URL covers both without per-env config. |
+
+## Agents
+
+| Instance | Tasks | Files |
+|----------|-------|-------|
+| devops-A | T1, T11 | scratch smoke, `.github/workflows/ci.yml` |
+| tester-A | T2, T13 | `auth/jwt.test.ts`, final verify |
+| tester-B | T4 | `auth/oauth.test.ts` |
+| tester-C | T6, T8 | `auth/session.test.ts`, `api/me.test.ts` |
+| backend-dev-A | T3, T5 | `auth/jwt.ts`, `auth/oauth.ts` |
+| backend-dev-B | T7, T9, T10 | `auth/session.ts`, `api/me.ts`, `router.ts` + `types.ts` |
+
+## Wave Structure
+
+4 waves + RED-GATE, max 4 parallel agents. Elapsed ~6 task-slots vs ~13 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 4 ∥ | devops-A: T1→T11 · tester-A: T2 · tester-B: T4 · tester-C: T6→T8 |
+| RG | T2,T4,T6,T8 done | lead | T12 RED-GATE (structural check, tests exist + fail) |
+| 2 | RG ∧ T1 PASS | 2 ∥ | backend-dev-A: T3 · backend-dev-B: T7 |
+| 3 | Wave 2 done | 2 ∥ | backend-dev-A: T5 · backend-dev-B: T9 |
+| 4 | Wave 3 done | 1 | backend-dev-B: T10 → tester-A: T13 |
+
+### Budget — per task
+
+| Task | Class | Est. ops | Split? |
+|------|-------|----------|--------|
+| T1 workerd RS256 smoke | judgmental | 6 | — |
+| T2 RED jwt | judgmental | 5 | — |
+| T3 GREEN jwt | judgmental | 5 | — |
+| T4 RED oauth | exploratory | 10 | — |
+| T5 GREEN oauth | exploratory | 12 | — |
+| T6 RED session | judgmental | 6 | — |
+| T7 GREEN session | judgmental | 6 | — |
+| T8 RED me/logout | judgmental | 5 | — |
+| T9 GREEN me/logout | bounded | 4 | — |
+| T10 wiring router+types | bounded | 3 | — |
+| T11 ci.yml guard fix | trivial | 2 | — |
+| T12 RED-GATE | trivial | 1 | — |
+| T13 final verify | bounded | 3 | — |
+
+**Total estimated ops: 68**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1, T11 | 8 | workerd, ci | — |
+| tester-A | T2, T13 | 8 | jwt, verify | — |
+| tester-B | T4 | 10 | oauth | — |
+| tester-C | T6, T8 | 11 | session, me | — |
+| backend-dev-A | T3, T5 | 17 | jwt, oauth | — |
+| backend-dev-B | T7, T9, T10 | 13 | session, http | — |
+
+## Consistency Report
+
+Covered 6/6 success criteria. Uncovered: none. Untraced tasks: T11 (D-5, infra debt from S1 —
+exemption: required for the S2 acceptance "secrets wired per-env" to be CI-visible), T12 (sentinel).
+
+| SC | Tasks |
+|----|-------|
+| SC-1 OAuth → session; /api/me; /logout → 401 | T4, T5, T8, T9, T10 |
+| SC-2 state single-use, TTL ≤10min, redirect_uri hard-coded | T4, T5 |
+| SC-3 fresh token, SHA-256 at rest, cookie attrs | T4, T6, T7 |
+| SC-4 suspended-tenant guard in session SELECT | T6, T7 |
+| SC-5 PRIVATE_KEY = b64(PKCS#8 DER), importKey('pkcs8') | T1, T3 (secrets already provisioned per contract) |
+| SC-6 vitest RS256 guard in CI | T2, T3 |
+
+## Micro-Tasks
+
+### Wave 1 — RED + gates
+
+**T1 — Pre-impl gate: RS256 sign/verify in real workerd** `[P]` — devops-A · workerd · GATE · diff 2 · ~8min
+- File: scratch only (`/tmp` worker entry or `--test-scheduled`-style probe; nothing committed except a PASS note in this plan)
+- Do: generate throwaway RSA-2048 PKCS#8; minimal worker route running `importKey('pkcs8', …, RSASSA-PKCS1-v1_5/SHA-256, ['sign'])` + `sign` + `verify`; run under `npx wrangler dev` (local mode = workerd) and curl it.
+- Verify: HTTP response shows `{imported:true, signed:true, verified:true}`.
+- Expected: PASS → unblocks Wave 2. FAIL → STOP, escalate (re-evaluate App-JWT path per spec).
+
+**T2 — RED: auth/jwt.test.ts** `[P]` — tester-A · jwt · RED · diff 2 · ~5min
+- File: `worker/src/auth/jwt.test.ts`
+- Tests: `crypto.subtle.generateKey` throwaway pair → export PKCS#8 → b64 → `importAppPrivateKey` → `signAppJwt('12345', key, now)` → split JWT: header `{alg:'RS256',typ:'JWT'}`, claims `{iss:'12345', iat:now-60, exp:now+540}`, b64url (no `=+/`), `crypto.subtle.verify` with public key = true; tampered payload → verify false.
+- Verify: `npx vitest run src/auth/jwt.test.ts` → fails (module missing) = RED OK.
+
+**T4 — RED: auth/oauth.test.ts** `[P]` — tester-B · oauth · RED · diff 3 · ~10min
+- File: `worker/src/auth/oauth.test.ts` (FakeD1 + mocked `fetch`)
+- Tests: `/login` → 302 Location = `github.com/login/oauth/authorize` with `client_id`, `state` (32 hex), `redirect_uri=<origin>/oauth/callback`; state row INSERTed with `expires_at` ≤ 10 min; `?redirect=/x` stored, `//evil` & `https://evil` rejected→`/`. Callback: unknown/expired state → 400; **replay (2nd use) → 400** (DELETE on first verify); happy path (mock token exchange + `/user` + `/user/installations`) → users upsert (on github_id), tenants+user_installations upserted (D-1), `Set-Cookie: __Host-session=…; HttpOnly; Secure; SameSite=Strict; Path=/` (no Domain), 302 to stored redirect; 0 installations → 302 to App install page, no session row.
+- Verify: file runs RED.
+
+**T6 — RED: auth/session.test.ts** `[P]` — tester-C · session · RED · diff 3 · ~6min
+- File: `worker/src/auth/session.test.ts` (FakeD1, captured SQL)
+- Tests: `mintSession` → INSERT binds SHA-256 hex of raw token (never raw), expires +8h, returns raw once; `validateSession` SQL `toContain` each guard: `token_hash=?`, `expires_at>datetime('now')` (or bound now), `revoked_at IS NULL`, `NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id=s.tenant_id AND t.suspended_at IS NOT NULL)`; behavior rows: valid→user, suspended-tenant fixture→null; `requireSession`: no cookie→401 JSON, bad token→401, valid→next() (fail-closed default).
+- Verify: file runs RED.
+
+**T8 — RED: api/me.test.ts** — tester-C · me · RED · diff 2 · ~5min (after T6, same instance)
+- File: `worker/src/api/me.test.ts`
+- Tests: GET `/api/me` no session → 401; with session fixture → 200 `{user:{github_id,github_login}, installations:[{tenant_id,installation_id,account_login}]}` (JOIN user_installations×tenants); POST `/logout` → DELETE session row by hash + `Set-Cookie` clearing (`Max-Age=0`) → subsequent me → 401.
+- Verify: file runs RED.
+
+**T11 — ci.yml: app-secrets-guard mapping fix** `[P]` — devops-A · ci · GREEN · diff 1 · ~3min (after T1, same instance)
+- File: `.github/workflows/ci.yml` (guard step only)
+- Do: `GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}`, `GITHUB_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}`, `GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.GH_APP_WEBHOOK_SECRET }}` + comment `# GitHub forbids GITHUB_-prefixed Actions secret names (422) — repo secrets are GH_APP_*`.
+- Verify: `grep -c "secrets.GH_APP_" .github/workflows/ci.yml` → 3; `secrets.GITHUB_APP_` → 0.
+
+**T12 — RED-GATE** — lead · sentinel
+- Verify: T2/T4/T6/T8 files exist, suite fails on the 4 new files only, 265 pre-existing tests still green.
+
+### Wave 2 — GREEN core
+
+**T3 — GREEN: auth/jwt.ts** `[P]` — backend-dev-A · jwt · GREEN · diff 2 · ~5min
+- Exports: `importAppPrivateKey(b64: string): Promise<CryptoKey>` (atob→bytes→importKey pkcs8, non-extractable, ['sign']), `signAppJwt(appId: string, key: CryptoKey, nowSec?: number): Promise<string>` (iat-60/exp+540 per GitHub docs), internal `b64url`.
+- Verify: T2 green + `tsc --noEmit`.
+
+**T7 — GREEN: auth/session.ts** `[P]` — backend-dev-B · session · GREEN · diff 3 · ~6min
+- Exports: `mintSession(db, userId, tenantId)` (32B random hex raw, SHA-256 via crypto.subtle, INSERT, returns raw), `validateSession(db, rawToken)` (hash → guarded SELECT JOIN users → `{userId, tenantId, githubId, githubLogin}` | null), `requireSession(c, next)` Hono middleware (cookie parse `__Host-session`, fail-closed 401 JSON, sets `c.set('session', …)`), `sessionCookie(raw)` / `clearSessionCookie()`.
+- Verify: T6 green + tsc.
+
+### Wave 3 — GREEN flow
+
+**T5 — GREEN: auth/oauth.ts** — backend-dev-A · oauth · GREEN · diff 4 · ~12min
+- Exports: `loginRoute`, `callbackRoute`. State: 32B hex, INSERT oauth_state (TTL 10 min, redirect_after validated `/^\/(?!\/)/`). Callback: consume state (`DELETE … RETURNING` or SELECT+DELETE), `POST github.com/login/oauth/access_token` (Accept: application/json, client_id+client_secret+code+redirect_uri), `GET api.github.com/user` + `GET api.github.com/user/installations` (Bearer + `User-Agent: roxabi-live`), upsert users on github_id, D-1 upsert tenants (on installation_id) + user_installations, mint session on first tenant, Set-Cookie, 302 redirect_after; 0 installs → 302 `https://github.com/apps/roxabi-live/installations/new`, no session. Never log tokens/secrets.
+- Verify: T4 green + tsc.
+
+**T9 — GREEN: api/me.ts** — backend-dev-B · me · GREEN · diff 2 · ~5min
+- Exports: `meRoute` (reads `c.get('session')`, SELECT installations JOIN tenants), `logoutRoute` (DELETE sessions WHERE token_hash, clear cookie, 204).
+- Verify: T8 green + tsc.
+
+### Wave 4 — wiring + verify
+
+**T10 — Wire router + Env types** — backend-dev-B · http · GREEN · diff 2 · ~4min
+- `router.ts`: `app.get("/login", loginRoute)`, `app.get("/oauth/callback", callbackRoute)`, `app.use("/api/me", requireSession)` + `app.get("/api/me", meRoute)`, `app.use("/logout", requireSession)` + `app.post("/logout", logoutRoute)` — registered BEFORE ASSETS fallback; existing routes untouched (D-4). `types.ts`: add `GITHUB_APP_ID/CLIENT_ID/CLIENT_SECRET/PRIVATE_KEY/WEBHOOK_SECRET: string` with provisioning docstrings.
+- Verify: `tsc --noEmit` + full `vitest run` green.
+
+**T13 — Final verify** — tester-A · verify · diff 1 · ~4min
+- Full suite + count delta (≥ +20 new tests expected), grep no `console.log` of secrets/tokens in `worker/src/auth/`, spot edge cases (expired session row, malformed cookie).
+- Verify: `npm test` exit 0; report counts.
+
+## Task Seeding Blueprint
+
+<!-- Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 4 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | workerd |
+| T2 | tester-A | — | jwt |
+| T4 | tester-B | — | oauth |
+| T6 | tester-C | — | session |
+| T8 | tester-C | T6 | me |
+| T11 | devops-A | T1 | ci |
+
+### RED-GATE — after T2, T4, T6, T8
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T12 | lead | T2,T4,T6,T8 | sentinel |
+
+### Wave 2 — after RG ∧ T1 PASS, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T1,T12 | jwt |
+| T7 | backend-dev-B | T12 | session |
+
+### Wave 3 — after Wave 2, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | backend-dev-A | T3,T7 | oauth |
+| T9 | backend-dev-B | T7 | me |
+
+### Wave 4 — after Wave 3
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | backend-dev-B | T5,T9 | http |
+| T13 | tester-A | T10 | verify |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 33 — workerd
+- T2: 34 — jwt
+- T4: 35 — oauth
+- T6: 36 — session
+- T8: 37 — me
+- T11: 38 — ci
+- T12: 39 — sentinel
+- T3: 40 — jwt
+- T7: 41 — session
+- T5: 42 — oauth
+- T9: 43 — me
+- T10: 44 — http
+- T13: 45 — verify

--- a/artifacts/plans/146-installation-sync-backfill-plan.mdx
+++ b/artifacts/plans/146-installation-sync-backfill-plan.mdx
@@ -1,0 +1,322 @@
+---
+title: "Plan: feat(sync) installation sync + per-repo fan-out + PAT retirement (S3)"
+issue: 146
+spec: artifacts/specs/146-installation-sync-backfill-spec.mdx
+parent_issue: 141
+complexity: 8/10
+tier: F-full
+generated: 2026-06-11
+---
+
+## Summary
+
+Wire the hourly + on-demand sync to **GitHub App installation tokens** (replacing the org-wide PAT),
+fan out **one GraphQL call per unique repo** across tenants, window repos under the 50-subrequest cap
+via `sync_control.sync_slot`, declare `SYNC_QUEUE` dormant, and **retire `GITHUB_TOKEN`** (no fallback)
+once a staging tick is verified. Transport (`ghGraphql`) is already token-parameterized — only the 6
+PAT callsites + 3 new modules change.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph entry [entry]
+    CRON[Cron 0 * * * *] --> RS[runSync env]
+    ADMIN[POST /admin/sync] --> RS
+    WH[webhook handlers.ts] --> RIT
+  end
+  subgraph token [auth/installToken.ts NEW]
+    RIT[resolveInstallToken owner/name] --> GIT[getInstallationToken tenantId,instId]
+    GIT -->|cache fresh| DEC[tokenCrypto.decryptToken]
+    GIT -->|stale/miss| JWT[jwt.signAppJwt] --> MINT[POST /app/installations/:id/access_tokens]
+    MINT --> ENC[tokenCrypto.encryptToken] --> ITUP[(install_tokens upsert)]
+    DEC --> TOK[bearer token]
+    ENC --> TOK
+  end
+  subgraph crypto [auth/tokenCrypto.ts NEW]
+    KEY[INSTALL_TOKEN_KEY secret] --> DEK[importDek AES-GCM]
+    DEK --> DEC
+    DEK --> ENC
+  end
+  subgraph sync [sync/sync.ts]
+    RS --> DISC[listInstallationRepos per tenant] --> TRA[(tenant_repo_access upsert)]
+    TRA --> DEDUP[dedup repo→tenant map]
+    DEDUP --> SLOT[slot window sync_control.sync_slot]
+    SLOT --> LOOP[per unique repo]
+    RIT --> GG
+    LOOP -->|resolveInstallToken| GG[ghGraphql token + sub_issues header]
+    GG --> WRITE[(issues / edges global PK)]
+    LOOP --> CHP[closedHopPass tokenResolver]
+    CHP --> GG
+  end
+  RIT -.-> GIT
+```
+
+### File × function map
+
+```mermaid
+flowchart LR
+  subgraph crypto_f [auth/tokenCrypto.ts]
+    f_importDek[importDek] --- f_enc[encryptToken] --- f_dec[decryptToken]
+  end
+  subgraph token_f [auth/installToken.ts]
+    f_get[getInstallationToken] --- f_res[resolveInstallToken] --- f_list[listInstallationRepos]
+  end
+  subgraph jwt_f [auth/jwt.ts reuse]
+    f_sign[signAppJwt] --- f_imp[importAppPrivateKey]
+  end
+  subgraph sync_f [sync/sync.ts]
+    f_run[runSync] --- f_bundle[syncRepoBundle] --- f_hop[closedHopPass] --- f_lock[acquireSyncLock tenantId]
+  end
+  subgraph gql_f [sync/graphql.ts]
+    f_gg[ghGraphql + GraphQL-Features header]
+  end
+  subgraph wh_f [webhook/handlers.ts]
+    f_dep[handleDeps] --- f_del[handleRefDelete]
+  end
+  f_res --> f_get
+  f_get --> f_sign
+  f_get --> f_dec
+  f_get --> f_enc
+  f_run --> f_list
+  f_run --> f_get
+  f_run --> f_bundle
+  f_bundle --> f_gg
+  f_hop --> f_res
+  f_dep --> f_res
+  f_del --> f_res
+  TESTS[*.test.ts] -.-> f_enc
+  TESTS -.-> f_get
+  TESTS -.-> f_run
+  TESTS -.-> f_dep
+```
+
+## Key Design Decisions
+
+- **D1 — SC-9 gate (sub_issues via install token):** No GitHub doc confirms the `GraphQL-Features: sub_issues`
+  preview header was retired at GA, BUT current sync queries `subIssues`/`parent` **headerless on the PAT
+  successfully** (live on staging), the installation has `issues:read`, and an installation access token (IAT)
+  with `issues:read` is documented-equivalent to a PAT for issue reads. **Resolution:** add the header
+  defensively (harmless if graduated) + empirical staging smoke-test post-deploy (RT2). Gate cleared with mitigation.
+- **D2 — SYNC_QUEUE dormant:** A producer binding to a non-existent queue **breaks `wrangler deploy`**, and Queues
+  require Workers **Paid** (plan unconfirmed). **Resolution:** keep the dormant **commented** stanza + add an
+  optional `SYNC_QUEUE?: Queue` Env type; defer real `wrangler queues create` + uncomment to Paid + >30 repos
+  (zero further code change). Satisfies SC-5 "declared, no consumer".
+- **D3 — tenant_repo_access population:** No code writes it today. **Resolution:** populate **at sync-time** via
+  `listInstallationRepos(token)` per tenant (self-healing, no webhook-timing dependency); installation-webhook
+  event handling deferred to S4 #147. This also replaces the PAT-based `enumerateOrgRepos` discovery.
+
+## Agents
+
+| Agent instance | Tasks | Files | Subjects |
+|---|---|---|---|
+| tester-A | T1, T2 | tokenCrypto.test.ts, installToken.test.ts | crypto, install-token |
+| tester-B | T3, T4, T13 | sync.test.ts, handlers.test.ts, full-suite sweep | sync, webhook, verify |
+| backend-dev-A | T5, T6 | tokenCrypto.ts, installToken.ts | crypto, install-token |
+| backend-dev-B | T7 | sync/sync.ts | sync |
+| backend-dev-C | T8, T9 | webhook/handlers.ts, sync/graphql.ts | webhook, graphql |
+| devops-A | T10, T11, T12 | types.ts, wrangler.toml, 0005_*.sql, ci.yml | config, ci |
+
+## Wave Structure
+
+4 waves, max 7 parallel agents. Elapsed ~4 agent-passes vs ~13 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 7 ∥ | tester-A: T1,T2 · tester-B: T3,T4 · backend-dev-C: T9 · devops-A: T11,T12 |
+| RED-GATE | W1 RED tests present+failing | — | RG1 (sentinel: T1,T2,T3,T4 failing) |
+| 2 | RED-GATE | 3 ∥ | backend-dev-A: T5→T6 · backend-dev-B: T7(⟸T6) · backend-dev-C: T8(⟸T6) |
+| 3 | W2 done | 1 | devops-A: T10 (⟸T7,T8 — drop PAT after callsites gone) |
+| 4 | W3 done | 1 | tester-B: T13 (⟸T9,T10,T11,T12) |
+
+### Budget — per task
+
+| Task | Class | Est. ops | Split? |
+|------|-------|----------|--------|
+| T1 crypto tests | bounded | 3 | — |
+| T2 install-token tests | judgmental | 6 | — |
+| T3 sync tests | judgmental | 8 | — |
+| T4 webhook tests | bounded | 4 | — |
+| T5 crypto impl | bounded | 3 | — |
+| T6 install-token impl | judgmental | 8 | — |
+| T7 sync refactor | exploratory | 15 | — (own instance) |
+| T8 webhook impl | bounded | 3 | — |
+| T9 graphql header | trivial | 2 | — |
+| T10 Env drop-PAT | trivial | 2 | — |
+| T11 migration+wrangler | bounded | 4 | — |
+| T12 CI inject | bounded | 3 | — |
+| T13 verify sweep | judgmental | 5 | — |
+
+**Total estimated ops: ~66**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| tester-A | T1,T2 | 9 | crypto, install-token | — |
+| tester-B | T3,T4,T13 | 17 | sync, webhook, verify(sweep) | — (verify = closeout sweep, not new surface) |
+| backend-dev-A | T5,T6 | 11 | crypto, install-token | — |
+| backend-dev-B | T7 | 15 | sync | — |
+| backend-dev-C | T8,T9 | 5 | webhook, graphql | — |
+| devops-A | T10,T11,T12 | 9 | config, ci | — |
+
+## Consistency Report
+
+| Spec criterion | Task(s) |
+|---|---|
+| SC-1 AES-GCM round-trip, DEK=INSTALL_TOKEN_KEY, no plaintext log | T1, T5 |
+| SC-2 refresh when expires_at ≤ now+5min, write D1 | T2, T6 |
+| SC-3 dedup repos across tenants, 1 GraphQL/unique repo | T3, T7 |
+| SC-4 slot-rotation via sync_control.sync_slot, no cap breach | T3, T7, T11 |
+| SC-5 SYNC_QUEUE declared, no consumer (DORMANT) | T10, T11 (D2) |
+| SC-6 GITHUB_TOKEN removed Env/wrangler/handleDeps/handleRefDelete | T8, T10 |
+| SC-7 PAT deleted staging→prod after verified tick | RT3 (runtime) |
+| SC-8 no tenant_id on issues/edges, no backfill | (design — confirmed, no task) |
+| SC-9 subIssues/parent gate cleared | D1 → T9 + RT2 |
+
+Covered: 9/9. Untraced tasks: none. Exemptions: SC-8 is a non-action (confirm absence).
+
+## Runtime Ops (ship — sequenced, NOT code tasks)
+
+- **RT1 [PRE-deploy gate]** provision `INSTALL_TOKEN_KEY` (32-byte base64) on staging+prod via
+  `wrangler secret put INSTALL_TOKEN_KEY [--env staging]`; add `GH_INSTALL_TOKEN_KEY` Actions secret.
+  Worker `Env` requires it → must exist before first deploy or the worker errors.
+- **RT2** deploy staging → `wrangler tail --env staging` confirms 1 cron tick mints an install token +
+  writes issue rows + `subIssues`/`parent` resolve (clears D1 empirically).
+- **RT3** `wrangler secret delete GITHUB_TOKEN --env staging` → confirm clean tick (no 401s) → repeat prod.
+
+## Micro-Tasks
+
+### Wave 1 — RED tests + independent config (7 ∥)
+
+**T1 [P] (RED, tester-A, crypto, diff 2)** — `worker/src/auth/tokenCrypto.test.ts`
+Tests against signatures: `importDek(b64:string):Promise<CryptoKey>`, `encryptToken(dek,plaintext):Promise<{enc:string,iv:string}>`, `decryptToken(dek,enc,iv):Promise<string>`.
+Cases: round-trip equality; IV is 12 bytes & differs across two encrypts of same plaintext; tampered ciphertext → throws; wrong DEK → throws; outputs base64url.
+Verify: `cd worker && npx vitest run src/auth/tokenCrypto.test.ts` → fails (no impl).
+
+**T2 [P] (RED, tester-A, install-token, diff 3)** — `worker/src/auth/installToken.test.ts`
+FakeD1 + mocked `fetch`. Signatures: `getInstallationToken(db,env,tenantId,installationId):Promise<string>`, `resolveInstallToken(db,env,owner,name):Promise<string>`.
+Cases: cache fresh (expires_at > now+5min) → decrypt, **no mint fetch**; cache stale/missing → signAppJwt + POST mint + encrypt + upsert; resolver with no `tenant_repo_access` row → throws (fail-closed); `tenants.suspended_at` set → throws; plaintext token never written raw (assert stored col is ciphertext).
+Verify: `cd worker && npx vitest run src/auth/installToken.test.ts` → fails.
+
+**T3 [P] (RED, tester-B, sync, diff 4)** — `worker/src/sync/sync.test.ts` (additions)
+Cases: two tenants sharing repo `o/r` → exactly **1** `REPO_BUNDLE_QUERY` for `o/r`; `sync_slot` advances per tick and windows the repo list (repos beyond per-tick cap deferred); per-tenant lock — tenant A `sync_running` does not block tenant B; assert **no `env.GITHUB_TOKEN`** read in runSync path.
+Verify: `cd worker && npx vitest run src/sync/sync.test.ts` → new cases fail.
+
+**T4 [P] (RED, tester-B, webhook, diff 2)** — `worker/src/webhook/handlers.test.ts` (updates)
+Cases: `handleDeps` cross-repo path calls `resolveInstallToken(db,env,owner,name)` (not `env.GITHUB_TOKEN`); `handleRefDelete` calls `resolveInstallToken` for the deleted-branch repo.
+Verify: `cd worker && npx vitest run src/webhook/handlers.test.ts` → fails.
+
+**T9 [P] (backend-dev-C, graphql, diff 1)** — `worker/src/sync/graphql.ts`
+Add `"GraphQL-Features": "sub_issues"` to the `ghGraphql` request headers (defensive, D1). Keep `token` param. Add a unit assertion the header is sent.
+Verify: `cd worker && npm run typecheck` + header test green.
+
+**T11 [P] (devops-A, config, diff 2)** — `worker/migrations/0005_sync_slot_seed.sql` + `wrangler.toml`
+Migration: `INSERT OR IGNORE INTO sync_control (tenant_id,key,value) VALUES (0,'sync_slot','0');`. wrangler.toml: keep `SYNC_QUEUE` stanza **commented** with a `DORMANT — activate on Workers Paid + >30 repos` note (D2); confirm no `GITHUB_TOKEN` var stanza (secret-only).
+Verify: `cd worker && npx wrangler d1 migrations list roxabi-live-production` lists 0005 locally; `grep -n DORMANT wrangler.toml`.
+
+**T12 [P] (devops-A, ci, diff 2)** — `.github/workflows/ci.yml`
+Add a guard+inject step mirroring `GH_APP_*`: `GH_INSTALL_TOKEN_KEY` → `wrangler secret put INSTALL_TOKEN_KEY` in the deploy job (staging + prod). Add a TODO comment for the sequenced `GITHUB_TOKEN` deletion (RT3) — do **not** delete in CI.
+Verify: `grep -n INSTALL_TOKEN_KEY .github/workflows/ci.yml`; yaml parses.
+
+### RED-GATE V1
+
+**RG1 (sentinel, lead)** — confirm T1–T4 present and failing before any GREEN task. blockedBy T1,T2,T3,T4.
+
+### Wave 2 — GREEN core (3 ∥)
+
+**T5 (GREEN, backend-dev-A, crypto, diff 2)** — `worker/src/auth/tokenCrypto.ts`
+Web Crypto AES-GCM. `importDek(b64)` → `crypto.subtle.importKey('raw', base64decode, {name:'AES-GCM'}, false, ['encrypt','decrypt'])`. `encryptToken` → 12-byte random IV, base64url out. `decryptToken`. Never log plaintext.
+Verify: `cd worker && npx vitest run src/auth/tokenCrypto.test.ts` green. blockedBy RG1.
+
+**T6 (GREEN, backend-dev-A, install-token, diff 4)** — `worker/src/auth/installToken.ts`
+`getInstallationToken(db,env,tenantId,installationId)`: SELECT install_tokens; if `expires_at > now+5min` → `decryptToken`; else `importAppPrivateKey`+`signAppJwt` (jwt.ts) → `POST /app/installations/{id}/access_tokens` → `encryptToken` → upsert → return. `resolveInstallToken(db,env,owner,name)`: JOIN `tenant_repo_access`(repo=`owner/name`)→`tenants`(id, installation_id, suspended_at); throw if no row or suspended (fail-closed) → `getInstallationToken`. `listInstallationRepos(token)`: GET `/installation/repositories` (paginated) → `owner/name[]`.
+Verify: `cd worker && npx vitest run src/auth/installToken.test.ts` green + typecheck. blockedBy T5.
+
+**T7 (GREEN, backend-dev-B, sync, diff 5)** — `worker/src/sync/sync.ts`
+(a) Repo discovery: for each `tenants` row → `getInstallationToken` → `listInstallationRepos` → upsert `tenant_repo_access`; build deduped `Map<repo, tenantId>` (first tenant wins; repo fetched once). Replaces `enumerateOrgRepos`/`enumerateArchivedOrgRepos` PAT calls.
+(b) Per-repo loop: `resolveInstallToken`/`getInstallationToken` token per repo bundle.
+(c) `sync_slot` windowing: read slot from `sync_control`, `LIMIT/OFFSET` repo list (~40/tick), advance `slot mod ceil(total/window)`.
+(d) Parameterize `acquireSyncLock`/`releaseSyncLock`/`isHalted`/`incrementAuthFailures`/`resetAuthFailures` with `tenantId` (default 0); seed per-tenant rows; per-tenant failure must not hold another tenant's lock.
+(e) `closedHopPass(db, tokenResolver)` callback — resolve per (owner,name) hop; unknown repo → caught as orphan stub.
+(f) Remove all `env.GITHUB_TOKEN` reads.
+Verify: `cd worker && npx vitest run src/sync/sync.test.ts` green + typecheck. blockedBy T6.
+
+**T8 (GREEN, backend-dev-C, webhook, diff 2)** — `worker/src/webhook/handlers.ts`
+Line 209 (`handleDeps` cross-repo) + line 364 (`handleRefDelete`): replace `env.GITHUB_TOKEN` with `await resolveInstallToken(db, env, owner, name)` (owner/name already in scope).
+Verify: `cd worker && npx vitest run src/webhook/handlers.test.ts` green. blockedBy T6.
+
+### Wave 3 — Env drop-PAT
+
+**T10 (devops-A, config, diff 1)** — `worker/src/types.ts`
+Add `INSTALL_TOKEN_KEY: string`; add `SYNC_QUEUE?: Queue` (optional, dormant); **remove `GITHUB_TOKEN`**.
+Verify: `cd worker && npm run typecheck` green (all callsites gone). blockedBy T7,T8.
+
+### Wave 4 — verify
+
+**T13 (tester-B, verify, diff 3)** — full gate + regression sweep
+`cd worker && npm run typecheck && npm test`; assert `grep -rn "GITHUB_TOKEN" worker/src` returns **no** runtime reads (only comments/tests asserting removal); coverage on new modules.
+Verify: suite green + grep clean. blockedBy T9,T10,T11,T12.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate. blockedBy refs T-numbers (not session task IDs). -->
+
+### Wave 1 — no deps, 7 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | tester-A | — | crypto |
+| T2 | tester-A | — | install-token |
+| T3 | tester-B | — | sync |
+| T4 | tester-B | — | webhook |
+| T9 | backend-dev-C | — | graphql |
+| T11 | devops-A | — | config |
+| T12 | devops-A | — | ci |
+
+### RED-GATE — after W1 RED tests
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| RG1 | lead | T1,T2,T3,T4 | gate |
+
+### Wave 2 — after RED-GATE, 3 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | backend-dev-A | RG1 | crypto |
+| T6 | backend-dev-A | T5 | install-token |
+| T7 | backend-dev-B | T6 | sync |
+| T8 | backend-dev-C | T6 | webhook |
+
+### Wave 3 — after W2
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | devops-A | T7,T8 | config |
+
+### Wave 4 — after W3
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T13 | tester-B | T9,T10,T11,T12 | verify |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to re-attach tasks on session restart. -->
+- T1: 58 — crypto (tester-A)
+- T2: 59 — install-token (tester-A)
+- T3: 60 — sync (tester-B)
+- T4: 61 — webhook (tester-B)
+- T9: 62 — graphql (backend-dev-C)
+- T11: 63 — config (devops-A)
+- T12: 64 — ci (devops-A)
+- RG1: 65 — RED-GATE (lead) ⟸ T1,T2,T3,T4
+- T5: 66 — crypto (backend-dev-A) ⟸ RG1
+- T6: 67 — install-token (backend-dev-A) ⟸ T5
+- T7: 68 — sync (backend-dev-B) ⟸ T6
+- T8: 69 — webhook (backend-dev-C) ⟸ T6
+- T10: 70 — config (devops-A) ⟸ T7,T8
+- T13: 71 — verify (tester-B) ⟸ T9,T10,T11,T12

--- a/artifacts/plans/160-per-installation-runsync-cutover-plan.mdx
+++ b/artifacts/plans/160-per-installation-runsync-cutover-plan.mdx
@@ -1,0 +1,266 @@
+---
+title: "Plan: per-installation runSync cutover + PAT retirement (S3b)"
+issue: 160
+spec: artifacts/specs/160-per-installation-runsync-cutover-spec.mdx
+complexity: 7/10
+tier: F-full
+generated: 2026-06-12
+---
+
+## Summary
+
+Rewrite `runSync` to per-installation GitHub App tokens — two-phase
+(discovery → deduped windowed fan-out), per-tenant lock/breaker, `closedHopPass`
+resolver callback — drop the org PAT, harden `listInstallationRepos` (W2), and
+reconcile the sync test suite (un-skip 4 RED + rewrite ~11 old-flow cases).
+
+## Architecture
+
+```mermaid
+flowchart TD
+  subgraph sync_ts["worker/src/sync/sync.ts"]
+    RS[runSync] --> GL[acquireSyncLock 0 · tick lock]
+    GL --> DT[discoverTenants Phase 1]
+    DT -->|Map repo→tenantId,installationId| P2[Phase 2 fan-out]
+    P2 --> CHP[closedHopPass db,resolveToken]
+    DT --> H7[7 lock/breaker helpers +tenantId]
+    P2 --> SLOT[advance sync_slot mod NUM_SLOTS]
+    P2 --> PR[prune vs tenant_repo_access union]
+  end
+  subgraph auth["worker/src/auth/installToken.ts"]
+    GIT[getInstallationToken] --> LIR[listInstallationRepos* W2]
+  end
+  subgraph types["worker/src/types.ts"]
+    ENV[Env − GITHUB_TOKEN]
+  end
+  DT --> GIT
+  P2 --> GIT
+  CHP --> GIT
+  classDef w2 stroke-dasharray:4 3
+  class LIR w2
+```
+
+```mermaid
+flowchart LR
+  subgraph prod["sync.ts (be-A) + installToken/types (be-B)"]
+    discoverTenants --> upsert_TRA[tenant_repo_access upsert]
+    runSync --> discoverTenants
+    runSync --> closedHopPass
+    helpers7[acquireSyncLock/releaseSyncLock/isHalted/getAuthFailures/incrementAuthFailures/haltSync/resetAuthFailures]
+    runSync --> helpers7
+    listInstallationRepos_W2
+  end
+  subgraph tests["sync.test.ts + installToken.test.ts (te-A)"]
+    RED4[4 RED cases + vi.mock] -.verifies.-> runSync
+    reconcile11[~11 old-flow cases] -.verifies.-> runSync
+    w2test -.verifies.-> listInstallationRepos_W2
+  end
+```
+
+## Bootstrap Context
+
+- Analysis (architect-reviewed): `artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx`
+- Spec (architect+devops-reviewed): `artifacts/specs/160-per-installation-runsync-cutover-spec.mdx`
+- Code map (from Explore): `runSync` @ `sync.ts:1127`; PAT reads @ L1161/1165/1277/1288;
+  7 helpers @ L213-279 (all hardcode `tenant_id=0`); `closedHopPass` @ L986;
+  `syncRepoBundle` @ L802; `ghGraphql(query,vars,token)` = c[0]/c[1]/c[2];
+  `getInstallationToken(db,env,tenantId,installationId)` @ `installToken.ts:73`;
+  `listInstallationRepos(token)` @ L226 (`while(true)`, no cap — W2 target);
+  `sync_control` PK `(tenant_id,key)` (0004); `tenant_repo_access(tenant_id,repo)` (0004);
+  `sync_slot=0` seeded for tenant_id=0 (0005). RED block @ `sync.test.ts:1485`
+  (4 cases: L1496/1531/1565/1601); **no** `vi.mock("../auth/installToken")` present;
+  old-flow `runSync` describe @ L924 (~11 cases). `wrangler.toml` has **no**
+  `GITHUB_TOKEN` (secret only). `ci.yml:181` = `TODO(RT3)` comment only.
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1, T2, T3, T4 | `worker/src/sync/sync.ts` |
+| backend-dev-B | T5, T6 | `worker/src/auth/installToken.ts`, `worker/src/types.ts`, `worker/src/sync/graphql.ts` |
+| tester-A | T7, T8, T9, T10 | `worker/src/auth/installToken.test.ts`, `worker/src/sync/sync.test.ts` |
+
+## Wave Structure
+
+4 waves, max 2 parallel agents. Elapsed ~ slowest chain (be-A T1→T2→T3→T4) vs sequential T1..T10.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | be-A: T1 · be-B: T5 |
+| 2 | Wave 1 done | 2 ∥ | be-A: T2→T3→T4 · te-A: T7 |
+| 3 | T4 done | 2 ∥ | be-B: T6 · te-A: T8→T9 |
+| 4 | T6,T7,T9 done | 1 | te-A: T10 (RED-GATE) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 thread tenantId ×7 | 7 helpers | bounded | 8 | — |
+| T2 closedHopPass resolver | 1 | judgmental | 5 | — |
+| T3 discoverTenants Phase 1 | 1 | judgmental | 10 | — |
+| T4 runSync Phase 2 rewrite | 1 | exploratory | 14 | — |
+| T5 W2 harden | 1 | judgmental | 6 | — |
+| T6 drop GITHUB_TOKEN | 2 files | bounded | 4 | — |
+| T7 W2 unit test | 1 | judgmental | 5 | — |
+| T8 un-skip 4 RED + vi.mock | 4 | judgmental | 9 | — |
+| T9 reconcile ~11 old-flow | 11 | judgmental | 13 | — |
+| T10 RED-GATE verify | 1 | bounded | 3 | — |
+
+**Total estimated ops: 77**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3, T4 | 37 | sync | — |
+| backend-dev-B | T5, T6 | 10 | token, env | — |
+| tester-A | T7, T8, T9, T10 | 30 | token, sync-tests | — |
+
+No instance exceeds 50 ops / 4 tasks / 2 subjects → no split required.
+
+## Consistency Report
+
+Covered: 10/10 success criteria + items traced.
+
+| Criterion | Task(s) |
+|---|---|
+| SC-3 dedup (RED 1) | T4, T8 |
+| SC-4 slot advance (RED 2) | T4, T8 |
+| Lock isolation (RED 3) | T1, T3, T8 |
+| SC-6 no PAT (RED 4) | T4, T6, T8 |
+| W2 hardening | T5, T7 |
+| tenant_repo_access populated | T3 |
+| prune union + guard | T4 |
+| CI gate (suite+typecheck green) | T9, T10 |
+| SC-9/RT2 (staging tick) | post-deploy (verify) |
+| SC-7/RT3 (PAT delete) | post-merge operational |
+
+Untraced tasks: none. Exemptions: SC-9/SC-7 are deploy-gated (not code tasks) — verified at /verify + RT3 runbook.
+
+## Micro-Tasks
+
+### Slice S2 — thread tenantId (Wave 1)
+
+**T1** — Thread `tenantId: number = 0` through the 7 lock/breaker helpers.
+- File: `worker/src/sync/sync.ts` (L213-279)
+- Shape: `acquireSyncLock(db, tenantId = 0)`, …, update SQL `WHERE tenant_id = ?` bound to `tenantId` (replace hardcoded `0`). Keep default so non-`runSync` callers + existing tests stay green.
+- Verify: `cd worker && npm run typecheck` · existing helper tests green.
+- Agent: backend-dev-A · Subject: sync · Spec: Lock isolation · Phase: REFACTOR · Diff: 2
+
+### Slice S3 — closedHopPass resolver (Wave 2)
+
+**T2** — Change `closedHopPass(db, token)` → `closedHopPass(db, resolveToken)`.
+- File: `worker/src/sync/sync.ts` (L986)
+- Shape: `resolveToken: (owner: string, name: string) => Promise<string>`; internal GraphQL calls use `await resolveToken(owner, name)` per hop.
+- Verify: `npm run typecheck`.
+- Agent: backend-dev-A · Subject: sync · Spec: SC-9 · Phase: REFACTOR · blockedBy: T1 · Diff: 2
+
+### Slice S4 — discoverTenants Phase 1 (Wave 2)
+
+**T3** — New `discoverTenants(db, env): Promise<Map<string, Array<{tenantId, installationId}>>>`.
+- File: `worker/src/sync/sync.ts`
+- Shape: `SELECT id, installation_id FROM tenants WHERE installation_id IS NOT NULL`; ∀ tenant → `INSERT OR IGNORE INTO sync_control(tenant_id,key,value) VALUES(?,'sync_running','0')` (also auth_failures/halted rows) → `acquireSyncLock(db, tenantId)` skip-guard → `getInstallationToken(db, env, tenantId, installationId)` → `listInstallationRepos(token)` → upsert `tenant_repo_access` for returned repos + delete this tenant's rows not returned → merge into Map (push `{tenantId, installationId}`, keep list sorted asc by tenantId).
+- Verify: unit test asserts `tenant_repo_access` populated + Map shape (covered by te-A).
+- Agent: backend-dev-A · Subject: sync · Spec: tenant_repo_access populated · Phase: GREEN · blockedBy: T2 · Diff: 4
+
+### Slice S5 — runSync Phase 2 rewrite (Wave 2)
+
+**T4** — Rewrite `runSync` body to the two-phase model; drop all 4 `env.GITHUB_TOKEN` reads.
+- File: `worker/src/sync/sync.ts` (L1127); export `const WINDOW = 20`, `const NUM_SLOTS = 3`.
+- Shape: `isHalted(db,0)` → `acquireSyncLock(db,0)` → `discoverTenants` → unique repos sorted by `owner/name` → read `sync_slot`, window `[slot*WINDOW,(slot+1)*WINDOW)` → ∀ repo: try `getInstallationToken(db,env,owningTenant.tenantId,owningTenant.installationId)`, on throw fall to next list entry (`incrementAuthFailures(thrower)`), all fail → skip+log → `syncRepoBundle(db, token, owner, name, edges)` → `flushEdges` → `closedHopPass(db, resolveTokenFor)` → `sync_slot = (slot+1)%NUM_SLOTS` → prune vs union of `tenant_repo_access` (re-target 0-live guard at union count) → `writeRunAudit` → release locks. Remove `enumerateOrgRepos`/`enumerateArchivedOrgRepos`/`getRepoAllowlist` calls (and the now-dead functions if unreferenced).
+- Verify: RED cases 1,2,4 green (te-A T8); `grep -n GITHUB_TOKEN worker/src/sync/sync.ts` → none.
+- Agent: backend-dev-A · Subject: sync · Spec: SC-3/4/6 · Phase: GREEN · blockedBy: T3 · Diff: 5
+
+### Slice S1 — W2 hardening (Wave 1)
+
+**T5** — Bound `listInstallationRepos` pagination.
+- File: `worker/src/auth/installToken.ts` (L226-)
+- Shape: `const MAX_PAGES = 10;` replace `while(true)` with `for (let page=1; page<=MAX_PAGES; page++)`; each `fetch(url, { signal: AbortSignal.timeout(10_000) })`; break on `< per_page`; if `MAX_PAGES` reached with a full last page → log a truncation warn.
+- Verify: te-A T7.
+- Agent: backend-dev-B · Subject: token · Spec: W2 · Phase: GREEN · Diff: 3
+
+### Slice S6 — drop GITHUB_TOKEN (Wave 3)
+
+**T6** — Remove `GITHUB_TOKEN` from `Env` + stale references.
+- Files: `worker/src/types.ts` (drop `GITHUB_TOKEN: string`), `worker/src/sync/graphql.ts` (drop stale doc-comments L6/L111). No `wrangler.toml` edit (secret, not a `[vars]` entry).
+- Verify: `npm run typecheck` green; `grep -rn GITHUB_TOKEN worker/src` → only test fixtures (cast) if any.
+- Agent: backend-dev-B · Subject: env · Spec: SC-6/T10 · Phase: REFACTOR · blockedBy: T4 · Diff: 2
+
+### Slice S1 test — W2 (Wave 2)
+
+**T7** — Unit-test the W2 bound.
+- File: `worker/src/auth/installToken.test.ts` (create or extend)
+- Shape: mock `fetch` returning full pages → assert ≤ `MAX_PAGES` fetches; mock a hanging fetch → assert `AbortSignal.timeout` rejects/handled.
+- Verify: `cd worker && npm test -- installToken`.
+- Agent: tester-A · Subject: token · Spec: W2 · Phase: GREEN · blockedBy: T5 · Diff: 3
+
+### Slice S7a — un-skip RED (Wave 3)
+
+**T8** — Un-skip the 4 RED cases + add the install-token mock.
+- File: `worker/src/sync/sync.test.ts` (L1485 block)
+- Shape: `describe.skip(...)` → `describe(...)`; add top-level `vi.mock("../auth/installToken", () => ({ getInstallationToken: vi.fn(...), resolveInstallToken: vi.fn(...), listInstallationRepos: vi.fn(...) }))`; verify dedup assertion reads `c[0]/c[1]` (already correct per Explore — fix only if it regressed); wire fake `tenants`/`tenant_repo_access`/`sync_control` rows.
+- Verify: `cd worker && npm test -- sync` → 4 cases green.
+- Agent: tester-A · Subject: sync-tests · Spec: SC-3/4/6 + lock · Phase: RED→GREEN · blockedBy: T4 · Diff: 4
+
+### Slice S7b — reconcile old-flow (Wave 3)
+
+**T9** — Reconcile the ~11 old-flow `runSync` cases (L924-1408).
+- File: `worker/src/sync/sync.test.ts`
+- Shape: rewrite/remove cases asserting org-enum (`enumerateOrgRepos`), empty `repo_allowlist` short-circuit (L967), and global `tenant_id=0` auth-halt to the per-tenant model (halt scoped to a tenant; prune driven by `tenant_repo_access` union; empty discovery → no-op+warn). Keep semantics that survive (audit write, NOTIFY_URL alert) re-pointed at the per-tenant breaker.
+- Verify: `cd worker && npm test -- sync` → full describe green.
+- Agent: tester-A · Subject: sync-tests · Spec: CI gate · Phase: GREEN · blockedBy: T8 · Diff: 4
+
+### RED-GATE (Wave 4)
+
+**T10** — Full suite + typecheck gate.
+- Verify: `cd worker && npm test && npm run typecheck` → all green; `grep -rn GITHUB_TOKEN worker/src` clean (fixtures excepted).
+- Agent: tester-A · Subject: sync-tests · Phase: RED-GATE · blockedBy: T6, T7, T9 · Diff: 1
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | sync |
+| T5 | backend-dev-B | — | token |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | sync |
+| T3 | backend-dev-A | T2 | sync |
+| T4 | backend-dev-A | T3 | sync |
+| T7 | tester-A | T5 | token |
+
+### Wave 3 — after T4, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | backend-dev-B | T4 | env |
+| T8 | tester-A | T4 | sync-tests |
+| T9 | tester-A | T8 | sync-tests |
+
+### Wave 4 — after T6,T7,T9, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | tester-A | T6, T7, T9 | sync-tests |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 13 — sync (thread tenantId ×7)
+- T2: 14 — sync (closedHopPass resolver)
+- T3: 15 — sync (discoverTenants Phase 1)
+- T4: 16 — sync (runSync Phase 2 rewrite)
+- T5: 17 — token (W2 harden)
+- T6: 18 — env (drop GITHUB_TOKEN)
+- T7: 19 — token (W2 unit test)
+- T8: 20 — sync-tests (un-skip 4 RED + vi.mock)
+- T9: 21 — sync-tests (reconcile ~11 old-flow)
+- T10: 22 — sync-tests (RED-GATE)

--- a/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
+++ b/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
@@ -5,7 +5,13 @@ status: approved
 tier: F-full
 date: 2026-06-09
 promoted_from: artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Data model amended from per-tenant (composite PKs + `tenant_id` on
+> all tables) to **repo-canonical**. `issues`/`edges`/`labels`/`pr_state` PKs are **unchanged**;
+> `tenant_id` is **never added** to those tables. Authorization is a JOIN-only layer
+> (`tenant_repo_access`). Risky table-recreation step eliminated. See analysis addendum.
 
 ## Context
 
@@ -34,50 +40,52 @@ with tenant isolation verified — without an auth rewrite when Phase-2 ZK lands
 1. **Logged-out** visitor hits `/` → unauthenticated landing with a **Log in with GitHub** button.
 2. **Login:** `/login` → GitHub authorize (with single-use `state`) → `/oauth/callback` exchanges
    `code`→token (`client_secret`), creates/updates the `users` row, mints a **fresh** session
-   (cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`).
+   (cookie `HttpOnly; Secure; SameSite=Strict; Domain=<exact host>`).
 3. **Not installed yet:** if the user has no installation, callback lands on an **"install the App"**
    CTA → GitHub App install page → on return, `installation` webhook (or callback re-check) populates
-   `installations` + `user_installations`.
+   `tenants` + `user_installations` + `tenant_repo_access` rows.
 4. **Consent:** before any issue data renders, the user must **acknowledge** a notice — "the operator
    can read your issue data in this phase; don't paste secrets into issue bodies." A persistent
    dashboard notice repeats it.
 5. **Active tenant:** exactly one installation → it becomes the active tenant; more than one → an
    **org-picker** sets the active `tenant_id` (switchable). The session carries one active `tenant_id`.
 6. **Viewing:** `/api/issues`, `/api/issues/:key`, `/api/graph` return **only** rows where
-   `tenant_id = session.active_tenant`. No session → **401 before any DB query**.
+   `tenant_repo_access.tenant_id = session.active_tenant` (JOIN filter). No session → **401 before any DB query**.
 7. **Sync:** hourly cron loops installations, mints an installation token (App-JWT RS256) per install,
    syncs that install's repos, writes rows tagged with the installation's `tenant_id`. The org webhook
    delivers to one endpoint (one App secret); each event is routed to a tenant by `installation.id`;
    an unknown installation → 200 OK, **no write**.
 8. **Logout / uninstall:** logout deletes the session row; GitHub App `installation.deleted` deletes
-   all sessions + data for that `tenant_id`.
+   `tenant_repo_access` rows for that tenant — **issue/edge rows are retained** (globally-keyed data).
 
 ## Data Model & Consumers
 
 ```mermaid
 classDiagram
-  class User { github_user_id PK; login; created_at }
-  class Installation { installation_id PK; account_login; account_type; suspended_at }
-  class UserInstallation { github_user_id FK; installation_id FK; "PK(user,install)" }
-  class Session { token_hash PK; github_user_id FK; active_tenant_id; expires_at; created_at }
+  class User { id PK; github_id UNIQUE; github_login; created_at }
+  class Tenant { id PK; installation_id UNIQUE; account_login; account_type; suspended_at }
+  class UserInstallation { user_id FK; tenant_id FK; "PK(user_id,tenant_id)" }
+  class Session { id PK; user_id FK; tenant_id FK; token_hash UNIQUE; expires_at; revoked_at }
   class OAuthState { state PK; redirect_after; expires_at }
-  class Issue { "PK(tenant_id,key)"; tenant_id; key; repo; number; state; payload_JSON_title_only; url; ...; is_stub }
-  class Edge { "PK(tenant_id,src_key,dst_key,kind)"; tenant_id; src_key; dst_key; kind }
-  class Label { "PK(tenant_id,issue_key,name)"; tenant_id; issue_key; name }
-  class PrState { "PK(tenant_id,repo,number)"; tenant_id; repo; number; state; ... }
-  class SyncControl { "PK(tenant_id,key)"; tenant_id; key; value; updated_at }
+  class InstallToken { tenant_id PK FK; token_enc; token_iv; expires_at }
+  class TenantRepoAccess { tenant_id FK; repo; "PK(tenant_id,repo)" }
+  class Issue { key PK; repo; number; state; payload; url; ...; is_stub }
+  class Edge { "PK(src_key,dst_key,kind)"; src_key; dst_key; kind }
+  class SyncControl { "PK(tenant_id,key)"; tenant_id FK; key; value; updated_at }
   User "1" --> "*" UserInstallation
-  Installation "1" --> "*" UserInstallation
+  Tenant "1" --> "*" UserInstallation
   User "1" --> "*" Session
-  Installation "1" --> "*" Issue : tenant_id
-  Installation "1" --> "*" Edge : tenant_id
+  Tenant "1" --> "*" TenantRepoAccess
+  Tenant "1" --> "*" SyncControl
+  Tenant "1" --> "1" InstallToken
+  TenantRepoAccess "*" --> "*" Issue : repo filter
   Issue "1" --> "*" Edge : key
 ```
 
 > **`payload` (D24, Phase-2 ZK seam):** `issues` has **no top-level `title` column** — `title` lives
-> inside `payload` JSON (`JSON_EXTRACT(payload,'$.title')`); `body` is **absent** in Phase 1. Composite
-> PKs (table-recreation, D9) apply to `issues`, `edges`, **`labels`**, **`pr_state`**. `tenant_id` is
-> also added to existing `sync_state`, `repos`, `repo_allowlist` (D8).
+> inside `payload` JSON (`JSON_EXTRACT(payload,'$.title')`); `body` is **absent** in Phase 1.
+> `issues`/`edges`/`labels`/`pr_state` **PKs are unchanged** — no `tenant_id` column added to those
+> tables. Authorization is a JOIN through `tenant_repo_access` (fail-closed: no row → no data).
 
 ```mermaid
 flowchart LR
@@ -95,11 +103,11 @@ flowchart LR
 
 | Consumer | Fields consumed | When | Status |
 |---|---|---|---|
-| session middleware | `Session.token_hash`, `active_tenant_id`, `expires_at` | every `/api/*` | this issue |
-| `api/graph` | `Issue.{tenant_id,key,state,payload.title}`, `Edge.*` | page load / refresh | this issue |
-| `api/issues` | `Issue.*` (tenant-scoped) | list / detail | this issue |
-| cron sync | `Installation.installation_id`, per-tenant `SyncControl` | hourly | this issue |
-| webhook router | `Installation.installation_id` → `tenant_id` | on event | this issue |
+| session middleware | `Session.token_hash`, `tenant_id`, `expires_at`; NOT-suspended guard via `tenants` | every `/api/*` | this issue |
+| `api/graph` | `Issue.{key,state,payload.title}`, `Edge.*`, JOIN `tenant_repo_access` | page load / refresh | this issue |
+| `api/issues` | `Issue.*` + JOIN `tenant_repo_access` (+ `user_repo_permission_cache` for private) | list / detail | this issue |
+| cron sync | `Tenant.installation_id`, `InstallToken.token_enc/iv`, per-tenant `SyncControl` | hourly | this issue |
+| webhook router | `payload.installation.id` → `tenants` lookup → `tenant_repo_access` writes | on event | this issue |
 | Phase-2 client | `Issue.payload` (→ ciphertext) | opt-in ZK | **future (#142)** — payload column accessible |
 
 ## Breadboard
@@ -113,11 +121,11 @@ flowchart LR
 | N3 | `GET /api/me` | session→user + installations + active tenant | `sessions`,`user_installations` |
 | N4 | `POST /logout` | delete session row | `sessions` |
 | N5 | `POST /api/active-tenant` | set `Session.active_tenant_id` (membership-checked) | `sessions`,`user_installations` |
-| N6 | `POST /webhook/github` (extend) | HMAC → `installation.id`→tenant → scoped mutate; `installation`/`installation.deleted` events | all tenant tables,`installations`,`sessions` |
-| N7 | `GET /api/issues` (extend) | middleware → `WHERE tenant_id=?` | `issues`,`labels` |
-| N8 | `GET /api/issues/:key` (extend) | middleware → `WHERE key=? AND tenant_id=?` | `issues`,`edges`,`labels` |
-| N9 | `GET /api/graph` (extend) | middleware → all 5 queries `WHERE tenant_id=?` | `issues`,`edges`,`labels`,`pr_state`,`repos` |
-| N10 | `scheduled` cron (extend) | loop installations → mint token → per-tenant sync | `installations`,`issues`,`edges`,per-tenant `sync_control` |
+| N6 | `POST /webhook/github` (extend) | HMAC → `installation.id`→`tenants` lookup → scoped mutate; `installation.created/deleted/suspend/unsuspend`, `installation_repositories`, `repository.renamed/transferred/privatized/publicized`, `member.removed`/`membership.removed` | `tenants`,`tenant_repo_access`,`user_installations`,`sessions` |
+| N7 | `GET /api/issues` (extend) | middleware → `JOIN tenant_repo_access WHERE tenant_id=?` | `issues`,`labels`,`tenant_repo_access` |
+| N8 | `GET /api/issues/:key` (extend) | middleware → `JOIN tenant_repo_access WHERE key=? AND tra.tenant_id=?` | `issues`,`edges`,`labels`,`tenant_repo_access` |
+| N9 | `GET /api/graph` (extend) | middleware → all 5 queries `JOIN tenant_repo_access WHERE tenant_id=?` | `issues`,`edges`,`labels`,`pr_state`,`repos`,`tenant_repo_access` |
+| N10 | `scheduled` cron (extend) | loop repos (from `tenant_repo_access`) → AES-GCM decrypt install token → per-repo sync + slot-rotation | `tenants`,`install_tokens`,`tenant_repo_access`,`issues`,`edges`,`sync_control` |
 
 **UI (U):**
 
@@ -140,11 +148,11 @@ Vertical increments, dependency-ordered. **Each slice = one child issue.**
 
 | # | Slice | Demo-able outcome | Depends |
 |---|-------|-------------------|---------|
-| **S1** | **Schema & auth-table migrations + CI/infra** | **M-a** migration: `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist` + **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`) on `issues`/`edges`/`labels`/`pr_state` + new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state` + per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent). `ci.yml`: add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, in the `deploy:` job, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`). `wrangler.toml`: `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`. **Excludes the NOT-NULL migration (ships in S7).** | — |
+| **S1** | **Schema & auth-table migrations + CI/infra** | **M-a** migration: **10 new tables** (`tenants`, `users`, `user_installations`, `sessions`, `oauth_state`, `install_tokens`, `tenant_repo_access`, `user_repo_permission_cache`, `sync_control` with composite PK `(tenant_id,key)`, `zk_payloads`) + **2 ALTERs** (`ALTER TABLE issues ADD COLUMN payload TEXT`; `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE`). **No composite-PK recreation; no `tenant_id` column on `issues`/`edges`/`labels`/`pr_state`.** **`title` moved into `payload` JSON** (no top-level `title`; `body` absent). `ci.yml`: add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, in the `deploy:` job, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`). `wrangler.toml`: `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true` + `SYNC_QUEUE` binding declared **DORMANT**. **Excludes the NOT-NULL migration (ships in S7).** | — |
 | **S2** | **GitHub App + OAuth login + sessions** | user OAuths → fresh session cookie; `GET /api/me` returns identity; logout revokes; `state` single-use+TTL; new secrets wired (per-env) | S1 |
-| **S3** | **Installation linking + per-installation sync (PAT retired) + backfill** | App install webhook populates `installations`/`user_installations`; `runSync` per-installation fan-out (App-JWT → install token); per-tenant `sync_control`/auth-halt; `closedHopPass` scoped per-tenant; **`GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete` — no fallback**; **backfill** existing rows to the operator's **real installation_id** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0` | S2 |
+| **S3** | **Per-repo sync fan-out + AES-GCM install tokens + PAT retired** | `installation` webhook populates `tenants`/`user_installations`/`tenant_repo_access`; `runSync` loops **repos** (from `tenant_repo_access`) not installations — deduplicated fan-out; credentials = AES-GCM-decrypted install token (`install_tokens.token_enc/iv`, DEK = `INSTALL_TOKEN_KEY` secret); per-tenant `sync_control` slot-rotation; `SYNC_QUEUE` binding declared **DORMANT** (no active consumer); **`GITHUB_TOKEN` (PAT) removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete` — no fallback**; PAT retired after **first successful installation sync, staging first**. No `tenant_id` backfill (no column to fill). | S2 |
 | **S4** | **Webhook tenant routing + stub policy** | webhook event from install A writes only A's rows (route by `installation.id`); unknown install → 200 no-write; cross-tenant dep ref → tenant-local title-less stub; `installation.deleted` wipes tenant | S3 |
-| **S5** | **Tenant-filtered reads + active-tenant + org-picker** | `/api/*` behind fail-closed middleware; all reads `WHERE tenant_id=?` (IDOR on `/:key` closed); active tenant in session; org-picker for >1 install — **second user sees only their own issues + graph** | S2, S3 |
+| **S5** | **Tenant-filtered reads + active-tenant + org-picker** | `/api/*` behind fail-closed middleware (session includes NOT-suspended-tenant guard); all reads filtered via `JOIN tenant_repo_access WHERE tenant_id=?` (IDOR on `/:key` closed); private repos add `user_repo_permission_cache` check; active tenant in session; org-picker for >1 install — **second user sees only their own issues + graph** | S2, S3 |
 | **S6** | **Login / account-link / consent UI** | full browser flow logged-out → login → install CTA → consent acknowledge → org-picker → scoped dashboard | S5 |
 | **S7** | **NOT-NULL migration + CF Access cutover + runbook** | re-verify `COUNT NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill); staging smoke-test gate passes (sessions return 401 unauth) → Access scoped to `/admin/*` only (`/webhook/*` keeps its bypass) → prod cutover; rollback runbook (re-enable Access rule) written to a tracked file | S6 |
 
@@ -153,22 +161,22 @@ Vertical increments, dependency-ordered. **Each slice = one child issue.**
 
 ## Success Criteria
 
-- [ ] **M-a** migration applies cleanly on **staging D1**: `tenant_id` nullable on issues/edges/labels/pr_state/sync_state/repos/repo_allowlist; **composite PKs via table-recreation on `issues`, `edges`, `labels`, `pr_state`**; 5 new auth tables; per-tenant `sync_control`.
+- [ ] **M-a** migration applies cleanly on **staging D1**: **10 new tables** created; `ALTER TABLE issues ADD COLUMN payload TEXT` + `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` applied; **no `tenant_id` column on `issues`/`edges`/`labels`/`pr_state`; no composite-PK table-recreation**.
 - [ ] `issues` has **no top-level `title` column** — `title` is stored inside `payload` and read via `JSON_EXTRACT(payload,'$.title')`; **`body` is absent** from the Phase-1 payload schema. (D24 ZK seam.)
 - [ ] `ci.yml` `deploy:` job runs `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`**; a CI secret-presence step (same pattern as `CF_API_TOKEN`) fails the deploy when any `GITHUB_APP_*` secret is empty.
 - [ ] `wrangler.toml` sets `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` and `[env.staging] workers_dev=true` (staging reachable for end-to-end auth test).
 - [ ] A user completes GitHub OAuth and receives a session; `GET /api/me` returns their GitHub identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
 - [ ] OAuth `state` is single-use (deleted on verify), TTL ≤ 10 min, and `redirect_uri` is Worker-hard-coded; a replayed `state` is rejected.
-- [ ] **Session security:** the token issued after OAuth is **freshly minted** (no pre-auth value reused); `sessions.token_hash` stores the **SHA-256 hash** of the token (never the token); the cookie is `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>` (not `.roxabi.dev`); presenting an old pre-auth value after login returns 401.
-- [ ] Cron sync mints a **per-installation** token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; `GITHUB_TOKEN` is removed from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` with **no fallback**; RS256 sign errors log the message only (never key/JWT).
-- [ ] Webhook resolves `payload.installation.id` → `tenant_id` via DB lookup **before** any INSERT/UPDATE/DELETE; unknown — or known-but-missing-`tenant_id` — installation → 200, **no write**; `installation.deleted` deletes that tenant's sessions + data.
+- [ ] **Session security:** the token issued after OAuth is **freshly minted** (no pre-auth value reused); `sessions.token_hash` stores the **SHA-256 hash** of the token (never the token); the cookie is `HttpOnly; Secure; SameSite=Strict; Domain=<exact host>` (not `.roxabi.dev`); presenting an old pre-auth value after login returns 401.
+- [ ] Cron sync loops **repos** (from `tenant_repo_access`) — not installations — deduplicated fan-out; credentials = AES-GCM-decrypted install token (`install_tokens.token_enc/iv`, DEK = `INSTALL_TOKEN_KEY` secret); per-tenant `sync_control` slot-rotation; `GITHUB_TOKEN` is removed from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` with **no fallback**; RS256 sign errors log the message only (never key/JWT). No `tenant_id` backfill (no column to fill).
+- [ ] Webhook resolves `payload.installation.id` → `tenants` lookup **before** any INSERT/UPDATE/DELETE; unknown installation → 200, **no write**; handles `installation.created/deleted/suspend/unsuspend`, `installation_repositories.added/removed`, `repository.renamed/transferred/privatized/publicized`, `member.removed`/`membership.removed`; `installation.deleted` deletes `tenant_repo_access` rows only — **issue/edge rows are retained** (globally-keyed data).
 - [ ] A cross-tenant dependency reference materializes only as a `tenant_id`=requester, `is_stub=1`, `title=NULL` row — never another tenant's real title/body.
 - [ ] Every `/api/*` route is gated by fail-closed session middleware (no/invalid session → 401 **before** any DB statement).
-- [ ] `GET /api/issues/:key` and its label/edge sub-queries include `AND tenant_id=?` bound to the session's `active_tenant_id` **in the SQL** (code-review-verified); `GET /api/issues` + all 5 `GET /api/graph` queries filter by `tenant_id`; fetching a key that exists for another tenant returns **404** (not 200/500). [IDOR closed]
+- [ ] `GET /api/issues/:key` and its label/edge sub-queries are filtered via **`JOIN tenant_repo_access tra ON tra.repo=i.repo AND tra.tenant_id=?`** bound to the session's `active_tenant` **in the SQL** (code-review-verified); `GET /api/issues` + all 5 `GET /api/graph` queries use the same JOIN; private repos add a `user_repo_permission_cache` check; fetching a key that belongs to another tenant returns **404** (not 200/500). [IDOR closed]
 - [ ] A user with >1 installation gets an org-picker; the session carries exactly one active `tenant_id`; **no query UNIONs across tenants**.
 - [ ] Before any issue data renders, the user must acknowledge the operator-read consent notice; a persistent dashboard notice is present.
 - [ ] **Acceptance:** a *second* GitHub account logs in, links its account, sees **only its own** issues + dep-graph; the operator account sees only `Roxabi`'s — verified live on staging.
-- [ ] **S7 cutover:** backfill re-verified (`COUNT NULL = 0`) → **M-b NOT-NULL migration** committed + applied (NOT-NULL file ships in S7, never earlier); app sessions verified returning 401 unauth on staging → CF Access scoped to `/admin/*` only (`/webhook/*` keeps bypass); rollback (re-enable Access) documented in a tracked runbook file.
+- [ ] **S7 cutover:** **M-b NOT-NULL migration** applies only to new tables (no NOT-NULL on `issues`/`edges`/`labels`/`pr_state` — no backfill required); NOT-NULL file committed + applied (ships in S7, never earlier); app sessions verified returning 401 unauth on staging → CF Access scoped to `/admin/*` only (`/webhook/*` keeps bypass); rollback (re-enable Access) documented in a tracked runbook file.
 
 ## Out of Scope (→ #142 or follow-up)
 

--- a/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
+++ b/artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
@@ -1,0 +1,176 @@
+---
+title: "Multi-tenant GitHub App auth — Phase 1 (#141)"
+issue: 141
+status: approved
+tier: F-full
+date: 2026-06-09
+promoted_from: artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx
+---
+
+## Context
+
+Source: `artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx` (approved, review-hardened)
+→ ADR `artifacts/analyses/zk-encryption-spike-analysis.mdx` (Shape D, Phase 1). Frame:
+`artifacts/frames/141-multi-tenant-github-app-auth-frame.mdx`.
+
+Turn the single-tenant cockpit (CF Worker + D1 behind CF Access for one identity) into a multi-user
+tool: any GitHub user logs in, links their account, sees **only their own** issues + dep-graph.
+Server-centric (operator *can* read — honest in UX); a single **GitHub App** serves both this phase
+and the future Phase-2 ZK mode (#142). Decision set = the analysis's 24 settled sub-decisions.
+
+## Goal
+
+A second GitHub user can log in, link their account, and see only their own issues + graph in prod,
+with tenant isolation verified — without an auth rewrite when Phase-2 ZK lands.
+
+## Users
+
+- **Primary:** any GitHub user (installs the App + authorizes) → scoped cockpit of their own issues.
+- **Secondary:** operator (mickael) — runs/maintains sync, holds D1; must enforce isolation and
+  honestly disclose Phase-1 operator-readability.
+
+## Expected Behavior
+
+1. **Logged-out** visitor hits `/` → unauthenticated landing with a **Log in with GitHub** button.
+2. **Login:** `/login` → GitHub authorize (with single-use `state`) → `/oauth/callback` exchanges
+   `code`→token (`client_secret`), creates/updates the `users` row, mints a **fresh** session
+   (cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`).
+3. **Not installed yet:** if the user has no installation, callback lands on an **"install the App"**
+   CTA → GitHub App install page → on return, `installation` webhook (or callback re-check) populates
+   `installations` + `user_installations`.
+4. **Consent:** before any issue data renders, the user must **acknowledge** a notice — "the operator
+   can read your issue data in this phase; don't paste secrets into issue bodies." A persistent
+   dashboard notice repeats it.
+5. **Active tenant:** exactly one installation → it becomes the active tenant; more than one → an
+   **org-picker** sets the active `tenant_id` (switchable). The session carries one active `tenant_id`.
+6. **Viewing:** `/api/issues`, `/api/issues/:key`, `/api/graph` return **only** rows where
+   `tenant_id = session.active_tenant`. No session → **401 before any DB query**.
+7. **Sync:** hourly cron loops installations, mints an installation token (App-JWT RS256) per install,
+   syncs that install's repos, writes rows tagged with the installation's `tenant_id`. The org webhook
+   delivers to one endpoint (one App secret); each event is routed to a tenant by `installation.id`;
+   an unknown installation → 200 OK, **no write**.
+8. **Logout / uninstall:** logout deletes the session row; GitHub App `installation.deleted` deletes
+   all sessions + data for that `tenant_id`.
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+  class User { github_user_id PK; login; created_at }
+  class Installation { installation_id PK; account_login; account_type; suspended_at }
+  class UserInstallation { github_user_id FK; installation_id FK; "PK(user,install)" }
+  class Session { token_hash PK; github_user_id FK; active_tenant_id; expires_at; created_at }
+  class OAuthState { state PK; redirect_after; expires_at }
+  class Issue { "PK(tenant_id,key)"; tenant_id; key; repo; number; state; payload_JSON_title_only; url; ...; is_stub }
+  class Edge { "PK(tenant_id,src_key,dst_key,kind)"; tenant_id; src_key; dst_key; kind }
+  class Label { "PK(tenant_id,issue_key,name)"; tenant_id; issue_key; name }
+  class PrState { "PK(tenant_id,repo,number)"; tenant_id; repo; number; state; ... }
+  class SyncControl { "PK(tenant_id,key)"; tenant_id; key; value; updated_at }
+  User "1" --> "*" UserInstallation
+  Installation "1" --> "*" UserInstallation
+  User "1" --> "*" Session
+  Installation "1" --> "*" Issue : tenant_id
+  Installation "1" --> "*" Edge : tenant_id
+  Issue "1" --> "*" Edge : key
+```
+
+> **`payload` (D24, Phase-2 ZK seam):** `issues` has **no top-level `title` column** — `title` lives
+> inside `payload` JSON (`JSON_EXTRACT(payload,'$.title')`); `body` is **absent** in Phase 1. Composite
+> PKs (table-recreation, D9) apply to `issues`, `edges`, **`labels`**, **`pr_state`**. `tenant_id` is
+> also added to existing `sync_state`, `repos`, `repo_allowlist` (D8).
+
+```mermaid
+flowchart LR
+  subgraph thisIssue[Phase 1 — this epic]
+    SES[session middleware] -->|active_tenant_id| READS[api/issues, api/graph]
+    CRON[cron fan-out] -->|installation token| ISS[(Issue/Edge rows<br/>tenant_id)]
+    WH[webhook router] -->|installation.id→tenant| ISS
+    READS --> ISS
+  end
+  subgraph future[Phase 2 #142 — out of scope]
+    CLIENT[browser ECIES] -.->|encrypts| PAY[payload column → ciphertext]
+  end
+  ISS -. payload swappable .-> PAY
+```
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| session middleware | `Session.token_hash`, `active_tenant_id`, `expires_at` | every `/api/*` | this issue |
+| `api/graph` | `Issue.{tenant_id,key,state,payload.title}`, `Edge.*` | page load / refresh | this issue |
+| `api/issues` | `Issue.*` (tenant-scoped) | list / detail | this issue |
+| cron sync | `Installation.installation_id`, per-tenant `SyncControl` | hourly | this issue |
+| webhook router | `Installation.installation_id` → `tenant_id` | on event | this issue |
+| Phase-2 client | `Issue.payload` (→ ciphertext) | opt-in ZK | **future (#142)** — payload column accessible |
+
+## Breadboard
+
+**Routes / handlers (N):**
+
+| ID | Affordance | Handler | Data touched |
+|----|-----------|---------|--------------|
+| N1 | `GET /login` | redirect→GitHub authorize + write `OAuthState` | `oauth_state` |
+| N2 | `GET /oauth/callback` | verify+delete `state`, `code`→token, upsert `User`, mint `Session` | `oauth_state`,`users`,`sessions` |
+| N3 | `GET /api/me` | session→user + installations + active tenant | `sessions`,`user_installations` |
+| N4 | `POST /logout` | delete session row | `sessions` |
+| N5 | `POST /api/active-tenant` | set `Session.active_tenant_id` (membership-checked) | `sessions`,`user_installations` |
+| N6 | `POST /webhook/github` (extend) | HMAC → `installation.id`→tenant → scoped mutate; `installation`/`installation.deleted` events | all tenant tables,`installations`,`sessions` |
+| N7 | `GET /api/issues` (extend) | middleware → `WHERE tenant_id=?` | `issues`,`labels` |
+| N8 | `GET /api/issues/:key` (extend) | middleware → `WHERE key=? AND tenant_id=?` | `issues`,`edges`,`labels` |
+| N9 | `GET /api/graph` (extend) | middleware → all 5 queries `WHERE tenant_id=?` | `issues`,`edges`,`labels`,`pr_state`,`repos` |
+| N10 | `scheduled` cron (extend) | loop installations → mint token → per-tenant sync | `installations`,`issues`,`edges`,per-tenant `sync_control` |
+
+**UI (U):**
+
+| ID | Affordance | Wires to |
+|----|-----------|----------|
+| U1 | Logged-out landing | N1 |
+| U2 | Log in with GitHub | N1 |
+| U3 | Install-App CTA (authorized-not-installed) | links to **GitHub App install URL (external)** → user installs → GitHub fires `installation` webhook → N6 |
+| U4 | Org-picker (>1 installation) | N5 |
+| U5 | Operator-read consent (acknowledge) | gates data render |
+| U6 | Persistent dashboard notice | — |
+| U7 | Logout | N4 |
+
+**Middleware/util (M):** M1 session middleware (fail-closed 401) on `/api/*`; M2 App-JWT RS256 signer;
+M3 installation-token minter (cache ≤1h); M4 HMAC verify (existing, reused).
+
+## Slices
+
+Vertical increments, dependency-ordered. **Each slice = one child issue.**
+
+| # | Slice | Demo-able outcome | Depends |
+|---|-------|-------------------|---------|
+| **S1** | **Schema & auth-table migrations + CI/infra** | **M-a** migration: `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist` + **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`) on `issues`/`edges`/`labels`/`pr_state` + new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state` + per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent). `ci.yml`: add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, in the `deploy:` job, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`). `wrangler.toml`: `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`. **Excludes the NOT-NULL migration (ships in S7).** | — |
+| **S2** | **GitHub App + OAuth login + sessions** | user OAuths → fresh session cookie; `GET /api/me` returns identity; logout revokes; `state` single-use+TTL; new secrets wired (per-env) | S1 |
+| **S3** | **Installation linking + per-installation sync (PAT retired) + backfill** | App install webhook populates `installations`/`user_installations`; `runSync` per-installation fan-out (App-JWT → install token); per-tenant `sync_control`/auth-halt; `closedHopPass` scoped per-tenant; **`GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete` — no fallback**; **backfill** existing rows to the operator's **real installation_id** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0` | S2 |
+| **S4** | **Webhook tenant routing + stub policy** | webhook event from install A writes only A's rows (route by `installation.id`); unknown install → 200 no-write; cross-tenant dep ref → tenant-local title-less stub; `installation.deleted` wipes tenant | S3 |
+| **S5** | **Tenant-filtered reads + active-tenant + org-picker** | `/api/*` behind fail-closed middleware; all reads `WHERE tenant_id=?` (IDOR on `/:key` closed); active tenant in session; org-picker for >1 install — **second user sees only their own issues + graph** | S2, S3 |
+| **S6** | **Login / account-link / consent UI** | full browser flow logged-out → login → install CTA → consent acknowledge → org-picker → scoped dashboard | S5 |
+| **S7** | **NOT-NULL migration + CF Access cutover + runbook** | re-verify `COUNT NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill); staging smoke-test gate passes (sessions return 401 unauth) → Access scoped to `/admin/*` only (`/webhook/*` keeps its bypass) → prod cutover; rollback runbook (re-enable Access rule) written to a tracked file | S6 |
+
+**Pre-impl validation (gates S2/S3, do first):** RS256 sign in workerd (`crypto.subtle` RSASSA-PKCS1-v1_5);
+`subIssues`/`parent` GraphQL via installation token (no preview header post-GA).
+
+## Success Criteria
+
+- [ ] **M-a** migration applies cleanly on **staging D1**: `tenant_id` nullable on issues/edges/labels/pr_state/sync_state/repos/repo_allowlist; **composite PKs via table-recreation on `issues`, `edges`, `labels`, `pr_state`**; 5 new auth tables; per-tenant `sync_control`.
+- [ ] `issues` has **no top-level `title` column** — `title` is stored inside `payload` and read via `JSON_EXTRACT(payload,'$.title')`; **`body` is absent** from the Phase-1 payload schema. (D24 ZK seam.)
+- [ ] `ci.yml` `deploy:` job runs `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`**; a CI secret-presence step (same pattern as `CF_API_TOKEN`) fails the deploy when any `GITHUB_APP_*` secret is empty.
+- [ ] `wrangler.toml` sets `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` and `[env.staging] workers_dev=true` (staging reachable for end-to-end auth test).
+- [ ] A user completes GitHub OAuth and receives a session; `GET /api/me` returns their GitHub identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
+- [ ] OAuth `state` is single-use (deleted on verify), TTL ≤ 10 min, and `redirect_uri` is Worker-hard-coded; a replayed `state` is rejected.
+- [ ] **Session security:** the token issued after OAuth is **freshly minted** (no pre-auth value reused); `sessions.token_hash` stores the **SHA-256 hash** of the token (never the token); the cookie is `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>` (not `.roxabi.dev`); presenting an old pre-auth value after login returns 401.
+- [ ] Cron sync mints a **per-installation** token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; `GITHUB_TOKEN` is removed from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` with **no fallback**; RS256 sign errors log the message only (never key/JWT).
+- [ ] Webhook resolves `payload.installation.id` → `tenant_id` via DB lookup **before** any INSERT/UPDATE/DELETE; unknown — or known-but-missing-`tenant_id` — installation → 200, **no write**; `installation.deleted` deletes that tenant's sessions + data.
+- [ ] A cross-tenant dependency reference materializes only as a `tenant_id`=requester, `is_stub=1`, `title=NULL` row — never another tenant's real title/body.
+- [ ] Every `/api/*` route is gated by fail-closed session middleware (no/invalid session → 401 **before** any DB statement).
+- [ ] `GET /api/issues/:key` and its label/edge sub-queries include `AND tenant_id=?` bound to the session's `active_tenant_id` **in the SQL** (code-review-verified); `GET /api/issues` + all 5 `GET /api/graph` queries filter by `tenant_id`; fetching a key that exists for another tenant returns **404** (not 200/500). [IDOR closed]
+- [ ] A user with >1 installation gets an org-picker; the session carries exactly one active `tenant_id`; **no query UNIONs across tenants**.
+- [ ] Before any issue data renders, the user must acknowledge the operator-read consent notice; a persistent dashboard notice is present.
+- [ ] **Acceptance:** a *second* GitHub account logs in, links its account, sees **only its own** issues + dep-graph; the operator account sees only `Roxabi`'s — verified live on staging.
+- [ ] **S7 cutover:** backfill re-verified (`COUNT NULL = 0`) → **M-b NOT-NULL migration** committed + applied (NOT-NULL file ships in S7, never earlier); app sessions verified returning 401 unauth on staging → CF Access scoped to `/admin/*` only (`/webhook/*` keeps bypass); rollback (re-enable Access) documented in a tracked runbook file.
+
+## Out of Scope (→ #142 or follow-up)
+
+Client-side ZK / operator-blind content; syncing issue `body`; merged cross-installation view;
+Cloudflare Queues fan-out; billing/quotas.

--- a/artifacts/specs/144-schema-tenant-migrations-spec.mdx
+++ b/artifacts/specs/144-schema-tenant-migrations-spec.mdx
@@ -1,0 +1,33 @@
+---
+title: "feat(schema): tenant_id + auth-table migrations + CI/infra (Phase 1 S1)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 144
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S1** of #141. Foundation migration + deploy plumbing — no runtime auth behavior yet.
+
+- **M-a migration:** `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist`; **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`, preserving indexes/FKs) on `issues`/`edges`/`labels`/`pr_state`; new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state`; per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent).
+- **CI (`ci.yml`, `deploy:` job):** add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`).
+- **`wrangler.toml`:** `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`.
+- **Excludes the NOT-NULL migration** (ships in S7/#150).
+
+## Success Criteria
+
+- [ ] M-a applies cleanly on staging D1 (nullable `tenant_id` on 7 tables; composite PKs on `issues`/`edges`/`labels`/`pr_state`; 5 new auth tables; per-tenant `sync_control`).
+- [ ] `issues` has no top-level `title` column — `title` in `payload` (`JSON_EXTRACT(payload,'$.title')`); `body` absent.
+- [ ] `ci.yml` migrate-step inside `CF_API_TOKEN` guard in `deploy:` job between `npm ci` and `wrangler deploy`; `GITHUB_APP_*` secret-presence guard present.
+- [ ] `wrangler.toml` staging R2 = `roxabi-live-logs-staging` + `[env.staging] workers_dev=true`.
+
+## Dependencies
+
+None (foundation).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx) ·
+ADR: [zk-encryption-spike-analysis.mdx](../analyses/zk-encryption-spike-analysis.mdx)

--- a/artifacts/specs/144-schema-tenant-migrations-spec.mdx
+++ b/artifacts/specs/144-schema-tenant-migrations-spec.mdx
@@ -1,27 +1,148 @@
 ---
-title: "feat(schema): tenant_id + auth-table migrations + CI/infra (Phase 1 S1)"
+title: "feat(schema): auth-table migrations + CI/infra (Phase 1 S1)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 144
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Scope rewritten from "nullable `tenant_id` on 7 existing tables +
+> composite-PK recreation + 5 new auth tables" to **10 new tables + 2 ALTERs only**.
+> No `tenant_id` column on `issues`/`edges`/`labels`/`pr_state`; no composite-PK table-recreation.
 
 ## Scope
 
 Slice **S1** of #141. Foundation migration + deploy plumbing — no runtime auth behavior yet.
 
-- **M-a migration:** `tenant_id` **nullable** on `issues`/`edges`/`labels`/`pr_state`/`sync_state`/`repos`/`repo_allowlist`; **composite-PK table-recreation** (`CREATE→INSERT…SELECT→DROP→RENAME`, preserving indexes/FKs) on `issues`/`edges`/`labels`/`pr_state`; new tables `users`/`installations`/`user_installations`/`sessions`/`oauth_state`; per-tenant `sync_control`; **`title` moved into `payload` JSON** (no top-level `title`; `body` absent).
-- **CI (`ci.yml`, `deploy:` job):** add `wrangler d1 migrations apply DB [--env staging]` **inside the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence guard (same pattern as `CF_API_TOKEN`).
-- **`wrangler.toml`:** `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` + `[env.staging] workers_dev=true`.
-- **Excludes the NOT-NULL migration** (ships in S7/#150).
+- **M-a migration:** Create **10 new tables** (all nullable-safe; no existing table PK recreation):
+  `tenants`, `users`, `user_installations`, `sessions`, `oauth_state`, `install_tokens`,
+  `tenant_repo_access`, `user_repo_permission_cache`, `sync_control` (composite PK `(tenant_id,key)`),
+  `zk_payloads` (PK `(user_id,issue_key)` — per-user browser keys, not per-tenant).
+- **2 ALTERs on existing tables:**
+  - `ALTER TABLE issues ADD COLUMN payload TEXT` — ZK seam (D24); `title` lives inside `payload`
+    JSON (`JSON_EXTRACT(payload,'$.title')`); `body` absent in Phase 1.
+  - `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` — rename anchor for `repository.renamed`
+    webhook events.
+- **No composite-PK recreation.** `issues`/`edges`/`labels`/`pr_state` keep globally-unique PKs
+  unchanged; `tenant_id` is **never added** to those tables.
+- **CI (`ci.yml`, `deploy:` job):** add `wrangler d1 migrations apply DB [--env staging]` **inside
+  the `CF_API_TOKEN` guard, between `npm ci` and `wrangler deploy`** + a `GITHUB_APP_*` secret-presence
+  guard (same pattern as `CF_API_TOKEN`).
+- **`wrangler.toml`:** `[[env.staging.r2_buckets]] bucket_name="roxabi-live-logs-staging"` +
+  `[env.staging] workers_dev=true` + `SYNC_QUEUE` binding declared **DORMANT** (no active consumer;
+  placeholder for future Queues-based fan-out).
+- **Excludes the NOT-NULL migration** (ships in S7/#150 — applies only to new tables).
+
+## DDL
+
+```sql
+-- tenants: one row per GitHub App installation
+CREATE TABLE tenants (
+  id              INTEGER PRIMARY KEY,
+  installation_id INTEGER NOT NULL UNIQUE,
+  account_login   TEXT NOT NULL,
+  account_type    TEXT NOT NULL CHECK(account_type IN ('User','Organization')),
+  suspended_at    TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- users: one row per GitHub user who has authorized the App
+CREATE TABLE users (
+  id           INTEGER PRIMARY KEY,
+  github_id    INTEGER NOT NULL UNIQUE,
+  github_login TEXT NOT NULL,
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- user_installations: which users belong to which tenant
+CREATE TABLE user_installations (
+  user_id   INTEGER NOT NULL REFERENCES users(id),
+  tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+  PRIMARY KEY (user_id, tenant_id)
+);
+
+-- sessions: D1 (not KV) for strongly-consistent revocation
+CREATE TABLE sessions (
+  id          INTEGER PRIMARY KEY,
+  user_id     INTEGER NOT NULL REFERENCES users(id),
+  tenant_id   INTEGER NOT NULL REFERENCES tenants(id),
+  token_hash  TEXT NOT NULL UNIQUE,
+  expires_at  TEXT NOT NULL,
+  revoked_at  TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- oauth_state: single-use PKCE-like state for OAuth flow
+CREATE TABLE oauth_state (
+  state         TEXT PRIMARY KEY,
+  redirect_after TEXT,
+  expires_at    TEXT NOT NULL,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- install_tokens: AES-GCM-encrypted installation access tokens; DEK = INSTALL_TOKEN_KEY secret
+CREATE TABLE install_tokens (
+  tenant_id  INTEGER NOT NULL REFERENCES tenants(id) PRIMARY KEY,
+  token_enc  TEXT NOT NULL,
+  token_iv   TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- tenant_repo_access: authorization layer (fail-closed: no row → no data)
+CREATE TABLE tenant_repo_access (
+  tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+  repo      TEXT NOT NULL,
+  PRIMARY KEY (tenant_id, repo)
+);
+
+-- user_repo_permission_cache: per-user private-repo permission; 24h TTL
+CREATE TABLE user_repo_permission_cache (
+  user_id    INTEGER NOT NULL REFERENCES users(id),
+  repo       TEXT NOT NULL,
+  has_access INTEGER NOT NULL DEFAULT 0,
+  checked_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, repo)
+);
+
+-- sync_control: per-tenant lock/slot-rotation state; composite PK avoids cross-tenant contention
+CREATE TABLE sync_control (
+  tenant_id  INTEGER NOT NULL REFERENCES tenants(id),
+  key        TEXT NOT NULL,
+  value      TEXT,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, key)
+);
+
+-- zk_payloads: Phase-2 ZK seam; PK is per-user (browser keys, not per-tenant)
+CREATE TABLE zk_payloads (
+  user_id           INTEGER NOT NULL REFERENCES users(id),
+  issue_key         TEXT NOT NULL,
+  pubkey_fp         TEXT NOT NULL,
+  encrypted_payload TEXT NOT NULL,
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, issue_key)
+);
+
+-- ALTERs on existing tables (safe: nullable, no PK change)
+ALTER TABLE issues ADD COLUMN payload TEXT;
+ALTER TABLE repos  ADD COLUMN repo_node_id TEXT UNIQUE;
+```
 
 ## Success Criteria
 
-- [ ] M-a applies cleanly on staging D1 (nullable `tenant_id` on 7 tables; composite PKs on `issues`/`edges`/`labels`/`pr_state`; 5 new auth tables; per-tenant `sync_control`).
+- [ ] M-a applies cleanly on staging D1: **10 new tables** created; `ALTER TABLE issues ADD COLUMN
+  payload TEXT` + `ALTER TABLE repos ADD COLUMN repo_node_id TEXT UNIQUE` applied; **no `tenant_id`
+  column on `issues`/`edges`/`labels`/`pr_state`; no composite-PK table-recreation**.
 - [ ] `issues` has no top-level `title` column — `title` in `payload` (`JSON_EXTRACT(payload,'$.title')`); `body` absent.
+- [ ] `zk_payloads` PK is `(user_id, issue_key)` (not `tenant_id`) — verified in migration DDL.
+- [ ] `sync_control` PK is `(tenant_id, key)` composite — verified in migration DDL.
 - [ ] `ci.yml` migrate-step inside `CF_API_TOKEN` guard in `deploy:` job between `npm ci` and `wrangler deploy`; `GITHUB_APP_*` secret-presence guard present.
-- [ ] `wrangler.toml` staging R2 = `roxabi-live-logs-staging` + `[env.staging] workers_dev=true`.
+- [ ] `wrangler.toml` staging R2 = `roxabi-live-logs-staging` + `[env.staging] workers_dev=true` + `SYNC_QUEUE` binding present but **DORMANT** (no active consumer).
 
 ## Dependencies
 

--- a/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
+++ b/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
@@ -5,22 +5,37 @@ parent_issue: 141
 issue: 145
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** SameSite=Lax → **SameSite=Strict**. Added: suspended-tenant session
+> guard; PKCS#8 private-key conversion contract; vitest RS256 sign/verify CI guard.
 
 ## Scope
 
 Slice **S2** of #141. Identity layer.
 
 - Register the single **GitHub App**; provision per-env secrets `GITHUB_APP_{ID,CLIENT_ID,CLIENT_SECRET,PRIVATE_KEY,WEBHOOK_SECRET}` (rotatable, never logged).
-- **App-JWT (RS256) signer** util (`crypto.subtle` RSASSA-PKCS1-v1_5). **Pre-impl gate: RS256-in-workerd smoke-test** — if it fails, re-evaluate the App-JWT path.
+- **`GITHUB_APP_PRIVATE_KEY` contract:** convert the PEM once:
+  `openssl pkcs8 -topk8 -nocrypt -in app.pem -outform DER | base64 -w0` → secret = `base64(PKCS#8 DER)`.
+  Worker: `atob(secret) → importKey('pkcs8', …, { name:'RSASSA-PKCS1-v1_5', hash:'SHA-256' }, false, ['sign'])`.
+  RS256 natively supported. Rotation: 2 active keys = zero-downtime; redeploy coupled; document in runbook.
+- **App-JWT (RS256) signer** util (`crypto.subtle` RSASSA-PKCS1-v1_5). **Pre-impl gate: RS256-in-workerd smoke-test** — if it fails, re-evaluate the App-JWT path. Add **vitest (workers pool) test** for RS256 sign/verify with a throwaway key as a permanent CI guard.
 - `GET /login` (redirect to GitHub authorize + single-use `state`) and `GET /oauth/callback` (verify+delete `state`, `code`→token with `client_secret`, upsert `users`, mint **fresh** session).
-- **`sessions`** writes (token **hashed at rest**); fail-closed session middleware (Hono, mirrors `checkAdminAuth`).
+- **`sessions`** writes (token **hashed at rest**, returned raw once, hash stored only); fail-closed session middleware (Hono, mirrors `checkAdminAuth`). Session SELECT includes NOT-suspended-tenant guard (see below).
 
 ## Success Criteria
 
 - [ ] OAuth → fresh session; `GET /api/me` returns identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
 - [ ] `state` single-use (deleted on verify), TTL ≤ 10 min, `redirect_uri` Worker-hard-coded; replay rejected.
-- [ ] Session token freshly minted post-auth (no pre-auth value reused); `sessions.token_hash` = SHA-256 of token; cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`.
+- [ ] Session token freshly minted post-auth (no pre-auth value reused); `sessions.token_hash` = SHA-256 of token; raw token returned once only; cookie `HttpOnly; Secure; SameSite=Strict; Domain=<exact host>`.
+- [ ] Session SELECT includes suspended-tenant guard:
+  ```sql
+  WHERE s.token_hash=? AND s.expires_at>datetime('now') AND s.revoked_at IS NULL
+    AND NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id=s.tenant_id AND t.suspended_at IS NOT NULL)
+  ```
+- [ ] `GITHUB_APP_PRIVATE_KEY` secret = `base64(PKCS#8 DER)`; Worker imports via `importKey('pkcs8', …)`; PKCS#1 PEM never stored.
+- [ ] Vitest (workers pool) RS256 sign/verify test with throwaway key passes in CI.
 
 ## Dependencies
 

--- a/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
+++ b/artifacts/specs/145-github-app-oauth-sessions-spec.mdx
@@ -1,0 +1,31 @@
+---
+title: "feat(auth): GitHub App + OAuth login + sessions (Phase 1 S2)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 145
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S2** of #141. Identity layer.
+
+- Register the single **GitHub App**; provision per-env secrets `GITHUB_APP_{ID,CLIENT_ID,CLIENT_SECRET,PRIVATE_KEY,WEBHOOK_SECRET}` (rotatable, never logged).
+- **App-JWT (RS256) signer** util (`crypto.subtle` RSASSA-PKCS1-v1_5). **Pre-impl gate: RS256-in-workerd smoke-test** — if it fails, re-evaluate the App-JWT path.
+- `GET /login` (redirect to GitHub authorize + single-use `state`) and `GET /oauth/callback` (verify+delete `state`, `code`→token with `client_secret`, upsert `users`, mint **fresh** session).
+- **`sessions`** writes (token **hashed at rest**); fail-closed session middleware (Hono, mirrors `checkAdminAuth`).
+
+## Success Criteria
+
+- [ ] OAuth → fresh session; `GET /api/me` returns identity + installations; `POST /logout` deletes the session row (subsequent `/api/*` → 401).
+- [ ] `state` single-use (deleted on verify), TTL ≤ 10 min, `redirect_uri` Worker-hard-coded; replay rejected.
+- [ ] Session token freshly minted post-auth (no pre-auth value reused); `sessions.token_hash` = SHA-256 of token; cookie `HttpOnly; Secure; SameSite=Lax; Domain=<exact host>`.
+
+## Dependencies
+
+Blocked by **#144** (S1 — schema/auth tables).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/146-installation-sync-backfill-spec.mdx
+++ b/artifacts/specs/146-installation-sync-backfill-spec.mdx
@@ -1,0 +1,33 @@
+---
+title: "feat(sync): installation linking + per-install sync + PAT retired + backfill (Phase 1 S3)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 146
+status: approved
+tier: L
+---
+
+## Scope
+
+Slice **S3** of #141. Data-access + sync fan-out (the largest slice).
+
+- `installation` webhook → populate `installations` + `user_installations`; onboarding "authorized-not-installed" handled in S6.
+- `runSync` becomes a **per-installation loop:** App-JWT → `POST /app/installations/:id/access_tokens` (cache ≤ 1 h) → sync that install's repos → write rows tagged with its `tenant_id`.
+- Per-tenant `sync_control` / auth-halt breaker; **`closedHopPass` scoped per-tenant** (walk only that tenant's edge graph).
+- **Remove `GITHUB_TOKEN` (PAT)** from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` — **no fallback**.
+- **Backfill** existing rows to the operator's **real `installation_id`** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0`.
+- **Pre-impl gate:** `subIssues`/`parent` GraphQL via an installation token (confirm no preview header post-GA — token type changed from PAT).
+
+## Success Criteria
+
+- [ ] Cron mints a per-installation token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; RS256 sign errors log message only (never key/JWT).
+- [ ] `GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete`; no fallback.
+- [ ] Backfill executed; `COUNT(*) WHERE tenant_id IS NULL = 0` verified.
+
+## Dependencies
+
+Blocked by **#145** (S2 — App/OAuth/sessions).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/146-installation-sync-backfill-spec.mdx
+++ b/artifacts/specs/146-installation-sync-backfill-spec.mdx
@@ -1,32 +1,114 @@
 ---
-title: "feat(sync): installation linking + per-install sync + PAT retired + backfill (Phase 1 S3)"
+title: "feat(sync): installation sync + per-repo fan-out + PAT retirement (Phase 1 S3)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 146
 status: approved
-tier: L
+tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Title + scope rewritten. Original tier: L. Original scope:
+> per-installation loop writing rows tagged with `tenant_id`, backfill, `COUNT(*) WHERE
+> tenant_id IS NULL = 0`. **New scope:** per-repo deduplicated fan-out + AES-GCM install
+> token management + slot-rotation under subrequest cap + SYNC_QUEUE DORMANT + PAT retirement.
+> No `tenant_id` on `issues`/`edges` — no backfill step. `installations` table renamed `tenants`.
 
 ## Scope
 
-Slice **S3** of #141. Data-access + sync fan-out (the largest slice).
+Slice **S3** of #141. Sync layer wired to GitHub App installation tokens.
 
-- `installation` webhook → populate `installations` + `user_installations`; onboarding "authorized-not-installed" handled in S6.
-- `runSync` becomes a **per-installation loop:** App-JWT → `POST /app/installations/:id/access_tokens` (cache ≤ 1 h) → sync that install's repos → write rows tagged with its `tenant_id`.
-- Per-tenant `sync_control` / auth-halt breaker; **`closedHopPass` scoped per-tenant** (walk only that tenant's edge graph).
-- **Remove `GITHUB_TOKEN` (PAT)** from `Env`, `wrangler.toml`, `handleDeps`, `handleRefDelete` — **no fallback**.
-- **Backfill** existing rows to the operator's **real `installation_id`** (runtime op — admin endpoint or `wrangler d1 execute "UPDATE … WHERE tenant_id IS NULL"`, chunked to D1 limits; orphan-row rollback defined) → verify `COUNT(*) WHERE tenant_id IS NULL = 0`.
-- **Pre-impl gate:** `subIssues`/`parent` GraphQL via an installation token (confirm no preview header post-GA — token type changed from PAT).
+### Installation token management
+
+On each cron tick (and on `POST /admin/sync`), the Worker:
+
+1. Reads `install_tokens` rows for all tenants (`token_enc`, `token_iv`, `expires_at`).
+2. For tokens expired or expiring within 5 min: re-mint via App-JWT RS256 →
+   `POST /app/installations/:id/access_tokens` → AES-GCM-encrypt new plaintext token →
+   upsert `install_tokens (tenant_id, token_enc, token_iv, expires_at)`.
+3. DEK = `INSTALL_TOKEN_KEY` Worker secret (set via `wrangler secret put INSTALL_TOKEN_KEY`).
+   Plaintext token is **never logged, never stored raw**.
+
+```
+encrypt: iv = crypto.getRandomValues(12 bytes)
+         ciphertext = AES-GCM.encrypt(DEK, iv, plaintext_token)
+         store (base64(ciphertext), base64(iv))
+
+decrypt: plaintext = AES-GCM.decrypt(DEK, base64decode(iv), base64decode(token_enc))
+```
+
+### Per-repo deduplicated fan-out
+
+The Cron Trigger (`0 * * * *`) iterates `tenant_repo_access`, **deduplicates by repo across
+all tenants**, and issues **one GitHub GraphQL call per unique repo** — not per tenant.
+Deduplication prevents N×redundant API calls for repos shared by colleagues under the same
+installation.
+
+Issue/edge writes go to the globally-keyed `issues`/`edges` tables (`owner/repo#N` PKs).
+No `tenant_id` column on those tables.
+
+**Subrequest cap:** Cloudflare Workers free tier: ~50 subrequests/invocation.
+At ~22 unique repos/tick, slot-rotation via `sync_control` is used to spread work across ticks:
+
+- `sync_control (tenant_id, 'sync_slot')` holds the last-synced repo offset.
+- Each tick syncs a window of repos; the slot advances per tick.
+- A full pass completes over N ticks (N = ceil(unique_repos / per_tick_limit)).
+- `sync_control (tenant_id, 'sync_running')` / `'sync_started_at'` guard against concurrent
+  invocations for that tenant. A per-installation failure must **not** hold another tenant's lock.
+
+**`sync_control` composite PK is `(tenant_id, key)`.** Per-tenant keys: `sync_slot`,
+`sync_running`, `sync_started_at`, `auth_halt_count`, `last_auth_halt_at`. Global key
+`data_version` uses a sentinel `tenant_id = 0` (or a separate non-FK row — implementation
+choice; document in code).
+
+### SYNC_QUEUE (DORMANT)
+
+A `SYNC_QUEUE` Cloudflare Queues binding is declared in `wrangler.toml` but has **no active
+consumer in Phase 1**. It is a placeholder for a future fan-out upgrade where each repo-sync
+task is enqueued independently. Do not wire a consumer handler in Phase 1.
+
+### PAT retirement
+
+`GITHUB_TOKEN` (PAT) is **removed** from `Env`, `wrangler.toml` (both envs), `handleDeps`,
+`handleRefDelete`, and all `sync/` paths — **no fallback**.
+
+Retirement order:
+1. Deploy S3 to **staging**.
+2. Verify one successful cron tick: `wrangler tail --env staging` confirms issue rows written.
+3. Remove `GITHUB_TOKEN` from staging secrets: `wrangler secret delete GITHUB_TOKEN --env staging`.
+4. Confirm next tick clean (no 401s, no PAT references in logs).
+5. Repeat steps 1–4 for **prod**.
+
+### No backfill
+
+`issues`/`edges` have no `tenant_id` column. No `COUNT(*) WHERE tenant_id IS NULL` check.
+No backfill migration. The original backfill step is superseded by the repo-canonical model
+(see analysis addendum, `artifacts/analyses/141-multi-tenant-github-app-auth-analysis.mdx`).
+
+### Pre-impl gate
+
+`subIssues`/`parent` GraphQL via an installation token — confirm no preview header needed
+post-GA when token type changes from PAT → installation. Gates this slice.
 
 ## Success Criteria
 
-- [ ] Cron mints a per-installation token (App-JWT RS256) and writes issues/edges tagged with that installation's `tenant_id`; RS256 sign errors log message only (never key/JWT).
-- [ ] `GITHUB_TOKEN` removed from `Env`/`wrangler.toml`/`handleDeps`/`handleRefDelete`; no fallback.
-- [ ] Backfill executed; `COUNT(*) WHERE tenant_id IS NULL = 0` verified.
+- [ ] AES-GCM encrypt/decrypt round-trips for install tokens; DEK = `INSTALL_TOKEN_KEY`;
+  plaintext never logged; `token_enc` + `token_iv` stored in `install_tokens`.
+- [ ] Install token refreshed when `expires_at` ≤ now + 5 min; fresh token written to D1.
+- [ ] Cron fan-out deduplicates repos across tenants: 1 GraphQL call per unique repo (not per tenant).
+- [ ] Slot-rotation: `sync_control (tenant_id, 'sync_slot')` advances per tick; repos beyond
+  the per-tick cap deferred to next tick; no subrequest-cap breach under ~22 repos/tick.
+- [ ] SYNC_QUEUE binding declared in `wrangler.toml`; **no consumer handler registered** (DORMANT).
+- [ ] `GITHUB_TOKEN` removed from `Env` / `wrangler.toml` / `handleDeps` / `handleRefDelete`;
+  no PAT fallback anywhere.
+- [ ] PAT deleted from staging secrets after first verified installation sync tick; then prod.
+- [ ] No `tenant_id` column on `issues`/`edges`; no backfill step.
+- [ ] `subIssues`/`parent` GraphQL pre-impl gate cleared before implementation begins.
 
 ## Dependencies
 
-Blocked by **#145** (S2 — App/OAuth/sessions).
+Blocked by **#145** (S2 — App-JWT signer ready, `install_tokens` + `sync_control` tables exist)
+and **#144** (S1 — `tenant_repo_access`, `install_tokens`, `sync_control` tables created).
 
 ## Reference
 

--- a/artifacts/specs/146-installation-sync-backfill-spec.mdx
+++ b/artifacts/specs/146-installation-sync-backfill-spec.mdx
@@ -98,7 +98,7 @@ post-GA when token type changes from PAT → installation. Gates this slice.
 - [ ] Cron fan-out deduplicates repos across tenants: 1 GraphQL call per unique repo (not per tenant).
 - [ ] Slot-rotation: `sync_control (tenant_id, 'sync_slot')` advances per tick; repos beyond
   the per-tick cap deferred to next tick; no subrequest-cap breach under ~22 repos/tick.
-- [ ] SYNC_QUEUE binding declared in `wrangler.toml`; **no consumer handler registered** (DORMANT).
+- [ ] SYNC_QUEUE binding declared in `wrangler.toml` as an intentional DORMANT placeholder for future fan-out (Phase 2); **no consumer handler registered** in Phase 1.
 - [ ] `GITHUB_TOKEN` removed from `Env` / `wrangler.toml` / `handleDeps` / `handleRefDelete`;
   no PAT fallback anywhere.
 - [ ] PAT deleted from staging secrets after first verified installation sync tick; then prod.

--- a/artifacts/specs/147-webhook-tenant-routing-spec.mdx
+++ b/artifacts/specs/147-webhook-tenant-routing-spec.mdx
@@ -1,31 +1,142 @@
 ---
-title: "feat(webhook): tenant routing + cross-tenant stub policy (Phase 1 S4)"
+title: "feat(webhook): tenant routing + installation lifecycle handlers (Phase 1 S4)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 147
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Title + scope rewritten. Original scope: routing via
+> `installations` table, `installation.deleted` deletes all tenant sessions + data,
+> cross-tenant dep stub policy. **New scope:** routing via `payload.installation.id` →
+> `tenants`; `installation.deleted` retains global issue rows, deletes `tenant_repo_access`
+> only; full lifecycle handlers for install/repo/member events; `user_repo_permission_cache`
+> invalidation. `installations` table renamed `tenants`. Cross-tenant stub policy superseded
+> by repo-canonical model (issue rows globally shared; authorization via `tenant_repo_access`).
 
 ## Scope
 
 Slice **S4** of #141. Webhook isolation. Reuses the existing single-secret HMAC (`webhook/hmac.ts`).
 
-- After HMAC pass, **mandatory** `payload.installation.id` → `installations` lookup → `tenant_id` **before any** INSERT/UPDATE/DELETE.
-- Unknown / known-but-missing-`tenant_id` installation → **200 OK, no DB write** (so GitHub doesn't retry; no orphan/wrong-tenant rows).
-- All webhook mutations (`webhook/mutations.ts`) tenant-scoped.
-- **Cross-tenant dep stub policy:** a referenced foreign-repo issue materializes only as `tenant_id`=requester, `is_stub=1`, `title=NULL`, `body=NULL` — never another tenant's real content fetched under another installation's token.
-- `installation.deleted` → delete that tenant's sessions + data.
+### Routing
+
+After HMAC pass, **mandatory**: `payload.installation.id` → `tenants` lookup → resolve
+`tenant_id` **before any** INSERT/UPDATE/DELETE.
+
+Unknown installation (not in `tenants`) → **200 OK, no DB write** (GitHub does not retry;
+no orphan rows). Suspended tenant → log, 200, no write.
+
+All webhook mutations remain in `webhook/mutations.ts`; all use repo-canonical tables
+(`issues`, `edges`) with no `tenant_id` filter.
+
+### Installation lifecycle handlers
+
+#### `installation.created`
+
+1. Upsert row in `tenants` (`installation_id`, `account_login`, `account_type`, `app_id`,
+   `suspended_at=NULL`, `installed_at=now`).
+2. For each repo in `repositories`: upsert `tenant_repo_access (tenant_id, repo, is_private)`.
+3. Enqueue a sync for newly accessible repos (via `sync_control` slot or direct cron hint).
+
+#### `installation.deleted`
+
+1. Delete `tenant_repo_access` rows where `tenant_id = ?`.
+2. Delete `install_tokens` for that tenant.
+3. Delete `sessions` for that tenant.
+4. **Retain** all rows in `issues` and `edges` — global issue data is not tenant-owned.
+5. Mark `tenants` row with `deleted_at = now` (soft-delete; do not hard-delete for audit trail).
+
+#### `installation.suspend`
+
+Set `tenants.suspended_at = now`. Active sessions will fail the NOT-EXISTS guard on next
+request (no immediate invalidation needed; session SELECT includes the guard).
+
+#### `installation.unsuspend`
+
+Set `tenants.suspended_at = NULL`. Sessions resume automatically on next request.
+
+### Repository lifecycle handlers
+
+#### `installation_repositories.added`
+
+For each added repo: upsert `tenant_repo_access (tenant_id, repo, is_private)`.
+Trigger sync for those repos via `sync_control`.
+
+#### `installation_repositories.removed`
+
+Delete `tenant_repo_access (tenant_id, repo)` rows for each removed repo.
+Issue rows in `issues` / `edges` are **retained** (globally shared; other tenants may still
+have access).
+
+#### `repository.renamed`
+
+Anchor: `repo_node_id` (GitHub node ID; stable across renames). Steps:
+1. Look up current `repo` slug by `repo_node_id` in `repos.repo_node_id`.
+2. Cascade update: `repos.repo = new_full_name` + `tenant_repo_access.repo = new_full_name`
+   + `issues.repo = new_full_name` + `edges` entries that embed the repo component of `key`.
+3. If `repo_node_id` not found: upsert with new name (first-time rename before node_id was
+   stored — fallback to `previous_repository.full_name` lookup by old slug).
+
+#### `repository.transferred`
+
+Same cascade as `repository.renamed` (repo gets a new owner/name; node_id stable).
+
+#### `repository.privatized`
+
+Set `tenant_repo_access.is_private = 1` for that repo. Invalidate
+`user_repo_permission_cache` rows for that repo (`DELETE WHERE repo = ?`).
+
+#### `repository.publicized`
+
+Set `tenant_repo_access.is_private = 0` for that repo. Invalidate
+`user_repo_permission_cache` rows for that repo (`DELETE WHERE repo = ?`).
+
+### Member / membership handlers (permission-cache invalidation)
+
+#### `member.removed`
+
+A collaborator was removed from a specific repo. Delete `user_repo_permission_cache` rows
+for `(user_id matching github_id, repo)`.
+
+#### `membership.removed`
+
+A member was removed from the org (or a team). Delete all `user_repo_permission_cache` rows
+for that `github_id` (all repos in that installation's scope — conservative invalidation;
+next read triggers live API fallback and re-populates).
+
+### No cross-tenant stub policy
+
+The original cross-tenant dep stub (`is_stub=1, title=NULL`) is superseded. In the
+repo-canonical model, `issues` rows are globally unique by `owner/repo#N`. A dep that
+references a foreign repo simply resolves to that repo's row (if synced) or is absent.
+No stub insertion. Authorization is at read time via `tenant_repo_access`.
 
 ## Success Criteria
 
-- [ ] Webhook resolves `installation.id` → `tenant_id` via DB lookup **before** any write; unknown/missing-tenant installation → 200, no write.
-- [ ] Cross-tenant dep reference → `tenant_id`=requester, `is_stub=1`, `title=NULL` row only.
-- [ ] `installation.deleted` deletes that tenant's sessions + data.
+- [ ] `payload.installation.id` → `tenants` lookup before any write; unknown installation
+  → 200, no write; suspended tenant → 200, no write.
+- [ ] `installation.created`: `tenants` row upserted + `tenant_repo_access` rows upserted
+  for each repo.
+- [ ] `installation.deleted`: `tenant_repo_access` + `install_tokens` + `sessions` deleted;
+  `issues`/`edges` rows **retained**; `tenants.deleted_at` set.
+- [ ] `installation.suspend` / `installation.unsuspend`: `tenants.suspended_at` toggled;
+  session NOT-EXISTS guard enforces revocation without immediate session flush.
+- [ ] `installation_repositories.added` / `removed`: `tenant_repo_access` upsert / delete;
+  issue rows retained on removal.
+- [ ] `repository.renamed` + `repository.transferred`: cascade update anchored by
+  `repo_node_id`; `repos`, `tenant_repo_access`, `issues` all consistent.
+- [ ] `repository.privatized` / `publicized`: `is_private` updated + `user_repo_permission_cache`
+  invalidated.
+- [ ] `member.removed` / `membership.removed`: `user_repo_permission_cache` rows deleted
+  for affected user+repo scope.
+- [ ] No cross-tenant stub insertion logic.
 
 ## Dependencies
 
-Blocked by **#146** (S3 — installations table + per-tenant writes).
+Blocked by **#144** (S1 — `tenants`, `tenant_repo_access`, `user_repo_permission_cache`
+tables created) and **#145** (S2 — sessions + HMAC infra).
 
 ## Reference
 

--- a/artifacts/specs/147-webhook-tenant-routing-spec.mdx
+++ b/artifacts/specs/147-webhook-tenant-routing-spec.mdx
@@ -1,0 +1,32 @@
+---
+title: "feat(webhook): tenant routing + cross-tenant stub policy (Phase 1 S4)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 147
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S4** of #141. Webhook isolation. Reuses the existing single-secret HMAC (`webhook/hmac.ts`).
+
+- After HMAC pass, **mandatory** `payload.installation.id` → `installations` lookup → `tenant_id` **before any** INSERT/UPDATE/DELETE.
+- Unknown / known-but-missing-`tenant_id` installation → **200 OK, no DB write** (so GitHub doesn't retry; no orphan/wrong-tenant rows).
+- All webhook mutations (`webhook/mutations.ts`) tenant-scoped.
+- **Cross-tenant dep stub policy:** a referenced foreign-repo issue materializes only as `tenant_id`=requester, `is_stub=1`, `title=NULL`, `body=NULL` — never another tenant's real content fetched under another installation's token.
+- `installation.deleted` → delete that tenant's sessions + data.
+
+## Success Criteria
+
+- [ ] Webhook resolves `installation.id` → `tenant_id` via DB lookup **before** any write; unknown/missing-tenant installation → 200, no write.
+- [ ] Cross-tenant dep reference → `tenant_id`=requester, `is_stub=1`, `title=NULL` row only.
+- [ ] `installation.deleted` deletes that tenant's sessions + data.
+
+## Dependencies
+
+Blocked by **#146** (S3 — installations table + per-tenant writes).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -1,30 +1,130 @@
 ---
-title: "feat(api): tenant-filtered reads + active-tenant + org-picker (Phase 1 S5)"
+title: "feat(api): tenant-filtered reads + repo-canonical auth + org-picker (Phase 1 S5)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 148
 status: approved
 tier: M
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Title + scope rewritten. Original scope: `AND tenant_id=?`
+> filter injected into every read; no `user_repo_permission_cache`. **New scope:**
+> authorization via `JOIN tenant_repo_access` (repo-canonical model); private-repo reads add
+> `user_repo_permission_cache` check (24h TTL, live API fallback); session middleware includes
+> NOT-EXISTS suspended-tenant guard; no `tenant_id` in response shapes.
 
 ## Scope
 
 Slice **S5** of #141. **This slice satisfies the epic acceptance criterion.**
 
-- Fail-closed **session middleware on `/api/*`**: no/invalid session → **401 before any DB statement**.
-- Inject `tenant_id` (= session's active tenant) into every read: `listIssuesRoute`, all 5 `graphRoute` queries, and **`getIssueRoute`** (issue + labels + edges) with SQL-level **`AND tenant_id=?`** (closes the IDOR — keys are public GitHub URLs).
-- Session encodes **one active `tenant_id`**; user with >1 installation → **org-picker** (`POST /api/active-tenant`, membership-checked). **No cross-tenant UNION** queries.
+### Session middleware
+
+All `/api/*` routes go through a fail-closed session middleware:
+- No session cookie → **401** before any DB statement.
+- Invalid / expired / revoked session → **401**.
+- Suspended tenant → **401** (NOT-EXISTS guard in the SELECT itself).
+
+Session SELECT (authoritative):
+
+```sql
+SELECT s.*, u.github_id, u.github_login
+FROM sessions s
+JOIN users u ON u.id = s.user_id
+WHERE s.token_hash = ?
+  AND s.expires_at > datetime('now')
+  AND s.revoked_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM tenants t
+    WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL
+  )
+```
+
+The middleware injects `{ tenant_id, user_id, github_id, github_login }` into the request
+context. No downstream handler calls the DB before this context is populated.
+
+### Repo-canonical auth filter
+
+**Superseded (stale — do not use):**
+```sql
+WHERE i.tenant_id = ?
+```
+
+**Current (repo-canonical):**
+```sql
+JOIN tenant_repo_access tra
+  ON tra.repo = i.repo
+  AND tra.tenant_id = ?
+```
+
+This JOIN applies to:
+- `listIssuesRoute` — all issue rows visible to this tenant
+- `getIssueRoute` — single issue + labels + edges (IDOR closed: unknown repo → 0 rows → 404)
+- All 5 `graphRoute` queries (nodes, edges, labels, etc.)
+
+### Private-repo permission check (`user_repo_permission_cache`)
+
+When `tenant_repo_access.is_private = 1`:
+
+1. **Cache hit** (row in `user_repo_permission_cache` where `user_id=? AND repo=?` and
+   `cached_at > now - 24h`): use `has_access` value directly — **fail-closed** (if
+   `has_access=0`, 404, no data returned).
+2. **Cache miss** (no row, or row older than 24h): call GitHub API
+   `GET /repos/:owner/:repo/collaborators/:username` with the installation token.
+   - 204 → `has_access=1`; upsert cache.
+   - 404/403 → `has_access=0`; upsert cache.
+   - API error / timeout → **fail-closed** (treat as no access, 404); do not cache.
+3. **Cache error** (D1 read failure): fail-closed → 404.
+
+Public repos (`is_private = 0`) skip the permission check entirely.
+
+TTL: 24 hours from `cached_at`. Cache is invalidated by webhook events
+(`member.removed` / `membership.removed` / `repository.privatized` — see #147).
+
+### `GET /api/me`
+
+Returns authenticated user info and installation list:
+```json
+{
+  "github_login": "...",
+  "active_tenant_id": 42,
+  "installations": [
+    { "tenant_id": 42, "account_login": "Roxabi", "account_type": "Organization" }
+  ]
+}
+```
+
+No `tenant_id` column exposed from `issues`/`edges` rows. Response shapes are identical to
+single-tenant responses — authorization is fully backend-side.
+
+### Org-picker (`POST /api/active-tenant`)
+
+When a user has >1 installation: a picker UI (see #149) POSTs `{ tenant_id }`. The endpoint:
+1. Verifies the user has a row in `user_installations` for that `tenant_id`.
+2. Updates `sessions.tenant_id = ?` for the current session token.
+3. Returns 200 + updated session context.
+
+No cross-tenant UNION queries anywhere.
 
 ## Success Criteria
 
-- [ ] Every `/api/*` route gated by fail-closed middleware (no/invalid session → 401 before any DB statement).
-- [ ] `getIssueRoute` issue/label/edge queries include SQL-level `AND tenant_id=?` (code-review-verified); foreign-tenant key → 404; `listIssuesRoute` + 5 `graphRoute` queries tenant-filtered. [IDOR closed]
-- [ ] >1 installation → org-picker; session carries exactly one active `tenant_id`; no cross-tenant UNION.
-- [ ] **Acceptance:** a second GitHub account sees only its own issues + graph; operator sees only `Roxabi` — verified on staging.
+- [ ] Every `/api/*` route gated by fail-closed session middleware; no/invalid session →
+  401 before any DB statement; suspended tenant → 401 (NOT-EXISTS guard in session SELECT).
+- [ ] `getIssueRoute` issue/label/edge queries use `JOIN tenant_repo_access` (no
+  `AND tenant_id=?`); foreign-tenant or unknown repo key → 404. [IDOR closed]
+- [ ] `listIssuesRoute` + all 5 `graphRoute` queries use `JOIN tenant_repo_access`.
+- [ ] Private-repo reads check `user_repo_permission_cache` (24h TTL); cache miss → live API
+  fallback; any error path → fail-closed (404).
+- [ ] `GET /api/me` returns `installations` array; no `tenant_id` in issue/edge response shapes.
+- [ ] `POST /api/active-tenant` switches session tenant; membership verified before update.
+- [ ] >1 installation → org-picker flow works end-to-end.
+- [ ] **Acceptance:** a second GitHub account sees only its own repos' issues + graph;
+  operator sees only `Roxabi` — verified on staging.
 
 ## Dependencies
 
-Blocked by **#145** (S2 — sessions) and **#146** (S3 — tenant data).
+Blocked by **#147** (S4 — `tenant_repo_access` populated by webhook; `user_repo_permission_cache`
+invalidation wired) and **#145** (S2 — sessions + `user_installations` table).
 
 ## Reference
 

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -1,0 +1,31 @@
+---
+title: "feat(api): tenant-filtered reads + active-tenant + org-picker (Phase 1 S5)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 148
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S5** of #141. **This slice satisfies the epic acceptance criterion.**
+
+- Fail-closed **session middleware on `/api/*`**: no/invalid session → **401 before any DB statement**.
+- Inject `tenant_id` (= session's active tenant) into every read: `listIssuesRoute`, all 5 `graphRoute` queries, and **`getIssueRoute`** (issue + labels + edges) with SQL-level **`AND tenant_id=?`** (closes the IDOR — keys are public GitHub URLs).
+- Session encodes **one active `tenant_id`**; user with >1 installation → **org-picker** (`POST /api/active-tenant`, membership-checked). **No cross-tenant UNION** queries.
+
+## Success Criteria
+
+- [ ] Every `/api/*` route gated by fail-closed middleware (no/invalid session → 401 before any DB statement).
+- [ ] `getIssueRoute` issue/label/edge queries include SQL-level `AND tenant_id=?` (code-review-verified); foreign-tenant key → 404; `listIssuesRoute` + 5 `graphRoute` queries tenant-filtered. [IDOR closed]
+- [ ] >1 installation → org-picker; session carries exactly one active `tenant_id`; no cross-tenant UNION.
+- [ ] **Acceptance:** a second GitHub account sees only its own issues + graph; operator sees only `Roxabi` — verified on staging.
+
+## Dependencies
+
+Blocked by **#145** (S2 — sessions) and **#146** (S3 — tenant data).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/149-login-consent-ui-spec.mdx
+++ b/artifacts/specs/149-login-consent-ui-spec.mdx
@@ -1,0 +1,30 @@
+---
+title: "feat(ui): login + account-link + operator-read consent (Phase 1 S6)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 149
+status: approved
+tier: M
+---
+
+## Scope
+
+Slice **S6** of #141. Frontend (`frontend/index.html`, `app.js`).
+
+- Unauthenticated landing + **Log in with GitHub** button.
+- **Install-App CTA** for the authorized-not-installed state → links to the GitHub App install URL.
+- **Org-picker** UI (when >1 installation).
+- **Operator-read consent** the user must **acknowledge before any issue data renders** + a persistent dashboard notice ("operator can read your data this phase; don't paste secrets into issue bodies").
+
+## Success Criteria
+
+- [ ] Consent acknowledged before any issue data renders; persistent dashboard notice present.
+- [ ] Full browser flow works: logged-out → login → install CTA → consent → org-picker → scoped dashboard.
+
+## Dependencies
+
+Blocked by **#148** (S5 — tenant-filtered reads + active-tenant API).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/150-notnull-access-cutover-spec.mdx
+++ b/artifacts/specs/150-notnull-access-cutover-spec.mdx
@@ -1,0 +1,31 @@
+---
+title: "feat(deploy): NOT-NULL migration + CF Access cutover + runbook (Phase 1 S7)"
+parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
+parent_issue: 141
+issue: 150
+status: approved
+tier: S
+---
+
+## Scope
+
+Slice **S7** of #141. Final cutover (one-way edge change — gated).
+
+- Re-verify `COUNT(*) WHERE tenant_id IS NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill runs).
+- **Staging smoke-test gate:** app sessions verified returning **401** for unauthenticated callers on staging.
+- → CF Access scoped to **`/admin/*` only** (`/webhook/*` keeps its existing bypass) → prod cutover.
+- Rollback runbook (re-enable the Access rule) written to a tracked file.
+
+## Success Criteria
+
+- [ ] Backfill re-verified (`COUNT NULL = 0`) → M-b NOT-NULL migration committed + applied (never earlier).
+- [ ] App sessions verified 401 unauth on staging → CF Access scoped to `/admin/*` only; `/webhook/*` bypass retained.
+- [ ] Rollback (re-enable Access) documented in a tracked runbook file.
+
+## Dependencies
+
+Blocked by **#149** (S6 — full UI flow shippable).
+
+## Reference
+
+Full spec: [141-multi-tenant-github-app-auth-spec.mdx](./141-multi-tenant-github-app-auth-spec.mdx)

--- a/artifacts/specs/150-notnull-access-cutover-spec.mdx
+++ b/artifacts/specs/150-notnull-access-cutover-spec.mdx
@@ -1,30 +1,50 @@
 ---
-title: "feat(deploy): NOT-NULL migration + CF Access cutover + runbook (Phase 1 S7)"
+title: "feat(deploy): NOT-NULL migration (new tables) + CF Access cutover + runbook (Phase 1 S7)"
 parent_spec: "artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx"
 parent_issue: 141
 issue: 150
 status: approved
 tier: S
+amended: 2026-06-10
 ---
+
+> **Pivot note (2026-06-10):** Scope shrunk. NOT-NULL cutover applies only to **new tables** created
+> in S1. No `COUNT(*) WHERE tenant_id IS NULL = 0` check (no `tenant_id` column on old tables).
+> No backfill step. CF Access narrowed to `/admin/*` only (coordinated with S2 deploy).
 
 ## Scope
 
 Slice **S7** of #141. Final cutover (one-way edge change — gated).
 
-- Re-verify `COUNT(*) WHERE tenant_id IS NULL = 0` → commit + apply **M-b `000N_tenant_not_null.sql`** (the NOT-NULL file is authored in S1's design but **committed here**, so CI never applies it before backfill runs).
-- **Staging smoke-test gate:** app sessions verified returning **401** for unauthenticated callers on staging.
-- → CF Access scoped to **`/admin/*` only** (`/webhook/*` keeps its existing bypass) → prod cutover.
-- Rollback runbook (re-enable the Access rule) written to a tracked file.
+- **M-b NOT-NULL migration** (`000N_new_tables_not_null.sql`): tighten nullable columns on the
+  **10 new tables** from S1 only (e.g. add NOT NULL constraints where nullable was used during
+  initial migration for safety). **No changes to `issues`/`edges`/`labels`/`pr_state`** — those
+  tables have no new nullable columns from this epic.
+  The SQL file is authored in S1's design but **committed here**, so CI never applies it before
+  S5 (reads) and S6 (UI) are verified on staging.
+- **Staging smoke-test gate:** app sessions verified returning **401** for unauthenticated callers
+  on staging before CF Access change is applied.
+- **CF Access narrowing:** scope CF Access rule from the entire Worker to **`/admin/*` only**.
+  `/webhook/*` retains its existing bypass. All other routes (`/login`, `/oauth/*`, `/api/*`)
+  rely on Worker-level session auth (S2) — CF Access is defense-in-depth for admin only.
+  Coordinate timing with S2 deploy completion to avoid lockout window.
+- **Rollback runbook:** re-enable the CF Access rule to full Worker scope; written to a tracked
+  file in `docs/runbooks/`.
 
 ## Success Criteria
 
-- [ ] Backfill re-verified (`COUNT NULL = 0`) → M-b NOT-NULL migration committed + applied (never earlier).
-- [ ] App sessions verified 401 unauth on staging → CF Access scoped to `/admin/*` only; `/webhook/*` bypass retained.
-- [ ] Rollback (re-enable Access) documented in a tracked runbook file.
+- [ ] M-b NOT-NULL migration applies cleanly on staging; only new-table columns affected; no
+  changes to `issues`/`edges`/`labels`/`pr_state` schema.
+- [ ] No `COUNT(*) WHERE tenant_id IS NULL` check — not applicable (no `tenant_id` column on
+  old tables).
+- [ ] App sessions verified → 401 unauth on staging before CF Access change.
+- [ ] CF Access rule scoped to `/admin/*` only; `/webhook/*` bypass retained; `/api/*` and
+  `/login` reachable without CF Access (Worker session auth governs).
+- [ ] Rollback runbook (re-enable Access to full Worker) committed to `docs/runbooks/`.
 
 ## Dependencies
 
-Blocked by **#149** (S6 — full UI flow shippable).
+Blocked by **#149** (S6 — full UI flow shippable on staging).
 
 ## Reference
 

--- a/artifacts/specs/160-per-installation-runsync-cutover-spec.mdx
+++ b/artifacts/specs/160-per-installation-runsync-cutover-spec.mdx
@@ -1,0 +1,189 @@
+---
+title: "per-installation runSync cutover + PAT retirement (S3b)"
+issue: 160
+status: approved
+tier: F-full
+date: 2026-06-12
+promoted_from: artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx
+---
+
+## Context
+
+Promoted from `artifacts/analyses/160-per-installation-runsync-cutover-analysis.mdx`
+(architect-reviewed, verdict: sound-with-changes). Split from #146 (S3a shipped).
+S3a landed the install-token plumbing; this slice cuts `runSync` over to it and
+retires the org PAT.
+
+## Goal
+
+`runSync` syncs every installed tenant's repos using per-installation GitHub App
+tokens — deduped to 1 GraphQL bundle call per unique repo, windowed under the
+~50-subrequest cap, lock/breaker isolated per tenant — and reads **zero**
+`env.GITHUB_TOKEN`; the PAT is removed from code/config and deleted from secrets.
+
+## Users
+
+- **Primary:** the hourly Cron sync + operator (Mickael) — D1 issue/edge data
+  must keep reconciling after the PAT is gone.
+- **Secondary:** future multi-tenant installations — each install's repos sync
+  via its own token; no cross-tenant lock/breaker bleed.
+
+## Expected Behavior
+
+A cron tick:
+
+1. Global tick lock `acquireSyncLock(db, 0)` (existing) — serialises the run;
+   `isHalted(db, 0)` short-circuits a halted system. Released in `finally`.
+2. **Phase 1 — discovery (per tenant):** for each tenant row with an
+   `installation_id`, `INSERT OR IGNORE` its `sync_control(tenantId,
+   'sync_running')` row (else the next step silently no-ops), then attempt
+   `acquireSyncLock(db, tenantId)` (discovery skip-guard); on success
+   `getInstallationToken(db, env, tenantId, installationId)` →
+   `listInstallationRepos(token)` (hardened) → upsert
+   `tenant_repo_access(tenant_id, repo)` (and delete rows no longer returned).
+   Accumulate `Map<repo, Array<{tenantId, installationId}>>` (sorted ascending by
+   `tenantId`; lowest = owning) — carry `installationId` so Phase 2 mints tokens
+   with no extra query.
+3. **Phase 2 — fan-out (global, deduped, windowed):** sort the unique-repo set
+   lexicographically by `owner/name`; take the window `[slot*WINDOW,
+   (slot+1)*WINDOW)`; for each repo resolve a token via
+   `getInstallationToken(db, env, owningTenantId, installationId)` from the head
+   of the repo's tenant list, falling back to the next `{tenantId, installationId}`
+   on a revoked/suspended install (only `incrementAuthFailures(tenantId)` for the
+   thrower; all fail → skip repo + log, never abort the run) → `syncRepoBundle`.
+   Then `closedHopPass(db, resolveToken)` with the same per-(owner,name)
+   resolver. Advance `sync_slot = (slot+1) % NUM_SLOTS`.
+4. Prune issues/edges/pr_state/sync_state/repos against the **union of
+   `tenant_repo_access`**; skip prune (warn) if the union is empty (guard).
+5. `writeRunAudit` to R2; release all acquired locks.
+
+Empty discovery (no installs / empty union) → no-op + warn (NOT the old empty-
+allowlist short-circuit). PAT stays live in secrets until a verified staging tick
+(RT2); deletion (RT3) is the post-merge operational tail.
+
+## Data Model & Consumers
+
+No migration — schema landed in 0004/0005. This slice fills + reads existing
+tables.
+
+```mermaid
+classDiagram
+  class tenants {
+    +INTEGER id
+    +INTEGER installation_id
+  }
+  class tenant_repo_access {
+    +INTEGER tenant_id FK
+    +TEXT repo
+    PK(tenant_id, repo)
+  }
+  class sync_control {
+    +INTEGER tenant_id
+    +TEXT key
+    +TEXT value
+    PK(tenant_id, key)
+  }
+  class install_tokens {
+    +INTEGER tenant_id
+    +TEXT ciphertext (AES-GCM)
+  }
+  tenants "1" --> "*" tenant_repo_access : grants
+  tenants "1" --> "*" sync_control : scopes lock/breaker/slot
+  tenants "1" --> "*" install_tokens : caches token
+```
+
+```mermaid
+flowchart LR
+  P1[runSync Phase 1] -->|upsert| TRA[tenant_repo_access]
+  P1 -->|read/write| SC[sync_control tenantId]
+  P1 -->|mint/cache| IT[install_tokens]
+  TRA -->|union, deduped| P2[runSync Phase 2 fan-out]
+  SC -->|slot tenant_id=0| P2
+  TRA -.->|JOIN tenants| WH[webhook resolveInstallToken]
+  IT --> P2
+  IT -.-> WH
+```
+
+| Consumer | Reads | When | Status |
+|---|---|---|---|
+| `runSync` Phase 1 | `tenants.installation_id` | every tick | this issue |
+| `runSync` Phase 2 | `tenant_repo_access` union, `sync_control.sync_slot` | every tick | this issue |
+| prune | `tenant_repo_access` union | every tick | this issue |
+| webhook handlers | `tenant_repo_access` via `resolveInstallToken` | on event | S3a (unchanged) |
+
+## Breadboard
+
+Affordances are the sync entry points + helpers (no UI). Wiring:
+
+| ID | Affordance | Handler | Data |
+|---|---|---|---|
+| N1 | `runSync(env)` | rewritten orchestrator | global lock → Phase 1 → Phase 2 → prune → audit |
+| N2 | `discoverTenants(db, env)` *(new)* | Phase 1 | `tenants{id,installation_id}` → `INSERT OR IGNORE sync_control` → `getInstallationToken` → `listInstallationRepos` → upsert `tenant_repo_access`; returns `Map<repo, Array<{tenantId,installationId}>>` |
+| N3 | lock/breaker helpers ×7 | `+tenantId=0` param | `sync_control(tenant_id,key)` |
+| N4 | `closedHopPass(db, resolveToken)` | resolver-callback signature | per-(owner,name) token |
+| N5 | `listInstallationRepos(token)` | W2 hardening | `MAX_PAGES` + `AbortSignal.timeout` |
+| N6 | `Env` (T10) | drop `GITHUB_TOKEN: string` from `types.ts` + all `sync/` reads + stale `graphql.ts` doc-comments | no fallback. **`wrangler.toml` has no `GITHUB_TOKEN` (it is a secret, not a `[vars]` entry) → no toml edit** |
+| N7 | `WINDOW`, `NUM_SLOTS` | exported consts | `WINDOW=20`, `NUM_SLOTS=3` |
+| N8 | `sync.test.ts` | un-skip 4 RED + reconcile 11 old-flow | `vi.mock("../auth/installToken")` |
+
+## Slices
+
+Internal build-order increments — **one cohesive PR** (test suite cannot be
+green mid-way if split: the 4 RED cases require the impl; already split from #146).
+
+| # | Slice | Affordances | Demo-able by |
+|---|---|---|---|
+| 1 | W2 harden `listInstallationRepos` | N5 | unit test: caps at `MAX_PAGES`, aborts on timeout |
+| 2 | Thread `tenantId` (default 0) through 7 helpers | N3 | existing helper tests stay green |
+| 3 | `closedHopPass` resolver callback | N4 | unit test: resolver invoked per (owner,name) |
+| 4 | Phase 1 `discoverTenants`: `INSERT OR IGNORE sync_control` per tenant → `Map<repo,Array<{tenantId,installationId}>>` + `tenant_repo_access` upsert | N2 | RED-adjacent: `tenant_repo_access` populated; new tenant's lock row seeded |
+| 5 | Phase 2 deduped windowed fan-out + token fallback; drop 4 PAT reads | N1, N7 | RED cases 1,2,4 green |
+| 6 | Drop `GITHUB_TOKEN` from `Env` (`types.ts`) + stale `graphql.ts` doc-comments (T10; no wrangler.toml edit) | N6 | typecheck green; `grep GITHUB_TOKEN worker/src` clean |
+| 7 | Test reconciliation: un-skip 4 RED + `vi.mock` + reconcile 11 old-flow | N8 | full `sync.test.ts` green |
+
+## Success Criteria
+
+Code (CI-verifiable):
+
+- [ ] **SC-3** — a tick with 2 tenants sharing repo `o/r` issues exactly **1**
+  `REPO_BUNDLE_QUERY` for `o/r` (RED case 1, L1496, green).
+- [ ] **SC-4** — `sync_slot` advances `(slot+1) % NUM_SLOTS` per tick; fan-out
+  window ≤ `WINDOW` repos so the ~50-subrequest cap is not breached (RED case 2,
+  L1531, green).
+- [ ] **Lock isolation** — tenant A holding `sync_running=1` does NOT prevent
+  tenant B's `acquireSyncLock` attempt (RED case 3, L1565, green).
+- [ ] **SC-6** — `GITHUB_TOKEN` absent from `Env` (`types.ts`), `wrangler.toml`
+  (both envs), and every `worker/src/sync/` path; no fallback. RED case 4
+  (L1601) green: `patAccessCount === 0`.
+- [ ] **W2** — `listInstallationRepos` bounded by `MAX_PAGES` + per-fetch
+  `AbortSignal.timeout`; unit-tested.
+- [ ] `tenant_repo_access` is upserted by Phase 1 each tick (rows for every
+  accessible repo; stale rows removed).
+- [ ] Prune sources the live set from the `tenant_repo_access` **union**; the
+  0-union guard prevents prune-all on empty/failed discovery.
+
+CI gate (structural, not a behavioral assertion):
+
+- [ ] All 4 RED cases un-skipped; top-level `vi.mock("../auth/installToken")`
+  present; the ~11 old-flow `runSync` cases (L924-1408) reconciled; full suite +
+  `npm run typecheck` green.
+
+Operational (deploy-gated, verified on staging post-merge — not CI):
+
+- [ ] **SC-9 / RT2** — `subIssues`/`parent` resolve via an installation token on
+  an empirical staging tick (R2 audit shows a clean run, no PAT read).
+- [ ] **SC-7 / RT3** — `GITHUB_TOKEN` deleted from secrets, **code-deploy-first**
+  (delete-before-deploy = guaranteed sync outage on `env.GITHUB_TOKEN===undefined`):
+  merge→deploy staging → verify clean tick (RT2) → `wrangler secret delete
+  GITHUB_TOKEN --env staging` → verify 2nd tick. **Prod leg hard-gated** on #164
+  (`7dbf512`) reaching `main` + CI re-injecting `GITHUB_APP_*`/`INSTALL_TOKEN_KEY`
+  on prod, then prod deploy → verify → `wrangler secret delete GITHUB_TOKEN`.
+  (CI has no `GITHUB_TOKEN` inject step — only the `TODO(RT3)` comment at
+  `ci.yml:181`; removal breaks no CI step.)
+
+## Gate 2.5 — Smart Splitting
+
+|slices| = 7 (> 3) triggers consideration → **declined**. Slices are
+test-coupled build increments of one sync rewrite (the RED cases go green only
+once Phase 1+2 land); the issue was already split from #146 precisely to make
+this the atomic unit. Keep as a single PR.

--- a/plugins/roxabi-issues/.claude-plugin/plugin.json
+++ b/plugins/roxabi-issues/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "roxabi-issues",
+  "version": "0.1.0",
+  "description": "Issue triage — set labels (size/priority/lane/type), manage blocked-by dependencies and parent/child sub-issues on GitHub issues. Labels + native relations, no Projects V2 board.",
+  "author": {
+    "name": "Roxabi"
+  }
+}

--- a/plugins/roxabi-issues/.gitignore
+++ b/plugins/roxabi-issues/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/plugins/roxabi-issues/bun.lock
+++ b/plugins/roxabi-issues/bun.lock
@@ -1,0 +1,173 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@roxabi/issue-triage-plugin",
+      "devDependencies": {
+        "bun-types": "^1.3.14",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7",
+      },
+    },
+  },
+  "packages": {
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.8", "", { "dependencies": { "@vitest/spy": "4.1.8", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "pathe": "^2.0.3" } }, "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "@vitest/utils": "4.1.8", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.8", "", {}, "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "obug": ["obug@2.1.2", "", {}, "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+
+    "vitest": ["vitest@4.1.8", "", { "dependencies": { "@vitest/expect": "4.1.8", "@vitest/mocker": "4.1.8", "@vitest/pretty-format": "4.1.8", "@vitest/runner": "4.1.8", "@vitest/snapshot": "4.1.8", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.8", "@vitest/browser-preview": "4.1.8", "@vitest/browser-webdriverio": "4.1.8", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+  }
+}

--- a/plugins/roxabi-issues/package.json
+++ b/plugins/roxabi-issues/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@roxabi/issue-triage-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/plugins/roxabi-issues/skills/issue-triage/README.md
+++ b/plugins/roxabi-issues/skills/issue-triage/README.md
@@ -1,0 +1,61 @@
+# issue-triage
+
+Create and triage GitHub issues — set size, priority, lane, type labels and manage parent/child/blocker relationships.
+
+## Why
+
+Raw GitHub issues lack structure. `/issue-triage` adds Size (XS→XL), Priority (P0→P3), Lane, and Type via native GitHub labels and issue relations — making the backlog plannable and giving downstream skills (`/dev`, `/plan`) the metadata they need to tier and prioritize work. No Project board required.
+
+## Usage
+
+```
+/issue-triage list                           List all open issues (tree view)
+/issue-triage list --untriaged               Show issues missing Size or Priority
+/issue-triage set 42 --size M --priority High
+/issue-triage set 91 --blocked-by 117
+/issue-triage set 164 --parent 163
+/issue-triage create --title "..." --size S --priority Medium --type feat --lane b --parent 163
+```
+
+`create` accepts the same field flags as `set`: `--size`, `--priority`, `--lane`, `--type` (plus `--parent`, `--add-child`, `--blocked-by`, `--blocks`) — set everything in one shot at creation instead of a follow-up `set`.
+
+Triggers: `"triage"` | `"create issue"` | `"set size"` | `"set priority"` | `"blocked by"` | `"set parent"` | `"sub-issue"` | `"file an issue"` | `"open an issue"`
+
+## Cross-repo create
+
+Prefix `GITHUB_REPO=<owner/repo>` to create an issue in a different repo than the current cwd:
+
+```bash
+GITHUB_REPO=Roxabi/voiceCLI /issue-triage create --title "..." --blocked-by Roxabi/lyra#728
+```
+
+Cross-repo relation flags (`--blocked-by`, `--blocks`, `--parent`, `--add-child`) accept `OWNER/REPO#N` natively and work independently of `GITHUB_REPO`. When the env var is set, always use fully-qualified refs — bare `#N` resolves against the overridden repo.
+
+## Size Guidelines
+
+| Size | Description |
+|------|-------------|
+| **XS** | Trivial, < 1 hour |
+| **S** | Small, < 4 hours |
+| **M** | Medium, 1–2 days |
+| **L** | Large, 3–5 days |
+| **XL** | Very large, > 1 week |
+
+## Priority Guidelines
+
+| Priority | Action |
+|----------|--------|
+| **Urgent** (P0) | Do immediately |
+| **High** (P1) | Do this sprint |
+| **Medium** (P2) | Plan for next sprint |
+| **Low** (P3) | Backlog |
+
+## Complexity Scoring
+
+Assigns a κ ∈ [1,10] score to determine implementation tier:
+
+| Score | Tier | Mode |
+|-------|------|------|
+| 1–3 | S | Single session, direct |
+| 4–6 | F-lite | 1–2 subagents |
+| 7–10 | F-full | Full agent team |

--- a/plugins/roxabi-issues/skills/issue-triage/SKILL.md
+++ b/plugins/roxabi-issues/skills/issue-triage/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: issue-triage
+argument-hint: [list | set <num> | create --title "..." [--parent N] [--size S] [--priority P] [--type T] [--lane L]]
+description: Triage/create GitHub issues — set size/priority/lane/type labels, manage dependencies & parent/child. Triggers: "triage" | "create issue" | "set size" | "set priority" | "blocked by" | "set parent" | "child of" | "sub-issue" | "file an issue" | "log a bug" | "open an issue" | "file a bug" | "add issue" | "new issue" | "set lane" | "set type".
+version: 0.4.0
+allowed-tools: Bash, Read, ToolSearch
+---
+
+# Issue Triage
+
+Let: τ := `bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts` | κ := complexity score
+
+Create GitHub issues, assign Size/Priority labels, manage blockedBy dependencies and parent/child relationships.
+
+## Instructions
+
+1. List all open issues: `τ list` | List untriaged only: `τ list --untriaged`
+2. ∀ issue: determine Size, Priority, κ (see [Complexity Scoring](#complexity-scoring))
+3. Set values: `τ set <number> --size <S> --priority <P>`
+4. Create issues: `τ create --title "Title" [--body "Body"] [--label "bug,frontend"] [--size M] [--priority High] [--type feat] [--lane b] [--parent 163]`
+5. → DP(B)if unsure about Size ∨ Priority.
+
+## Size Guidelines
+
+| Size | Description | Example |
+|------|-------------|---------|
+| **XS** | Trivial, < 1 hour | Typo fix, config tweak |
+| **S** | Small, < 4 hours | Single file change, simple feature |
+| **M** | Medium, 1-2 days | Multi-file feature, requires testing |
+| **L** | Large, 3-5 days | Complex feature, architectural changes |
+| **XL** | Very large, > 1 week | Major refactor, new system |
+
+**Canonical tier names:** `S / F-lite / F-full` (maps to dev tiers: S=simple, F-lite=subagents, F-full=agent team). Legacy size labels use `XS / S / M / L / XL`. Both are accepted as `--size` input. When a canonical name is used it aliases to the nearest size label (`F-full`→`XL`/`L`, `F-lite`→`M`, `S`→`S`/`XS`) — this is expected presentation drift, not a bug.
+
+## Priority Guidelines
+
+| Priority | Description | Action |
+|----------|-------------|--------|
+| **Urgent** (P0) | Blocking or critical | Do immediately |
+| **High** (P1) | Important for current milestone | Do this sprint |
+| **Medium** (P2) | Should be done soon | Plan for next sprint |
+| **Low** (P3) | Nice to have | Backlog |
+
+## Commands
+
+### `list` — Show open issues
+
+| Flag | Description |
+|------|-------------|
+| *(none)* | Tree of all open issues with N-level parent-child hierarchy. Parents with ≥1 closed child show `… ✓ Done`. |
+| `--untriaged` | Flat table of issues missing Size or Priority |
+| `--json` | JSON output (all open issues); combine with `--untriaged` to filter |
+
+### `set <num>` — Update an existing issue
+
+| Flag | Description |
+|------|-------------|
+| `--size <S>` | Set size label — canonical `S/F-lite/F-full` or legacy `XS/S/M/L/XL` (canonical names alias to nearest legacy label) |
+| `--priority <P>` | Set priority label (Urgent, High, Medium, Low) |
+| `--blocked-by <REF>[,<REF>...]` | Add blocked-by dependency. REF = `#N` or `owner/repo#N` |
+| `--blocks <REF>[,<REF>...]` | Add blocking dependency. REF = `#N` or `owner/repo#N` |
+| `--rm-blocked-by <REF>[,<REF>...]` | Remove blocked-by dependency |
+| `--rm-blocks <REF>[,<REF>...]` | Remove blocking dependency |
+| `--parent <REF>` | Set parent issue. REF = `#N` or `owner/repo#N` |
+| `--add-child <REF>[,<REF>...]` | Add child sub-issues |
+| `--rm-parent` | Remove parent relationship |
+| `--rm-child <REF>[,<REF>...]` | Remove child sub-issues |
+| `--lane <L>` | Set lane label (optional, additive). Valid: `a1`, `a2`, `a3`, `b`, `c1`, `c2`, `c3`, `d`–`o`, `standalone` |
+| `--type <T>` | Set org issueType (optional, additive). Valid: `fix`, `feat`, `docs`, `test`, `chore`, `ci`, `perf`, `epic`, `research`, `refactor` |
+
+### `create` — Create a new issue
+
+| Flag | Description |
+|------|-------------|
+| `--title "..."` | Issue title (**required**) |
+| `--body "..."` | Issue body/description |
+| `--label "l1,l2"` | Comma-separated labels |
+| `--size <S>` | Set size on creation — canonical `S/F-lite/F-full` or legacy `XS/S/M/L/XL` accepted |
+| `--priority <P>` | Set priority on creation |
+| `--lane <L>` | Set lane on creation (label-only, additive). Valid: `a1`, `a2`, `a3`, `b`, `c1`, `c2`, `c3`, `d`–`o`, `standalone` |
+| `--type <T>` | Set org issueType on creation (additive). Valid: `fix`, `feat`, `docs`, `test`, `chore`, `ci`, `perf`, `epic`, `research`, `refactor` |
+| `--parent <REF>` | Set parent issue on creation. REF = `#N` or `owner/repo#N` |
+| `--add-child <REF>[,<REF>...]` | Add existing issues as children |
+| `--blocked-by <REF>[,<REF>...]` | Set blocked-by on creation |
+| `--blocks <REF>[,<REF>...]` | Set blocking on creation |
+
+### Cross-repo create
+
+Set `GITHUB_REPO=<owner/repo>` to retarget the CREATE to a different repo than the cwd's git remote:
+
+```bash
+# File a voiceCLI issue while cwd is lyra (or any other repo)
+GITHUB_REPO=Roxabi/voiceCLI τ create \
+  --title 'STT: audio dropout at segment boundary' \
+  --blocked-by Roxabi/lyra#728
+```
+
+Cross-repo **relations** (`--blocked-by`, `--blocks`, `--parent`, `--add-child`) accept `OWNER/REPO#N` natively — they work regardless of `GITHUB_REPO`.
+
+**Caveat — keep refs fully-qualified:** `GITHUB_REPO` retargets the entire invocation. A bare `#N` in any ref resolves against the overridden repo, not the cwd repo → always use `OWNER/REPO#N` for any cross-repo ref when the env var is set.
+
+**Resolution order** (`detectGitHubRepo`): (1) `github_repo` in dev-core config ∨ `GITHUB_REPO` env var (validated as `owner/repo`) → (2) fallback `git remote get-url origin` of the cwd.
+
+## Deferred Follow-Ups — Sibling Rule
+
+**Defer ≠ decomposition.** When an issue A defers work to a new follow-up B (out-of-scope finding, post-merge gap, "do this later"), B is a **sibling** of A under their shared parent — NOT a child of A.
+
+```
+       Epic E
+      ╱      ╲
+     A ←—————— B     B.parent = A.parent (= E)
+       blocked-by    B.blocked-by = A   (traceability of origin)
+```
+
+**Why:**
+- `gh issue view E` shows the full fan-out flat (A + B + future C…) — true scope of the epic, ¬nested cascade
+- `/dev` re-scan retombe correctement sur l'épic origin pour tout follow-up
+- Multi-level deferrals (A→B→C) stay flat under E — ¬arbre profond ingérable
+
+**Decomposition vs deferral:**
+
+| Pattern | Parent-child? | Example |
+|---------|---------------|---------|
+| **Epic → phase** (planned decomposition) | ✓ child of epic | `/spec` smart-splitting: phase 1, phase 2 are children of epic |
+| **Issue → follow-up** (deferral, post-hoc) | ✗ sibling under shared parent | `/fix` Phase 5 Defer: out-of-scope finding becomes sibling |
+| **Bug → regression** (related ¬caused) | ✗ standalone | New bug surfaced post-merge, ¬child, ¬sibling necessarily |
+
+**Recipe — defer A → create follow-up B:**
+
+```bash
+# 1. Resolve A's parent (may be null if A is top-level)
+A_PARENT=$(gh api graphql -f query="query{repository(owner:\"$OWNER\",name:\"$REPO\"){issue(number:$A){parent{number}}}}" \
+  --jq '.data.repository.issue.parent.number // empty')
+
+# 2. Create B as sibling: same parent as A, blocked-by A
+τ create \
+  --title "{deferred title}" \
+  --body "**Origin:** #${A} (deferred from ...)\n\n{details}" \
+  --blocked-by "#${A}" \
+  ${A_PARENT:+--parent "#${A_PARENT}"}
+```
+
+**Edge cases:**
+- A has no parent → B has no parent either (both top-level). Consider whether A should be re-parented under a freshly-created epic if the fan-out grows.
+- A is already top-level epic → defer creates child of A (epic decomposition pattern applies).
+- Existing follow-up issue B mis-parented under A → fix retroactively:
+  ```bash
+  τ set <B> --rm-parent
+  τ set <B> --parent "#${A_PARENT}"
+  τ set <B> --blocked-by "#${A}"  # ensure traceability link
+  ```
+
+## Complexity Scoring
+
+Assess κ ∈ [1,10] to inform tier (S / F-lite / F-full). Record by appending to issue body:
+
+```bash
+BODY=$(gh issue view <number> --json body --jq .body)
+gh issue edit <number> --body "$BODY
+
+<!-- complexity: <score> -->"
+```
+
+`<!-- complexity: N -->` is machine-parseable; downstream tools (e.g. `/plan`) read it.
+
+**Factors (each 1-10, weighted):**
+
+| Factor | Weight | 1 (Low) | 5 (Medium) | 10 (High) |
+|--------|--------|---------|------------|-----------|
+| **Files touched** | 20% | 1-3 files | 5-10 files | 15+ files |
+| **Technical risk** | 25% | Known patterns | New library/pattern in 1 domain | New architecture |
+| **Architectural impact** | 25% | Single module | Shared types, 2 modules | Cross-domain, new abstractions |
+| **Unknowns count** | 15% | 0 unknowns | 1-2 open questions | 3+ unknowns |
+| **Domain breadth** | 15% | 1 domain | 2 domains | 3+ domains |
+
+**Formula:** `κ = round(files × 0.20 + risk × 0.25 + arch × 0.25 + unknowns × 0.15 + domains × 0.15)`
+
+**Tier mapping:**
+
+| Score | Tier | Process | Agent Mode |
+|-------|------|---------|-----------|
+| 1-3 | **S** | Worktree + direct implementation + PR | Single session, no agents |
+| 4-6 | **F-lite** | Worktree + subagents + /code-review | Task subagents (1-2 domain + tester) |
+| 7-10 | **F-full** | Bootstrap + worktree + agent team + /code-review | TeamCreate (3+ agents, test-first) |
+
+κ is advisory. Human judgment overrides. → DP(B)if score ≠ intuition.
+
+See [Tier Classification Reference](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/tier-classification.md) for full rules.
+Reference: `artifacts/analyses/280-token-consumption.mdx` for scoring examples.
+
+## Example Workflow
+
+```bash
+τ list
+τ list --untriaged
+τ set 42 --size M --priority High
+τ set 91 --blocked-by 117
+τ set 117 --blocks 91,118
+τ set 91 --rm-blocked-by 117
+τ set 164 --parent 163
+τ set 163 --add-child 164,165,166
+τ set 164 --rm-parent
+τ set 163 --rm-child 166
+
+# Cross-repo dependencies (owner/repo#N format)
+τ set 42 --blocked-by Roxabi/lyra#728
+τ set 42 --blocks Roxabi/voiceCLI#94
+
+τ create \
+  --title "research: compare against example/repo" \
+  --body "Deep analysis of example/repo" \
+  --label "research" \
+  --size S --priority Medium \
+  --parent 163
+τ create \
+  --title "epic: improve CI pipeline" \
+  --size L --priority High \
+  --add-child 150,151,152
+
+# Lane and type (additive, optional)
+τ set 42 --lane b
+τ set 42 --type feat
+τ set 42 --size M --priority High --lane c1 --type fix
+```
+
+## Chain Position
+
+- **Phase:** Frame
+- **Predecessor:** — (entry point)
+- **Successor:** `/frame`
+- **Class:** adv (continuous flow, no gate)
+
+## Task Integration
+
+- `/dev` owns the dev-pipeline task lifecycle externally
+- This skill does NOT update its own dev-pipeline task
+- Sub-tasks created: none
+
+## Exit
+
+- **Success via `/dev`:** return control silently. ¬write summary. ¬ask user. ¬announce `/frame`. `/dev` re-scans and advances.
+- **Success standalone:** print one line: `Done. Next: /frame --issue N`. Stop.
+- **Failure:** return error. `/dev` presents Retry | Skip | Abort.
+
+## Related
+
+- [Taxonomy SSoT](../../references/issue-taxonomy.md) — field set, cross-repo behavior, plugin contracts, anti-patterns
+
+$ARGUMENTS

--- a/plugins/roxabi-issues/skills/issue-triage/__tests__/create.test.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/__tests__/create.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+process.env.GITHUB_REPO = 'Test/test-repo'
+
+vi.mock('../../shared/adapters/config-helpers', () => ({
+  GITHUB_REPO: 'Test/test-repo',
+  resolveStatus: (input: string) => {
+    const canonical = new Set(['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      BACKLOG: 'Backlog',
+      ANALYSIS: 'Analysis',
+      SPECS: 'Specs',
+      'IN PROGRESS': 'In Progress',
+      IN_PROGRESS: 'In Progress',
+      INPROGRESS: 'In Progress',
+      REVIEW: 'Review',
+      DONE: 'Done',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveSize: (input: string) => {
+    const u = input.toUpperCase()
+    return new Set(['XS', 'S', 'M', 'L', 'XL']).has(u) ? u : undefined
+  },
+  resolvePriority: (input: string) => {
+    const canonical = new Set(['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      URGENT: 'P0 - Urgent',
+      HIGH: 'P1 - High',
+      MEDIUM: 'P2 - Medium',
+      LOW: 'P3 - Low',
+      P0: 'P0 - Urgent',
+      P1: 'P1 - High',
+      P2: 'P2 - Medium',
+      P3: 'P3 - Low',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveLane: (input: string) =>
+    new Set(['a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3', 'd', 'e']).has(input) ? input : undefined,
+}))
+
+vi.mock('../../shared/adapters/github-infra', () => ({
+  syncPriorityLabel: vi.fn(),
+  syncSizeLabel: vi.fn(),
+  syncLaneLabel: vi.fn(),
+  syncStatusLabel: vi.fn(),
+}))
+
+vi.mock('../../shared/adapters/github-adapter', () => ({
+  createGitHubIssue: vi.fn(),
+  getNodeId: vi.fn(),
+  addBlockedBy: vi.fn(),
+  addSubIssue: vi.fn(),
+  resolveIssueTypeId: vi.fn(),
+  updateIssueIssueType: vi.fn(),
+}))
+
+const github = await import('../../shared/adapters/github-adapter')
+const mockCreateGitHubIssue = github.createGitHubIssue as ReturnType<typeof vi.fn>
+const mockGetNodeId = github.getNodeId as ReturnType<typeof vi.fn>
+const mockAddBlockedBy = github.addBlockedBy as ReturnType<typeof vi.fn>
+const mockAddSubIssue = github.addSubIssue as ReturnType<typeof vi.fn>
+
+const githubInfra = await import('../../shared/adapters/github-infra')
+const mockSyncPriorityLabel = githubInfra.syncPriorityLabel as ReturnType<typeof vi.fn>
+const mockSyncSizeLabel = githubInfra.syncSizeLabel as ReturnType<typeof vi.fn>
+const mockSyncLaneLabel = githubInfra.syncLaneLabel as ReturnType<typeof vi.fn>
+const mockSyncStatusLabel = githubInfra.syncStatusLabel as ReturnType<typeof vi.fn>
+const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
+const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
+
+const { createIssue } = await import('../lib/create')
+
+function setupMocks() {
+  vi.clearAllMocks()
+  mockCreateGitHubIssue.mockResolvedValue({
+    url: 'https://github.com/test/repo/issues/99',
+    number: 99,
+  })
+  mockGetNodeId.mockImplementation(async (num) => `node-${num}`)
+  mockResolveIssueTypeId.mockResolvedValue('issue-type-id')
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+}
+
+describe('issue-triage/create > basic creation', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates an issue with title', async () => {
+    await createIssue(['--title', 'Test issue'])
+    expect(mockCreateGitHubIssue).toHaveBeenCalledWith('Test issue', undefined, undefined)
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Created #99'))
+  })
+
+  it('syncs size label on creation', async () => {
+    await createIssue(['--title', 'Test', '--size', 'M'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(99, 'M')
+  })
+
+  it('syncs priority label on creation', async () => {
+    await createIssue(['--title', 'Test', '--priority', 'High'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(99, 'P1 - High')
+  })
+
+  it('syncs status label on creation', async () => {
+    await createIssue(['--title', 'Test', '--status', 'In Progress'])
+    expect(mockSyncStatusLabel).toHaveBeenCalledWith(99, 'In Progress')
+  })
+})
+
+describe('issue-triage/create > relationships', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('sets parent relationship', async () => {
+    await createIssue(['--title', 'Child', '--parent', '50'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-50', 'node-99')
+  })
+
+  it('sets cross-repo parent relationship', async () => {
+    await createIssue(['--title', 'Child', '--parent', 'Roxabi/lyra#100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-100', 'node-99')
+  })
+
+  it('adds children', async () => {
+    await createIssue(['--title', 'Epic', '--add-child', '60,61'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-99', 'node-60')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-99', 'node-61')
+  })
+
+  it('adds cross-repo children', async () => {
+    await createIssue(['--title', 'Epic', '--add-child', 'Roxabi/lyra#60'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(60, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-99', 'node-60')
+  })
+
+  it('sets blocked-by dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocked-by', '10,11'])
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-99', 'node-10')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-99', 'node-11')
+  })
+
+  it('sets cross-repo blocked-by dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocked-by', 'Roxabi/lyra#728'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-99', 'node-728')
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Roxabi/lyra#728'))
+  })
+
+  it('sets blocking dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocks', '20'])
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-20', 'node-99')
+  })
+
+  it('sets cross-repo blocking dependencies', async () => {
+    await createIssue(['--title', 'Test', '--blocks', 'Roxabi/voiceCLI#94'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(94, 'Roxabi/voiceCLI')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-94', 'node-99')
+  })
+
+  it('handles mixed local and cross-repo refs', async () => {
+    await createIssue(['--title', 'Test', '--blocked-by', '10, Roxabi/lyra#728, #11'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(10, undefined)
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockGetNodeId).toHaveBeenCalledWith(11, undefined)
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('issue-triage/create > options and error handling', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('includes labels in create call', async () => {
+    await createIssue(['--title', 'Test', '--label', 'bug,frontend'])
+    expect(mockCreateGitHubIssue).toHaveBeenCalledWith('Test', undefined, ['bug', 'frontend'])
+  })
+
+  it('includes body in create call', async () => {
+    await createIssue(['--title', 'Test', '--body', 'Description here'])
+    expect(mockCreateGitHubIssue).toHaveBeenCalledWith('Test', 'Description here', undefined)
+  })
+})
+
+describe('issue-triage/create > priority label sync', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('syncs priority label when --priority is provided', async () => {
+    await createIssue(['--title', 'Test', '--priority', 'High'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(99, 'P1 - High')
+  })
+
+  it('does not sync priority label when --priority is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockSyncPriorityLabel).not.toHaveBeenCalled()
+  })
+
+  it('syncs size label when --size is provided', async () => {
+    await createIssue(['--title', 'Test', '--size', 'M'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(99, 'M')
+  })
+
+  it('syncs status label when --status is provided', async () => {
+    await createIssue(['--title', 'Test', '--status', 'In Progress'])
+    expect(mockSyncStatusLabel).toHaveBeenCalledWith(99, 'In Progress')
+  })
+})
+
+describe('issue-triage/create > type', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('sets issue type on creation', async () => {
+    await createIssue(['--title', 'Test', '--type', 'feat'])
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'feat')
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-99', 'issue-type-id')
+  })
+
+  it('accepts extended types (epic)', async () => {
+    await createIssue(['--title', 'Test', '--type', 'epic'])
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-99', 'issue-type-id')
+  })
+
+  it('normalizes type case', async () => {
+    await createIssue(['--title', 'Test', '--type', 'FIX'])
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'fix')
+  })
+
+  it('does not set type when --type is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/create > lane', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('syncs lane label when --lane is provided', async () => {
+    await createIssue(['--title', 'Test', '--lane', 'a1'])
+    expect(mockSyncLaneLabel).toHaveBeenCalledWith(99, 'a1')
+  })
+
+  it('does not sync lane label when --lane is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockSyncLaneLabel).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/roxabi-issues/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/__tests__/set.test.ts
@@ -1,0 +1,460 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
+
+// Provide base project config for tests
+process.env.GITHUB_REPO = 'Test/test-repo'
+
+// Mock config before github — vi.mock is hoisted before process.env assignments,
+// so importOriginal would load config.ts with empty env vars. Manual factory is required.
+vi.mock('../../shared/adapters/config-helpers', () => ({
+  NOT_CONFIGURED_MSG: 'GitHub Project V2 is not configured.',
+  GITHUB_REPO: 'Test/test-repo',
+  DEFAULT_SIZE_OPTIONS: ['S', 'F-lite', 'F-full'],
+  resolveStatus: (input: string) => {
+    const canonical = new Set(['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      BACKLOG: 'Backlog',
+      ANALYSIS: 'Analysis',
+      SPECS: 'Specs',
+      'IN PROGRESS': 'In Progress',
+      IN_PROGRESS: 'In Progress',
+      INPROGRESS: 'In Progress',
+      REVIEW: 'Review',
+      DONE: 'Done',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveSize: (input: string) => {
+    const valid = new Set(['S', 'F-lite', 'F-full'])
+    if (valid.has(input)) return input
+    const u = input.toUpperCase().replace(/[-\s]/g, '-')
+    if (valid.has(u as 'S' | 'F-lite' | 'F-full')) return u
+    // Aliases
+    if (u === 'XS') return 'S'
+    if (u === 'M') return 'F-lite'
+    if (u === 'L' || u === 'XL') return 'F-full'
+    return undefined
+  },
+  resolvePriority: (input: string) => {
+    const canonical = new Set(['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      URGENT: 'P0 - Urgent',
+      HIGH: 'P1 - High',
+      MEDIUM: 'P2 - Medium',
+      LOW: 'P3 - Low',
+      P0: 'P0 - Urgent',
+      P1: 'P1 - High',
+      P2: 'P2 - Medium',
+      P3: 'P3 - Low',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveLane: (input: string) => {
+    const valid = new Set(['a1', 'a2', 'b', 'c1', 'c2', 'c3', 'd', 'e', 'f', 'standalone'])
+    return valid.has(input) ? input : undefined
+  },
+}))
+
+vi.mock('../../shared/adapters/github-infra', () => ({
+  syncPriorityLabel: vi.fn(),
+  syncSizeLabel: vi.fn(),
+  syncLaneLabel: vi.fn(),
+  syncStatusLabel: vi.fn(),
+}))
+
+vi.mock('../../shared/adapters/github-adapter', () => ({
+  getNodeId: vi.fn(),
+  getParentNumber: vi.fn(),
+  addBlockedBy: vi.fn(),
+  removeBlockedBy: vi.fn(),
+  addSubIssue: vi.fn(),
+  removeSubIssue: vi.fn(),
+  resolveIssueTypeId: vi.fn(),
+  updateIssueIssueType: vi.fn(),
+}))
+
+const github = await import('../../shared/adapters/github-adapter')
+const mockGetNodeId = github.getNodeId as ReturnType<typeof vi.fn>
+const mockAddBlockedBy = github.addBlockedBy as ReturnType<typeof vi.fn>
+const mockRemoveBlockedBy = github.removeBlockedBy as ReturnType<typeof vi.fn>
+const mockAddSubIssue = github.addSubIssue as ReturnType<typeof vi.fn>
+const mockRemoveSubIssue = github.removeSubIssue as ReturnType<typeof vi.fn>
+const mockGetParentNumber = github.getParentNumber as ReturnType<typeof vi.fn>
+const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
+const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
+
+const githubInfra = await import('../../shared/adapters/github-infra')
+const mockSyncPriorityLabel = githubInfra.syncPriorityLabel as ReturnType<typeof vi.fn>
+const mockSyncSizeLabel = githubInfra.syncSizeLabel as ReturnType<typeof vi.fn>
+const mockSyncLaneLabel = githubInfra.syncLaneLabel as ReturnType<typeof vi.fn>
+const mockSyncStatusLabel = githubInfra.syncStatusLabel as ReturnType<typeof vi.fn>
+
+const { setIssue } = await import('../lib/set')
+
+function setupMocks() {
+  vi.clearAllMocks()
+  // repo included in key so cross-repo calls return distinguishable node IDs
+  mockGetNodeId.mockImplementation(async (num, repo?: string) =>
+    repo ? `node-${repo.replace('/', '-')}-${num}` : `node-${num}`,
+  )
+  mockResolveIssueTypeId.mockResolvedValue('type-id-feat')
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  // console.error spy installed here — .mock.calls still accessible when impl is () => {}
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+}
+
+describe('issue-triage/set > field updates', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('updates size via label', async () => {
+    await setIssue(['42', '--size', 'F-lite'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(42, 'F-lite')
+  })
+
+  it('updates priority via label with alias', async () => {
+    await setIssue(['42', '--priority', 'High'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(42, 'P1 - High')
+  })
+
+  it('updates status — no status:* label sync (issues-only model)', async () => {
+    await setIssue(['42', '--status', 'In Progress'])
+    // issues-only model: status is open/closed; no redundant status:* label
+    expect(mockSyncStatusLabel).not.toHaveBeenCalled()
+  })
+
+  it('exits with error for invalid --size value', async () => {
+    // Arrange — throw on exit so execution stops after the guard, matching real process.exit semantics
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`process.exit:${code}`)
+    }) as never)
+    // Act
+    await setIssue(['42', '--size', 'bogus']).catch(() => {})
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('Invalid size'))).toBe(true)
+  })
+
+  it('logs Size= exactly once for --size (no duplicate)', async () => {
+    // Arrange
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(String(args[0])))
+    // Act
+    await setIssue(['42', '--size', 'F-lite'])
+    // Assert
+    expect(logs.filter((l) => l.startsWith('Size=')).length).toBe(1)
+  })
+})
+
+describe('issue-triage/set > dependencies', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('adds blocked-by dependency', async () => {
+    await setIssue(['42', '--blocked-by', '100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(42, undefined)
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, undefined)
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-42', 'node-100')
+  })
+
+  it('adds multiple comma-separated blocked-by deps', async () => {
+    await setIssue(['42', '--blocked-by', '100,101,102'])
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(3)
+  })
+
+  it('adds blocking dependency (reverse direction)', async () => {
+    await setIssue(['42', '--blocks', '50'])
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-50', 'node-42')
+  })
+
+  it('removes blocked-by dependency', async () => {
+    await setIssue(['42', '--rm-blocked-by', '100'])
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-42', 'node-100')
+  })
+
+  it('removes blocking dependency', async () => {
+    await setIssue(['42', '--rm-blocks', '50'])
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-50', 'node-42')
+  })
+
+  it('adds cross-repo blocked-by dependency', async () => {
+    await setIssue(['42', '--blocked-by', 'Roxabi/lyra#728'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-42', 'node-Roxabi-lyra-728')
+  })
+
+  it('adds cross-repo blocks dependency', async () => {
+    await setIssue(['42', '--blocks', 'Roxabi/voiceCLI#94'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(94, 'Roxabi/voiceCLI')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-Roxabi-voiceCLI-94', 'node-42')
+  })
+
+  it('handles mixed local and cross-repo refs', async () => {
+    await setIssue(['42', '--blocked-by', '100, Roxabi/lyra#728, #101'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, undefined)
+    expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
+    expect(mockGetNodeId).toHaveBeenCalledWith(101, undefined)
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('issue-triage/set > parent-child relationships', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('sets parent relationship', async () => {
+    await setIssue(['42', '--parent', '10'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-10', 'node-42')
+  })
+
+  it('sets cross-repo parent relationship', async () => {
+    await setIssue(['42', '--parent', 'Roxabi/lyra#100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-lyra-100', 'node-42')
+  })
+
+  it('adds children', async () => {
+    await setIssue(['42', '--add-child', '50,51'])
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-50')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-51')
+  })
+
+  it('adds cross-repo children', async () => {
+    await setIssue(['42', '--add-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-Roxabi-lyra-50')
+  })
+
+  it('removes parent', async () => {
+    mockGetParentNumber.mockResolvedValue(10)
+    await setIssue(['42', '--rm-parent'])
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith('node-10', 'node-42')
+  })
+
+  it('removes children', async () => {
+    await setIssue(['42', '--rm-child', '50'])
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith('node-42', 'node-50')
+  })
+})
+
+describe('issue-triage/set > combined flags', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('handles multiple flags at once', async () => {
+    await setIssue(['42', '--size', 'F-full', '--priority', 'Urgent', '--blocked-by', '99'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(42, 'F-full')
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(42, 'P0 - Urgent')
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(1)
+  })
+
+  it('strips # prefix from issue numbers', async () => {
+    await setIssue(['42', '--blocked-by', '#100'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(100, undefined)
+  })
+})
+
+describe('issue-triage/set > priority label sync', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('syncs priority label when --priority is provided', async () => {
+    await setIssue(['42', '--priority', 'Medium'])
+    expect(mockSyncPriorityLabel).toHaveBeenCalledWith(42, 'P2 - Medium')
+  })
+
+  it('does not sync priority label when --priority is not provided', async () => {
+    await setIssue(['42', '--size', 'F-lite'])
+    expect(mockSyncPriorityLabel).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > --lane flag', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('updates lane via label', async () => {
+    await setIssue(['123', '--lane', 'c1'])
+    expect(mockSyncLaneLabel).toHaveBeenCalledWith(123, 'c1')
+  })
+
+  it('does nothing for invalid lane key (resolveLane returns undefined)', async () => {
+    await setIssue(['123', '--lane', 'zzz'])
+    expect(mockSyncLaneLabel).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > --type flag', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves type id and calls updateIssueIssueType for valid type', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--type', 'feat'])
+    // Assert
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'feat')
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', 'type-id-feat')
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls process.exit(1) and prints error for invalid type', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--type', 'bogus'])
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((msg) => msg.includes('Invalid type') || msg.includes('Valid'))).toBe(true)
+  })
+})
+
+describe('issue-triage/set > cross-repo subject', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves cross-repo subject for --blocked-by', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--blocked-by', 'Roxabi/lyra#1063,Roxabi/lyra#1064'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1063, 'Roxabi/lyra')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1064, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves cross-repo subject for --blocks', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--blocks', 'Roxabi/lyra#200'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-Roxabi-lyra-200', 'node-Roxabi-voiceCLI-144')
+  })
+
+  it('resolves cross-repo subject for --parent', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--parent', 'Roxabi/lyra#10'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(10, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-lyra-10', 'node-Roxabi-voiceCLI-144')
+  })
+
+  it('resolves cross-repo subject for --add-child', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--add-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-50')
+  })
+
+  it('skips label sync for cross-repo subject with --status (no-op, no error)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['Roxabi/voiceCLI#144', '--status', 'Backlog'])
+    expect(exitSpy).not.toHaveBeenCalled()
+    // issues-only model: --status is a no-op (open/closed only), no label sync for any subject
+    expect(mockSyncStatusLabel).not.toHaveBeenCalled()
+    // No label-sync warning fires for --status-only cross-repo call
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.every((m) => !m.includes('label sync'))).toBe(true)
+  })
+
+  it('skips label sync for cross-repo subject with --size', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--size', 'S'])
+    expect(mockSyncSizeLabel).not.toHaveBeenCalled()
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('label sync') && m.includes('cross-repo'))).toBe(true)
+  })
+
+  it('exits with error for --rm-parent on cross-repo subject', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-parent'])
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('--rm-parent') && m.includes('cross-repo'))).toBe(true)
+  })
+
+  it('log output shows cross-repo subject correctly', async () => {
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(String(args[0])))
+    await setIssue(['Roxabi/voiceCLI#144', '--blocked-by', '100'])
+    expect(logs.some((l) => l.includes('Roxabi/voiceCLI#144'))).toBe(true)
+    expect(logs.some((l) => l.includes('#100'))).toBe(true)
+  })
+
+  it('removes blocked-by with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-blocked-by', 'Roxabi/lyra#1063'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1063, 'Roxabi/lyra')
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-1063')
+  })
+
+  it('removes blocks with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-blocks', 'Roxabi/lyra#200'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-Roxabi-lyra-200', 'node-Roxabi-voiceCLI-144')
+  })
+
+  it('removes child with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-50')
+  })
+})
+
+describe('issue-triage/set > additive regression', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('--size alone does not call lane or type mutations', async () => {
+    await setIssue(['123', '--size', 'S'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(123, 'S')
+    expect(mockSyncLaneLabel).not.toHaveBeenCalled()
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > applyType accepts all 10 canonical values', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  const ALL_VALID_TYPES = [...ISSUE_TYPE_NAMES, ...EXTENDED_ISSUE_TYPES]
+
+  it('accepts every value in the canonical set without calling process.exit', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    for (const t of ALL_VALID_TYPES) {
+      vi.clearAllMocks()
+      mockGetNodeId.mockResolvedValue(`node-123`)
+      mockResolveIssueTypeId.mockResolvedValue(`type-id-${t}`)
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      await setIssue(['123', '--type', t])
+      expect(exitSpy).not.toHaveBeenCalled()
+      expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', `type-id-${t}`)
+    }
+  })
+
+  it('rejects an unknown type and calls process.exit(1)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['123', '--type', 'unknown-type'])
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('Invalid type'))).toBe(true)
+  })
+})
+
+describe('issue-triage/set > combined --lane + --type + --size', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('applies all three mutations when combined flags provided', async () => {
+    await setIssue(['123', '--lane', 'a1', '--type', 'feat', '--size', 'S'])
+    // Assert — size label
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(123, 'S')
+    // Assert — lane label
+    expect(mockSyncLaneLabel).toHaveBeenCalledWith(123, 'a1')
+    // Assert — type mutation
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', 'type-id-feat')
+  })
+})

--- a/plugins/roxabi-issues/skills/issue-triage/lib/create.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/lib/create.ts
@@ -1,0 +1,192 @@
+/**
+ * Create a new GitHub issue with optional labels, parent, children, and dependencies.
+ * Issues-only mode: size/priority/status/lane are set via labels only (no ProjectV2 board).
+ */
+
+import {
+  GITHUB_REPO,
+  resolveLane,
+  resolvePriority,
+  resolveSize,
+  resolveStatus,
+} from '../../shared/adapters/config-helpers'
+import {
+  addBlockedBy,
+  addSubIssue,
+  createGitHubIssue,
+  getNodeId,
+  resolveIssueTypeId,
+  updateIssueIssueType,
+} from '../../shared/adapters/github-adapter'
+import { syncLaneLabel, syncPriorityLabel, syncSizeLabel, syncStatusLabel } from '../../shared/adapters/github-infra'
+import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
+import { formatRef, parseIssueRefs } from '../../shared/domain/parse-issue-ref'
+
+interface CreateOptions {
+  title: string
+  body?: string
+  labels?: string
+  size?: string
+  priority?: string
+  status?: string
+  lane?: string
+  type?: string
+  parent?: string
+  blockedBy?: string
+  blocks?: string
+  addChild?: string
+}
+
+function parseArgs(args: string[]): CreateOptions {
+  const opts: CreateOptions = { title: '' }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    switch (arg) {
+      case '--title':
+        opts.title = args[++i]
+        break
+      case '--body':
+        opts.body = args[++i]
+        break
+      case '--label':
+        opts.labels = args[++i]
+        break
+      case '--size':
+        opts.size = args[++i]
+        break
+      case '--priority':
+        opts.priority = args[++i]
+        break
+      case '--status':
+        opts.status = args[++i]
+        break
+      case '--lane':
+        opts.lane = args[++i]
+        break
+      case '--type':
+        opts.type = args[++i]
+        break
+      case '--parent':
+        opts.parent = args[++i]
+        break
+      case '--blocked-by':
+        opts.blockedBy = args[++i]
+        break
+      case '--blocks':
+        opts.blocks = args[++i]
+        break
+      case '--add-child':
+        opts.addChild = args[++i]
+        break
+      default:
+        console.error(`Error: Unknown option '${arg}'`)
+        process.exit(1)
+    }
+    i++
+  }
+
+  return opts
+}
+
+const VALID_TYPES: string[] = [...ISSUE_TYPE_NAMES, ...EXTENDED_ISSUE_TYPES]
+
+async function applyType(issueNumber: number, nodeId: string, type: string): Promise<void> {
+  const canonical = type.toLowerCase()
+  if (!VALID_TYPES.includes(canonical)) {
+    console.error(`Error: Invalid type. Valid: ${VALID_TYPES.join(', ')}`)
+    process.exit(1)
+  }
+  const org = GITHUB_REPO.split('/')[0]
+  const typeId = await resolveIssueTypeId(org, canonical)
+  await updateIssueIssueType(nodeId, typeId)
+  console.log(`Type=${canonical} #${issueNumber}`)
+}
+
+async function syncLabels(issueNumber: number, opts: CreateOptions): Promise<void> {
+  if (opts.priority) {
+    const canonical = resolvePriority(opts.priority)
+    if (canonical) await syncPriorityLabel(issueNumber, canonical)
+  }
+  if (opts.size) {
+    const canonical = resolveSize(opts.size)
+    if (canonical) await syncSizeLabel(issueNumber, canonical)
+  }
+  if (opts.lane) {
+    const canonical = resolveLane(opts.lane)
+    if (canonical) {
+      await syncLaneLabel(issueNumber, canonical)
+      console.log(`Lane=${canonical} #${issueNumber}`)
+    }
+  }
+  if (opts.status) {
+    const canonical = resolveStatus(opts.status)
+    if (canonical) await syncStatusLabel(issueNumber, canonical)
+  }
+}
+
+async function applyRelationships(nodeId: string, issueNumber: number, opts: CreateOptions): Promise<void> {
+  if (opts.parent) {
+    const parentRef = parseIssueRefs(opts.parent)[0]
+    if (parentRef) {
+      const parentNodeId = await getNodeId(parentRef.number, parentRef.repo)
+      await addSubIssue(parentNodeId, nodeId)
+      console.log(`Parent=${formatRef(parentRef)} #${issueNumber}`)
+    }
+  }
+
+  if (opts.addChild) {
+    for (const childRef of parseIssueRefs(opts.addChild)) {
+      const childNodeId = await getNodeId(childRef.number, childRef.repo)
+      await addSubIssue(nodeId, childNodeId)
+      console.log(`Child=${formatRef(childRef)} #${issueNumber}`)
+    }
+  }
+
+  if (opts.blockedBy) {
+    for (const ref of parseIssueRefs(opts.blockedBy)) {
+      const blockingNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(nodeId, blockingNodeId)
+      console.log(`BlockedBy=${formatRef(ref)} #${issueNumber}`)
+    }
+  }
+
+  if (opts.blocks) {
+    for (const ref of parseIssueRefs(opts.blocks)) {
+      const blockedNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(blockedNodeId, nodeId)
+      console.log(`Blocks=${formatRef(ref)} #${issueNumber}`)
+    }
+  }
+}
+
+export async function createIssue(args: string[]): Promise<void> {
+  const opts = parseArgs(args)
+
+  if (!opts.title) {
+    console.error('Error: --title is required')
+    process.exit(1)
+  }
+
+  // Create the issue via REST API
+  const labels = opts.labels
+    ?.split(',')
+    .map((l) => l.trim())
+    .filter(Boolean)
+  const result = await createGitHubIssue(opts.title, opts.body, labels)
+  const issueNumber = result.number
+  console.log(`Created #${issueNumber}: ${opts.title}`)
+
+  const nodeId = await getNodeId(issueNumber)
+
+  // Issue type is independent of the project board
+  if (opts.type) {
+    await applyType(issueNumber, nodeId, opts.type)
+  }
+
+  // Set size/priority/status/lane via labels only (issues-only mode)
+  await syncLabels(issueNumber, opts)
+
+  await applyRelationships(nodeId, issueNumber, opts)
+}

--- a/plugins/roxabi-issues/skills/issue-triage/lib/set.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/lib/set.ts
@@ -1,0 +1,292 @@
+/**
+ * Update an existing issue: labels, dependencies, and parent/child relations.
+ * Replaces set.sh.
+ */
+
+import {
+  DEFAULT_SIZE_OPTIONS,
+  GITHUB_REPO,
+  resolveLane,
+  resolvePriority,
+  resolveSize,
+} from '../../shared/adapters/config-helpers'
+import {
+  addBlockedBy,
+  addSubIssue,
+  getNodeId,
+  getParentNumber,
+  removeBlockedBy,
+  removeSubIssue,
+  resolveIssueTypeId,
+  updateIssueIssueType,
+} from '../../shared/adapters/github-adapter'
+import { syncLaneLabel, syncPriorityLabel, syncSizeLabel } from '../../shared/adapters/github-infra'
+import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
+import { formatRef, parseIssueRef, parseIssueRefs } from '../../shared/domain/parse-issue-ref'
+
+interface SetOptions {
+  issueNumber: number
+  subjectRepo?: string
+  size?: string
+  priority?: string
+  status?: string
+  lane?: string
+  type?: string
+  blockedBy?: string
+  blocks?: string
+  rmBlockedBy?: string
+  rmBlocks?: string
+  parent?: string
+  addChild?: string
+  rmParent: boolean
+  rmChild?: string
+}
+
+function parseArgs(args: string[]): SetOptions {
+  const opts: SetOptions = { issueNumber: 0, rmParent: false }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    switch (arg) {
+      case '--size':
+        opts.size = args[++i]
+        break
+      case '--priority':
+        opts.priority = args[++i]
+        break
+      case '--status':
+        opts.status = args[++i]
+        break
+      case '--lane':
+        opts.lane = args[++i]
+        break
+      case '--type':
+        opts.type = args[++i]
+        break
+      case '--blocked-by':
+        opts.blockedBy = args[++i]
+        break
+      case '--blocks':
+        opts.blocks = args[++i]
+        break
+      case '--rm-blocked-by':
+        opts.rmBlockedBy = args[++i]
+        break
+      case '--rm-blocks':
+        opts.rmBlocks = args[++i]
+        break
+      case '--parent':
+        opts.parent = args[++i]
+        break
+      case '--add-child':
+        opts.addChild = args[++i]
+        break
+      case '--rm-parent':
+        opts.rmParent = true
+        break
+      case '--rm-child':
+        opts.rmChild = args[++i]
+        break
+      default:
+        if (!opts.issueNumber) {
+          if (/^\d+$/.test(arg)) {
+            opts.issueNumber = Number(arg)
+          } else {
+            const ref = parseIssueRef(arg)
+            if (ref) {
+              opts.issueNumber = ref.number
+              opts.subjectRepo = ref.repo
+            }
+          }
+        }
+        break
+    }
+    i++
+  }
+
+  return opts
+}
+
+function subjectStr(issueNumber: number, repo?: string): string {
+  return repo ? `${repo}#${issueNumber}` : `#${issueNumber}`
+}
+
+const VALID_TYPES: string[] = [...ISSUE_TYPE_NAMES, ...EXTENDED_ISSUE_TYPES]
+
+async function applyType(issueNumber: number, type: string): Promise<void> {
+  const canonical = type.toLowerCase()
+  if (!VALID_TYPES.includes(canonical)) {
+    console.error(`Error: Invalid type. Valid: ${VALID_TYPES.join(', ')}`)
+    process.exit(1)
+  }
+  const issueNodeId = await getNodeId(issueNumber)
+  const org = GITHUB_REPO.split('/')[0]
+  const typeId = await resolveIssueTypeId(org, canonical)
+  await updateIssueIssueType(issueNodeId, typeId)
+  console.log(`Type=${canonical} #${issueNumber}`)
+}
+
+async function applyDependencies(issueNumber: number, opts: SetOptions): Promise<void> {
+  const subjStr = subjectStr(issueNumber, opts.subjectRepo)
+
+  if (opts.blockedBy) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.blockedBy)) {
+      const blockingNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(issueNodeId, blockingNodeId)
+      console.log(`BlockedBy=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+
+  if (opts.blocks) {
+    const blockingNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.blocks)) {
+      const blockedNodeId = await getNodeId(ref.number, ref.repo)
+      await addBlockedBy(blockedNodeId, blockingNodeId)
+      console.log(`Blocks=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+
+  if (opts.rmBlockedBy) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.rmBlockedBy)) {
+      const blockingNodeId = await getNodeId(ref.number, ref.repo)
+      await removeBlockedBy(issueNodeId, blockingNodeId)
+      console.log(`RemovedBlockedBy=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+
+  if (opts.rmBlocks) {
+    const blockingNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const ref of parseIssueRefs(opts.rmBlocks)) {
+      const blockedNodeId = await getNodeId(ref.number, ref.repo)
+      await removeBlockedBy(blockedNodeId, blockingNodeId)
+      console.log(`RemovedBlocks=${formatRef(ref)} ${subjStr}`)
+    }
+  }
+}
+
+async function applyParentChild(issueNumber: number, opts: SetOptions): Promise<void> {
+  const subjStr = subjectStr(issueNumber, opts.subjectRepo)
+
+  if (opts.parent) {
+    const parentRef = parseIssueRefs(opts.parent)[0]
+    if (parentRef) {
+      const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+      const parentNodeId = await getNodeId(parentRef.number, parentRef.repo)
+      await addSubIssue(parentNodeId, issueNodeId)
+      console.log(`Parent=${formatRef(parentRef)} ${subjStr}`)
+    }
+  }
+
+  if (opts.addChild) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const childRef of parseIssueRefs(opts.addChild)) {
+      const childNodeId = await getNodeId(childRef.number, childRef.repo)
+      await addSubIssue(issueNodeId, childNodeId)
+      console.log(`Child=${formatRef(childRef)} ${subjStr}`)
+    }
+  }
+
+  if (opts.rmParent) {
+    if (opts.subjectRepo) {
+      console.error(`Error: --rm-parent is not supported for cross-repo subjects (${subjStr}) — use direct GraphQL`)
+      process.exit(1)
+    }
+    const parentNum = await getParentNumber(issueNumber)
+    if (parentNum) {
+      const issueNodeId = await getNodeId(issueNumber)
+      const parentNodeId = await getNodeId(parentNum)
+      await removeSubIssue(parentNodeId, issueNodeId)
+      console.log(`RemovedParent=#${parentNum} ${subjStr}`)
+    } else {
+      console.log(`No parent found for ${subjStr}`)
+    }
+  }
+
+  if (opts.rmChild) {
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
+    for (const childRef of parseIssueRefs(opts.rmChild)) {
+      const childNodeId = await getNodeId(childRef.number, childRef.repo)
+      await removeSubIssue(issueNodeId, childNodeId)
+      console.log(`RemovedChild=${formatRef(childRef)} ${subjStr}`)
+    }
+  }
+}
+
+export async function setIssue(args: string[]): Promise<void> {
+  const opts = parseArgs(args)
+
+  if (!opts.issueNumber) {
+    console.error('Error: Issue number required')
+    process.exit(1)
+  }
+
+  const hasAction =
+    opts.size ||
+    opts.priority ||
+    opts.status ||
+    opts.lane ||
+    opts.type ||
+    opts.blockedBy ||
+    opts.blocks ||
+    opts.rmBlockedBy ||
+    opts.rmBlocks ||
+    opts.parent ||
+    opts.addChild ||
+    opts.rmParent ||
+    opts.rmChild
+
+  if (!hasAction) {
+    console.error(
+      'Error: Specify --size, --priority, --status, --lane, --type, --blocked-by, --blocks, --rm-blocked-by, --rm-blocks, --parent, --add-child, --rm-parent, and/or --rm-child',
+    )
+    process.exit(1)
+  }
+
+  // Type is independent of project board
+  if (opts.type) {
+    if (opts.subjectRepo) {
+      console.error(
+        `Warning: --type is not supported for cross-repo subjects (${opts.subjectRepo}#${opts.issueNumber}) — skipped`,
+      )
+    } else {
+      await applyType(opts.issueNumber, opts.type)
+    }
+  }
+
+  // Sync labels — skipped for cross-repo subjects.
+  // Status is intentionally excluded: in the issues-only model status is just
+  // open/closed and the dep-graph derives ready/blocked/done from edges, so a
+  // `status:*` label is redundant (and noisy on repos that lack the label).
+  if (opts.subjectRepo && (opts.priority || opts.size || opts.lane)) {
+    console.error(
+      `Warning: --size/--priority/--lane label sync is not supported for cross-repo subjects (${opts.subjectRepo}#${opts.issueNumber}) — skipped`,
+    )
+  } else {
+    if (opts.priority) {
+      const canonical = resolvePriority(opts.priority)
+      if (canonical) await syncPriorityLabel(opts.issueNumber, canonical)
+    }
+    if (opts.size) {
+      const canonical = resolveSize(opts.size)
+      if (!canonical) {
+        console.error(`Error: Invalid size '${opts.size}'. Valid: ${DEFAULT_SIZE_OPTIONS.join(', ')}`)
+        process.exit(1)
+      }
+      await syncSizeLabel(opts.issueNumber, canonical)
+      console.log(`Size=${canonical} #${opts.issueNumber}`)
+    }
+    if (opts.lane) {
+      const canonical = resolveLane(opts.lane)
+      if (canonical) {
+        await syncLaneLabel(opts.issueNumber, canonical)
+        console.log(`Lane=${canonical} #${opts.issueNumber}`)
+      }
+    }
+  }
+
+  await applyDependencies(opts.issueNumber, opts)
+  await applyParentChild(opts.issueNumber, opts)
+}

--- a/plugins/roxabi-issues/skills/issue-triage/triage.ts
+++ b/plugins/roxabi-issues/skills/issue-triage/triage.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+/**
+ * Issue triage CLI — router that delegates to command modules.
+ * Replaces triage.sh.
+ *
+ * Usage:
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set <number> [--size S] [--priority P] [--lane L] [--blocked-by N] [--parent N] [--child N] ...
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts create --title "Title" [--body "Body"] ...
+ */
+
+const args = process.argv.slice(2)
+const command = args[0] ?? ''
+const rest = args.slice(1)
+
+switch (command) {
+  case 'set': {
+    const { setIssue } = await import('./lib/set')
+    await setIssue(rest)
+    break
+  }
+  case 'create': {
+    const { createIssue } = await import('./lib/create')
+    await createIssue(rest)
+    break
+  }
+  default:
+    console.error('Usage: triage.ts [set|create] ...')
+    process.exit(1)
+}

--- a/plugins/roxabi-issues/skills/shared/adapters/config-helpers.ts
+++ b/plugins/roxabi-issues/skills/shared/adapters/config-helpers.ts
@@ -1,0 +1,273 @@
+/**
+ * Pure config helper functions extracted from the legacy config.ts shim.
+ * These are used by EnvConfigAdapter and re-exported from config.ts for backward compat.
+ */
+
+import { readFileSync } from 'node:fs'
+import { ConfigError } from '../domain/errors'
+
+/**
+ * Load a config value from .claude/dev-core.yml with 3-tier fallback:
+ *   1st: .claude/dev-core.yml (YAML key lookup)
+ *   2nd: process.env[envKey]
+ *   3rd: gh CLI auto-detect (github_repo, gh_project_id)
+ */
+function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
+  // 1st: Try .claude/dev-core.yml
+  try {
+    const yaml = readFileSync('.claude/dev-core.yml', 'utf-8')
+    const match = yaml.match(new RegExp(`^${key}:\\s*['"]?(.+?)['"]?\\s*$`, 'm'))
+    const value = match?.[1]
+    if (value && value !== "''") return value
+  } catch {
+    /* file not found — fall through */
+  }
+
+  // 2nd: Fall back to env var
+  const envValue = process.env[envKey ?? key.toUpperCase()]
+  if (envValue) return envValue
+
+  // 3rd: Auto-detect via gh CLI for supported keys
+  if (key === 'github_repo') {
+    try {
+      const proc = Bun.spawnSync(['gh', 'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (proc.exitCode === 0) return new TextDecoder().decode(proc.stdout).trim()
+    } catch {
+      /* gh not available */
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * A GitHub repo slug: exactly `owner/repo`.
+ * Owner: alphanumeric + hyphen, must start with an alphanumeric character
+ * (GitHub username rule — dots/underscores not allowed in owner segment).
+ * Name: allows dots/underscores after a leading alphanumeric character.
+ * Callers do `detectGitHubRepo().split('/')` and expect exactly two non-empty segments.
+ */
+export const REPO_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/**
+ * Validate a candidate GitHub repo slug and throw a clear error if it doesn't match.
+ * Used by both the yaml/env path and the git-remote fallback in detectGitHubRepo().
+ */
+function assertValidRepoSlug(value: string): string {
+  if (!REPO_SLUG_RE.test(value)) {
+    throw new ConfigError(
+      `Invalid GitHub repo "${value}". Expected "owner/repo" format ` +
+        '(set github_repo in dev-core config or the GITHUB_REPO env var).',
+    )
+  }
+  return value
+}
+
+export function detectGitHubRepo(): string {
+  const fromYamlOrEnv = loadDevCoreConfig('github_repo', 'GITHUB_REPO')
+  if (fromYamlOrEnv) {
+    // Guard the yaml/env path: callers do `detectGitHubRepo().split('/')` and
+    // expect `owner/repo`. A bare value (e.g. `GITHUB_REPO=myrepo`) would slip
+    // through as a silent `undefined` repo → malformed GraphQL. Fail loud here.
+    return assertValidRepoSlug(fromYamlOrEnv)
+  }
+  try {
+    const proc = Bun.spawnSync(['git', 'remote', 'get-url', 'origin'], { stdout: 'pipe', stderr: 'pipe' })
+    const url = new TextDecoder().decode(proc.stdout).trim()
+    // SSH: git@github.com:owner/repo.git  |  HTTPS: https://github.com/owner/repo.git
+    const match = url.match(/[:/]([^/:]+\/[^/]+?)(?:\.git)?$/)
+    // Validate the extracted candidate — a malformed remote must not silently
+    // return a bad slug that callers would split('/') into garbage GraphQL args.
+    if (match?.[1]) return assertValidRepoSlug(match[1])
+  } catch {}
+  throw new ConfigError(
+    'Cannot detect GitHub repo. Set GITHUB_REPO env var or ensure git remote "origin" is configured.',
+  )
+}
+
+// CLI aliases — map loose user input to canonical option keys
+export const STATUS_ALIASES: Record<string, string> = {
+  BACKLOG: 'Backlog',
+  ANALYSIS: 'Analysis',
+  SPECS: 'Specs',
+  'IN PROGRESS': 'In Progress',
+  IN_PROGRESS: 'In Progress',
+  INPROGRESS: 'In Progress',
+  REVIEW: 'Review',
+  DONE: 'Done',
+}
+
+export const PRIORITY_ALIASES: Record<string, string> = {
+  URGENT: 'P0 - Urgent',
+  HIGH: 'P1 - High',
+  MEDIUM: 'P2 - Medium',
+  LOW: 'P3 - Low',
+  P0: 'P0 - Urgent',
+  P1: 'P1 - High',
+  P2: 'P2 - Medium',
+  P3: 'P3 - Low',
+}
+
+// Canonical field option arrays — single source of truth for field creation and validation
+export const DEFAULT_STATUS_OPTIONS = ['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done']
+// Tier-based sizes: S (simple), F-lite (subagents), F-full (agent team)
+export const DEFAULT_SIZE_OPTIONS = ['S', 'F-lite', 'F-full']
+export const PRIORITY_VALUES = ['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'] as const
+export const DEFAULT_PRIORITY_OPTIONS: string[] = [...PRIORITY_VALUES]
+export const DEFAULT_LANE_OPTIONS = [
+  'a1',
+  'a2',
+  'a3',
+  'b',
+  'c1',
+  'c2',
+  'c3',
+  'd',
+  'e',
+  'f',
+  'g',
+  'h',
+  'i',
+  'j',
+  'k',
+  'l',
+  'm',
+  'n',
+  'o',
+  'standalone',
+]
+
+const CANONICAL_STATUSES = new Set(DEFAULT_STATUS_OPTIONS)
+const CANONICAL_SIZES = new Set(DEFAULT_SIZE_OPTIONS)
+const CANONICAL_PRIORITIES = new Set(DEFAULT_PRIORITY_OPTIONS)
+export const CANONICAL_LANES = new Set(DEFAULT_LANE_OPTIONS)
+
+/** Resolve loose user input to a canonical status key, or undefined. */
+export function resolveStatus(input: string): string | undefined {
+  if (CANONICAL_STATUSES.has(input)) return input
+  return STATUS_ALIASES[input.toUpperCase()]
+}
+
+/** Resolve loose user input to a canonical priority key, or undefined. */
+export function resolvePriority(input: string): string | undefined {
+  if (CANONICAL_PRIORITIES.has(input)) return input
+  return PRIORITY_ALIASES[input.toUpperCase()]
+}
+
+/** Resolve loose user input to a canonical size key, or undefined. */
+export function resolveSize(input: string): string | undefined {
+  const upper = input.toUpperCase().replace(/[-\s]/g, '-')
+  // Tier-based schema (S / F-lite / F-full).
+  if (CANONICAL_SIZES.has(input)) return input
+  if (CANONICAL_SIZES.has(upper)) return upper
+  // Legacy → new schema aliasing.
+  if (upper === 'XS') return 'S'
+  if (upper === 'M') return 'F-lite'
+  if (upper === 'L' || upper === 'XL') return 'F-full'
+  // F-lite variations
+  if (upper === 'FLITE' || upper === 'F_LITE' || upper === 'F-LITE') return 'F-lite'
+  // F-full variations
+  if (upper === 'FFULL' || upper === 'F_FULL' || upper === 'F-FULL') return 'F-full'
+  return
+}
+
+/** Resolve loose user input to a canonical lane key, or undefined. */
+export function resolveLane(input: string): string | undefined {
+  if (CANONICAL_LANES.has(input)) return input
+  return
+}
+
+// --- Exports consolidated from legacy config.ts shim ---
+
+export const GITHUB_REPO = detectGitHubRepo()
+
+export const PRIORITY_SHORT: Record<string, string> = {
+  'P0 - Urgent': 'P0',
+  'P1 - High': 'P1',
+  'P2 - Medium': 'P2',
+  'P3 - Low': 'P3',
+}
+
+/** Map canonical project priority → GitHub label name. */
+export const PRIORITY_LABEL_MAP: Record<string, string> = {
+  'P0 - Urgent': 'P0-critical',
+  'P1 - High': 'P1-high',
+  'P2 - Medium': 'P2-medium',
+  'P3 - Low': 'P3-low',
+}
+
+/** Set of all priority label names (for stale label removal). */
+export const PRIORITY_LABELS_SET = new Set(Object.values(PRIORITY_LABEL_MAP))
+
+/** Map canonical size → GitHub label name. */
+export const SIZE_LABEL_MAP: Record<string, string> = {
+  S: 'size:S',
+  'F-lite': 'size:F-lite',
+  'F-full': 'size:F-full',
+}
+
+/** Set of all size label names (for stale label removal). */
+export const SIZE_LABELS_SET = new Set(Object.values(SIZE_LABEL_MAP))
+
+/** Map canonical lane → GitHub label name. */
+export const LANE_LABEL_MAP: Record<string, string> = Object.fromEntries(
+  DEFAULT_LANE_OPTIONS.map((lane) => [lane, `graph:lane/${lane}`]),
+)
+
+/** Set of all lane label names (for stale label removal). */
+export const LANE_LABELS_SET = new Set(Object.values(LANE_LABEL_MAP))
+
+/** Map canonical status → GitHub label name. */
+export const STATUS_LABEL_MAP: Record<string, string> = {
+  Backlog: 'status:Backlog',
+  Analysis: 'status:Analysis',
+  Specs: 'status:Specs',
+  'In Progress': 'status:In Progress',
+  Review: 'status:Review',
+  Done: 'status:Done',
+}
+
+/** Set of all status label names (for stale label removal). */
+export const STATUS_LABELS_SET = new Set(Object.values(STATUS_LABEL_MAP))
+
+export const STATUS_SHORT: Record<string, string> = {
+  'In Progress': 'In Prog',
+  Backlog: 'Backlog',
+  Analysis: 'Analysis',
+  Specs: 'Specs',
+  Review: 'Review',
+  Done: 'Done',
+}
+
+export const PRIORITY_ORDER: Record<string, number> = {
+  'P0 - Urgent': 0,
+  'P1 - High': 1,
+  'P2 - Medium': 2,
+  'P3 - Low': 3,
+  '-': 99,
+}
+
+export const SIZE_ORDER: Record<string, number> = {
+  'F-full': 0,
+  'F-lite': 1,
+  S: 2,
+  '-': 99,
+}
+
+export const STATUS_ORDER: Record<string, number> = {
+  Review: 0,
+  'In Progress': 1,
+  Specs: 2,
+  Analysis: 3,
+  Backlog: 4,
+  '-': 99,
+}
+
+export const BLOCK_ORDER: Record<string, number> = {
+  blocking: 0,
+  ready: 1,
+  blocked: 2,
+}

--- a/plugins/roxabi-issues/skills/shared/adapters/github-adapter.ts
+++ b/plugins/roxabi-issues/skills/shared/adapters/github-adapter.ts
@@ -1,0 +1,233 @@
+/**
+ * GitHub adapter — standalone helper functions wrapping GitHub REST + GraphQL APIs.
+ * Exports canonical getGitHubToken() for auth, plus all operational helpers.
+ */
+
+import { ConfigError, DevCoreError, GitHubApiError } from '../domain/errors'
+import {
+  ADD_BLOCKED_BY_MUTATION,
+  ADD_SUB_ISSUE_MUTATION,
+  ORG_ISSUE_TYPES_QUERY,
+  PARENT_QUERY,
+  REMOVE_BLOCKED_BY_MUTATION,
+  REMOVE_SUB_ISSUE_MUTATION,
+  UPDATE_ISSUE_ISSUE_TYPE_MUTATION,
+  UPDATE_ISSUE_TYPE_MUTATION,
+} from '../queries'
+
+const GITHUB_API = 'https://api.github.com'
+const GRAPHQL_URL = `${GITHUB_API}/graphql`
+
+// --- Standalone helper functions ---
+
+import { GITHUB_REPO } from './config-helpers'
+
+let cachedToken: string | undefined
+
+export function getGitHubToken(): string {
+  if (cachedToken) return cachedToken
+
+  if (process.env.GITHUB_TOKEN) {
+    cachedToken = process.env.GITHUB_TOKEN
+    return cachedToken
+  }
+
+  try {
+    const proc = Bun.spawnSync(['gh', 'auth', 'token'], { stdout: 'pipe', stderr: 'pipe' })
+    const token = new TextDecoder().decode(proc.stdout).trim()
+    if (token) {
+      cachedToken = token
+      return cachedToken
+    }
+  } catch {
+    // gh not available
+  }
+
+  throw new ConfigError('GITHUB_TOKEN env var required (or gh auth login for local dev)')
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${getGitHubToken()}`,
+    'Content-Type': 'application/json',
+    'User-Agent': 'roxabi-skills',
+  }
+}
+
+/** Run a local shell command and return trimmed stdout. Throws on non-zero exit. */
+export async function run(cmd: string[], cwd?: string): Promise<string> {
+  const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe', cwd })
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const code = await proc.exited
+
+  if (code !== 0) {
+    throw new DevCoreError(`Command failed (${code}): ${cmd.join(' ')}\n${stderr}`)
+  }
+  return stdout.trim()
+}
+
+/** Execute a GraphQL query/mutation against GitHub API. */
+export async function ghGraphQL(query: string, variables: Record<string, unknown>): Promise<unknown> {
+  const res = await fetch(GRAPHQL_URL, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ query, variables }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new GitHubApiError(`GitHub GraphQL error (${res.status}): ${text}`, res.status)
+  }
+
+  const json = (await res.json()) as { errors?: { message: string }[] }
+  if (json.errors?.length) {
+    throw new GitHubApiError(`GitHub GraphQL error: ${JSON.stringify(json.errors)}`)
+  }
+  return json
+}
+
+/** Get issue node ID via REST API. */
+export async function getNodeId(issueNumber: number | string, repo?: string): Promise<string> {
+  const repoSlug = repo ?? GITHUB_REPO
+  const res = await fetch(`${GITHUB_API}/repos/${repoSlug}/issues/${issueNumber}`, {
+    headers: authHeaders(),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new GitHubApiError(`Failed to get node ID for #${issueNumber} (${res.status}): ${text}`, res.status)
+  }
+  const data = (await res.json()) as { node_id: string }
+  return data.node_id
+}
+
+/** Create a new GitHub issue via REST API. Returns the issue URL and number. */
+export async function createGitHubIssue(
+  title: string,
+  body?: string,
+  labels?: string[],
+): Promise<{ url: string; number: number }> {
+  const payload: Record<string, unknown> = { title }
+  if (body) payload.body = body
+  if (labels?.length) payload.labels = labels
+
+  const res = await fetch(`${GITHUB_API}/repos/${GITHUB_REPO}/issues`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new GitHubApiError(`Failed to create issue (${res.status}): ${text}`, res.status)
+  }
+
+  const data = (await res.json()) as { html_url: string; number: number }
+  return { url: data.html_url, number: data.number }
+}
+
+/** Add a blocked-by dependency between two issues. */
+export async function addBlockedBy(issueId: string, blockingId: string): Promise<void> {
+  await ghGraphQL(ADD_BLOCKED_BY_MUTATION, { issueId, blockingId })
+}
+
+/** Remove a blocked-by dependency between two issues. */
+export async function removeBlockedBy(issueId: string, blockingId: string): Promise<void> {
+  await ghGraphQL(REMOVE_BLOCKED_BY_MUTATION, { issueId, blockingId })
+}
+
+/** Add a sub-issue (parent/child) relationship. */
+export async function addSubIssue(parentId: string, childId: string): Promise<void> {
+  await ghGraphQL(ADD_SUB_ISSUE_MUTATION, { parentId, childId })
+}
+
+/** Remove a sub-issue (parent/child) relationship. */
+export async function removeSubIssue(parentId: string, childId: string): Promise<void> {
+  await ghGraphQL(REMOVE_SUB_ISSUE_MUTATION, { parentId, childId })
+}
+
+export interface OrgIssueType {
+  id: string
+  name: string
+  color: string
+  isEnabled: boolean
+}
+
+export async function listOrgIssueTypes(login: string): Promise<OrgIssueType[]> {
+  const data = (await ghGraphQL(ORG_ISSUE_TYPES_QUERY, { login })) as {
+    data: { organization: { issueTypes: { nodes: OrgIssueType[] } } }
+  }
+  return data.data.organization.issueTypes.nodes
+}
+
+export async function updateIssueType(
+  issueTypeId: string,
+  patch: { name?: string; description?: string; color?: string; isEnabled?: boolean },
+): Promise<OrgIssueType> {
+  const data = (await ghGraphQL(UPDATE_ISSUE_TYPE_MUTATION, {
+    issueTypeId,
+    ...(patch.name !== undefined && { name: patch.name }),
+    ...(patch.description !== undefined && { description: patch.description }),
+    ...(patch.color !== undefined && { color: patch.color }),
+    ...(patch.isEnabled !== undefined && { isEnabled: patch.isEnabled }),
+  })) as { data: { updateIssueType: { issueType: OrgIssueType } } }
+  return data.data.updateIssueType.issueType
+}
+
+/** Update labels on a GitHub issue: add and/or remove labels. */
+export async function updateLabels(issueNumber: number, add: string[], remove: string[]): Promise<void> {
+  let removeExisting = remove
+  if (remove.length) {
+    const out = await run([
+      'gh',
+      'label',
+      'list',
+      '--repo',
+      GITHUB_REPO,
+      '--limit',
+      '200',
+      '--json',
+      'name',
+      '--jq',
+      '.[].name',
+    ])
+    const existing = new Set(
+      out
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+    removeExisting = remove.filter((l) => existing.has(l))
+  }
+  const args = ['gh', 'issue', 'edit', String(issueNumber), '--repo', GITHUB_REPO]
+  if (add.length) args.push('--add-label', add.join(','))
+  if (removeExisting.length) args.push('--remove-label', removeExisting.join(','))
+  await run(args)
+}
+
+/** Update the issue type on a GitHub issue. Pass null issueTypeId to clear. */
+export async function updateIssueIssueType(issueNodeId: string, issueTypeId: string | null): Promise<void> {
+  // FIXME(#121): revert with null issueTypeId is unverified — schema allows it but API behaviour unconfirmed.
+  // Manual verification needed before production revert. Raw mutation error surfaces via ghGraphQL throw.
+  await ghGraphQL(UPDATE_ISSUE_ISSUE_TYPE_MUTATION, { issueId: issueNodeId, issueTypeId })
+}
+
+/** Resolve an issue type name to its node ID for a given org (case-insensitive). */
+export async function resolveIssueTypeId(org: string, typeName: string): Promise<string> {
+  const types = await listOrgIssueTypes(org)
+  const match = types.find((t) => t.name.toLowerCase() === typeName.toLowerCase())
+  if (!match) {
+    const valid = types.map((t) => t.name).join(', ')
+    throw new GitHubApiError(`Unknown issue type: ${typeName}. Valid: ${valid}`)
+  }
+  return match.id
+}
+
+/** Get the parent issue number for an issue, or null if none. */
+export async function getParentNumber(issueNumber: number): Promise<number | null> {
+  const [owner, repo] = GITHUB_REPO.split('/')
+  const data = (await ghGraphQL(PARENT_QUERY, { owner, repo, number: issueNumber })) as {
+    data: { repository: { issue: { parent: { number: number } | null } } }
+  }
+  return data.data.repository.issue.parent?.number ?? null
+}

--- a/plugins/roxabi-issues/skills/shared/adapters/github-infra.ts
+++ b/plugins/roxabi-issues/skills/shared/adapters/github-infra.ts
@@ -1,0 +1,109 @@
+/**
+ * GitHub label constants and sync helpers used by issue-triage skills.
+ *
+ * Dependency direction: github-infra → github-adapter (clean, no cycle).
+ */
+
+import {
+  LANE_LABEL_MAP,
+  LANE_LABELS_SET,
+  PRIORITY_LABEL_MAP,
+  PRIORITY_LABELS_SET,
+  SIZE_LABEL_MAP,
+  SIZE_LABELS_SET,
+  STATUS_LABEL_MAP,
+  STATUS_LABELS_SET,
+} from './config-helpers'
+
+export interface LabelDef {
+  name: string
+  color: string
+  description: string
+  category: 'type' | 'area'
+}
+
+export const STANDARD_LABELS: LabelDef[] = [
+  { name: 'bug', color: 'd73a4a', description: "Something isn't working", category: 'type' },
+  { name: 'feature', color: '0075ca', description: 'New functionality', category: 'type' },
+  { name: 'enhancement', color: 'a2eeef', description: 'Improve existing functionality', category: 'type' },
+  { name: 'docs', color: '5319e7', description: 'Documentation only', category: 'type' },
+  { name: 'chore', color: 'ededed', description: 'Maintenance, deps, config', category: 'type' },
+  { name: 'research', color: 'd4c5f9', description: 'Investigation or spike', category: 'type' },
+  { name: 'frontend', color: '1d76db', description: 'Frontend', category: 'area' },
+  { name: 'backend', color: 'e99695', description: 'Backend', category: 'area' },
+  { name: 'infra', color: 'f9d0c4', description: 'Infrastructure', category: 'area' },
+  { name: 'api', color: 'bfd4f2', description: 'API', category: 'area' },
+  { name: 'design', color: 'c5def5', description: 'Design', category: 'area' },
+]
+
+/**
+ * Sync priority label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncPriorityLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = PRIORITY_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...PRIORITY_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync priority label for #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Sync size label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncSizeLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = SIZE_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...SIZE_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync size label for #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Sync lane label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncLaneLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = LANE_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...LANE_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync lane label for #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Sync status label on a GitHub issue. Adds the target label and removes stale ones.
+ * Non-fatal: logs a warning on failure but does not throw.
+ */
+export async function syncStatusLabel(issueNumber: number, canonical: string): Promise<void> {
+  const target = STATUS_LABEL_MAP[canonical]
+  if (!target) return
+
+  const stale = [...STATUS_LABELS_SET].filter((l) => l !== target)
+
+  try {
+    const { updateLabels } = await import('./github-adapter')
+    await updateLabels(issueNumber, [target], stale)
+  } catch (err) {
+    console.error(`Warning: Failed to sync status label for #${issueNumber}: ${err}`)
+  }
+}

--- a/plugins/roxabi-issues/skills/shared/domain/errors.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Dev-core error hierarchy — plugin-specific exceptions replacing generic Error throws.
+ */
+
+export class DevCoreError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DevCoreError'
+  }
+}
+
+export class GitHubApiError extends DevCoreError {
+  readonly statusCode: number | undefined
+
+  constructor(message: string, statusCode?: number) {
+    super(message)
+    this.name = 'GitHubApiError'
+    this.statusCode = statusCode
+  }
+}
+
+export class ConfigError extends DevCoreError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConfigError'
+  }
+}
+
+export class WorkspaceError extends DevCoreError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorkspaceError'
+  }
+}
+
+export class ArtifactError extends DevCoreError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ArtifactError'
+  }
+}

--- a/plugins/roxabi-issues/skills/shared/domain/issue-types.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/issue-types.ts
@@ -1,0 +1,8 @@
+/**
+ * Issue type constants — single source of truth for issue classification strings.
+ * Consumed by set.ts (validation) and migrate.ts (legacy map keys).
+ */
+
+export const ISSUE_TYPE_NAMES = ['feat', 'fix', 'docs', 'test', 'chore', 'ci', 'perf', 'refactor'] as const
+
+export const EXTENDED_ISSUE_TYPES = ['epic', 'research'] as const

--- a/plugins/roxabi-issues/skills/shared/domain/parse-issue-ref.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/parse-issue-ref.ts
@@ -1,0 +1,63 @@
+/**
+ * Parse issue references — local (#123) or cross-repo (owner/repo#123).
+ */
+
+import type { ParsedIssueRef } from './types'
+
+const CROSS_REPO_RE = /^([A-Za-z0-9_-]+\/[A-Za-z0-9_-]+)#(\d+)$/
+const LOCAL_RE = /^#?(\d+)$/
+
+/**
+ * Parse a single issue reference string.
+ *
+ * Formats:
+ *   - "123" or "#123" → local ref (number only)
+ *   - "owner/repo#123" → cross-repo ref (number + repo)
+ *
+ * Returns undefined for invalid input.
+ */
+export function parseIssueRef(input: string): ParsedIssueRef | undefined {
+  const trimmed = input.trim()
+
+  // Cross-repo: owner/repo#123
+  const crossMatch = trimmed.match(CROSS_REPO_RE)
+  if (crossMatch) {
+    return { repo: crossMatch[1], number: Number(crossMatch[2]) }
+  }
+
+  // Local: #123 or 123
+  const localMatch = trimmed.match(LOCAL_RE)
+  if (localMatch) {
+    return { number: Number(localMatch[1]) }
+  }
+
+  return undefined
+}
+
+/** Format a ParsedIssueRef as "repo#number" (cross-repo) or "#number" (local). */
+export function formatRef(ref: ParsedIssueRef): string {
+  return ref.repo ? `${ref.repo}#${ref.number}` : `#${ref.number}`
+}
+
+/**
+ * Parse a comma-separated list of issue references.
+ * Skips invalid entries (logs warning to console.error).
+ *
+ * @example
+ *   parseIssueRefs("100, #101, Roxabi/lyra#728")
+ *   // → [{ number: 100 }, { number: 101 }, { number: 728, repo: "Roxabi/lyra" }]
+ */
+export function parseIssueRefs(input: string): ParsedIssueRef[] {
+  const refs: ParsedIssueRef[] = []
+
+  for (const part of input.split(',')) {
+    const ref = parseIssueRef(part)
+    if (ref) {
+      refs.push(ref)
+    } else {
+      console.error(`Warning: Invalid issue reference "${part.trim()}" — skipped`)
+    }
+  }
+
+  return refs
+}

--- a/plugins/roxabi-issues/skills/shared/domain/types.ts
+++ b/plugins/roxabi-issues/skills/shared/domain/types.ts
@@ -1,0 +1,134 @@
+/**
+ * Dev-core domain types — replaces ad-hoc inline types across skills.
+ * These are the canonical representations of GitHub entities within dev-core.
+ */
+
+export interface SubIssue {
+  number: number
+  state: string
+  title: string
+}
+
+export interface BlockRef {
+  number: number
+  state: string
+}
+
+export interface Issue {
+  number: number
+  title: string
+  url: string
+  state: string
+  status: string
+  size: string | null
+  priority: string | null
+  labels: string[]
+  assignees: string[]
+  children: SubIssue[]
+  blockStatus?: 'ready' | 'blocked' | 'blocking'
+  blockedBy?: BlockRef[]
+  blocking?: BlockRef[]
+  projectLabel?: string
+}
+
+export interface CICheck {
+  name: string
+  status: string
+  conclusion: string
+  detailsUrl: string
+}
+
+export interface PR {
+  number: number
+  title: string
+  branch: string
+  state: string
+  isDraft: boolean
+  url: string
+  author: string
+  updatedAt: string
+  additions: number
+  deletions: number
+  reviewDecision: string
+  labels: string[]
+  mergeable: string
+  checks: CICheck[]
+}
+
+export interface Project {
+  id: string
+  title: string
+  repo: string
+}
+
+export interface Branch {
+  name: string
+  isCurrent: boolean
+}
+
+export interface Worktree {
+  path: string
+  branch: string
+  commit: string
+  isBare: boolean
+}
+
+export interface BuildStep {
+  name: string
+  status: 'done' | 'running' | 'pending' | 'error'
+}
+
+export interface VercelDeployment {
+  uid: string
+  url: string
+  name: string
+  state: string
+  isCurrent?: boolean
+  target: string
+  createdAt: number
+  buildingAt: number
+  ready: number
+  source: string
+  meta: { githubCommitRef?: string; githubCommitMessage?: string }
+  inspectorUrl: string
+  buildSteps: BuildStep[]
+}
+
+export interface BranchCI {
+  branch: string
+  commitSha: string
+  commitMessage: string
+  committedAt: string
+  overallState: string
+  checks: CICheck[]
+}
+
+export interface WorkflowRun {
+  id: number
+  name: string
+  displayTitle: string
+  event: string
+  status: string
+  conclusion: string | null
+  htmlUrl: string
+  createdAt: string
+  updatedAt: string
+  headBranch: string
+  headCommitMessage: string
+}
+
+export interface ProjectFieldIds {
+  status?: string
+  col2?: string
+  col3?: string
+  statusOptions?: Record<string, string>
+  col2Options?: Record<string, string>
+  col3Options?: Record<string, string>
+}
+
+/** Parsed issue reference — local (#123) or cross-repo (owner/repo#123). */
+export interface ParsedIssueRef {
+  number: number
+  /** Undefined for local refs (use default repo). */
+  repo?: string
+}

--- a/plugins/roxabi-issues/skills/shared/ports/workspace.ts
+++ b/plugins/roxabi-issues/skills/shared/ports/workspace.ts
@@ -1,0 +1,36 @@
+/**
+ * WorkspacePort — role interface for workspace/worktree/git operations.
+ */
+import type { Branch, ProjectFieldIds, Worktree } from '../domain/types'
+
+export interface VercelProjectRef {
+  projectId: string
+  teamId: string
+}
+
+export interface WorkspaceProject {
+  repo: string
+  projectId: string
+  label: string
+  type?: 'technical' | 'company'
+  fieldIds?: ProjectFieldIds
+  vercelProjectId?: string // single Vercel project ID (legacy / single-project)
+  vercelTeamId?: string // Vercel team ID for single project
+  vercelProjects?: VercelProjectRef[]
+  localPath?: string
+}
+
+export type ProjectType = 'technical' | 'company'
+
+export interface Workspace {
+  projects: WorkspaceProject[]
+  roadmapProjectId?: string
+}
+
+export interface WorkspacePort {
+  readWorkspace(): Workspace
+  writeWorkspace(ws: Workspace): void
+  discoverProject(repo: string, localPath?: string): Promise<WorkspaceProject[]>
+  listBranches(): Promise<Branch[]>
+  listWorktrees(): Promise<Worktree[]>
+}

--- a/plugins/roxabi-issues/skills/shared/queries.ts
+++ b/plugins/roxabi-issues/skills/shared/queries.ts
@@ -1,0 +1,177 @@
+/**
+ * All GraphQL query and mutation strings — single source of truth.
+ *
+ * Mock routing pattern (for tests):
+ * Import constants and route via exact match: `if (query === MILESTONE_QUERY)`.
+ * Throw explicit error on unexpected queries — no silent {} fallback.
+ * This makes query refactors immediately visible in test output.
+ */
+
+/** Get parent issue number. */
+export const PARENT_QUERY = `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) { parent { number } }
+  }
+}`
+
+export const ADD_BLOCKED_BY_MUTATION = `
+mutation($issueId: ID!, $blockingId: ID!) {
+  addBlockedBy(input: { issueId: $issueId, blockingIssueId: $blockingId }) {
+    issue { number } blockingIssue { number }
+  }
+}`
+
+export const REMOVE_BLOCKED_BY_MUTATION = `
+mutation($issueId: ID!, $blockingId: ID!) {
+  removeBlockedBy(input: { issueId: $issueId, blockingIssueId: $blockingId }) {
+    issue { number } blockingIssue { number }
+  }
+}`
+
+/** Open PRs with CI checks — used by dashboard. */
+export const PRS_QUERY = `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: 50, states: OPEN) {
+      nodes {
+        number
+        title
+        headRefName
+        state
+        isDraft
+        url
+        author { login }
+        updatedAt
+        additions
+        deletions
+        reviewDecision
+        labels(first: 10) { nodes { name } }
+        mergeable
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                contexts(first: 50) {
+                  nodes {
+                    ... on CheckRun {
+                      __typename
+                      name
+                      status
+                      conclusion
+                      detailsUrl
+                    }
+                    ... on StatusContext {
+                      __typename
+                      context
+                      state
+                      targetUrl
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+/** CI status for main/master and staging branches — used by dashboard. */
+export const BRANCH_CI_QUERY = `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    main: ref(qualifiedName: "refs/heads/main") { ...BranchCI }
+    master: ref(qualifiedName: "refs/heads/master") { ...BranchCI }
+    staging: ref(qualifiedName: "refs/heads/staging") { ...BranchCI }
+  }
+}
+fragment BranchCI on Ref {
+  name
+  target {
+    ... on Commit {
+      oid
+      messageHeadline
+      committedDate
+      statusCheckRollup {
+        state
+        contexts(first: 50) {
+          nodes {
+            ... on CheckRun {
+              __typename name status conclusion detailsUrl
+            }
+            ... on StatusContext {
+              __typename context state targetUrl
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+export const ADD_SUB_ISSUE_MUTATION = `
+mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { number } subIssue { number }
+  }
+}`
+
+export const REMOVE_SUB_ISSUE_MUTATION = `
+mutation($parentId: ID!, $childId: ID!) {
+  removeSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { number } subIssue { number }
+  }
+}`
+
+/** Get repository node ID. */
+export const REPO_ID_QUERY = `
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) { id }
+}`
+
+/** Fetch milestones for a repository. */
+export const MILESTONE_QUERY = `
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      milestones(first: 50, states: OPEN) {
+        nodes {
+          id
+          title
+        }
+      }
+    }
+  }
+`
+
+export const CREATE_ISSUE_TYPE_MUTATION = `
+mutation($ownerId: ID!, $name: String!, $description: String, $color: IssueTypeColor!, $isEnabled: Boolean!) {
+  createIssueType(input: { ownerId: $ownerId, name: $name, description: $description, color: $color, isEnabled: $isEnabled }) {
+    issueType { id name color isEnabled }
+  }
+}`
+
+export const UPDATE_ISSUE_TYPE_MUTATION = `
+mutation($issueTypeId: ID!, $name: String, $description: String, $color: IssueTypeColor, $isEnabled: Boolean) {
+  updateIssueType(input: { issueTypeId: $issueTypeId, name: $name, description: $description, color: $color, isEnabled: $isEnabled }) {
+    issueType { id name color isEnabled }
+  }
+}`
+
+export const UPDATE_ISSUE_ISSUE_TYPE_MUTATION = `
+mutation($issueId: ID!, $issueTypeId: ID) {
+  updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $issueTypeId }) {
+    issue { id issueType { id name } }
+  }
+}`
+
+export const ORG_ISSUE_TYPES_QUERY = `
+query($login: String!) {
+  organization(login: $login) {
+    id
+    issueTypes(first: 50) { nodes { id name color isEnabled } }
+  }
+}`
+
+

--- a/plugins/roxabi-issues/tsconfig.json
+++ b/plugins/roxabi-issues/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["vitest.config.ts", "vitest.setup.ts", "skills/**/*.ts"],
+  "exclude": ["node_modules", "skills/issue-triage/triage.ts"]
+}

--- a/plugins/roxabi-issues/vitest.config.ts
+++ b/plugins/roxabi-issues/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**'],
+    setupFiles: ['./vitest.setup.ts'],
+    env: {
+      // Prevent config from throwing during module evaluation.
+      GITHUB_REPO: 'Test/test-repo',
+    },
+  },
+})

--- a/plugins/roxabi-issues/vitest.setup.ts
+++ b/plugins/roxabi-issues/vitest.setup.ts
@@ -1,0 +1,42 @@
+import { spawnSync as nodeSpawnSync } from 'node:child_process'
+
+/**
+ * Bun global shim for Vitest (Node.js worker) environment.
+ *
+ * Tests that spy on Bun.spawnSync / Bun.spawn via vi.spyOn need Bun to be
+ * defined — the spy wraps the shim and the mock replaces the return value,
+ * so the shim implementation only matters for tests that call it directly
+ * (e.g. doctor.test.ts subprocess integration tests).
+ */
+if (typeof globalThis.Bun === 'undefined') {
+  // biome-ignore lint/suspicious/noExplicitAny: bun-types makes the Bun global too complex to satisfy without any
+  ;(globalThis as any).Bun = {
+    spawnSync: (
+      cmd: string[],
+      opts?: {
+        stdout?: string
+        stderr?: string
+        cwd?: string
+        env?: Record<string, string>
+      },
+    ) => {
+      const result = nodeSpawnSync(cmd[0], cmd.slice(1), {
+        cwd: opts?.cwd,
+        env: opts?.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      return {
+        stdout: result.stdout ? new Uint8Array(result.stdout) : new Uint8Array(),
+        stderr: result.stderr ? new Uint8Array(result.stderr) : new Uint8Array(),
+        exitCode: result.status ?? 1,
+        success: (result.status ?? 1) === 0,
+      }
+    },
+    // Async spawn — tests that use it mock it via vi.spyOn(Bun, 'spawn')
+    spawn: (..._args: unknown[]) => ({
+      exited: Promise.resolve(1),
+      stdout: null,
+      stderr: null,
+    }),
+  }
+}

--- a/worker/migrations/0004_tenancy_auth.sql
+++ b/worker/migrations/0004_tenancy_auth.sql
@@ -3,6 +3,8 @@
 
 -- D1 runs in WAL mode natively; `PRAGMA journal_mode` is rejected at
 -- `wrangler d1 migrations apply` time, so it must not appear here.
+-- D1 accepts PRAGMA foreign_keys (verified against remote staging D1 2026-06-10) and
+-- enforces FK constraints by default; this line is belt-and-braces for local/vanilla SQLite runs.
 PRAGMA foreign_keys = ON;
 
 -- tenants: one row per GitHub App installation
@@ -42,18 +44,23 @@ CREATE TABLE IF NOT EXISTS sessions (
   revoked_at  TEXT,
   created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
+-- S2 revocation/expiry lookups
+CREATE INDEX IF NOT EXISTS ix_sessions_user_id ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS ix_sessions_expires_at ON sessions(expires_at);
 
 -- oauth_state: single-use PKCE-like state for OAuth flow
 CREATE TABLE IF NOT EXISTS oauth_state (
   state          TEXT PRIMARY KEY,
-  redirect_after TEXT,
+  -- same-origin relative paths only — S2 OAuth callback must still validate
+  redirect_after TEXT CHECK(redirect_after IS NULL OR (redirect_after LIKE '/%' AND redirect_after NOT LIKE '//%')),
   expires_at     TEXT NOT NULL,
   created_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 -- install_tokens: AES-GCM-encrypted installation access tokens; DEK = INSTALL_TOKEN_KEY secret
--- Deviation: spec wrote `tenant_id INTEGER NOT NULL REFERENCES tenants(id) PRIMARY KEY` which is
--- invalid SQLite column-level PK syntax; reordered to `PRIMARY KEY NOT NULL REFERENCES tenants(id)`.
+-- Note: spec wrote `tenant_id INTEGER NOT NULL REFERENCES tenants(id) PRIMARY KEY`; SQLite
+-- column constraints are order-independent so that form is valid and equivalent — reordered here
+-- to `PRIMARY KEY NOT NULL REFERENCES tenants(id)` for readability only.
 CREATE TABLE IF NOT EXISTS install_tokens (
   tenant_id  INTEGER PRIMARY KEY NOT NULL REFERENCES tenants(id),
   token_enc  TEXT NOT NULL,
@@ -82,7 +89,9 @@ CREATE TABLE IF NOT EXISTS user_repo_permission_cache (
 -- Deviation D-2: NO foreign key on tenant_id — the existing 5 sentinel rows use tenant_id=0
 -- (a sentinel, not a real tenant), which would violate a FK constraint to tenants(id).
 -- Strategy: rename-rebuild to preserve existing data, seeding sentinel rows at tenant_id=0.
--- recovery guard — if a prior partial run failed between CREATE and RENAME, re-apply starts clean
+-- Three-step swap: data exists in at least one table at every crash point. A partial-failure
+-- re-run fails loudly (recoverable manually) rather than silently destroying data.
+-- recovery guard — if a prior partial run failed between CREATE and first RENAME, re-apply starts clean
 DROP TABLE IF EXISTS sync_control_new;
 CREATE TABLE sync_control_new (
   tenant_id  INTEGER NOT NULL DEFAULT 0,
@@ -93,8 +102,9 @@ CREATE TABLE sync_control_new (
 );
 INSERT INTO sync_control_new (tenant_id, key, value, updated_at)
   SELECT 0, key, value, updated_at FROM sync_control;
-DROP TABLE sync_control;
+ALTER TABLE sync_control RENAME TO sync_control_old;
 ALTER TABLE sync_control_new RENAME TO sync_control;
+DROP TABLE sync_control_old;
 
 -- zk_payloads: Phase-2 ZK seam; PK is per-user (browser keys, not per-tenant)
 CREATE TABLE IF NOT EXISTS zk_payloads (

--- a/worker/migrations/0004_tenancy_auth.sql
+++ b/worker/migrations/0004_tenancy_auth.sql
@@ -1,0 +1,116 @@
+-- migration: 0004_tenancy_auth.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+
+-- D1 runs in WAL mode natively; `PRAGMA journal_mode` is rejected at
+-- `wrangler d1 migrations apply` time, so it must not appear here.
+PRAGMA foreign_keys = ON;
+
+-- tenants: one row per GitHub App installation
+CREATE TABLE IF NOT EXISTS tenants (
+  id              INTEGER PRIMARY KEY,
+  installation_id INTEGER NOT NULL UNIQUE,
+  account_login   TEXT NOT NULL,
+  account_type    TEXT NOT NULL CHECK(account_type IN ('User','Organization')),
+  suspended_at    TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- users: one row per GitHub user who has authorized the App
+CREATE TABLE IF NOT EXISTS users (
+  id           INTEGER PRIMARY KEY,
+  github_id    INTEGER NOT NULL UNIQUE,
+  github_login TEXT NOT NULL,
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- user_installations: which users belong to which tenant
+CREATE TABLE IF NOT EXISTS user_installations (
+  user_id   INTEGER NOT NULL REFERENCES users(id),
+  tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+  PRIMARY KEY (user_id, tenant_id)
+);
+
+-- sessions: D1 (not KV) for strongly-consistent revocation
+CREATE TABLE IF NOT EXISTS sessions (
+  id          INTEGER PRIMARY KEY,
+  user_id     INTEGER NOT NULL REFERENCES users(id),
+  tenant_id   INTEGER NOT NULL REFERENCES tenants(id),
+  token_hash  TEXT NOT NULL UNIQUE,
+  expires_at  TEXT NOT NULL,
+  revoked_at  TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- oauth_state: single-use PKCE-like state for OAuth flow
+CREATE TABLE IF NOT EXISTS oauth_state (
+  state          TEXT PRIMARY KEY,
+  redirect_after TEXT,
+  expires_at     TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- install_tokens: AES-GCM-encrypted installation access tokens; DEK = INSTALL_TOKEN_KEY secret
+-- Deviation: spec wrote `tenant_id INTEGER NOT NULL REFERENCES tenants(id) PRIMARY KEY` which is
+-- invalid SQLite column-level PK syntax; reordered to `PRIMARY KEY NOT NULL REFERENCES tenants(id)`.
+CREATE TABLE IF NOT EXISTS install_tokens (
+  tenant_id  INTEGER PRIMARY KEY NOT NULL REFERENCES tenants(id),
+  token_enc  TEXT NOT NULL,
+  token_iv   TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- tenant_repo_access: authorization layer (fail-closed: no row → no data)
+CREATE TABLE IF NOT EXISTS tenant_repo_access (
+  tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+  repo      TEXT NOT NULL,
+  PRIMARY KEY (tenant_id, repo)
+);
+
+-- user_repo_permission_cache: per-user private-repo permission; 24h TTL
+CREATE TABLE IF NOT EXISTS user_repo_permission_cache (
+  user_id    INTEGER NOT NULL REFERENCES users(id),
+  repo       TEXT NOT NULL,
+  has_access INTEGER NOT NULL DEFAULT 0,
+  checked_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, repo)
+);
+
+-- sync_control rebuild: add composite PK (tenant_id, key) to support per-tenant state.
+-- Deviation D-2: NO foreign key on tenant_id — the existing 5 sentinel rows use tenant_id=0
+-- (a sentinel, not a real tenant), which would violate a FK constraint to tenants(id).
+-- Strategy: rename-rebuild to preserve existing data, seeding sentinel rows at tenant_id=0.
+CREATE TABLE sync_control_new (
+  tenant_id  INTEGER NOT NULL DEFAULT 0,
+  key        TEXT NOT NULL,
+  value      TEXT,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, key)
+);
+INSERT INTO sync_control_new (tenant_id, key, value, updated_at)
+  SELECT 0, key, value, updated_at FROM sync_control;
+DROP TABLE sync_control;
+ALTER TABLE sync_control_new RENAME TO sync_control;
+
+-- zk_payloads: Phase-2 ZK seam; PK is per-user (browser keys, not per-tenant)
+CREATE TABLE IF NOT EXISTS zk_payloads (
+  user_id           INTEGER NOT NULL REFERENCES users(id),
+  issue_key         TEXT NOT NULL,
+  pubkey_fp         TEXT NOT NULL,
+  encrypted_payload TEXT NOT NULL,
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, issue_key)
+);
+
+-- title → payload move: ZK seam (D24); title lives inside payload JSON going forward.
+-- JSON_EXTRACT(payload,'$.title') replaces direct title column access.
+ALTER TABLE issues ADD COLUMN payload TEXT;
+UPDATE issues SET payload = json_object('title', title) WHERE title IS NOT NULL;
+ALTER TABLE issues DROP COLUMN title;
+
+-- repos rename anchor (deviation D-1): SQLite forbids ADD COLUMN ... UNIQUE inline,
+-- so the UNIQUE constraint is implemented as a separate index.
+ALTER TABLE repos ADD COLUMN repo_node_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_repos_node_id ON repos(repo_node_id);

--- a/worker/migrations/0004_tenancy_auth.sql
+++ b/worker/migrations/0004_tenancy_auth.sql
@@ -82,6 +82,8 @@ CREATE TABLE IF NOT EXISTS user_repo_permission_cache (
 -- Deviation D-2: NO foreign key on tenant_id — the existing 5 sentinel rows use tenant_id=0
 -- (a sentinel, not a real tenant), which would violate a FK constraint to tenants(id).
 -- Strategy: rename-rebuild to preserve existing data, seeding sentinel rows at tenant_id=0.
+-- recovery guard — if a prior partial run failed between CREATE and RENAME, re-apply starts clean
+DROP TABLE IF EXISTS sync_control_new;
 CREATE TABLE sync_control_new (
   tenant_id  INTEGER NOT NULL DEFAULT 0,
   key        TEXT NOT NULL,

--- a/worker/migrations/0005_sync_slot_seed.sql
+++ b/worker/migrations/0005_sync_slot_seed.sql
@@ -1,0 +1,7 @@
+-- migration: 0005_sync_slot_seed.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+
+-- Seed the global sync_slot sentinel row (tenant_id=0).
+-- INSERT OR IGNORE: idempotent — no-op if the row already exists (e.g. re-applied migration).
+-- sync_control PK is (tenant_id, key); tenant_id=0 is the global sentinel (no FK to tenants).
+INSERT OR IGNORE INTO sync_control (tenant_id, key, value) VALUES (0, 'sync_slot', '0');

--- a/worker/migrations/0006_sync_started_at_seed.sql
+++ b/worker/migrations/0006_sync_started_at_seed.sql
@@ -1,0 +1,12 @@
+-- migration: 0006_sync_started_at_seed.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+
+-- Seed the global sync_started_at row (tenant_id=0).
+-- runSync does `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_started_at'
+-- AND tenant_id=0` (worker/src/sync/sync.ts). SQLite UPDATE on a missing row is a silent
+-- no-op (0 rows changed, no error), so without this seed sync_started_at is never written
+-- and any reader (monitoring, dashboard) sees NULL forever. Surfaced by the #167 review.
+-- INSERT OR IGNORE: idempotent — no-op if the row already exists (re-applied migration, or
+-- a tick that already wrote it). sync_control PK is (tenant_id, key); tenant_id=0 is the
+-- global sentinel (no FK to tenants), same as the sync_slot seed in 0005.
+INSERT OR IGNORE INTO sync_control (tenant_id, key, value) VALUES (0, 'sync_started_at', '');

--- a/worker/src/api/admin.test.ts
+++ b/worker/src/api/admin.test.ts
@@ -20,7 +20,6 @@ function mockEnv(adminToken?: string): Env {
       dump: async () => new ArrayBuffer(0),
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
     ...(adminToken !== undefined ? { ADMIN_TOKEN: adminToken } : {}),

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -41,6 +41,42 @@ function makeGraphEnv(
   } as unknown as Env;
 }
 
+/**
+ * Like makeGraphEnv but also accumulates every SQL string passed to prepare()
+ * so tests can assert on the exact queries issued by graphRoute.
+ */
+function makeGraphEnvWithCapture(
+  labels: unknown[],
+  prState: unknown[],
+  issues: unknown[],
+  edges: unknown[],
+  repos: unknown[] = [],
+): { env: Env; capturedSqls: string[] } {
+  const capturedSqls: string[] = [];
+  const env = {
+    DB: {
+      prepare: (sql: string) => {
+        capturedSqls.push(sql);
+        return {
+          all: async () => {
+            if (sql.includes("FROM labels")) return { results: labels };
+            if (sql.includes("FROM pr_state")) return { results: prState };
+            if (sql.includes("FROM issues")) return { results: issues };
+            if (sql.includes("FROM edges")) return { results: edges };
+            if (sql.includes("FROM repos")) return { results: repos };
+            return { results: [] };
+          },
+        };
+      },
+    },
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
+    GITHUB_TOKEN: "",
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+  return { env, capturedSqls };
+}
+
 describe("GET /api/graph", () => {
   describe("response shape", () => {
     it("returns {nodes, edges} with correct types", async () => {
@@ -436,6 +472,18 @@ describe("GET /api/graph", () => {
         { repo: "Roxabi/roxabi-live", archived: false },
         { repo: "Roxabi/roxabi-vault", archived: true },
       ]);
+    });
+  });
+
+  describe("SQL shape assertions", () => {
+    it("issues SELECT uses JSON_EXTRACT(payload,'$.title') AS title", async () => {
+      // Arrange
+      const { env, capturedSqls } = makeGraphEnvWithCapture([], [], [], []);
+      // Act
+      await app.request("/api/graph", {}, env);
+      // Assert — the issues query must project title via JSON_EXTRACT
+      const issuesSql = capturedSqls.find((s) => s.includes("FROM issues"));
+      expect(issuesSql).toContain("JSON_EXTRACT(payload,'$.title') AS title");
     });
   });
 });

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -35,7 +35,6 @@ function makeGraphEnv(
       }),
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -70,7 +69,6 @@ function makeGraphEnvWithCapture(
       },
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -154,7 +154,7 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
 
   // (c) issues
   const issueRows = await c.env.DB.prepare(
-    "SELECT key, repo, number, title, state, url, milestone," +
+    "SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone," +
       " lane, priority, size, status, is_stub, has_active_branch FROM issues",
   ).all<IssueRow>();
 

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -156,6 +156,54 @@ function makeGetEnv(opts: GetEnvOptions): Env {
   } as unknown as Env;
 }
 
+/**
+ * Like makeGetEnv but captures every prepare(sql) call so tests can assert
+ * on the exact SQL issued for the single-issue path.
+ */
+function makeGetEnvWithCapture(opts: GetEnvOptions): {
+  env: Env;
+  capturedSqls: string[];
+} {
+  const {
+    issueRow,
+    labels = [],
+    blocking = [],
+    blockedBy = [],
+  } = opts;
+  const capturedSqls: string[] = [];
+
+  const env = {
+    DB: {
+      prepare: (sql: string) => {
+        capturedSqls.push(sql);
+        return {
+          bind: (..._args: unknown[]) => ({
+            first: async () => {
+              if (sql.includes("FROM issues WHERE key")) return issueRow;
+              return null;
+            },
+            all: async () => {
+              if (sql.includes("FROM labels WHERE issue_key")) return { results: labels };
+              if (sql.includes("e.src_key = ?")) return { results: blocking };
+              if (sql.includes("e.dst_key = ?")) return { results: blockedBy };
+              return { results: [] };
+            },
+          }),
+          first: async () => null,
+          all: async () => ({ results: [] }),
+        };
+      },
+      batch: async () => [],
+    },
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
+    GITHUB_TOKEN: "",
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+
+  return { env, capturedSqls };
+}
+
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
 function makeIssueRow(overrides: Partial<Record<string, unknown>> = {}) {
@@ -391,6 +439,17 @@ describe("GET /api/issues/:key", () => {
       expect(Array.isArray(body.blocked_by)).toBe(true);
     });
 
+    it("issues SELECT uses JSON_EXTRACT(payload,'$.title') AS title", async () => {
+      // Arrange
+      const row = makeIssueRow();
+      const { env, capturedSqls } = makeGetEnvWithCapture({ issueRow: row });
+      // Act
+      await app.request("/api/issues/Roxabi/roxabi-live%231", {}, env);
+      // Assert — the single-issue SELECT must project title via JSON_EXTRACT
+      const issueSql = capturedSqls.find((s) => s.includes("FROM issues WHERE key"));
+      expect(issueSql).toContain("JSON_EXTRACT(payload,'$.title') AS title");
+    });
+
     it("attaches labels from DB", async () => {
       const row = makeIssueRow();
       const labels = [{ name: "bug" }, { name: "P1" }];
@@ -494,6 +553,7 @@ describe("GET /api/issues — filter SQL params and clamping (FIX 4)", () => {
       expect(batchSqls.some((s) => s.includes("issues.repo = ?"))).toBe(true);
       expect(countCall?.args).toContain("foo");
       expect(dataCall?.args).toContain("foo");
+      expect(dataCall?.sql).toContain("JSON_EXTRACT(issues.payload,'$.title') AS title");
     });
 
     it("?state=open binds state param in WHERE clause", async () => {

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -73,7 +73,6 @@ function makeListEnvWithCapture(
       },
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -101,7 +100,6 @@ function makeListEnv(opts: ListEnvOptions): Env {
       ],
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -150,7 +148,6 @@ function makeGetEnv(opts: GetEnvOptions): Env {
       batch: async () => [],
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
@@ -196,7 +193,6 @@ function makeGetEnvWithCapture(opts: GetEnvOptions): {
       batch: async () => [],
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/api/issues.ts
+++ b/worker/src/api/issues.ts
@@ -87,7 +87,7 @@ export const listIssuesRoute = async (c: Context<{ Bindings: Env }>) => {
 
   const countSql = `SELECT COUNT(*) AS n FROM issues ${where}`;
   const dataSql =
-    `SELECT issues.key, issues.repo, issues.number, issues.title,` +
+    `SELECT issues.key, issues.repo, issues.number, JSON_EXTRACT(issues.payload,'$.title') AS title,` +
     ` issues.state, issues.url, issues.milestone, issues.is_stub,` +
     ` issues.created_at, issues.updated_at, issues.closed_at` +
     ` FROM issues ${where} ORDER BY issues.updated_at ASC LIMIT ? OFFSET ?`;
@@ -152,7 +152,7 @@ export const getIssueRoute = async (c: Context<{ Bindings: Env }>) => {
   }
 
   const issueSql =
-    "SELECT key, repo, number, title, state, url, milestone, is_stub," +
+    "SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, is_stub," +
     " created_at, updated_at, closed_at FROM issues WHERE key = ?";
   const row = await c.env.DB.prepare(issueSql).bind(rawKey).first<IssueListRow>();
 

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -335,4 +335,23 @@ describe("logoutRoute", () => {
     // Should still succeed (204) even with no cookie
     expect(res.status).toBe(204);
   });
+
+  it("returns 204 + clears session cookie even when no Cookie header is present (ungated — null-safe)", async () => {
+    // Arrange — bare app with no requireSession, no stub session middleware.
+    // This is the negative guard test: if /logout were gated by requireSession,
+    // this request (no cookie) would return 401 instead of 204, proving the guard was
+    // present. Its 204 response proves the route is truly ungated and null-safe.
+    const { db } = captureDb();
+    const logoutApp = new Hono<AuthEnv>();
+    logoutApp.post("/logout", logoutRoute);
+
+    // Act — POST /logout with no Cookie header
+    const res = await logoutApp.request("/logout", { method: "POST" }, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(204);
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("__Host-session=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
 });

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -121,7 +121,6 @@ function makeEnv(db: D1Database): Env {
   return {
     DB: db,
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { meRoute, logoutRoute } from "./me";
+import type { AuthEnv, SessionContext } from "../auth/session";
+import { requireSession } from "../auth/session";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from src/webhook/mutations.test.ts
+// ---------------------------------------------------------------------------
+
+type FakeResult = { [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements — returns empty rows for every query. */
+function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/** Capture variant — every query returns the provided rows. */
+function captureDbWithRows(
+  rows: FakeResult[],
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+/** Build a minimal Env with the given D1 instance. */
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
+    GITHUB_TOKEN: "",
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+/**
+ * Build a test Hono app with a stub middleware that injects STUB_SESSION,
+ * then mounts meRoute + logoutRoute.
+ * This tests the route handlers in isolation — independent of requireSession.
+ */
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+
+  // Stub middleware: injects session without any cookie/DB check
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+
+  app.get("/api/me", meRoute);
+  app.post("/api/logout", logoutRoute);
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// meRoute
+// ---------------------------------------------------------------------------
+
+describe("meRoute", () => {
+  it("returns 200 with user fields from injected session", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json() as { user: { github_id: number; github_login: string } };
+    expect(body.user.github_id).toBe(42);
+    expect(body.user.github_login).toBe("alice");
+  });
+
+  it("response body contains an installations array", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json() as { installations: unknown[] };
+    expect(Array.isArray(body.installations)).toBe(true);
+  });
+
+  it("installations SELECT references user_installations table", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — the SQL issued must mention user_installations
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).toContain("user_installations");
+  });
+
+  it("installations SELECT JOINs the tenants table", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — the SQL must JOIN tenants
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).toContain("JOIN tenants");
+  });
+
+  it("surfaces installation rows returned by D1 in the response body", async () => {
+    // Arrange — FakeD1 returns one installation row
+    const fakeRow = { tenant_id: 9, installation_id: 5, account_login: "Roxabi" };
+    const { db } = captureDbWithRows([fakeRow]);
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json() as { installations: typeof fakeRow[] };
+    expect(body.installations).toHaveLength(1);
+    expect(body.installations[0]).toMatchObject({
+      tenant_id: 9,
+      installation_id: 5,
+      account_login: "Roxabi",
+    });
+  });
+
+  it("returns 401 when requireSession finds no session cookie (negative guard test)", async () => {
+    // Arrange — separate throwaway app mounting real requireSession, no stub session
+    // This verifies the guard is not tautological: deleting requireSession would let
+    // the request reach the handler without a session, changing the response.
+    const { db } = captureDb();
+    const guardApp = new Hono<AuthEnv>();
+    guardApp.use("/api/me", requireSession);
+    guardApp.get("/api/me", meRoute);
+
+    // Act — no Cookie header → requireSession should fail closed with 401
+    const res = await guardApp.request("/api/me", {}, makeEnv(db));
+
+    // Assert
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logoutRoute
+// ---------------------------------------------------------------------------
+
+describe("logoutRoute", () => {
+  it("returns 204 on successful logout", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert
+    expect(res.status).toBe(204);
+  });
+
+  it("issues DELETE FROM sessions WHERE token_hash when cookie present", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert — the SQL must be DELETE FROM sessions keyed on token_hash
+    const deleteStmt = stmts().find((s) => s.sql.includes("DELETE FROM sessions"));
+    expect(deleteStmt).toBeDefined();
+    expect(deleteStmt!.sql).toContain("token_hash");
+  });
+
+  it("binds a 64-char hex hash (SHA-256 of raw token) — not the raw token itself", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert — args[0] must be a 64-char lowercase hex string (SHA-256 digest)
+    const deleteStmt = stmts().find((s) => s.sql.includes("DELETE FROM sessions"));
+    expect(deleteStmt).toBeDefined();
+    expect(deleteStmt!.args[0]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("Set-Cookie response header clears the session cookie (Max-Age=0)", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request(
+      "/api/logout",
+      { method: "POST", headers: { Cookie: "__Host-session=raw-test-token" } },
+      makeEnv(db),
+    );
+
+    // Assert
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("Max-Age=0");
+    expect(setCookie).toContain("__Host-session");
+  });
+
+  it("does NOT issue DELETE when no session cookie is present", async () => {
+    // Arrange — no Cookie header → logoutRoute guards if (raw) before calling deleteSession
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/logout", { method: "POST" }, makeEnv(db));
+
+    // Assert — no DELETE FROM sessions should have been issued
+    const deleteStmt = stmts().find((s) => s.sql.includes("DELETE FROM sessions"));
+    expect(deleteStmt).toBeUndefined();
+    // Should still succeed (204) even with no cookie
+    expect(res.status).toBe(204);
+  });
+});

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -17,6 +17,9 @@ import { readSessionToken, deleteSession, clearSessionCookie } from "../auth/ses
  */
 export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
   const s = c.get("session");
+  if (!s) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
 
   const rows = await c.env.DB
     .prepare(

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -1,0 +1,56 @@
+/**
+ * /api/me — current user profile + installations.
+ * /logout  — revoke session cookie.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/session";
+import { readSessionToken, deleteSession, clearSessionCookie } from "../auth/session";
+
+// ---------------------------------------------------------------------------
+// GET /api/me
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the authenticated user's GitHub identity and their GitHub App
+ * installations (tenants) linked to their account.
+ */
+export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
+  const s = c.get("session");
+
+  const rows = await c.env.DB
+    .prepare(
+      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login
+       FROM user_installations ui JOIN tenants t ON t.id = ui.tenant_id WHERE ui.user_id = ?`,
+    )
+    .bind(s.userId)
+    .all<{ tenant_id: number; installation_id: number; account_login: string }>();
+
+  return c.json({
+    user: {
+      github_id: s.githubId,
+      github_login: s.githubLogin,
+    },
+    installations: rows.results,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /logout
+// ---------------------------------------------------------------------------
+
+/**
+ * Revokes the current session (deletes from D1) and clears the session cookie.
+ * Gracefully handles the case where no cookie is present (returns 204 anyway).
+ */
+export async function logoutRoute(c: Context<AuthEnv>): Promise<Response> {
+  const raw = readSessionToken(c);
+  if (raw) {
+    await deleteSession(c.env.DB, raw);
+  }
+
+  return new Response(null, {
+    status: 204,
+    headers: { "Set-Cookie": clearSessionCookie() },
+  });
+}

--- a/worker/src/api/version.test.ts
+++ b/worker/src/api/version.test.ts
@@ -6,58 +6,72 @@ import type { Env } from "../types";
  * Minimal D1/ASSETS stub for version endpoint tests.
  * The UNION ALL query calls .first() on a single prepared statement, so we
  * only need to intercept that one call and return the row we want.
+ * capturedSql is set to the SQL string passed to prepare() so tests can assert
+ * on the exact query issued.
  */
-function mockEnv(row: Record<string, unknown> | null): Env {
-  return {
+function mockEnv(row: Record<string, unknown> | null): { env: Env; getCapturedSql: () => string } {
+  let capturedSql = "";
+  const env = {
     DB: {
-      prepare: () => ({ first: async () => row }),
+      prepare: (sql: string) => {
+        capturedSql = sql;
+        return { first: async () => row };
+      },
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
     GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;
+  return { env, getCapturedSql: () => capturedSql };
 }
 
 describe("GET /api/version", () => {
   it("returns the MAX version token when cron sync is newest", async () => {
     // Simulates: cron ran at 12:00, last webhook at 11:00 — cron wins
-    const res = await app.request(
-      "/api/version",
-      {},
-      mockEnv({ version: "2026-06-05T12:00:00.000Z" }),
-    );
+    const { env } = mockEnv({ version: "2026-06-05T12:00:00.000Z" });
+    const res = await app.request("/api/version", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ version: "2026-06-05T12:00:00.000Z" });
   });
 
   it("returns the MAX version token when webhook mutation is newest", async () => {
     // Simulates: data_version bumped at 12:30 after a webhook, cron only at 12:00
-    const res = await app.request(
-      "/api/version",
-      {},
-      mockEnv({ version: "2026-06-05T12:30:00.000Z" }),
-    );
+    const { env } = mockEnv({ version: "2026-06-05T12:30:00.000Z" });
+    const res = await app.request("/api/version", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ version: "2026-06-05T12:30:00.000Z" });
   });
 
   it("returns an empty version when no sync or webhook mutation has run yet", async () => {
-    const res = await app.request("/api/version", {}, mockEnv({ version: null }));
+    const { env } = mockEnv({ version: null });
+    const res = await app.request("/api/version", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ version: "" });
   });
 
   it("returns an empty string when the db returns a null row", async () => {
-    const res = await app.request("/api/version", {}, mockEnv(null));
+    const { env } = mockEnv(null);
+    const res = await app.request("/api/version", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ version: "" });
+  });
+
+  it("version SQL filters sync_control row with AND tenant_id = 0", async () => {
+    // Arrange
+    const { env, getCapturedSql } = mockEnv({ version: "2026-06-05T12:00:00.000Z" });
+    // Act
+    await app.request("/api/version", {}, env);
+    // Assert — the UNION ALL query must scope sync_control to tenant 0
+    const capturedSql = getCapturedSql();
+    expect(capturedSql).toContain("AND tenant_id = 0");
   });
 });
 
 describe("GET /health", () => {
   it("reports ok + issue count when the db is reachable", async () => {
-    const res = await app.request("/health", {}, mockEnv({ n: 42 }));
+    const { env } = mockEnv({ n: 42 });
+    const res = await app.request("/health", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ status: "ok", db_reachable: true, issue_count: 42 });
   });
@@ -65,7 +79,8 @@ describe("GET /health", () => {
 
 describe("unmatched routes", () => {
   it("falls through to the ASSETS binding", async () => {
-    const res = await app.request("/index.html", {}, mockEnv(null));
+    const { env } = mockEnv(null);
+    const res = await app.request("/index.html", {}, env);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("asset");
   });

--- a/worker/src/api/version.test.ts
+++ b/worker/src/api/version.test.ts
@@ -19,7 +19,6 @@ function mockEnv(row: Record<string, unknown> | null): { env: Env; getCapturedSq
       },
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_TOKEN: "",
     GITHUB_ORG: "",
     GITHUB_WEBHOOK_SECRET: "",
   } as unknown as Env;

--- a/worker/src/api/version.ts
+++ b/worker/src/api/version.ts
@@ -21,7 +21,7 @@ export const versionRoute = async (c: Context<{ Bindings: Env }>) => {
     `SELECT MAX(v) AS version FROM (
        SELECT COALESCE(MAX(last_synced_at), '') AS v FROM sync_state
        UNION ALL
-       SELECT COALESCE(value, '') AS v FROM sync_control WHERE key = 'data_version'
+       SELECT COALESCE(value, '') AS v FROM sync_control WHERE key = 'data_version' AND tenant_id = 0
      )`,
   ).first<{ version: string | null }>();
   return c.json({ version: row?.version ?? "" });

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { getInstallationToken, resolveInstallToken } from "./installToken";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// NOTE: installToken.ts does not exist yet — these tests are intentionally RED.
+// They define the contract that installToken.ts must satisfy (S3 task).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// FakeD1 — local copy of the project pattern (see session.test.ts)
+// ---------------------------------------------------------------------------
+
+type FakeResult = { [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Test key generation helpers (mirrors jwt.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+async function generateTestKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  ) as Promise<CryptoKeyPair>;
+}
+
+async function exportPrivateKeyAsB64(key: CryptoKey): Promise<string> {
+  const der = (await crypto.subtle.exportKey("pkcs8", key)) as ArrayBuffer;
+  return btoa(String.fromCharCode(...new Uint8Array(der)));
+}
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+/** Generate a fresh 32-byte INSTALL_TOKEN_KEY as base64. */
+function generateInstallTokenKey(): string {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  return btoa(String.fromCharCode(...raw));
+}
+
+/** Encrypt a plaintext token using the same AES-GCM approach as tokenCrypto
+ *  so we can seed install_tokens with a realistic encrypted row.
+ *  NOTE: this is a test-local helper — it imports from tokenCrypto which
+ *  doesn't exist yet, so it will also fail at import time (expected RED). */
+// We'll use a simple approach: store a known "encrypted" value using the
+// real tokenCrypto module once it exists. For now, tests that need a seeded
+// encrypted row (cache-hit path) import encryptToken directly.
+import { importDek, encryptToken } from "./tokenCrypto";
+
+// ---------------------------------------------------------------------------
+// Fake env builder
+// ---------------------------------------------------------------------------
+
+async function buildFakeEnv(
+  overrides: Partial<Env> = {},
+): Promise<{ env: Env; appPrivKeyB64: string; installTokenKeyB64: string }> {
+  const pair = await generateTestKeyPair();
+  const appPrivKeyB64 = await exportPrivateKeyAsB64(pair.privateKey);
+  const installTokenKeyB64 = generateInstallTokenKey();
+
+  const env: Env = {
+    DB: null as unknown as D1Database, // overridden per test
+    ASSETS: null as unknown as Fetcher,
+    GITHUB_TOKEN: "gh_test_token",
+    GITHUB_ORG: "TestOrg",
+    GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
+    GITHUB_APP_ID: "999999",
+    GITHUB_APP_CLIENT_ID: "Iv1.test",
+    GITHUB_APP_CLIENT_SECRET: "test-client-secret",
+    GITHUB_APP_PRIVATE_KEY: appPrivKeyB64,
+    GITHUB_APP_WEBHOOK_SECRET: "test-app-webhook-secret",
+    INSTALL_TOKEN_KEY: installTokenKeyB64,
+    ...overrides,
+  } as unknown as Env;
+
+  return { env, appPrivKeyB64, installTokenKeyB64 };
+}
+
+// ---------------------------------------------------------------------------
+// FakeD1 factory for install token scenarios
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a FakeD1 seeded with tenants + install_tokens + tenant_repo_access rows.
+ * The stmtFactory inspects the SQL to route queries to the right fixture data.
+ */
+function buildSeededDb(opts: {
+  tenant?: {
+    id: number;
+    installation_id: number;
+    account_login: string;
+    account_type: string;
+    suspended_at: string | null;
+  };
+  installToken?: {
+    tenant_id: number;
+    token_enc: string;
+    token_iv: string;
+    expires_at: string; // ISO 8601
+  };
+  repoAccess?: { tenant_id: number; repo: string }[];
+  /** Track upsert calls to install_tokens */
+  upsertCapture?: Array<{ sql: string; args: unknown[] }>;
+}): D1Database {
+  const {
+    tenant,
+    installToken,
+    repoAccess = [],
+    upsertCapture,
+  } = opts;
+
+  return makeFakeDb((sql, args) => {
+    const sqlLower = sql.toLowerCase();
+
+    // Capture upsert/insert into install_tokens
+    if (
+      upsertCapture &&
+      (sqlLower.includes("insert") || sqlLower.includes("update")) &&
+      sqlLower.includes("install_tokens")
+    ) {
+      upsertCapture.push({ sql, args });
+      return makeFakeStmt(sql, args, [], 1);
+    }
+
+    // Query on install_tokens (cache lookup)
+    if (sqlLower.includes("install_tokens")) {
+      if (installToken) {
+        return makeFakeStmt(sql, args, [installToken as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []); // cache miss
+    }
+
+    // Query on tenant_repo_access
+    if (sqlLower.includes("tenant_repo_access")) {
+      const matchingRow = repoAccess.find(
+        (r) => args.includes(r.repo) || args.length === 0,
+      );
+      if (matchingRow) {
+        return makeFakeStmt(sql, args, [matchingRow as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []); // no access row
+    }
+
+    // Query on tenants (suspended check or JOIN)
+    if (sqlLower.includes("tenants")) {
+      if (tenant) {
+        return makeFakeStmt(sql, args, [tenant as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []);
+    }
+
+    // Default: empty result
+    return makeFakeStmt(sql, args, [], 0);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------------
+
+/** ISO timestamp offset from now by `seconds`. */
+function nowPlusSeconds(seconds: number): string {
+  return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// getInstallationToken — cache fresh path
+// ---------------------------------------------------------------------------
+
+describe("getInstallationToken — cache fresh", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the decrypted token from cache when expires_at > now+5min, without calling fetch", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const plaintext = "ghs_cached_fresh_token";
+    const { enc, iv } = await encryptToken(dek, plaintext);
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(10 * 60), // 10 min from now — well past 5-min threshold
+      },
+    });
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const token = await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert
+    expect(token).toBe(plaintext);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getInstallationToken — cache stale/miss path
+// ---------------------------------------------------------------------------
+
+describe("getInstallationToken — cache stale/missing", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls GitHub mint endpoint once when cache is missing, returns fresh token", async () => {
+    // Arrange
+    const { env } = await buildFakeEnv();
+    const freshToken = "ghs_freshly_minted_token";
+    const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      // No installToken row → cache miss
+      upsertCapture,
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: freshToken,
+          expires_at: nowPlusSeconds(3600),
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const token = await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert
+    expect(token).toBe(freshToken);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The fetch URL must reference the installation ID
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("42");
+    expect(calledUrl).toContain("access_tokens");
+  });
+
+  it("calls GitHub mint endpoint once when cache is stale (expires_at ≤ now+5min)", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const staleToken = "ghs_stale_token";
+    const { enc, iv } = await encryptToken(dek, staleToken);
+    const freshToken = "ghs_new_token_after_refresh";
+    const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(2 * 60), // 2 min — within the 5-min stale window
+      },
+      upsertCapture,
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: freshToken,
+          expires_at: nowPlusSeconds(3600),
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const token = await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert
+    expect(token).toBe(freshToken);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("after a mint, the stored token_enc value is NOT the plaintext token", async () => {
+    // Arrange
+    const { env } = await buildFakeEnv();
+    const freshToken = "ghs_freshly_minted_secret";
+    const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "TestOrg",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      upsertCapture,
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: freshToken,
+          expires_at: nowPlusSeconds(3600),
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    ) as typeof fetch;
+
+    // Act
+    await getInstallationToken(db, { ...env, DB: db }, 1, 42);
+
+    // Assert — upsert must have been called, and the stored enc must NOT be plaintext
+    expect(upsertCapture.length).toBeGreaterThanOrEqual(1);
+    const upsertArgs = upsertCapture[upsertCapture.length - 1].args;
+    // token_enc arg must not equal the plaintext token
+    const storedEnc = upsertArgs.find(
+      (a) => typeof a === "string" && a !== freshToken,
+    );
+    expect(storedEnc).toBeDefined();
+    // None of the args should literally be the plaintext
+    expect(upsertArgs).not.toContain(freshToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInstallToken — fail-closed guards
+// ---------------------------------------------------------------------------
+
+describe("resolveInstallToken — fail-closed guards", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when no tenant_repo_access row exists for the given owner/name", async () => {
+    // Arrange
+    const { env } = await buildFakeEnv();
+
+    // DB has no tenant_repo_access for "owner/missing-repo"
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "owner",
+        account_type: "Organization",
+        suspended_at: null,
+      },
+      repoAccess: [], // no access rows
+    });
+
+    // Act + Assert — fail-closed: unknown repo must not produce a token
+    await expect(
+      resolveInstallToken(db, { ...env, DB: db }, "owner", "missing-repo"),
+    ).rejects.toThrow();
+  });
+
+  it("throws when the owning tenant has suspended_at set (suspended guard)", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const { enc, iv } = await encryptToken(dek, "ghs_some_token");
+
+    // DB has access row but tenant is suspended
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "owner",
+        account_type: "Organization",
+        suspended_at: "2026-06-01T00:00:00.000Z", // non-null → suspended
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(10 * 60),
+      },
+      repoAccess: [{ tenant_id: 1, repo: "owner/my-repo" }],
+    });
+
+    // Act + Assert — suspended tenant must be rejected
+    await expect(
+      resolveInstallToken(db, { ...env, DB: db }, "owner", "my-repo"),
+    ).rejects.toThrow();
+  });
+});

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { getInstallationToken, resolveInstallToken } from "./installToken";
+import {
+  getInstallationToken,
+  resolveInstallToken,
+  listInstallationRepos,
+} from "./installToken";
 import type { Env } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -129,7 +133,6 @@ async function buildFakeEnv(
   const env: Env = {
     DB: null as unknown as D1Database, // overridden per test
     ASSETS: null as unknown as Fetcher,
-    GITHUB_TOKEN: "gh_test_token",
     GITHUB_ORG: "TestOrg",
     GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
     GITHUB_APP_ID: "999999",
@@ -534,5 +537,74 @@ describe("resolveInstallToken — fail-closed guards", () => {
 
     // Assert — cache-hit decrypt path returns the expected plaintext token
     expect(token).toBe(plaintext);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listInstallationRepos — W2 pagination bound (#160)
+// ---------------------------------------------------------------------------
+
+describe("listInstallationRepos — W2 pagination bound", () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  function fullPage(): Response {
+    // Exactly 100 repos → a "full" page that signals more pages may follow.
+    const repositories = Array.from({ length: 100 }, (_, i) => ({
+      full_name: `o/repo-${i}`,
+    }));
+    return new Response(JSON.stringify({ repositories }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("caps pagination at MAX_PAGES (10) and warns on truncation when every page is full", async () => {
+    const fetchMock = vi.fn(async () => fullPage());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const repos = await listInstallationRepos("fake-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(10); // MAX_PAGES — never exceeded
+    expect(repos).toHaveLength(1000); // 10 pages × 100 repos
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("MAX_PAGES"));
+  });
+
+  it("passes an AbortSignal (per-page timeout) on every fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ repositories: [{ full_name: "o/r" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await listInstallationRepos("fake-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const opts = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("stops early on a short final page and does NOT warn (normal case)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ repositories: [{ full_name: "o/only" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const repos = await listInstallationRepos("fake-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // short page → single fetch
+    expect(repos).toEqual(["o/only"]);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -198,7 +198,19 @@ function buildSeededDb(opts: {
       return makeFakeStmt(sql, args, []); // cache miss
     }
 
-    // Query on tenant_repo_access
+    // JOIN query: SQL contains both "tenant_repo_access" and "join" — this branch must
+    // precede the bare tenant_repo_access branch because the JOIN SQL includes both table
+    // names and would be incorrectly intercepted by that branch, returning the wrong row
+    // shape ({tenant_id, repo} instead of {id, installation_id, suspended_at}).
+    if (sqlLower.includes("tenant_repo_access") && sqlLower.includes("join")) {
+      const matchingAccess = repoAccess.find((r) => args.includes(r.repo));
+      if (matchingAccess && tenant) {
+        return makeFakeStmt(sql, args, [tenant as unknown as FakeResult]);
+      }
+      return makeFakeStmt(sql, args, []); // no matching tenant
+    }
+
+    // Query on tenant_repo_access (bare — no JOIN)
     if (sqlLower.includes("tenant_repo_access")) {
       const matchingRow = repoAccess.find(
         (r) => args.includes(r.repo),
@@ -486,5 +498,41 @@ describe("resolveInstallToken — fail-closed guards", () => {
     await expect(
       resolveInstallToken(db, { ...env, DB: db }, "owner", "my-repo"),
     ).rejects.toThrow();
+  });
+
+  it("resolves to the decrypted token via cache-hit when tenant is active", async () => {
+    // Arrange
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
+    const dek = await importDek(installTokenKeyB64);
+    const plaintext = "ghs_live_token";
+    const { enc, iv } = await encryptToken(dek, plaintext);
+
+    const db = buildSeededDb({
+      tenant: {
+        id: 1,
+        installation_id: 42,
+        account_login: "owner",
+        account_type: "Organization",
+        suspended_at: null, // active — not suspended
+      },
+      installToken: {
+        tenant_id: 1,
+        token_enc: enc,
+        token_iv: iv,
+        expires_at: nowPlusSeconds(10 * 60), // fresh — well beyond 5-min stale window
+      },
+      repoAccess: [{ tenant_id: 1, repo: "owner/active-repo" }],
+    });
+
+    // Act
+    const token = await resolveInstallToken(
+      db,
+      { ...env, DB: db },
+      "owner",
+      "active-repo",
+    );
+
+    // Assert — cache-hit decrypt path returns the expected plaintext token
+    expect(token).toBe(plaintext);
   });
 });

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -118,7 +118,7 @@ function generateInstallTokenKey(): string {
 // We'll use a simple approach: store a known "encrypted" value using the
 // real tokenCrypto module once it exists. For now, tests that need a seeded
 // encrypted row (cache-hit path) import encryptToken directly.
-import { importDek, encryptToken } from "./tokenCrypto";
+import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
 
 // ---------------------------------------------------------------------------
 // Fake env builder
@@ -375,9 +375,9 @@ describe("getInstallationToken — cache stale/missing", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("after a mint, the stored token_enc value is NOT the plaintext token", async () => {
+  it("after a mint, the stored token_enc value is NOT the plaintext token (real decryption round-trip)", async () => {
     // Arrange
-    const { env } = await buildFakeEnv();
+    const { env, installTokenKeyB64 } = await buildFakeEnv();
     const freshToken = "ghs_freshly_minted_secret";
     const upsertCapture: Array<{ sql: string; args: unknown[] }> = [];
 
@@ -405,16 +405,27 @@ describe("getInstallationToken — cache stale/missing", () => {
     // Act
     await getInstallationToken(db, { ...env, DB: db }, 1, 42);
 
-    // Assert — upsert must have been called, and the stored enc must NOT be plaintext
+    // Assert — upsert must have been called
     expect(upsertCapture.length).toBeGreaterThanOrEqual(1);
     const upsertArgs = upsertCapture[upsertCapture.length - 1].args;
-    // token_enc arg must not equal the plaintext token
-    const storedEnc = upsertArgs.find(
-      (a) => typeof a === "string" && a !== freshToken,
-    );
-    expect(storedEnc).toBeDefined();
-    // None of the args should literally be the plaintext
+
+    // None of the args should literally be the plaintext (basic guard)
     expect(upsertArgs).not.toContain(freshToken);
+
+    // Real guard: recover token_enc and token_iv by SQL parameter position
+    // INSERT INTO install_tokens (tenant_id, token_enc, token_iv, expires_at, updated_at)
+    // VALUES (?, ?, ?, ?, ?)
+    // .bind(tenantId, enc, iv, expires_at, updatedAt)
+    //        idx 0    1    2   3           4
+    const storedTokenEnc = upsertArgs[1] as string;
+    const storedTokenIv = upsertArgs[2] as string;
+    expect(typeof storedTokenEnc).toBe("string");
+    expect(typeof storedTokenIv).toBe("string");
+
+    // Decrypt and verify round-trip — this FAILS if impl stored plaintext instead of ciphertext
+    const dek = await importDek(installTokenKeyB64);
+    const recovered = await decryptToken(dek, storedTokenEnc, storedTokenIv);
+    expect(recovered).toBe(freshToken);
   });
 });
 

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -3,11 +3,6 @@ import { getInstallationToken, resolveInstallToken } from "./installToken";
 import type { Env } from "../types";
 
 // ---------------------------------------------------------------------------
-// NOTE: installToken.ts does not exist yet — these tests are intentionally RED.
-// They define the contract that installToken.ts must satisfy (S3 task).
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // FakeD1 — local copy of the project pattern (see session.test.ts)
 // ---------------------------------------------------------------------------
 
@@ -206,7 +201,7 @@ function buildSeededDb(opts: {
     // Query on tenant_repo_access
     if (sqlLower.includes("tenant_repo_access")) {
       const matchingRow = repoAccess.find(
-        (r) => args.includes(r.repo) || args.length === 0,
+        (r) => args.includes(r.repo),
       );
       if (matchingRow) {
         return makeFakeStmt(sql, args, [matchingRow as unknown as FakeResult]);
@@ -328,6 +323,9 @@ describe("getInstallationToken — cache stale/missing", () => {
     const calledUrl = fetchMock.mock.calls[0][0] as string;
     expect(calledUrl).toContain("42");
     expect(calledUrl).toContain("access_tokens");
+    // Assert upsert was issued to install_tokens cache
+    expect(upsertCapture.length).toBeGreaterThanOrEqual(1);
+    expect(upsertCapture[0].sql.toLowerCase()).toContain("install_tokens");
   });
 
   it("calls GitHub mint endpoint once when cache is stale (expires_at ≤ now+5min)", async () => {

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -109,6 +109,7 @@ export async function getInstallationToken(
       "User-Agent": "roxabi-live-worker",
       "X-GitHub-Api-Version": "2022-11-28",
     },
+    signal: AbortSignal.timeout(10_000),
   });
 
   if (!mintRes.ok) {
@@ -230,7 +231,7 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
     const url = `https://api.github.com/installation/repositories?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
-        Authorization: `token ${token}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "User-Agent": "roxabi-live-worker",
         "X-GitHub-Api-Version": "2022-11-28",

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -45,6 +45,9 @@ const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
 /** Read the AES-GCM DEK (base64) used to encrypt install tokens at rest. */
 function getInstallTokenKey(env: Env): string {
+  if (!env.INSTALL_TOKEN_KEY) {
+    throw new Error("INSTALL_TOKEN_KEY secret is not configured");
+  }
   return env.INSTALL_TOKEN_KEY;
 }
 
@@ -172,7 +175,11 @@ export async function resolveInstallToken(
 ): Promise<string> {
   const repo = `${owner}/${name}`;
 
-  // JOIN tenant_repo_access → tenants to get suspension status + installation_id
+  // JOIN tenant_repo_access → tenants to get suspension status + installation_id.
+  // Phase-1 invariant (see #141/#147): one repo → one installation (enforced by
+  // tenants UNIQUE(installation_id) + tenant_repo_access FK). .first() is therefore
+  // deterministic here. Re-verify this assumption before extending to multi-tenant
+  // (Phase 2 / #147) — the query will need GROUP BY or a different resolution strategy.
   const row = await db
     .prepare(
       `SELECT t.id, t.installation_id, t.suspended_at

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -224,10 +224,11 @@ interface GHInstallationReposResponse {
  * @returns Array of `"owner/name"` full_name strings.
  */
 export async function listInstallationRepos(token: string): Promise<string[]> {
+  const MAX_PAGES = 10;
   const repos: string[] = [];
-  let page = 1;
+  let lastPageFull = false;
 
-  while (true) {
+  for (let page = 1; page <= MAX_PAGES; page++) {
     const url = `https://api.github.com/installation/repositories?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
@@ -236,6 +237,7 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
         "User-Agent": "roxabi-live-worker",
         "X-GitHub-Api-Version": "2022-11-28",
       },
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!res.ok) {
@@ -259,12 +261,18 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
       repos.push(r.full_name);
     }
 
+    lastPageFull = pageRepos.length === 100;
+
     // Stop if this page was not full (last page)
     if (pageRepos.length < 100) {
       break;
     }
+  }
 
-    page++;
+  if (lastPageFull) {
+    console.warn(
+      `[installToken] listInstallationRepos hit MAX_PAGES (${MAX_PAGES}) — repo list may be truncated`,
+    );
   }
 
   return repos;

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -1,0 +1,250 @@
+/**
+ * Installation access token management for GitHub App installs.
+ *
+ * Tokens are encrypted at rest using AES-GCM (tokenCrypto.ts) in the
+ * install_tokens D1 table and refreshed proactively 5 minutes before expiry.
+ *
+ * Compatible with the Cloudflare Workers runtime — no Node.js imports.
+ */
+
+import { importAppPrivateKey, signAppJwt } from "./jwt";
+import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface InstallTokenRow {
+  token_enc: string;
+  token_iv: string;
+  expires_at: string;
+}
+
+interface TenantRow {
+  id: number;
+  installation_id: number;
+  suspended_at: string | null;
+}
+
+interface GHAccessTokenResponse {
+  token: string;
+  expires_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Proactive refresh window: treat tokens expiring within 5 minutes as stale. */
+const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Env access helper
+// ---------------------------------------------------------------------------
+
+/** Read the AES-GCM DEK (base64) used to encrypt install tokens at rest. */
+function getInstallTokenKey(env: Env): string {
+  return env.INSTALL_TOKEN_KEY;
+}
+
+// ---------------------------------------------------------------------------
+// Core: getInstallationToken
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a valid installation access token for the given tenant/installation.
+ *
+ * Cache-hit path: if install_tokens has a row with expires_at > now+5min, decrypts
+ * and returns it without calling GitHub.
+ *
+ * Mint path: calls POST /app/installations/{id}/access_tokens, encrypts the new
+ * token, upserts into install_tokens, and returns the plaintext token (once).
+ *
+ * @param db             - D1 database binding.
+ * @param env            - Worker env bindings.
+ * @param tenantId       - Primary key in the tenants table.
+ * @param installationId - GitHub App installation ID.
+ * @returns Plaintext GitHub installation access token.
+ */
+export async function getInstallationToken(
+  db: D1Database,
+  env: Env,
+  tenantId: number,
+  installationId: number,
+): Promise<string> {
+  const installTokenKey = getInstallTokenKey(env);
+
+  // Step 1 — Check cache
+  const row = await db
+    .prepare(
+      `SELECT token_enc, token_iv, expires_at FROM install_tokens WHERE tenant_id = ?`,
+    )
+    .bind(tenantId)
+    .first<InstallTokenRow>();
+
+  if (row) {
+    const expiresAt = new Date(row.expires_at).getTime();
+    const threshold = Date.now() + STALE_THRESHOLD_MS;
+    if (expiresAt > threshold) {
+      // Cache hit — decrypt and return
+      const dek = await importDek(installTokenKey);
+      return decryptToken(dek, row.token_enc, row.token_iv);
+    }
+  }
+
+  // Step 2 — Mint a fresh token via GitHub App JWT
+  const appKey = await importAppPrivateKey(env.GITHUB_APP_PRIVATE_KEY);
+  const jwt = await signAppJwt(env.GITHUB_APP_ID, appKey);
+
+  const mintUrl = `https://api.github.com/app/installations/${installationId}/access_tokens`;
+  const mintRes = await fetch(mintUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "roxabi-live-worker",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!mintRes.ok) {
+    const text = await mintRes.text();
+    throw new Error(
+      `GitHub installation token mint failed: HTTP ${mintRes.status} — ${text}`,
+    );
+  }
+
+  const { token, expires_at } = (await mintRes.json()) as GHAccessTokenResponse;
+
+  // Step 3 — Encrypt and upsert
+  const dek = await importDek(installTokenKey);
+  const { enc, iv } = await encryptToken(dek, token);
+  const updatedAt = new Date().toISOString();
+
+  await db
+    .prepare(
+      `INSERT INTO install_tokens (tenant_id, token_enc, token_iv, expires_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(tenant_id) DO UPDATE SET
+         token_enc  = excluded.token_enc,
+         token_iv   = excluded.token_iv,
+         expires_at = excluded.expires_at,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(tenantId, enc, iv, expires_at, updatedAt)
+    .run();
+
+  // Step 4 — Return the fresh plaintext token (never persisted raw)
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// resolveInstallToken
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an installation access token by repository owner + name.
+ *
+ * Fail-closed: throws if no tenant_repo_access row exists for the repo, or if
+ * the owning tenant is suspended.
+ *
+ * @param db    - D1 database binding.
+ * @param env   - Worker env bindings.
+ * @param owner - Repository owner (org or user login).
+ * @param name  - Repository name.
+ * @returns Plaintext GitHub installation access token for the owning installation.
+ * @throws If the repo is not registered or the tenant is suspended.
+ */
+export async function resolveInstallToken(
+  db: D1Database,
+  env: Env,
+  owner: string,
+  name: string,
+): Promise<string> {
+  const repo = `${owner}/${name}`;
+
+  // JOIN tenant_repo_access → tenants to get suspension status + installation_id
+  const row = await db
+    .prepare(
+      `SELECT t.id, t.installation_id, t.suspended_at
+       FROM tenant_repo_access tra
+       JOIN tenants t ON t.id = tra.tenant_id
+       WHERE tra.repo = ?`,
+    )
+    .bind(repo)
+    .first<TenantRow>();
+
+  if (!row) {
+    throw new Error(`No installation found for repository: ${repo}`);
+  }
+
+  if (row.suspended_at !== null) {
+    throw new Error(
+      `Installation for repository ${repo} is suspended (suspended_at: ${row.suspended_at})`,
+    );
+  }
+
+  return getInstallationToken(db, env, row.id, row.installation_id);
+}
+
+// ---------------------------------------------------------------------------
+// listInstallationRepos
+// ---------------------------------------------------------------------------
+
+interface GHRepository {
+  full_name: string;
+}
+
+interface GHInstallationReposResponse {
+  repositories: GHRepository[];
+  total_count: number;
+}
+
+/**
+ * List all repositories accessible to an installation via its access token.
+ *
+ * Paginates automatically (100 per page) until all repos are collected.
+ *
+ * @param token - GitHub installation access token (from getInstallationToken).
+ * @returns Array of `"owner/name"` full_name strings.
+ */
+export async function listInstallationRepos(token: string): Promise<string[]> {
+  const repos: string[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/installation/repositories?per_page=100&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "roxabi-live-worker",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `GitHub list installation repositories failed: HTTP ${res.status} — ${text}`,
+      );
+    }
+
+    const body = (await res.json()) as GHInstallationReposResponse;
+    const pageRepos = body.repositories ?? [];
+
+    for (const r of pageRepos) {
+      repos.push(r.full_name);
+    }
+
+    // Stop if this page was not full (last page)
+    if (pageRepos.length < 100) {
+      break;
+    }
+
+    page++;
+  }
+
+  return repos;
+}

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -111,11 +111,19 @@ export async function getInstallationToken(
   if (!mintRes.ok) {
     const text = await mintRes.text();
     throw new Error(
-      `GitHub installation token mint failed: HTTP ${mintRes.status} — ${text}`,
+      `GitHub installation token mint failed: HTTP ${mintRes.status} — ${text.slice(0, 200)}`,
     );
   }
 
-  const { token, expires_at } = (await mintRes.json()) as GHAccessTokenResponse;
+  let mintBody: GHAccessTokenResponse;
+  try {
+    mintBody = (await mintRes.json()) as GHAccessTokenResponse;
+  } catch {
+    throw new Error(
+      `GitHub installation token mint failed: unexpected non-JSON response for installation ${installationId}`,
+    );
+  }
+  const { token, expires_at } = mintBody;
 
   // Step 3 — Encrypt and upsert
   const dek = await importDek(installTokenKey);
@@ -180,9 +188,7 @@ export async function resolveInstallToken(
   }
 
   if (row.suspended_at !== null) {
-    throw new Error(
-      `Installation for repository ${repo} is suspended (suspended_at: ${row.suspended_at})`,
-    );
+    throw new Error(`Installation for ${repo} is suspended`);
   }
 
   return getInstallationToken(db, env, row.id, row.installation_id);
@@ -227,11 +233,18 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
     if (!res.ok) {
       const text = await res.text();
       throw new Error(
-        `GitHub list installation repositories failed: HTTP ${res.status} — ${text}`,
+        `GitHub list installation repositories failed: HTTP ${res.status} — ${text.slice(0, 200)}`,
       );
     }
 
-    const body = (await res.json()) as GHInstallationReposResponse;
+    let body: GHInstallationReposResponse;
+    try {
+      body = (await res.json()) as GHInstallationReposResponse;
+    } catch {
+      throw new Error(
+        `GitHub list installation repositories failed: unexpected non-JSON response (page ${page})`,
+      );
+    }
     const pageRepos = body.repositories ?? [];
 
     for (const r of pageRepos) {

--- a/worker/src/auth/jwt.test.ts
+++ b/worker/src/auth/jwt.test.ts
@@ -1,0 +1,316 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { importAppPrivateKey, signAppJwt } from "./jwt";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a throwaway RSA-2048 key pair (extractable) for use in tests. */
+async function generateTestKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  ) as Promise<CryptoKeyPair>;
+}
+
+/** Export a private CryptoKey as base64-encoded PKCS#8 DER. */
+async function exportPrivateKeyAsB64(key: CryptoKey): Promise<string> {
+  const der = (await crypto.subtle.exportKey("pkcs8", key)) as ArrayBuffer;
+  return btoa(String.fromCharCode(...new Uint8Array(der)));
+}
+
+/** Convert a base64url string to standard base64 (add padding, swap chars). */
+function b64urlToB64(s: string): string {
+  return s.replace(/-/g, "+").replace(/_/g, "/").padEnd(
+    s.length + ((4 - (s.length % 4)) % 4),
+    "=",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// importAppPrivateKey
+// ---------------------------------------------------------------------------
+
+describe("importAppPrivateKey", () => {
+  it("imports a base64 PKCS#8 private key and returns a CryptoKey usable for signing", async () => {
+    // Arrange
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+
+    // Act
+    const imported = await importAppPrivateKey(b64);
+
+    // Assert — should be a non-extractable CryptoKey with sign usage
+    expect(imported).toBeInstanceOf(CryptoKey);
+    expect(imported.type).toBe("private");
+    expect(imported.extractable).toBe(false);
+    expect(imported.usages).toContain("sign");
+  });
+
+  it("imported key can actually sign data (round-trip with crypto.subtle.sign)", async () => {
+    // Arrange
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    const imported = await importAppPrivateKey(b64);
+    const data = new TextEncoder().encode("test payload");
+
+    // Act — signing must not throw
+    const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", imported, data);
+
+    // Assert — signature has non-zero length (RSA-2048 produces 256 bytes)
+    expect(new Uint8Array(sig).length).toBe(256);
+  });
+
+  it("imported key can verify against the corresponding public key", async () => {
+    // Arrange
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    const imported = await importAppPrivateKey(b64);
+    const data = new TextEncoder().encode("test payload");
+
+    // Act
+    const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", imported, data);
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pair.publicKey,
+      sig,
+      data,
+    );
+
+    // Assert
+    expect(valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signAppJwt — structure
+// ---------------------------------------------------------------------------
+
+describe("signAppJwt", () => {
+  // Shared key pair for all signing tests
+  let privKey: CryptoKey;
+  let pubKey: CryptoKey;
+
+  // We generate once (before all) to keep tests fast — key generation is expensive
+  beforeAll(async () => {
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    privKey = await importAppPrivateKey(b64);
+    pubKey = pair.publicKey;
+  });
+
+  const NOW_SEC = 1_700_000_000;
+  const APP_ID = "123456";
+
+  it("produces a JWT with exactly 3 dot-separated parts", async () => {
+    // Arrange / Act
+    const token = await signAppJwt(APP_ID, privKey, NOW_SEC);
+
+    // Assert
+    const parts = token.split(".");
+    expect(parts).toHaveLength(3);
+  });
+
+  it("header decodes to { alg: 'RS256', typ: 'JWT' }", async () => {
+    // Arrange / Act
+    const token = await signAppJwt(APP_ID, privKey, NOW_SEC);
+    const [headerB64url] = token.split(".");
+
+    // Assert
+    const header = JSON.parse(atob(b64urlToB64(headerB64url))) as unknown;
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+  });
+
+  it("payload decodes to { iss, iat: now-60, exp: now+540 }", async () => {
+    // Arrange / Act
+    const token = await signAppJwt(APP_ID, privKey, NOW_SEC);
+    const [, payloadB64url] = token.split(".");
+
+    // Assert
+    const payload = JSON.parse(atob(b64urlToB64(payloadB64url))) as unknown;
+    expect(payload).toEqual({
+      iss: APP_ID,
+      iat: NOW_SEC - 60,
+      exp: NOW_SEC + 540,
+    });
+  });
+
+  it("iss equals the appId passed in", async () => {
+    // Arrange
+    const customId = "987654";
+    // Act
+    const token = await signAppJwt(customId, privKey, NOW_SEC);
+    const [, payloadB64url] = token.split(".");
+    const payload = JSON.parse(atob(b64urlToB64(payloadB64url))) as { iss: string };
+
+    // Assert
+    expect(payload.iss).toBe(customId);
+  });
+
+  it("uses Math.floor(Date.now()/1000) when nowSec is omitted", async () => {
+    // Arrange
+    const before = Math.floor(Date.now() / 1000);
+    // Act
+    const token = await signAppJwt(APP_ID, privKey);
+    const after = Math.floor(Date.now() / 1000);
+
+    const [, payloadB64url] = token.split(".");
+    const payload = JSON.parse(atob(b64urlToB64(payloadB64url))) as { iat: number; exp: number };
+
+    // Assert — iat = now - 60, exp = now + 540; before/after bracket the actual now
+    expect(payload.iat).toBeGreaterThanOrEqual(before - 60);
+    expect(payload.iat).toBeLessThanOrEqual(after - 60);
+    expect(payload.exp).toBeGreaterThanOrEqual(before + 540);
+    expect(payload.exp).toBeLessThanOrEqual(after + 540);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signAppJwt — base64url encoding (no padding, URL-safe chars)
+// ---------------------------------------------------------------------------
+
+describe("signAppJwt base64url encoding", () => {
+  let privKey: CryptoKey;
+
+  beforeAll(async () => {
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    privKey = await importAppPrivateKey(b64);
+  });
+
+  it("header part contains none of '=', '+', '/'", async () => {
+    // Arrange / Act
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [header] = token.split(".");
+
+    // Assert
+    expect(header).not.toContain("=");
+    expect(header).not.toContain("+");
+    expect(header).not.toContain("/");
+  });
+
+  it("payload part contains none of '=', '+', '/'", async () => {
+    // Arrange / Act
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [, payload] = token.split(".");
+
+    // Assert
+    expect(payload).not.toContain("=");
+    expect(payload).not.toContain("+");
+    expect(payload).not.toContain("/");
+  });
+
+  it("signature part contains none of '=', '+', '/'", async () => {
+    // Arrange / Act
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [,, sig] = token.split(".");
+
+    // Assert
+    expect(sig).not.toContain("=");
+    expect(sig).not.toContain("+");
+    expect(sig).not.toContain("/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signAppJwt — cryptographic signature verification
+// ---------------------------------------------------------------------------
+
+describe("signAppJwt signature verification", () => {
+  let privKey: CryptoKey;
+  let pubKey: CryptoKey;
+
+  beforeAll(async () => {
+    const pair = await generateTestKeyPair();
+    const b64 = await exportPrivateKeyAsB64(pair.privateKey);
+    privKey = await importAppPrivateKey(b64);
+    pubKey = pair.publicKey;
+  });
+
+  it("crypto.subtle.verify returns true for the signed header.payload", async () => {
+    // Arrange
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [headerB64url, payloadB64url, sigB64url] = token.split(".");
+    const signingInput = new TextEncoder().encode(`${headerB64url}.${payloadB64url}`);
+
+    // Decode signature from base64url back to bytes
+    const sigBytes = Uint8Array.from(atob(b64urlToB64(sigB64url)), (c) =>
+      c.charCodeAt(0),
+    );
+
+    // Act
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pubKey,
+      sigBytes,
+      signingInput,
+    );
+
+    // Assert
+    expect(valid).toBe(true);
+  });
+
+  it("crypto.subtle.verify returns false when payload is tampered", async () => {
+    // Arrange
+    const token = await signAppJwt("123456", privKey, 1_700_000_000);
+    const [headerB64url, , sigB64url] = token.split(".");
+
+    // Tamper: use a different payload (different iat/exp)
+    const tamperedPayload = { iss: "123456", iat: 0, exp: 9_999_999_999 };
+    const tamperedPayloadB64url = btoa(JSON.stringify(tamperedPayload))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const signingInput = new TextEncoder().encode(
+      `${headerB64url}.${tamperedPayloadB64url}`,
+    );
+
+    const sigBytes = Uint8Array.from(atob(b64urlToB64(sigB64url)), (c) =>
+      c.charCodeAt(0),
+    );
+
+    // Act
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pubKey,
+      sigBytes,
+      signingInput,
+    );
+
+    // Assert
+    expect(valid).toBe(false);
+  });
+
+  it("deleting the signing step (zeroed signature) makes verify return false — negative guard test", async () => {
+    // Arrange — build the header.payload manually but use a zeroed-out 256-byte signature
+    const headerB64url = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const payloadB64url = btoa(JSON.stringify({ iss: "123456", iat: 1_699_999_940, exp: 1_700_000_540 }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const signingInput = new TextEncoder().encode(`${headerB64url}.${payloadB64url}`);
+    const zeroedSig = new Uint8Array(256); // all zeros — not a real RSA signature
+
+    // Act
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      pubKey,
+      zeroedSig,
+      signingInput,
+    );
+
+    // Assert — a zeroed signature must NOT verify (confirms guard is meaningful)
+    expect(valid).toBe(false);
+  });
+});

--- a/worker/src/auth/jwt.ts
+++ b/worker/src/auth/jwt.ts
@@ -1,0 +1,64 @@
+/**
+ * GitHub App JWT signing — RS256 / RSASSA-PKCS1-v1_5 via Web Crypto.
+ *
+ * Uses only ambient globals (crypto.subtle, TextEncoder, btoa, atob) —
+ * no Node.js imports, compatible with both the Cloudflare Workers runtime
+ * and the vitest test environment.
+ */
+
+/**
+ * Encode a string or ArrayBuffer as base64url (no padding, URL-safe chars).
+ * - Strings are encoded directly via btoa.
+ * - ArrayBuffers are converted to binary string first.
+ */
+function b64url(input: string | ArrayBuffer): string {
+  let b64: string;
+  if (typeof input === "string") {
+    b64 = btoa(input);
+  } else {
+    b64 = btoa(String.fromCharCode(...new Uint8Array(input)));
+  }
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Import a base64-encoded PKCS#8 DER private key for use with RS256.
+ *
+ * @param b64Pkcs8Der - base64 (standard, not base64url) encoding of the PKCS#8 DER bytes.
+ * @returns A non-extractable CryptoKey with the "sign" usage.
+ */
+export async function importAppPrivateKey(b64Pkcs8Der: string): Promise<CryptoKey> {
+  const derBytes = Uint8Array.from(atob(b64Pkcs8Der), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "pkcs8",
+    derBytes,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+/**
+ * Sign a GitHub App JWT using RS256.
+ *
+ * @param appId  - GitHub App numeric ID (becomes the `iss` claim).
+ * @param key    - Private CryptoKey returned by importAppPrivateKey.
+ * @param nowSec - Unix timestamp in seconds (defaults to current time).
+ * @returns Compact serialized JWT: `<header>.<payload>.<signature>` (all base64url).
+ */
+export async function signAppJwt(
+  appId: string,
+  key: CryptoKey,
+  nowSec?: number,
+): Promise<string> {
+  const now = nowSec ?? Math.floor(Date.now() / 1000);
+
+  const headerB64 = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payloadB64 = b64url(JSON.stringify({ iss: appId, iat: now - 60, exp: now + 540 }));
+
+  const signingInput = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+  const sigBuffer = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, signingInput);
+  const sigB64 = b64url(sigBuffer);
+
+  return `${headerB64}.${payloadB64}.${sigB64}`;
+}

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -95,7 +95,6 @@ function makeEnv(db: D1Database): Env {
   return {
     DB: db,
     ASSETS: {} as Fetcher,
-    GITHUB_TOKEN: "gh-token",
     GITHUB_ORG: "Roxabi",
     GITHUB_WEBHOOK_SECRET: "webhook-secret",
     GITHUB_APP_ID: "12345",

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -1,0 +1,1044 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { loginRoute, callbackRoute } from "./oauth";
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from src/webhook/mutations.test.ts
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements produced via bind() calls on the FakeDb. */
+function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/**
+ * Build a FakeD1 whose prepare().bind().first() returns the given row the first
+ * time it is called, then null thereafter. Used to model single-use state lookup.
+ */
+function captureDbWithFirstRow(
+  firstRowBySql: Map<string, FakeResult | null>,
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const callCounts = new Map<string, number>();
+  const db = makeFakeDb((sql, args) => {
+    const count = callCounts.get(sql) ?? 0;
+    callCounts.set(sql, count + 1);
+    const rowForSql = firstRowBySql.get(sql);
+    // Return the configured row only on the first call with this SQL.
+    const row = count === 0 ? (rowForSql ?? null) : null;
+    const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
+    // Override first() to return the per-call row.
+    (stmt as { first: <T>() => Promise<T | null> }).first = vi
+      .fn()
+      .mockResolvedValue(row);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal Env stub — only the fields needed for OAuth routes. */
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: {} as Fetcher,
+    GITHUB_TOKEN: "gh-token",
+    GITHUB_ORG: "Roxabi",
+    GITHUB_WEBHOOK_SECRET: "webhook-secret",
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_CLIENT_ID: "Iv1.abc123",
+    GITHUB_APP_CLIENT_SECRET: "secret-xyz",
+    GITHUB_APP_PRIVATE_KEY: "base64privkey",
+    GITHUB_APP_WEBHOOK_SECRET: "app-webhook-secret",
+  } as unknown as Env;
+}
+
+/** Mount the login and callback routes on a throwaway Hono app. */
+function makeApp(db: D1Database) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.get("/login", loginRoute);
+  app.get("/oauth/callback", callbackRoute);
+  const env = makeEnv(db);
+  return { app, env };
+}
+
+// ---------------------------------------------------------------------------
+// loginRoute
+// ---------------------------------------------------------------------------
+
+describe("loginRoute", () => {
+  describe("GET /login", () => {
+    it("returns 302 redirect", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(302);
+    });
+
+    it("Location starts with https://github.com/login/oauth/authorize", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      expect(location).toMatch(/^https:\/\/github\.com\/login\/oauth\/authorize/);
+    });
+
+    it("Location query includes client_id matching env", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      const url = new URL(location);
+      expect(url.searchParams.get("client_id")).toBe("Iv1.abc123");
+    });
+
+    it("Location query includes state as 32 hex chars", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      const url = new URL(location);
+      const state = url.searchParams.get("state") ?? "";
+      expect(state).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("Location redirect_uri ends with /oauth/callback derived from request origin", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://myapp.example.com/login",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const location = res.headers.get("Location") ?? "";
+      const url = new URL(location);
+      const redirectUri = url.searchParams.get("redirect_uri") ?? "";
+      expect(redirectUri).toMatch(/\/oauth\/callback$/);
+      expect(redirectUri).toContain("myapp.example.com");
+    });
+
+    it("oauth_state INSERT SQL contains '+10 minutes' for expiry", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request("http://localhost/login", { method: "GET" }, env);
+
+      // Assert — state row has datetime('now', '+10 minutes')
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.sql).toContain("+10 minutes");
+    });
+
+    it("oauth_state INSERT binds [state, redirectAfter] in that order", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request("http://localhost/login", { method: "GET" }, env);
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      // args[0] = state (32 hex), args[1] = redirectAfter
+      expect(insertStmt!.args[0]).toMatch(/^[0-9a-f]{32}$/);
+      expect(insertStmt!.args[1]).toBe("/"); // default when no ?redirect param
+    });
+
+    it("?redirect=/dash stores '/dash' as redirect_after", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=/dash",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/dash");
+    });
+
+    it("?redirect=//evil stores '/' (open-redirect guard)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=//evil",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+
+    it("?redirect=https://evil stores '/' (absolute URL guard)", async () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=https://evil",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// callbackRoute
+// ---------------------------------------------------------------------------
+
+describe("callbackRoute", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("missing parameters", () => {
+    it("returns 400 when code is missing", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?state=abc123",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when state is missing", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?code=somecode",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when both code and state are missing", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("unknown or expired state", () => {
+    it("returns 400 when state lookup returns null (unknown state)", async () => {
+      // Arrange — FakeD1 first() returns null for oauth_state lookup
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?code=code1&state=unknownstate000000000000000000",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("happy path — user has installations", () => {
+    function stubFetchSequence(
+      accessToken: string,
+      user: { id: number; login: string },
+      installations: Array<{ id: number; account: { login: string; type: string } }>,
+    ) {
+      let callCount = 0;
+      const mockFetch = vi.fn(async (url: string, _init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          // Token exchange
+          return new Response(
+            JSON.stringify({ access_token: accessToken }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        } else if (callCount === 2) {
+          // /user
+          return new Response(JSON.stringify(user), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        } else {
+          // /user/installations
+          return new Response(JSON.stringify({ installations }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      });
+      vi.stubGlobal("fetch", mockFetch);
+      return mockFetch;
+    }
+
+    it("issues DELETE FROM oauth_state to consume state single-use", async () => {
+      // Arrange
+      const stateValue = "a".repeat(32);
+      const stateRowBySql = new Map<string, FakeResult | null>([
+        [
+          // The SELECT that looks up the state row — matched via substring
+          "SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')",
+          { redirect_after: "/" } as FakeResult,
+        ],
+      ]);
+      // Use a flexible factory so ANY sql with oauth_state SELECT returns the row
+      const captured: FakeStmt[] = [];
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+
+        // For users RETURNING id, return a row with id
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        // For tenants RETURNING id
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        // For sessions INSERT
+        const isSessionInsert =
+          sql.toLowerCase().includes("sessions") &&
+          sql.toLowerCase().includes("insert");
+
+        const rows = isOauthSelect
+          ? (row ? [row] : [])
+          : isUsersInsert
+            ? (usersRow ? [usersRow] : [])
+            : isTenantsInsert
+              ? (tenantsRow ? [tenantsRow] : [])
+              : [];
+
+        const stmt = makeFakeStmt(sql, args, rows, 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — a DELETE FROM oauth_state statement was issued
+      const deleteStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("delete") &&
+          s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(deleteStmt).toBeDefined();
+    });
+
+    it("issues users upsert with ON CONFLICT(github_id)", async () => {
+      // Arrange
+      const stateValue = "b".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const usersStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("users") &&
+          s.sql.toUpperCase().includes("ON CONFLICT(github_id)".toUpperCase()),
+      );
+      expect(usersStmt).toBeDefined();
+      expect(usersStmt!.sql).toContain("ON CONFLICT(github_id)");
+    });
+
+    it("issues tenants upsert with ON CONFLICT(installation_id)", async () => {
+      // Arrange
+      const stateValue = "c".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const tenantsStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("tenants") &&
+          s.sql.toUpperCase().includes("ON CONFLICT(installation_id)".toUpperCase()),
+      );
+      expect(tenantsStmt).toBeDefined();
+      expect(tenantsStmt!.sql).toContain("ON CONFLICT(installation_id)");
+    });
+
+    it("issues user_installations INSERT", async () => {
+      // Arrange
+      const stateValue = "d".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      const uiStmt = captured.find((s) =>
+        s.sql.toLowerCase().includes("user_installations"),
+      );
+      expect(uiStmt).toBeDefined();
+    });
+
+    it("returns 302 with Set-Cookie __Host-session containing HttpOnly Secure SameSite=Strict Path=/ and NO Domain", async () => {
+      // Arrange
+      const stateValue = "e".repeat(32);
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, _args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, _args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        } else if (isTenantsInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(tenantsRow);
+        }
+        return stmt;
+      });
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(302);
+      const cookie = res.headers.get("Set-Cookie") ?? "";
+      expect(cookie).toContain("__Host-session=");
+      expect(cookie).toContain("HttpOnly");
+      expect(cookie).toContain("Secure");
+      expect(cookie).toContain("SameSite=Strict");
+      expect(cookie).toContain("Path=/");
+      expect(cookie).not.toContain("Domain");
+    });
+  });
+
+  describe("replay attack — state already consumed (first()→null on 2nd call)", () => {
+    it("returns 400 on replay (state gone after first use)", async () => {
+      // Arrange — state row returns null (simulating already-consumed state)
+      const { db } = captureDb();
+      const { app, env } = makeApp(db);
+      // captureDb returns null for first() by default — models "state not found"
+
+      // Act
+      const res = await app.request(
+        "http://localhost/oauth/callback?code=replaycode&state=aaaa0000bbbb1111cccc2222dddd3333",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — state is unknown (null row) → 400
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("zero installations", () => {
+    it("returns 302 to GitHub app install page when installations is empty", async () => {
+      // Arrange
+      const stateValue = "f".repeat(32);
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, _args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, _args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        return stmt;
+      });
+
+      // Stub fetch with empty installations
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok" }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          } else if (fetchCallCount === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [] }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location") ?? "";
+      expect(location).toContain("github.com/apps/");
+      expect(location).toContain("installations/new");
+    });
+
+    it("does NOT set a session cookie when installations is empty", async () => {
+      // Arrange
+      const stateValue = "0".repeat(32);
+      let oauthSelectCallCount = 0;
+      const db = makeFakeDb((sql, _args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, _args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        return stmt;
+      });
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (fetchCallCount === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [] }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — no Set-Cookie header when no installations
+      expect(res.headers.get("Set-Cookie")).toBeNull();
+    });
+
+    it("does NOT insert a session row when installations is empty", async () => {
+      // Arrange
+      const stateValue = "1".repeat(32);
+      let oauthSelectCallCount = 0;
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isOauthSelect =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("select");
+        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+        const row =
+          isOauthSelect && oauthSelectCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthSelect) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (fetchCallCount === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [] }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — no INSERT INTO sessions statement
+      const sessionsInsert = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("sessions") &&
+          s.sql.toLowerCase().includes("insert"),
+      );
+      expect(sessionsInsert).toBeUndefined();
+    });
+  });
+});

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -86,32 +86,6 @@ function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
   return { db, stmts: () => captured };
 }
 
-/**
- * Build a FakeD1 whose prepare().bind().first() returns the given row the first
- * time it is called, then null thereafter. Used to model single-use state lookup.
- */
-function captureDbWithFirstRow(
-  firstRowBySql: Map<string, FakeResult | null>,
-): { db: D1Database; stmts: () => FakeStmt[] } {
-  const captured: FakeStmt[] = [];
-  const callCounts = new Map<string, number>();
-  const db = makeFakeDb((sql, args) => {
-    const count = callCounts.get(sql) ?? 0;
-    callCounts.set(sql, count + 1);
-    const rowForSql = firstRowBySql.get(sql);
-    // Return the configured row only on the first call with this SQL.
-    const row = count === 0 ? (rowForSql ?? null) : null;
-    const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
-    // Override first() to return the per-call row.
-    (stmt as { first: <T>() => Promise<T | null> }).first = vi
-      .fn()
-      .mockResolvedValue(row);
-    captured.push(stmt);
-    return stmt;
-  });
-  return { db, stmts: () => captured };
-}
-
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -330,6 +304,66 @@ describe("loginRoute", () => {
       expect(insertStmt).toBeDefined();
       expect(insertStmt!.args[1]).toBe("/");
     });
+
+    it("?redirect=/\\evil stores '/' (backslash bypass guard)", async () => {
+      // Arrange — backslash-prefixed path; sanitizeRedirect regex (?![/\\]) rejects it
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        "http://localhost/login?redirect=/\\evil",
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the /[/\\]/ check in sanitizeRedirect would let "/\evil" pass
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+
+    it("?redirect=/ok\\r\\nX-Injected:x stores '/' (CRLF injection guard)", async () => {
+      // Arrange — CRLF chars smuggled in the redirect param; sanitizeRedirect rejects via /[\r\n\0]/
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act — encodeURIComponent so the URL parser doesn't strip the special chars
+      await app.request(
+        "http://localhost/login?redirect=" + encodeURIComponent("/ok\r\nX-Injected: x"),
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the /[\r\n\0]/ check in sanitizeRedirect would let the injection through
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
+
+    it("?redirect=/ok\\0null stores '/' (NUL injection guard)", async () => {
+      // Arrange — NUL byte smuggled in the redirect param; sanitizeRedirect rejects via /[\r\n\0]/
+      const { db, stmts } = captureDb();
+      const { app, env } = makeApp(db);
+
+      // Act — encodeURIComponent so the URL parser doesn't strip the NUL byte
+      await app.request(
+        "http://localhost/login?redirect=" + encodeURIComponent("/ok\0null"),
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the /[\r\n\0]/ check in sanitizeRedirect would let the NUL through
+      const insertStmt = stmts().find((s) =>
+        s.sql.toLowerCase().includes("oauth_state"),
+      );
+      expect(insertStmt).toBeDefined();
+      expect(insertStmt!.args[1]).toBe("/");
+    });
   });
 });
 
@@ -450,7 +484,7 @@ describe("callbackRoute", () => {
      * Build a FakeD1 for happy-path callback tests.
      * State consumption is now a DELETE...RETURNING (detected via "delete" + "oauth_state").
      */
-    function makeHappyPathDb(captured: FakeStmt[]): D1Database {
+    function makeHappyPathDb(captured: FakeStmt[], redirectAfter = "/"): D1Database {
       let oauthDeleteCallCount = 0;
       return makeFakeDb((sql, args) => {
         const isOauthDelete =
@@ -459,7 +493,7 @@ describe("callbackRoute", () => {
         oauthDeleteCallCount += isOauthDelete ? 1 : 0;
         const row =
           isOauthDelete && oauthDeleteCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
+            ? ({ redirect_after: redirectAfter } as FakeResult)
             : null;
 
         // For users RETURNING id, return a row with id
@@ -653,6 +687,34 @@ describe("callbackRoute", () => {
       expect(cookie).toContain("SameSite=Strict");
       expect(cookie).toContain("Path=/");
       expect(cookie).not.toContain("Domain");
+    });
+
+    it("redirects to redirect_after from state row when it is '/dashboard'", async () => {
+      // Arrange — state row returns redirect_after: "/dashboard"
+      const stateValue = "f".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured, "/dashboard");
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — Location must reflect the stored redirect_after, not the hardcoded "/"
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard");
+      const cookie = res.headers.get("Set-Cookie") ?? "";
+      expect(cookie).toContain("__Host-session=");
     });
   });
 
@@ -848,6 +910,47 @@ describe("callbackRoute", () => {
       );
 
       // Assert
+      expect(res.status).toBe(502);
+    });
+
+    it("returns 502 when /user/installations fetch returns non-ok status", async () => {
+      // Arrange — token exchange + /user succeed but /user/installations returns 500
+      const { db } = makeStateOnlyDb();
+      const stateValue = "a".repeat(32);
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            // Token exchange succeeds
+            return new Response(
+              JSON.stringify({ access_token: "tok-abc" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (fetchCallCount === 2) {
+            // /user succeeds
+            return new Response(
+              JSON.stringify({ id: 1, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          // /user/installations returns 500
+          return new Response("Internal Server Error", { status: 500 });
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=goodcode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — deleting the if (!installRes.ok) guard would let the route parse a 500 body
       expect(res.status).toBe(502);
     });
   });

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -394,7 +394,7 @@ describe("callbackRoute", () => {
 
   describe("unknown or expired state", () => {
     it("returns 400 when state lookup returns null (unknown state)", async () => {
-      // Arrange — FakeD1 first() returns null for oauth_state lookup
+      // Arrange — FakeD1 first() returns null for oauth_state DELETE...RETURNING
       const { db } = captureDb();
       const { app, env } = makeApp(db);
 
@@ -446,26 +446,19 @@ describe("callbackRoute", () => {
       return mockFetch;
     }
 
-    it("issues DELETE FROM oauth_state to consume state single-use", async () => {
-      // Arrange
-      const stateValue = "a".repeat(32);
-      const stateRowBySql = new Map<string, FakeResult | null>([
-        [
-          // The SELECT that looks up the state row — matched via substring
-          "SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')",
-          { redirect_after: "/" } as FakeResult,
-        ],
-      ]);
-      // Use a flexible factory so ANY sql with oauth_state SELECT returns the row
-      const captured: FakeStmt[] = [];
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
+    /**
+     * Build a FakeD1 for happy-path callback tests.
+     * State consumption is now a DELETE...RETURNING (detected via "delete" + "oauth_state").
+     */
+    function makeHappyPathDb(captured: FakeStmt[]): D1Database {
+      let oauthDeleteCallCount = 0;
+      return makeFakeDb((sql, args) => {
+        const isOauthDelete =
           sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+          sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
         const row =
-          isOauthSelect && oauthSelectCallCount === 1
+          isOauthDelete && oauthDeleteCallCount === 1
             ? ({ redirect_after: "/" } as FakeResult)
             : null;
 
@@ -481,12 +474,7 @@ describe("callbackRoute", () => {
           sql.toLowerCase().includes("returning");
         const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
 
-        // For sessions INSERT
-        const isSessionInsert =
-          sql.toLowerCase().includes("sessions") &&
-          sql.toLowerCase().includes("insert");
-
-        const rows = isOauthSelect
+        const rows = isOauthDelete
           ? (row ? [row] : [])
           : isUsersInsert
             ? (usersRow ? [usersRow] : [])
@@ -495,7 +483,7 @@ describe("callbackRoute", () => {
               : [];
 
         const stmt = makeFakeStmt(sql, args, rows, 0);
-        if (isOauthSelect) {
+        if (isOauthDelete) {
           (stmt as { first: <T>() => Promise<T | null> }).first = vi
             .fn()
             .mockResolvedValue(row);
@@ -511,6 +499,13 @@ describe("callbackRoute", () => {
         captured.push(stmt);
         return stmt;
       });
+    }
+
+    it("uses atomic DELETE...RETURNING to consume state (closes TOCTOU)", async () => {
+      // Arrange
+      const stateValue = "a".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -527,55 +522,22 @@ describe("callbackRoute", () => {
         env,
       );
 
-      // Assert — a DELETE FROM oauth_state statement was issued
+      // Assert — a DELETE FROM oauth_state statement was issued (the atomic consume)
       const deleteStmt = captured.find(
         (s) =>
           s.sql.toLowerCase().includes("delete") &&
           s.sql.toLowerCase().includes("oauth_state"),
       );
       expect(deleteStmt).toBeDefined();
+      // It must also have RETURNING (atomic, not a separate DELETE)
+      expect(deleteStmt!.sql.toUpperCase()).toContain("RETURNING");
     });
 
     it("issues users upsert with ON CONFLICT(github_id)", async () => {
       // Arrange
       const stateValue = "b".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -605,43 +567,8 @@ describe("callbackRoute", () => {
     it("issues tenants upsert with ON CONFLICT(installation_id)", async () => {
       // Arrange
       const stateValue = "c".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -671,43 +598,8 @@ describe("callbackRoute", () => {
     it("issues user_installations INSERT", async () => {
       // Arrange
       const stateValue = "d".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -734,41 +626,8 @@ describe("callbackRoute", () => {
     it("returns 302 with Set-Cookie __Host-session containing HttpOnly Secure SameSite=Strict Path=/ and NO Domain", async () => {
       // Arrange
       const stateValue = "e".repeat(32);
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, _args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-        const isTenantsInsert =
-          sql.toLowerCase().includes("tenants") &&
-          sql.toLowerCase().includes("returning");
-        const tenantsRow = isTenantsInsert ? ({ id: 10 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, _args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        } else if (isTenantsInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(tenantsRow);
-        }
-        return stmt;
-      });
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
 
       stubFetchSequence(
         "t",
@@ -797,37 +656,216 @@ describe("callbackRoute", () => {
     });
   });
 
-  describe("replay attack — state already consumed (first()→null on 2nd call)", () => {
-    it("returns 400 on replay (state gone after first use)", async () => {
-      // Arrange — state row returns null (simulating already-consumed state)
-      const { db } = captureDb();
-      const { app, env } = makeApp(db);
-      // captureDb returns null for first() by default — models "state not found"
+  describe("replay attack — behavioral single-use enforcement", () => {
+    it("first request mints session (302 + Set-Cookie); second with same state returns 400", async () => {
+      // Arrange — FakeD1 whose state-consume DELETE...RETURNING returns a row
+      // on the first call and null on the second (simulating row deleted by first request).
+      const stateValue = "aaaa0000bbbb1111cccc2222dddd3333";
+      const atomicDeleteSql =
+        `DELETE FROM oauth_state WHERE state = ? AND expires_at > datetime('now') RETURNING redirect_after`;
 
-      // Act
-      const res = await app.request(
-        "http://localhost/oauth/callback?code=replaycode&state=aaaa0000bbbb1111cccc2222dddd3333",
+      let atomicDeleteCallCount = 0;
+
+      const captured: FakeStmt[] = [];
+      const db = makeFakeDb((sql, args) => {
+        const isAtomicDelete = sql.trim() === atomicDeleteSql.trim() ||
+          (sql.toLowerCase().includes("delete") &&
+            sql.toLowerCase().includes("oauth_state") &&
+            sql.toLowerCase().includes("returning"));
+
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") &&
+          sql.toLowerCase().includes("returning");
+        const isTenantsInsert =
+          sql.toLowerCase().includes("tenants") &&
+          sql.toLowerCase().includes("returning");
+
+        let row: FakeResult | null = null;
+        if (isAtomicDelete) {
+          atomicDeleteCallCount++;
+          row = atomicDeleteCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        } else if (isUsersInsert) {
+          row = { id: 1 } as FakeResult;
+        } else if (isTenantsInsert) {
+          row = { id: 10 } as FakeResult;
+        }
+
+        const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
+        (stmt as { first: <T>() => Promise<T | null> }).first = vi
+          .fn()
+          .mockResolvedValue(row);
+        captured.push(stmt);
+        return stmt;
+      });
+
+      // Stub fetch so both calls hit GitHub APIs successfully
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string) => {
+          fetchCallCount++;
+          // Cycle through token → user → installations for each OAuth callback
+          const pos = ((fetchCallCount - 1) % 3) + 1;
+          if (pos === 1) {
+            return new Response(
+              JSON.stringify({ access_token: "tok-abc" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else if (pos === 2) {
+            return new Response(
+              JSON.stringify({ id: 42, login: "alice" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          } else {
+            return new Response(
+              JSON.stringify({ installations: [{ id: 9, account: { login: "Roxabi", type: "Organization" } }] }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act — first call
+      const res1 = await app.request(
+        `http://localhost/oauth/callback?code=code1&state=${stateValue}`,
         { method: "GET" },
         env,
       );
 
-      // Assert — state is unknown (null row) → 400
+      // Act — second call with the same state (simulates replay)
+      const res2 = await app.request(
+        `http://localhost/oauth/callback?code=code2&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — first request succeeds with session cookie
+      expect(res1.status).toBe(302);
+      expect(res1.headers.get("Set-Cookie")).toContain("__Host-session=");
+
+      // Assert — second request fails (state row gone after first consume)
+      expect(res2.status).toBe(400);
+    });
+  });
+
+  describe("F1 — GitHub token / API error handling", () => {
+    /**
+     * Build a FakeD1 that successfully returns a state row (for state consume)
+     * but returns null for all other first() calls (sessions, etc.).
+     */
+    function makeStateOnlyDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+      const captured: FakeStmt[] = [];
+      let oauthDeleteCallCount = 0;
+      const db = makeFakeDb((sql, args) => {
+        const isOauthDelete =
+          sql.toLowerCase().includes("oauth_state") &&
+          sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
+        const row =
+          isOauthDelete && oauthDeleteCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+
+        const stmt = makeFakeStmt(sql, args, row !== null ? [row] : [], 0);
+        (stmt as { first: <T>() => Promise<T | null> }).first = vi
+          .fn()
+          .mockResolvedValue(row);
+        captured.push(stmt);
+        return stmt;
+      });
+      return { db, stmts: () => captured };
+    }
+
+    it("returns 400 when token endpoint returns {error} with no access_token", async () => {
+      // Arrange — GitHub returns HTTP 200 with error body (standard OAuth error shape)
+      const { db, stmts } = makeStateOnlyDb();
+      const stateValue = "e".repeat(32);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(
+            JSON.stringify({ error: "bad_verification_code" }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=badcode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
       expect(res.status).toBe(400);
+
+      // No INSERT INTO sessions should have been executed
+      const sessionsInsert = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("sessions") &&
+          s.sql.toLowerCase().includes("insert"),
+      );
+      expect(sessionsInsert).toBeUndefined();
+    });
+
+    it("returns 502 when /user fetch returns non-ok status", async () => {
+      // Arrange — token exchange succeeds but /user returns 401
+      const { db } = makeStateOnlyDb();
+      const stateValue = "f".repeat(32);
+
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            // Token exchange succeeds
+            return new Response(
+              JSON.stringify({ access_token: "tok-xyz" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          // /user returns 401
+          return new Response("Unauthorized", { status: 401 });
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+
+      // Act
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=goodcode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(502);
     });
   });
 
   describe("zero installations", () => {
-    it("returns 302 to GitHub app install page when installations is empty", async () => {
-      // Arrange
-      const stateValue = "f".repeat(32);
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, _args) => {
-        const isOauthSelect =
+    /**
+     * Build a FakeD1 for zero-installation tests.
+     * Tracks whether INSERT INTO users was ever called.
+     */
+    function makeZeroInstallDb(captured: FakeStmt[]): D1Database {
+      let oauthDeleteCallCount = 0;
+      return makeFakeDb((sql, args) => {
+        const isOauthDelete =
           sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
+          sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
         const row =
-          isOauthSelect && oauthSelectCallCount === 1
+          isOauthDelete && oauthDeleteCallCount === 1
             ? ({ redirect_after: "/" } as FakeResult)
             : null;
         const isUsersInsert =
@@ -835,8 +873,8 @@ describe("callbackRoute", () => {
           sql.toLowerCase().includes("returning");
         const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
 
-        const stmt = makeFakeStmt(sql, _args, [], 0);
-        if (isOauthSelect) {
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthDelete) {
           (stmt as { first: <T>() => Promise<T | null> }).first = vi
             .fn()
             .mockResolvedValue(row);
@@ -845,10 +883,12 @@ describe("callbackRoute", () => {
             .fn()
             .mockResolvedValue(usersRow);
         }
+        captured.push(stmt);
         return stmt;
       });
+    }
 
-      // Stub fetch with empty installations
+    function stubZeroInstallFetch() {
       let fetchCallCount = 0;
       vi.stubGlobal(
         "fetch",
@@ -881,7 +921,14 @@ describe("callbackRoute", () => {
           }
         }),
       );
+    }
 
+    it("returns 302 to GitHub app install page when installations is empty", async () => {
+      // Arrange
+      const stateValue = "f".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
       const { app, env } = makeApp(db);
 
       // Act
@@ -901,58 +948,9 @@ describe("callbackRoute", () => {
     it("does NOT set a session cookie when installations is empty", async () => {
       // Arrange
       const stateValue = "0".repeat(32);
-      let oauthSelectCallCount = 0;
-      const db = makeFakeDb((sql, _args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, _args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        }
-        return stmt;
-      });
-
-      let fetchCallCount = 0;
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (_url: string) => {
-          fetchCallCount++;
-          if (fetchCallCount === 1) {
-            return new Response(
-              JSON.stringify({ access_token: "tok" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else if (fetchCallCount === 2) {
-            return new Response(
-              JSON.stringify({ id: 42, login: "alice" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else {
-            return new Response(
-              JSON.stringify({ installations: [] }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          }
-        }),
-      );
-
+      const captured: FakeStmt[] = [];
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
       const { app, env } = makeApp(db);
 
       // Act
@@ -969,60 +967,9 @@ describe("callbackRoute", () => {
     it("does NOT insert a session row when installations is empty", async () => {
       // Arrange
       const stateValue = "1".repeat(32);
-      let oauthSelectCallCount = 0;
       const captured: FakeStmt[] = [];
-      const db = makeFakeDb((sql, args) => {
-        const isOauthSelect =
-          sql.toLowerCase().includes("oauth_state") &&
-          sql.toLowerCase().includes("select");
-        oauthSelectCallCount += isOauthSelect ? 1 : 0;
-        const row =
-          isOauthSelect && oauthSelectCallCount === 1
-            ? ({ redirect_after: "/" } as FakeResult)
-            : null;
-        const isUsersInsert =
-          sql.toLowerCase().includes("users") &&
-          sql.toLowerCase().includes("returning");
-        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
-
-        const stmt = makeFakeStmt(sql, args, [], 0);
-        if (isOauthSelect) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(row);
-        } else if (isUsersInsert) {
-          (stmt as { first: <T>() => Promise<T | null> }).first = vi
-            .fn()
-            .mockResolvedValue(usersRow);
-        }
-        captured.push(stmt);
-        return stmt;
-      });
-
-      let fetchCallCount = 0;
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (_url: string) => {
-          fetchCallCount++;
-          if (fetchCallCount === 1) {
-            return new Response(
-              JSON.stringify({ access_token: "tok" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else if (fetchCallCount === 2) {
-            return new Response(
-              JSON.stringify({ id: 42, login: "alice" }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          } else {
-            return new Response(
-              JSON.stringify({ installations: [] }),
-              { status: 200, headers: { "Content-Type": "application/json" } },
-            );
-          }
-        }),
-      );
-
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
       const { app, env } = makeApp(db);
 
       // Act
@@ -1039,6 +986,31 @@ describe("callbackRoute", () => {
           s.sql.toLowerCase().includes("insert"),
       );
       expect(sessionsInsert).toBeUndefined();
+    });
+
+    it("F4 — does NOT insert a user row when installations is empty (no ghost users)", async () => {
+      // Arrange — F4: user upsert must happen AFTER the install check, so zero
+      // installations must never produce an INSERT INTO users.
+      const stateValue = "2".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeZeroInstallDb(captured);
+      stubZeroInstallFetch();
+      const { app, env } = makeApp(db);
+
+      // Act
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      // Assert — no INSERT INTO users statement was executed
+      const usersInsert = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("insert") &&
+          s.sql.toLowerCase().includes("users"),
+      );
+      expect(usersInsert).toBeUndefined();
     });
   });
 });

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -19,10 +19,11 @@ import { mintSession, sessionCookie } from "./session";
 /**
  * Validate a `redirect` query parameter as a safe relative path.
  * Accepts paths starting with "/" but not "//" (open-redirect via protocol-
- * relative URLs) and rejects anything that is not a plain relative path.
+ * relative URLs), not starting with "/\" (backslash bypass), and rejects
+ * CRLF / NUL injection.
  */
 function sanitizeRedirect(raw: string | undefined): string {
-  if (raw && /^\/(?!\/)/.test(raw)) return raw;
+  if (raw && /^\/(?![/\\])/.test(raw) && !/[\r\n\0]/.test(raw)) return raw;
   return "/";
 }
 
@@ -90,11 +91,11 @@ export async function loginRoute(
  * GitHub redirects here after the user authorises (or denies) the app.
  * Flow:
  *   1. Validate code + state params.
- *   2. Consume state single-use (SELECT then DELETE).
+ *   2. Consume state — atomic single-use DELETE ... RETURNING (closes TOCTOU).
  *   3. Exchange code for access_token.
  *   4. Fetch /user and /user/installations.
- *   5. Upsert user → tenants → user_installations.
- *   6. If no installations → redirect to app install page (no session).
+ *   5. If no installations → redirect to app install page (no DB write, no session).
+ *   6. Upsert user → tenants → user_installations.
  *   7. Mint session tied to first installation, set __Host-session cookie.
  */
 export async function callbackRoute(
@@ -107,9 +108,9 @@ export async function callbackRoute(
     return c.json({ error: "bad_request" }, 400);
   }
 
-  // Consume state — single-use: SELECT (with expiry guard) then DELETE
+  // Consume state — single-use + expiry guard in one atomic statement (closes TOCTOU)
   const stateRow = await c.env.DB.prepare(
-    `SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')`,
+    `DELETE FROM oauth_state WHERE state = ? AND expires_at > datetime('now') RETURNING redirect_after`,
   )
     .bind(state)
     .first<{ redirect_after: string | null }>();
@@ -117,10 +118,6 @@ export async function callbackRoute(
   if (!stateRow) {
     return c.json({ error: "bad_request" }, 400);
   }
-
-  await c.env.DB.prepare(`DELETE FROM oauth_state WHERE state = ?`)
-    .bind(state)
-    .run();
 
   const redirectAfter = stateRow.redirect_after ?? "/";
 
@@ -146,9 +143,15 @@ export async function callbackRoute(
       }),
     },
   );
-  const { access_token } = (await tokenRes.json()) as {
-    access_token: string;
-  };
+
+  if (!tokenRes.ok) {
+    return c.json({ error: "oauth_failed" }, 502);
+  }
+  const tokenBody = (await tokenRes.json()) as { access_token?: string; error?: string };
+  if (tokenBody.error || !tokenBody.access_token) {
+    return c.json({ error: "oauth_failed" }, 400);
+  }
+  const access_token = tokenBody.access_token;
 
   const ghHeaders = {
     Authorization: `Bearer ${access_token}`,
@@ -160,6 +163,9 @@ export async function callbackRoute(
   const userRes = await fetch("https://api.github.com/user", {
     headers: ghHeaders,
   });
+  if (!userRes.ok) {
+    return c.json({ error: "github_unavailable" }, 502);
+  }
   const ghUser = (await userRes.json()) as { id: number; login: string };
 
   // Fetch user installations
@@ -167,12 +173,25 @@ export async function callbackRoute(
     "https://api.github.com/user/installations",
     { headers: ghHeaders },
   );
+  if (!installRes.ok) {
+    return c.json({ error: "github_unavailable" }, 502);
+  }
   const { installations } = (await installRes.json()) as {
     installations: Array<{
       id: number;
       account: { login: string; type: string };
     }>;
   };
+
+  // No installations — redirect to app install page, no session, no DB write
+  if (installations.length === 0) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: "https://github.com/apps/roxabi-live/installations/new",
+      },
+    });
+  }
 
   // Upsert user — get internal id
   const userRow = await c.env.DB.prepare(
@@ -183,17 +202,10 @@ export async function callbackRoute(
     .bind(ghUser.id, ghUser.login)
     .first<{ id: number }>();
 
-  const userId = userRow!.id;
-
-  // No installations — redirect to app install page, no session
-  if (installations.length === 0) {
-    return new Response(null, {
-      status: 302,
-      headers: {
-        Location: "https://github.com/apps/roxabi-live/installations/new",
-      },
-    });
+  if (!userRow) {
+    return c.json({ error: "db_error" }, 500);
   }
+  const userId = userRow.id;
 
   // Upsert each installation as a tenant and link to user
   let firstTenantId: number | null = null;
@@ -208,7 +220,10 @@ export async function callbackRoute(
       .bind(inst.id, inst.account.login, inst.account.type)
       .first<{ id: number }>();
 
-    const tenantId = tenantRow!.id;
+    if (!tenantRow) {
+      return c.json({ error: "db_error" }, 500);
+    }
+    const tenantId = tenantRow.id;
 
     await c.env.DB.prepare(
       `INSERT OR IGNORE INTO user_installations (user_id, tenant_id) VALUES (?, ?)`,
@@ -221,8 +236,12 @@ export async function callbackRoute(
     }
   }
 
+  if (firstTenantId === null) {
+    return c.json({ error: "db_error" }, 500);
+  }
+
   // Mint session tied to the first installation's tenant
-  const rawToken = await mintSession(c.env.DB, userId, firstTenantId!);
+  const rawToken = await mintSession(c.env.DB, userId, firstTenantId);
 
   return new Response(null, {
     status: 302,

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -1,0 +1,234 @@
+/**
+ * GitHub App OAuth routes.
+ *
+ * loginRoute    — initiates the OAuth flow (stores state, redirects to GitHub).
+ * callbackRoute — handles the GitHub callback (exchanges code, upserts user +
+ *                 tenants, mints session).
+ *
+ * Never logs tokens, client_secret, or raw session tokens.
+ */
+
+import type { Context } from "hono";
+import type { Env } from "../types";
+import { mintSession, sessionCookie } from "./session";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a `redirect` query parameter as a safe relative path.
+ * Accepts paths starting with "/" but not "//" (open-redirect via protocol-
+ * relative URLs) and rejects anything that is not a plain relative path.
+ */
+function sanitizeRedirect(raw: string | undefined): string {
+  if (raw && /^\/(?!\/)/.test(raw)) return raw;
+  return "/";
+}
+
+/**
+ * Encode a Uint8Array of random bytes as a lowercase hex string.
+ */
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// loginRoute
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /login
+ *
+ * Generates a random state token, persists it in D1 oauth_state with a
+ * 10-minute expiry, then redirects the browser to GitHub's OAuth authorize
+ * endpoint.  The redirect_uri is derived from the request origin — never from
+ * a query parameter — to prevent redirect-uri injection (D-6).
+ */
+export async function loginRoute(
+  c: Context<{ Bindings: Env }>,
+): Promise<Response> {
+  const redirectAfter = sanitizeRedirect(c.req.query("redirect") ?? undefined);
+
+  // 16 random bytes → 32 hex chars
+  const stateBytes = new Uint8Array(16);
+  crypto.getRandomValues(stateBytes);
+  const state = bytesToHex(stateBytes);
+
+  // Store state in D1 — single-use, expires in 10 minutes
+  await c.env.DB.prepare(
+    `INSERT INTO oauth_state (state, redirect_after, expires_at)
+     VALUES (?, ?, datetime('now', '+10 minutes'))`,
+  )
+    .bind(state, redirectAfter)
+    .run();
+
+  // Build GitHub authorize URL — redirect_uri derived from origin only (D-6)
+  const origin = new URL(c.req.url).origin;
+  const redirectUri = `${origin}/oauth/callback`;
+
+  const dest = new URL("https://github.com/login/oauth/authorize");
+  dest.searchParams.set("client_id", c.env.GITHUB_APP_CLIENT_ID);
+  dest.searchParams.set("redirect_uri", redirectUri);
+  dest.searchParams.set("state", state);
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: dest.toString() },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// callbackRoute
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /oauth/callback
+ *
+ * GitHub redirects here after the user authorises (or denies) the app.
+ * Flow:
+ *   1. Validate code + state params.
+ *   2. Consume state single-use (SELECT then DELETE).
+ *   3. Exchange code for access_token.
+ *   4. Fetch /user and /user/installations.
+ *   5. Upsert user → tenants → user_installations.
+ *   6. If no installations → redirect to app install page (no session).
+ *   7. Mint session tied to first installation, set __Host-session cookie.
+ */
+export async function callbackRoute(
+  c: Context<{ Bindings: Env }>,
+): Promise<Response> {
+  const code = c.req.query("code");
+  const state = c.req.query("state");
+
+  if (!code || !state) {
+    return c.json({ error: "bad_request" }, 400);
+  }
+
+  // Consume state — single-use: SELECT (with expiry guard) then DELETE
+  const stateRow = await c.env.DB.prepare(
+    `SELECT redirect_after FROM oauth_state WHERE state = ? AND expires_at > datetime('now')`,
+  )
+    .bind(state)
+    .first<{ redirect_after: string | null }>();
+
+  if (!stateRow) {
+    return c.json({ error: "bad_request" }, 400);
+  }
+
+  await c.env.DB.prepare(`DELETE FROM oauth_state WHERE state = ?`)
+    .bind(state)
+    .run();
+
+  const redirectAfter = stateRow.redirect_after ?? "/";
+
+  // Build redirect_uri from origin (D-6)
+  const origin = new URL(c.req.url).origin;
+  const redirectUri = `${origin}/oauth/callback`;
+
+  // Exchange code for access_token
+  const tokenRes = await fetch(
+    "https://github.com/login/oauth/access_token",
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "roxabi-live",
+      },
+      body: JSON.stringify({
+        client_id: c.env.GITHUB_APP_CLIENT_ID,
+        client_secret: c.env.GITHUB_APP_CLIENT_SECRET,
+        code,
+        redirect_uri: redirectUri,
+      }),
+    },
+  );
+  const { access_token } = (await tokenRes.json()) as {
+    access_token: string;
+  };
+
+  const ghHeaders = {
+    Authorization: `Bearer ${access_token}`,
+    "User-Agent": "roxabi-live",
+    Accept: "application/vnd.github+json",
+  };
+
+  // Fetch authenticated user
+  const userRes = await fetch("https://api.github.com/user", {
+    headers: ghHeaders,
+  });
+  const ghUser = (await userRes.json()) as { id: number; login: string };
+
+  // Fetch user installations
+  const installRes = await fetch(
+    "https://api.github.com/user/installations",
+    { headers: ghHeaders },
+  );
+  const { installations } = (await installRes.json()) as {
+    installations: Array<{
+      id: number;
+      account: { login: string; type: string };
+    }>;
+  };
+
+  // Upsert user — get internal id
+  const userRow = await c.env.DB.prepare(
+    `INSERT INTO users (github_id, github_login) VALUES (?, ?)
+     ON CONFLICT(github_id) DO UPDATE SET github_login=excluded.github_login, updated_at=datetime('now')
+     RETURNING id`,
+  )
+    .bind(ghUser.id, ghUser.login)
+    .first<{ id: number }>();
+
+  const userId = userRow!.id;
+
+  // No installations — redirect to app install page, no session
+  if (installations.length === 0) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: "https://github.com/apps/roxabi-live/installations/new",
+      },
+    });
+  }
+
+  // Upsert each installation as a tenant and link to user
+  let firstTenantId: number | null = null;
+
+  for (const inst of installations) {
+    const tenantRow = await c.env.DB.prepare(
+      `INSERT INTO tenants (installation_id, account_login, account_type) VALUES (?, ?, ?)
+       ON CONFLICT(installation_id) DO UPDATE SET account_login=excluded.account_login,
+         account_type=excluded.account_type, updated_at=datetime('now')
+       RETURNING id`,
+    )
+      .bind(inst.id, inst.account.login, inst.account.type)
+      .first<{ id: number }>();
+
+    const tenantId = tenantRow!.id;
+
+    await c.env.DB.prepare(
+      `INSERT OR IGNORE INTO user_installations (user_id, tenant_id) VALUES (?, ?)`,
+    )
+      .bind(userId, tenantId)
+      .run();
+
+    if (firstTenantId === null) {
+      firstTenantId = tenantId;
+    }
+  }
+
+  // Mint session tied to the first installation's tenant
+  const rawToken = await mintSession(c.env.DB, userId, firstTenantId!);
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: redirectAfter,
+      "Set-Cookie": sessionCookie(rawToken),
+    },
+  });
+}

--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -1,0 +1,538 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+// ---------------------------------------------------------------------------
+// NOTE: session.ts does not exist yet — these tests are intentionally RED.
+// They define the contract that session.ts must satisfy (T6 task).
+// ---------------------------------------------------------------------------
+
+import {
+  mintSession,
+  validateSession,
+  deleteSession,
+  requireSession,
+  sessionCookie,
+  clearSessionCookie,
+  SESSION_COOKIE,
+  SESSION_TTL_SECONDS,
+} from "./session";
+import type { AuthEnv, SessionContext } from "./session";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// FakeD1 — cloned from src/webhook/mutations.test.ts (captureDb pattern)
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+/** Capture all statements produced via bind() calls on the FakeDb. */
+function captureDb(): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, [], 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/**
+ * Build a FakeD1 where `first()` always resolves with the provided row.
+ * Used to test the "found" path of validateSession.
+ */
+function fixedFirstDb(row: FakeResult | null): D1Database {
+  return makeFakeDb((sql, args) =>
+    makeFakeStmt(sql, args, row !== null ? [row] : [], 0),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const HEX64_RE = /^[0-9a-f]{64}$/;
+
+// ---------------------------------------------------------------------------
+// mintSession
+// ---------------------------------------------------------------------------
+
+describe("mintSession", () => {
+  it("INSERT SQL contains datetime('now', '+8 hours') for expires_at", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await mintSession(db, 7, 9);
+    // Assert
+    expect(stmts()[0].sql).toContain("datetime('now', '+8 hours')");
+  });
+
+  it("binds exactly 3 args: [userId, tenantId, token_hash]", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await mintSession(db, 7, 9);
+    // Assert
+    expect(stmts()[0].args).toHaveLength(3);
+    expect(stmts()[0].args[0]).toBe(7);
+    expect(stmts()[0].args[1]).toBe(9);
+  });
+
+  it("arg[2] (token_hash) is a 64-char lowercase hex string", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await mintSession(db, 7, 9);
+    // Assert
+    const hash = stmts()[0].args[2];
+    expect(typeof hash).toBe("string");
+    expect(hash).toMatch(HEX64_RE);
+  });
+
+  it("returned raw token is a 64-char lowercase hex string", async () => {
+    // Arrange
+    const { db } = captureDb();
+    // Act
+    const raw = await mintSession(db, 7, 9);
+    // Assert
+    expect(raw).toMatch(HEX64_RE);
+  });
+
+  it("returned raw token is NOT the stored token_hash (raw ≠ sha256(raw))", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    const raw = await mintSession(db, 7, 9);
+    // Assert — the raw token must differ from its own hash stored in arg[2]
+    const storedHash = stmts()[0].args[2];
+    expect(raw).not.toBe(storedHash);
+  });
+
+  it("two consecutive calls produce different raw tokens (randomness)", async () => {
+    // Arrange
+    const { db: db1 } = captureDb();
+    const { db: db2 } = captureDb();
+    // Act
+    const raw1 = await mintSession(db1, 1, 1);
+    const raw2 = await mintSession(db2, 1, 1);
+    // Assert
+    expect(raw1).not.toBe(raw2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSession — SQL guard clauses
+// ---------------------------------------------------------------------------
+
+describe("validateSession — SQL guard clauses", () => {
+  it("SQL contains token_hash = ? clause", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "a".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("token_hash = ?");
+  });
+
+  it("SQL contains expires_at > datetime('now') guard", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "b".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("expires_at > datetime('now')");
+  });
+
+  it("SQL contains revoked_at IS NULL guard", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "c".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("revoked_at IS NULL");
+  });
+
+  it("SQL contains NOT EXISTS subquery for tenant suspension", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "d".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("NOT EXISTS");
+  });
+
+  it("SQL contains suspended_at IS NOT NULL guard inside NOT EXISTS", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "e".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("suspended_at IS NOT NULL");
+  });
+
+  it("passes the hash of rawToken as the bound arg (¬raw token itself)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const raw = "f".repeat(64);
+    // Act
+    await validateSession(db, raw);
+    // Assert — bound arg must be a different value (the hash), not the raw token
+    expect(stmts()[0].args[0]).not.toBe(raw);
+    // The hash should itself be a 64-char hex string
+    expect(stmts()[0].args[0]).toMatch(HEX64_RE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSession — behaviour with FakeD1 rows
+// ---------------------------------------------------------------------------
+
+describe("validateSession — return value", () => {
+  const SESSION_ROW: FakeResult = {
+    userId: 7,
+    tenantId: 9,
+    githubId: 42,
+    githubLogin: "alice",
+  };
+
+  it("returns the SessionContext when first() resolves with a row", async () => {
+    // Arrange
+    const db = fixedFirstDb(SESSION_ROW);
+    // Act
+    const result = await validateSession(db, "rawtoken");
+    // Assert
+    expect(result).toEqual({
+      userId: 7,
+      tenantId: 9,
+      githubId: 42,
+      githubLogin: "alice",
+    });
+  });
+
+  it("returns null when first() resolves with null (expired/revoked/unknown)", async () => {
+    // Arrange
+    const db = fixedFirstDb(null);
+    // Act
+    const result = await validateSession(db, "rawtoken");
+    // Assert
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteSession
+// ---------------------------------------------------------------------------
+
+describe("deleteSession", () => {
+  it("issues DELETE FROM sessions WHERE token_hash = ?", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await deleteSession(db, "rawtoken");
+    // Assert
+    expect(stmts()[0].sql).toContain("DELETE FROM sessions");
+    expect(stmts()[0].sql).toContain("token_hash = ?");
+  });
+
+  it("binds the SHA-256 hash of the raw token, not the raw token itself", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const raw = "myrawtoken";
+    // Act
+    await deleteSession(db, raw);
+    // Assert
+    const bound = stmts()[0].args[0];
+    expect(bound).not.toBe(raw);
+    expect(bound).toMatch(HEX64_RE);
+  });
+
+  it("consistent hashing: same raw token → same hash in both deleteSession and mintSession", async () => {
+    // Arrange — capture hash from mintSession, then verify deleteSession uses same hash
+    const { db: mintDb, stmts: mintStmts } = captureDb();
+    const raw = await mintSession(mintDb, 1, 1);
+    const mintedHash = mintStmts()[0].args[2] as string;
+
+    const { db: delDb, stmts: delStmts } = captureDb();
+    // Act
+    await deleteSession(delDb, raw);
+    // Assert
+    expect(delStmts()[0].args[0]).toBe(mintedHash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireSession middleware
+// ---------------------------------------------------------------------------
+
+describe("requireSession", () => {
+  function buildApp(
+    db: D1Database,
+    probeHandler: (session: SessionContext) => Response = (s) =>
+      new Response(JSON.stringify(s), { status: 200 }),
+  ) {
+    const app = new Hono<AuthEnv>();
+
+    app.use("/protected", requireSession);
+    app.get("/protected", (c) => {
+      const session = c.get("session");
+      return probeHandler(session);
+    });
+
+    return app;
+  }
+
+  const VALID_SESSION: SessionContext = {
+    userId: 7,
+    tenantId: 9,
+    githubId: 42,
+    githubLogin: "alice",
+  };
+
+  it("returns 401 JSON {error:'unauthorized'} when no Cookie header is present", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    // Act
+    const res = await app.request("/protected", { method: "GET" }, env);
+    // Assert
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "unauthorized" });
+  });
+
+  it("returns 401 when Cookie is present but validateSession returns null (bad/expired token)", async () => {
+    // Arrange — DB always returns null for first()
+    const db = fixedFirstDb(null);
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    const cookieValue = `${SESSION_COOKIE}=badtoken`;
+    // Act
+    const res = await app.request(
+      "/protected",
+      { method: "GET", headers: { Cookie: cookieValue } },
+      env,
+    );
+    // Assert
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "unauthorized" });
+  });
+
+  it("calls next and sets session context when token is valid", async () => {
+    // Arrange — DB returns a valid session row
+    const db = fixedFirstDb(VALID_SESSION as unknown as FakeResult);
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    // mintSession to get a valid raw token format (64-char hex)
+    const { db: mintDb } = captureDb();
+    const raw = await mintSession(mintDb, 7, 9);
+    const cookieValue = `${SESSION_COOKIE}=${raw}`;
+    // Act
+    const res = await app.request(
+      "/protected",
+      { method: "GET", headers: { Cookie: cookieValue } },
+      env,
+    );
+    // Assert — next handler ran, session was set
+    expect(res.status).toBe(200);
+    const body = await res.json<SessionContext>();
+    expect(body.userId).toBe(7);
+    expect(body.tenantId).toBe(9);
+    expect(body.githubId).toBe(42);
+    expect(body.githubLogin).toBe("alice");
+  });
+
+  it("returns 401 when Cookie header has wrong cookie name", async () => {
+    // Arrange
+    const db = fixedFirstDb(VALID_SESSION as unknown as FakeResult);
+    const app = buildApp(db);
+    const env = { DB: db } as unknown as Env;
+    const cookieValue = `wrong-name=sometoken`;
+    // Act
+    const res = await app.request(
+      "/protected",
+      { method: "GET", headers: { Cookie: cookieValue } },
+      env,
+    );
+    // Assert — no __Host-session cookie → 401
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionCookie
+// ---------------------------------------------------------------------------
+
+describe("sessionCookie", () => {
+  it("contains __Host-session=<rawToken>", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("abc123");
+    // Assert
+    expect(cookie).toContain("__Host-session=abc123");
+  });
+
+  it("contains HttpOnly flag", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("HttpOnly");
+  });
+
+  it("contains Secure flag", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("Secure");
+  });
+
+  it("contains SameSite=Strict", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("SameSite=Strict");
+  });
+
+  it("contains Path=/", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("Path=/");
+  });
+
+  it("contains Max-Age=28800 (8 hours)", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert
+    expect(cookie).toContain("Max-Age=28800");
+    // Verify SESSION_TTL_SECONDS export matches
+    expect(SESSION_TTL_SECONDS).toBe(28800);
+  });
+
+  it("does NOT contain Domain attribute (__Host- prefix requires omission)", () => {
+    // Arrange + Act
+    const cookie = sessionCookie("tok");
+    // Assert — __Host- prefix mandates no Domain attribute
+    expect(cookie).not.toContain("Domain");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearSessionCookie
+// ---------------------------------------------------------------------------
+
+describe("clearSessionCookie", () => {
+  it("contains __Host-session= (empty value)", () => {
+    // Arrange + Act
+    const cookie = clearSessionCookie();
+    // Assert
+    expect(cookie).toContain("__Host-session=");
+  });
+
+  it("contains Max-Age=0 to expire the cookie immediately", () => {
+    // Arrange + Act
+    const cookie = clearSessionCookie();
+    // Assert
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("contains HttpOnly flag", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("HttpOnly");
+  });
+
+  it("contains Secure flag", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("Secure");
+  });
+
+  it("contains SameSite=Strict", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("SameSite=Strict");
+  });
+
+  it("contains Path=/", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).toContain("Path=/");
+  });
+
+  it("does NOT contain Domain attribute", () => {
+    const cookie = clearSessionCookie();
+    expect(cookie).not.toContain("Domain");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SESSION_COOKIE constant
+// ---------------------------------------------------------------------------
+
+describe("SESSION_COOKIE constant", () => {
+  it("equals '__Host-session'", () => {
+    expect(SESSION_COOKIE).toBe("__Host-session");
+  });
+});

--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -285,6 +285,47 @@ describe("validateSession — return value", () => {
 });
 
 // ---------------------------------------------------------------------------
+// validateSession — suspended-tenant behavioral guard (mutation-catching)
+// ---------------------------------------------------------------------------
+
+describe("validateSession — suspended-tenant behavioral guard", () => {
+  /**
+   * SQL-discriminating FakeD1: if the executed SQL contains the
+   * suspended_at IS NOT NULL guard (i.e. the guard is present in source),
+   * first() returns null — correctly filtering out the suspended tenant.
+   * If the guard is ABSENT from the SQL, first() returns a valid row —
+   * which would make validateSession return non-null and break toBeNull().
+   *
+   * This test FAILS if the suspended-tenant guard is removed from
+   * validateSession's SQL, because the fake would then return a row
+   * and validateSession would return non-null instead of null.
+   */
+  it("returns null for a suspended tenant (guard is mutation-catching)", async () => {
+    // Arrange — a valid session row that would be returned if the guard is absent
+    const validRow: FakeResult = {
+      userId: 7,
+      tenantId: 9,
+      githubId: 42,
+      githubLogin: "alice",
+    };
+
+    const db = makeFakeDb((sql, args) => {
+      // If the suspended-tenant guard is present in the SQL, simulate the DB
+      // filtering out the row (suspended tenant → no result).
+      // If the guard is absent, the DB returns a valid row — causing toBeNull() to fail.
+      const guardPresent = sql.includes("suspended_at IS NOT NULL");
+      return makeFakeStmt(sql, args, guardPresent ? [] : [validRow], 0);
+    });
+
+    // Act
+    const result = await validateSession(db, "a".repeat(64));
+
+    // Assert — suspended tenant session must be filtered out → null
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // deleteSession
 // ---------------------------------------------------------------------------
 
@@ -339,7 +380,9 @@ describe("requireSession", () => {
 
     app.use("/protected", requireSession);
     app.get("/protected", (c) => {
-      const session = c.get("session");
+      // requireSession guarantees session is set before next() is called;
+      // the non-null assertion is safe here (the middleware returns 401 otherwise).
+      const session = c.get("session")!;
       return probeHandler(session);
     });
 

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -21,7 +21,7 @@ export interface SessionContext {
 
 export type AuthEnv = {
   Bindings: Env;
-  Variables: { session: SessionContext };
+  Variables: { session?: SessionContext };
 };
 
 // ---------------------------------------------------------------------------

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -1,0 +1,188 @@
+/**
+ * Session management for GitHub App OAuth sessions.
+ *
+ * Tokens are stored as SHA-256 hashes (never raw). The __Host- cookie prefix
+ * mandates Secure + Path=/ + no Domain — enforced by sessionCookie().
+ */
+
+import type { MiddlewareHandler, Context } from "hono";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SessionContext {
+  userId: number;
+  tenantId: number;
+  githubId: number;
+  githubLogin: string;
+}
+
+export type AuthEnv = {
+  Bindings: Env;
+  Variables: { session: SessionContext };
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const SESSION_COOKIE = "__Host-session";
+export const SESSION_TTL_SECONDS = 28800; // 8 hours
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * SHA-256 digest of a UTF-8 string, returned as lowercase hex.
+ * Uses the ambient crypto.subtle (Cloudflare Workers / Vitest Node env).
+ */
+async function sha256hex(s: string): Promise<string> {
+  const bytes = new TextEncoder().encode(s);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Cookie helpers (pure, synchronous)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Set-Cookie header value for the session token.
+ * __Host- prefix requires: Secure, Path=/, no Domain.
+ */
+export function sessionCookie(rawToken: string): string {
+  return `${SESSION_COOKIE}=${rawToken}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${SESSION_TTL_SECONDS}`;
+}
+
+/**
+ * Build a Set-Cookie header value that immediately expires the session cookie.
+ */
+export function clearSessionCookie(): string {
+  return `${SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0`;
+}
+
+// ---------------------------------------------------------------------------
+// Token reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the __Host-session cookie value from the Cookie header.
+ * Returns null if the cookie is absent or the header is missing.
+ */
+export function readSessionToken(c: Context): string | null {
+  const cookieHeader = c.req.header("Cookie");
+  if (!cookieHeader) return null;
+
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const name = trimmed.slice(0, eqIdx).trim();
+    if (name === SESSION_COOKIE) {
+      return trimmed.slice(eqIdx + 1).trim() || null;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// D1 operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a new session: generate 32 random bytes as a 64-char hex token,
+ * store its SHA-256 hash in D1, and return the raw token (once, never stored).
+ */
+export async function mintSession(
+  db: D1Database,
+  userId: number,
+  tenantId: number,
+): Promise<string> {
+  const randomBytes = new Uint8Array(32);
+  crypto.getRandomValues(randomBytes);
+  const rawToken = Array.from(randomBytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  const hash = await sha256hex(rawToken);
+
+  await db
+    .prepare(
+      `INSERT INTO sessions (user_id, tenant_id, token_hash, expires_at)
+       VALUES (?, ?, ?, datetime('now', '+8 hours'))`,
+    )
+    .bind(userId, tenantId, hash)
+    .run();
+
+  return rawToken;
+}
+
+/**
+ * Validate a raw session token.
+ * Returns the SessionContext if the session is valid (not expired, not revoked,
+ * tenant not suspended), or null otherwise.
+ */
+export async function validateSession(
+  db: D1Database,
+  rawToken: string,
+): Promise<SessionContext | null> {
+  const hash = await sha256hex(rawToken);
+
+  const row = await db
+    .prepare(
+      `SELECT s.user_id AS userId, s.tenant_id AS tenantId, u.github_id AS githubId, u.github_login AS githubLogin
+       FROM sessions s JOIN users u ON u.id = s.user_id
+       WHERE s.token_hash = ?
+         AND s.expires_at > datetime('now')
+         AND s.revoked_at IS NULL
+         AND NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL)`,
+    )
+    .bind(hash)
+    .first<SessionContext>();
+
+  return row ?? null;
+}
+
+/**
+ * Delete a session by raw token (hashes before querying).
+ */
+export async function deleteSession(
+  db: D1Database,
+  rawToken: string,
+): Promise<void> {
+  const hash = await sha256hex(rawToken);
+
+  await db
+    .prepare(`DELETE FROM sessions WHERE token_hash = ?`)
+    .bind(hash)
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Fail-closed session middleware. Reads the __Host-session cookie, validates
+ * against D1, and sets the session context on the Hono context. Returns 401
+ * JSON if the token is absent or invalid.
+ */
+export const requireSession: MiddlewareHandler<AuthEnv> = async (c, next) => {
+  const token = readSessionToken(c);
+  if (!token) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const ctx = await validateSession(c.env.DB, token);
+  if (!ctx) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  c.set("session", ctx);
+  await next();
+};

--- a/worker/src/auth/tokenCrypto.test.ts
+++ b/worker/src/auth/tokenCrypto.test.ts
@@ -2,11 +2,6 @@ import { describe, expect, it } from "vitest";
 import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
 
 // ---------------------------------------------------------------------------
-// NOTE: tokenCrypto.ts does not exist yet — these tests are intentionally RED.
-// They define the AES-GCM encryption contract that tokenCrypto.ts must satisfy.
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -52,6 +47,12 @@ describe("importDek", () => {
     expect(key.algorithm).toMatchObject({ name: "AES-GCM" });
     expect(key.usages).toContain("encrypt");
     expect(key.usages).toContain("decrypt");
+  });
+
+  it("rejects a non-32-byte (AES-128 / 16-byte) key with a clear error", async () => {
+    const raw = crypto.getRandomValues(new Uint8Array(16));
+    const b64 = btoa(String.fromCharCode(...raw));
+    await expect(importDek(b64)).rejects.toThrow(/32 bytes/);
   });
 });
 

--- a/worker/src/auth/tokenCrypto.test.ts
+++ b/worker/src/auth/tokenCrypto.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { importDek, encryptToken, decryptToken } from "./tokenCrypto";
+
+// ---------------------------------------------------------------------------
+// NOTE: tokenCrypto.ts does not exist yet — these tests are intentionally RED.
+// They define the AES-GCM encryption contract that tokenCrypto.ts must satisfy.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a random 32-byte DEK and return it as a base64 string + CryptoKey. */
+async function generateDek(): Promise<{ b64: string; key: CryptoKey }> {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  const b64 = btoa(String.fromCharCode(...raw));
+  const key = await importDek(b64);
+  return { b64, key };
+}
+
+/** Decode a base64url string to bytes. */
+function decodeBase64url(s: string): Uint8Array {
+  // Convert base64url → standard base64, add padding
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/").padEnd(
+    s.length + ((4 - (s.length % 4)) % 4),
+    "=",
+  );
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+/** Check that a string contains only base64url characters (no +, /, =). */
+function isBase64url(s: string): boolean {
+  return /^[A-Za-z0-9\-_]+$/.test(s);
+}
+
+// ---------------------------------------------------------------------------
+// importDek
+// ---------------------------------------------------------------------------
+
+describe("importDek", () => {
+  it("imports a 32-byte base64 DEK and returns a CryptoKey usable for AES-GCM", async () => {
+    // Arrange
+    const raw = crypto.getRandomValues(new Uint8Array(32));
+    const b64 = btoa(String.fromCharCode(...raw));
+
+    // Act
+    const key = await importDek(b64);
+
+    // Assert
+    expect(key).toBeInstanceOf(CryptoKey);
+    expect(key.type).toBe("secret");
+    expect(key.algorithm).toMatchObject({ name: "AES-GCM" });
+    expect(key.usages).toContain("encrypt");
+    expect(key.usages).toContain("decrypt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encryptToken / decryptToken — round-trip
+// ---------------------------------------------------------------------------
+
+describe("encryptToken / decryptToken", () => {
+  it("round-trip: encryptToken then decryptToken returns the original plaintext", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const plaintext = "ghs_test_github_token_abc123";
+
+    // Act
+    const { enc, iv } = await encryptToken(key, plaintext);
+    const decrypted = await decryptToken(key, enc, iv);
+
+    // Assert
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("IV is 12 bytes (decoded from base64url)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+
+    // Act
+    const { iv } = await encryptToken(key, "some-token");
+
+    // Assert — AES-GCM standard IV length
+    const ivBytes = decodeBase64url(iv);
+    expect(ivBytes.byteLength).toBe(12);
+  });
+
+  it("two encrypts of the same plaintext produce different iv values (random IV)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const plaintext = "repeated-token";
+
+    // Act
+    const result1 = await encryptToken(key, plaintext);
+    const result2 = await encryptToken(key, plaintext);
+
+    // Assert — random IV means each encryption is unique
+    expect(result1.iv).not.toBe(result2.iv);
+  });
+
+  it("two encrypts of the same plaintext produce different enc values (random IV)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const plaintext = "repeated-token";
+
+    // Act
+    const result1 = await encryptToken(key, plaintext);
+    const result2 = await encryptToken(key, plaintext);
+
+    // Assert — different IV ⇒ different ciphertext
+    expect(result1.enc).not.toBe(result2.enc);
+  });
+
+  it("tampered ciphertext (flip a char in enc) causes decryptToken to reject/throw", async () => {
+    // Arrange
+    const { key } = await generateDek();
+    const { enc, iv } = await encryptToken(key, "sensitive-token");
+
+    // Tamper: flip the first character of enc
+    const tamperedEnc = enc[0] === "A" ? "B" + enc.slice(1) : "A" + enc.slice(1);
+
+    // Act + Assert — AES-GCM authentication tag must fail
+    await expect(decryptToken(key, tamperedEnc, iv)).rejects.toThrow();
+  });
+
+  it("wrong DEK causes decryptToken to reject/throw", async () => {
+    // Arrange
+    const { key: key1 } = await generateDek();
+    const { key: key2 } = await generateDek();
+    const { enc, iv } = await encryptToken(key1, "sensitive-token");
+
+    // Act + Assert — wrong key ⇒ authentication tag mismatch
+    await expect(decryptToken(key2, enc, iv)).rejects.toThrow();
+  });
+
+  it("enc output is base64url (no '+', '/', '=' chars)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+
+    // Act
+    const { enc } = await encryptToken(key, "test-token-value");
+
+    // Assert
+    expect(isBase64url(enc)).toBe(true);
+  });
+
+  it("iv output is base64url (no '+', '/', '=' chars)", async () => {
+    // Arrange
+    const { key } = await generateDek();
+
+    // Act
+    const { iv } = await encryptToken(key, "test-token-value");
+
+    // Assert
+    expect(isBase64url(iv)).toBe(true);
+  });
+});

--- a/worker/src/auth/tokenCrypto.ts
+++ b/worker/src/auth/tokenCrypto.ts
@@ -1,0 +1,96 @@
+/**
+ * AES-GCM token encryption/decryption using the Web Crypto API.
+ *
+ * Compatible with Cloudflare Workers runtime and the Vitest test environment.
+ * Never logs or surfaces plaintext tokens.
+ */
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode an ArrayBuffer as base64url (no padding, URL-safe chars).
+ * Reuses the same approach as b64url in jwt.ts.
+ */
+function toBase64url(buf: ArrayBuffer): string {
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Decode a base64url string to Uint8Array.
+ */
+function fromBase64url(s: string): Uint8Array {
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), "=");
+  return Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Import a base64-encoded 32-byte raw key as an AES-GCM CryptoKey.
+ *
+ * @param b64 - Standard base64 (not base64url) encoding of the 32-byte DEK.
+ * @returns A non-extractable CryptoKey usable for encrypt and decrypt.
+ */
+export async function importDek(b64: string): Promise<CryptoKey> {
+  const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "raw",
+    bytes,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Encrypt a plaintext token using AES-GCM with a random 12-byte IV.
+ *
+ * @param dek       - CryptoKey returned by importDek.
+ * @param plaintext - The plaintext installation access token to encrypt.
+ * @returns `{ enc, iv }` — both are base64url-encoded (no +, /, = chars).
+ */
+export async function encryptToken(
+  dek: CryptoKey,
+  plaintext: string,
+): Promise<{ enc: string; iv: string }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plaintext);
+  const ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, dek, encoded);
+  return {
+    enc: toBase64url(ct),
+    iv: toBase64url(iv.buffer as ArrayBuffer),
+  };
+}
+
+/**
+ * Decrypt an AES-GCM ciphertext back to plaintext.
+ *
+ * Propagates the rejection from crypto.subtle.decrypt on authentication failure
+ * (tampered ciphertext, wrong DEK). Never swallows errors.
+ *
+ * @param dek - CryptoKey returned by importDek.
+ * @param enc - base64url-encoded ciphertext (from encryptToken).
+ * @param iv  - base64url-encoded 12-byte IV (from encryptToken).
+ * @returns The original plaintext string.
+ * @throws If decryption fails (authentication tag mismatch, wrong key, etc.)
+ */
+export async function decryptToken(
+  dek: CryptoKey,
+  enc: string,
+  iv: string,
+): Promise<string> {
+  const ctBytes = fromBase64url(enc);
+  const ivBytes = fromBase64url(iv);
+  const plainBuffer = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: ivBytes },
+    dek,
+    ctBytes,
+  );
+  return new TextDecoder().decode(plainBuffer);
+}

--- a/worker/src/auth/tokenCrypto.ts
+++ b/worker/src/auth/tokenCrypto.ts
@@ -39,6 +39,11 @@ function fromBase64url(s: string): Uint8Array {
  */
 export async function importDek(b64: string): Promise<CryptoKey> {
   const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  if (bytes.byteLength !== 32) {
+    throw new Error(
+      `INSTALL_TOKEN_KEY must decode to exactly 32 bytes (AES-256), got ${bytes.byteLength}`,
+    );
+  }
   return crypto.subtle.importKey(
     "raw",
     bytes,
@@ -64,7 +69,7 @@ export async function encryptToken(
   const ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, dek, encoded);
   return {
     enc: toBase64url(ct),
-    iv: toBase64url(iv.buffer as ArrayBuffer),
+    iv: toBase64url(iv.buffer),
   };
 }
 

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -64,7 +64,8 @@ app.get("/login", loginRoute);
 app.get("/oauth/callback", callbackRoute);
 app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
-app.use("/logout", requireSession);
+// /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
+// blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);
 
 // ── Static-assets fallback — last resort (frontend populated in S7, #99) ────

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -6,8 +6,11 @@ import { listIssuesRoute, getIssueRoute } from "./api/issues";
 import { adminSyncRoute } from "./api/admin";
 import { webhookRoute } from "./webhook/handlers";
 import { checkAdminAuth } from "./api/auth";
+import { loginRoute, callbackRoute } from "./auth/oauth";
+import { meRoute, logoutRoute } from "./api/me";
+import { requireSession, type AuthEnv } from "./auth/session";
 
-const app = new Hono<{ Bindings: Env }>();
+const app = new Hono<AuthEnv>();
 
 // ── API routes — evaluated BEFORE the ASSETS fallback ───────────────────────
 // S1 scaffold wires /health + /api/version. S5 (#97) adds POST /webhook/github.
@@ -55,6 +58,14 @@ app.get("/health", async (c) => {
   }
   return c.json({ status: "ok", db_reachable: dbReachable, issue_count: issueCount });
 });
+
+// ── Auth routes (#145, S2) ───────────────────────────────────────────────────
+app.get("/login", loginRoute);
+app.get("/oauth/callback", callbackRoute);
+app.use("/api/me", requireSession);
+app.get("/api/me", meRoute);
+app.use("/logout", requireSession);
+app.post("/logout", logoutRoute);
 
 // ── Static-assets fallback — last resort (frontend populated in S7, #99) ────
 app.all("*", (c) => c.env.ASSETS.fetch(c.req.raw));

--- a/worker/src/sync/graphql.test.ts
+++ b/worker/src/sync/graphql.test.ts
@@ -68,6 +68,21 @@ describe("ghGraphql — request headers", () => {
     const headers = init.headers as Record<string, string>;
     expect(headers["User-Agent"]).toBe("roxabi-live-worker");
   });
+
+  it("sends GraphQL-Features: sub_issues", async () => {
+    const mockFetch = makeFetchMock({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: {} }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await ghGraphql("query { viewer { login } }", {}, "any-token");
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["GraphQL-Features"]).toBe("sub_issues");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/worker/src/sync/graphql.ts
+++ b/worker/src/sync/graphql.ts
@@ -52,6 +52,7 @@ export async function ghGraphql<T = unknown>(
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
       "User-Agent": "roxabi-live-worker",
+      "GraphQL-Features": "sub_issues",
     },
     body: JSON.stringify({ query, variables }),
   });

--- a/worker/src/sync/graphql.ts
+++ b/worker/src/sync/graphql.ts
@@ -3,7 +3,7 @@
  *
  * Replaces the `gh api graphql` subprocess with a direct fetch() call so the
  * transport runs inside the Cloudflare Worker runtime. The token is an explicit
- * parameter (comes from env.GITHUB_TOKEN) rather than being ambient.
+ * parameter (a per-installation GitHub App token, #160) rather than being ambient.
  */
 
 import { SINGLE_ISSUE_DEPS_QUERY } from "./queries";
@@ -108,7 +108,7 @@ interface IssueDepsData {
  * @param owner   Repository owner (org or user login).
  * @param name    Repository name.
  * @param number  Issue number.
- * @param token   GitHub PAT (env.GITHUB_TOKEN in Worker context).
+ * @param token   GitHub token (per-installation GitHub App token, #160).
  * @returns       `{ blocked_by, blocking }` — each a list of `"owner/repo#N"` keys.
  */
 export async function fetchIssueDeps(

--- a/worker/src/sync/graphql.ts
+++ b/worker/src/sync/graphql.ts
@@ -37,7 +37,7 @@ export class GraphQLError extends Error {
  *
  * @param query     GraphQL query string (one of the constants from queries.ts).
  * @param variables Variable map matching the query's parameter declarations.
- * @param token     GitHub PAT (env.GITHUB_TOKEN in Worker context).
+ * @param token     GitHub token — org PAT in S3a; GitHub App installation token from #160.
  * @returns         Parsed response body; always contains a `data` key on success.
  * @throws          GraphQLError on HTTP errors or GraphQL-level `errors` in body.
  */

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1432,6 +1432,401 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// runSync — breaker + discovery (#160)
+// ---------------------------------------------------------------------------
+
+describe("runSync — breaker + discovery (#160)", () => {
+  function makeEnv(overrides: Record<string, unknown> = {}): Env {
+    return {
+      DB: undefined as unknown as D1Database,
+      GITHUB_ORG: "Roxabi",
+      ...overrides,
+    } as unknown as Env;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("B1: discovery failure increments the tenant breaker", async () => {
+    // Arrange
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockRejectedValue(new Error("token-error"));
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
+
+    const db = makeFakeDb((sql, args) => {
+      // Global tick lock (tenant_id=0) → acquired (changes=1)
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // Tenant lock (tenant_id=1) → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // halted guard
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT for tenant after increment → return count
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "1" }], 0);
+      }
+      // tenants discovery
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — auth_failures UPDATE was issued bound to tenant_id=1
+    const recorded = db._recorded;
+    const authFailureUpdate = recorded.find(
+      (s) =>
+        s.sql.includes("auth_failures") &&
+        s.sql.includes("UPDATE") &&
+        s.args.includes(1),
+    );
+    expect(authFailureUpdate).toBeDefined();
+  });
+
+  it("B3: discoverTenants upserts repos and deletes stale tenant_repo_access", async () => {
+    // Arrange
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("tok");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/keep"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      // Global tick lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // Tenant lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // halted guard
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT → not halted
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // tenants discovery → 1 tenant
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      // existing tenant_repo_access rows → keep + stale
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/keep" }, { repo: "o/stale" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — INSERT for "o/keep"
+    const recorded = db._recorded;
+    const insertKeep = recorded.find(
+      (s) =>
+        s.sql.includes("INSERT OR IGNORE INTO tenant_repo_access") &&
+        s.args.includes("o/keep"),
+    );
+    expect(insertKeep).toBeDefined();
+
+    // Assert — DELETE for "o/stale" (not for "o/keep")
+    const deleteStale = recorded.find(
+      (s) =>
+        s.sql.includes("DELETE FROM tenant_repo_access") &&
+        s.args.includes("o/stale"),
+    );
+    expect(deleteStale).toBeDefined();
+
+    const deleteKeep = recorded.find(
+      (s) =>
+        s.sql.includes("DELETE FROM tenant_repo_access") &&
+        s.args.includes("o/keep"),
+    );
+    expect(deleteKeep).toBeUndefined();
+  });
+
+  it("B4: token-exhausted repo is skipped, runSync resolves without throwing", async () => {
+    // Arrange — getInstallationToken always rejects for Phase 2 lookups
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockRejectedValue(new Error("no-token"));
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/a"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "1" }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/a" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act + Assert — runSync resolves (does not throw)
+    await expect(runSync(env)).resolves.toBeUndefined();
+
+    // ghGraphql must NOT have been called with REPO_BUNDLE_QUERY for o/a
+    const bundleCalls = vi.mocked(ghGraphql).mock.calls.filter(
+      (c) => c[0] === "REPO_BUNDLE_QUERY",
+    );
+    expect(bundleCalls).toHaveLength(0);
+  });
+
+  it("B2: systemic failure halts and POSTs NOTIFY at threshold (≥2)", async () => {
+    // Arrange — discovery succeeds (listInstallationRepos returns repos), Phase 2
+    // token fetch always fails → every windowed repo skipped → systemic failure.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    // Discovery Phase 1 calls: getInstallationToken (once, for the tenant) then listInstallationRepos.
+    // We need Phase 1 to succeed so repos enter the window, then Phase 2 token fetch to fail.
+    // Use mockResolvedValueOnce for the Phase 1 call, then reject for all subsequent.
+    vi.mocked(getInstallationToken)
+      .mockResolvedValueOnce("tok-discovery") // Phase 1 success
+      .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT — return ≥2 for global (tenant_id=0) to trigger halt
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        const val = args[0] === 0 ? "2" : "1";
+        return makeFakeStmt(sql, args, [{ value: val }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db, NOTIFY_URL: "https://notify.example.com/hook" });
+
+    // Act
+    await runSync(env);
+
+    // Assert — a halted-related UPDATE was fired (haltSync writes to sync_control)
+    // The SQL sets halted='1' or value='1' where key='halted'
+    const recorded = db._recorded;
+    const haltUpdate = recorded.find(
+      (s) =>
+        s.sql.includes("halted") &&
+        s.sql.includes("UPDATE"),
+    );
+    expect(haltUpdate).toBeDefined();
+
+    // Assert — fetch was called with NOTIFY_URL and body containing 'sync_halted'
+    const notifyCalls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("notify.example.com"),
+    );
+    expect(notifyCalls.length).toBeGreaterThan(0);
+    const bodyArg = notifyCalls[0][1] as { body?: string };
+    expect(bodyArg?.body).toMatch(/sync_halted/);
+  });
+
+  it("B2: systemic failure below threshold does NOT halt (auth_failures=1)", async () => {
+    // Arrange — same as B2 threshold but auth_failures stays at 1 (below halt trigger)
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken)
+      .mockResolvedValueOnce("tok-discovery") // Phase 1 success
+      .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT always returns 1 (below threshold — no halt)
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "1" }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db, NOTIFY_URL: "https://notify.example.com/hook" });
+
+    // Act
+    await runSync(env);
+
+    // Assert — NO halted UPDATE issued
+    const recorded = db._recorded;
+    const haltUpdate = recorded.find(
+      (s) =>
+        s.sql.includes("halted") &&
+        s.sql.includes("UPDATE"),
+    );
+    expect(haltUpdate).toBeUndefined();
+
+    // Assert — fetch was NOT called with NOTIFY_URL
+    const notifyCalls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("notify.example.com"),
+    );
+    expect(notifyCalls).toHaveLength(0);
+  });
+
+  it("B1b: successful run resets auth_failures for both global (tenant_id=0) and participating tenant", async () => {
+    // Arrange — 1 tenant id=7, 1 repo synced OK
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("tok-7");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/ok"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 7, installation_id: 70 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/ok" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — auth_failures reset UPDATE (value='0') for tenant_id=0
+    const recorded = db._recorded;
+    const resetGlobal = recorded.find(
+      (s) =>
+        s.sql.includes("auth_failures") &&
+        s.sql.includes("UPDATE") &&
+        s.sql.includes("value='0'") &&
+        s.args.includes(0),
+    );
+    expect(resetGlobal).toBeDefined();
+
+    // Assert — auth_failures reset UPDATE (value='0') for tenant_id=7
+    const resetTenant = recorded.find(
+      (s) =>
+        s.sql.includes("auth_failures") &&
+        s.sql.includes("UPDATE") &&
+        s.sql.includes("value='0'") &&
+        s.args.includes(7),
+    );
+    expect(resetTenant).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Teardown
 // ---------------------------------------------------------------------------
 

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -504,7 +504,7 @@ describe("acquireSyncLock", () => {
     // Assert
     expect(capturedStmts).toHaveLength(1);
     expect(capturedStmts[0].sql).toContain("key = 'sync_running'");
-    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = ?");
   });
 });
 
@@ -553,9 +553,9 @@ describe("haltSync", () => {
     expect(capturedStmts[0].sql).toContain("value='1'");
     expect(capturedStmts[0].sql).toContain("key='halted'");
     // tenant isolation guard must be present (TF3)
-    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
-    // only the ISO timestamp is bound
-    expect(capturedStmts[0].args).toHaveLength(1);
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = ?");
+    // ISO timestamp + tenantId are bound
+    expect(capturedStmts[0].args).toHaveLength(2);
     expect(typeof capturedStmts[0].args[0]).toBe("string");
     expect(String(capturedStmts[0].args[0])).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
@@ -590,9 +590,9 @@ describe("auth failure helpers", () => {
     expect(capturedStmts[0].sql).toContain("value='0'");
     expect(capturedStmts[0].sql).toContain("key='auth_failures'");
     // tenant isolation guard must be present (TF3)
-    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
-    // only the ISO timestamp is bound
-    expect(capturedStmts[0].args).toHaveLength(1);
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = ?");
+    // ISO timestamp + tenantId are bound
+    expect(capturedStmts[0].args).toHaveLength(2);
     expect(String(capturedStmts[0].args[0])).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
@@ -656,6 +656,12 @@ vi.mock("./queries", () => ({
   REPO_BUNDLE_QUERY: "REPO_BUNDLE_QUERY",
   REPOS_QUERY: "REPOS_QUERY",
   STUB_ISSUE_QUERY: "STUB_ISSUE_QUERY",
+}));
+
+vi.mock("../auth/installToken", () => ({
+  getInstallationToken: vi.fn(),
+  resolveInstallToken: vi.fn(),
+  listInstallationRepos: vi.fn(),
 }));
 
 describe("syncRepoIssues", () => {
@@ -925,7 +931,6 @@ describe("runSync", () => {
   function makeEnv(overrides: Record<string, unknown> = {}): Env {
     return {
       DB: undefined as unknown as D1Database,
-      GITHUB_TOKEN: "tok",
       GITHUB_ORG: "Roxabi",
       ...overrides,
     } as unknown as Env;
@@ -964,162 +969,38 @@ describe("runSync", () => {
     expect(vi.mocked(ghGraphql)).not.toHaveBeenCalled();
   });
 
-  it("returns early (logs warn) when allowlist is empty", async () => {
-    let callIdx = 0;
+  it("returns early (logs warn) when no tenants with installation_id exist", async () => {
+    const { listInstallationRepos } = await import("../auth/installToken");
+    const { getInstallationToken } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
+
     const db = makeFakeDb((sql, args) => {
-      callIdx++;
-      if (sql.includes("key='halted'") || (callIdx === 1 && sql.includes("sync_control"))) {
-        // isHalted → halted=0
-        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
-      }
-      if (sql.includes("UPDATE") && sql.includes("sync_running")) {
-        // acquireSyncLock → acquired (changes=1)
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      if (sql.includes("sync_started_at")) {
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      if (sql.includes("repo_allowlist") || sql.includes("SELECT key FROM")) {
-        // getRepoAllowlist → empty
+      if (sql.includes("FROM tenants")) {
+        // discoverTenants → empty (no tenants with installation_id)
         return makeFakeStmt(sql, args, []);
       }
-      // releaseSyncLock
       return makeFakeStmt(sql, args, [], 1);
     });
-
-    // Override batch to work nicely
-    (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch.mockResolvedValue([]);
 
     const env = makeEnv({ DB: db });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     await expect(runSync(env)).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("repo_allowlist empty"));
-    warnSpy.mockRestore();
-  });
-
-  it("halts when auth failures reach threshold (>=2)", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // enumerateOrgRepos calls ghGraphql; throw auth error
-    mockGhGraphql.mockRejectedValue(new GraphQLError("auth", true));
-
-    let callIdx = 0;
-    const db = makeFakeDb((sql, args) => {
-      callIdx++;
-      // isHalted → not halted
-      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
-      // acquireSyncLock → acquired
-      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      // sync_started_at update
-      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      // getRepoAllowlist → one repo so we proceed past the empty check
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/lyra" }]);
-      }
-      // incrementAuthFailures UPDATE → changes=1
-      if (sql.includes("auth_failures") && sql.includes("UPDATE")) {
-        return makeFakeStmt(sql, args, [], 1);
-      }
-      // incrementAuthFailures SELECT → value=2 (at threshold)
-      if (sql.includes("auth_failures") && sql.includes("SELECT")) {
-        return makeFakeStmt(sql, args, [{ value: "2" }], 0);
-      }
-      // haltSync UPDATE, releaseSyncLock
-      return makeFakeStmt(sql, args, [], 1);
-    });
-
-    const env = makeEnv({ DB: db });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("HALTED"),
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("no repos discovered across all installations — nothing to sync"),
     );
-    errorSpy.mockRestore();
-  });
-
-  // Halt-alert POST path (S8, #100) ----------------------------------------
-
-  // Builds a FakeD1 that drives runSync straight to the auth-halt branch
-  // (isHalted=0 → lock acquired → one allowlist repo → ghGraphql throws auth →
-  // auth_failures=2 → haltSync). Shared by the two NOTIFY_URL tests below.
-  function makeHaltDb() {
-    return makeFakeDb((sql, args) => {
-      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
-      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/lyra" }]);
-      }
-      if (sql.includes("auth_failures") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("auth_failures") && sql.includes("SELECT")) return makeFakeStmt(sql, args, [{ value: "2" }], 0);
-      return makeFakeStmt(sql, args, [], 1);
-    });
-  }
-
-  it("POSTs a sync_halted alert to NOTIFY_URL when the breaker trips", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(null, { status: 200 }));
-
-    const env = makeEnv({ DB: makeHaltDb(), NOTIFY_URL: "https://ntfy.example/roxabi" });
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe("https://ntfy.example/roxabi");
-    expect(init).toMatchObject({ method: "POST" });
-    expect(String((init as RequestInit).body)).toContain("sync_halted");
-  });
-
-  it("does not POST when NOTIFY_URL is unset", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    const env = makeEnv({ DB: makeHaltDb() }); // no NOTIFY_URL
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  // R2 run-audit (#120) -----------------------------------------------------
-
-  it("writes a run-audit object to R2 (outcome=halted) on the halt path", async () => {
-    const { ghGraphql, GraphQLError } = await import("./graphql");
-    vi.mocked(ghGraphql).mockRejectedValue(new GraphQLError("auth", true));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const put = vi.fn().mockResolvedValue(undefined);
-
-    const env = makeEnv({ DB: makeHaltDb(), LOGS: { put } as unknown as R2Bucket });
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    expect(put).toHaveBeenCalledTimes(1);
-    const [key, body] = put.mock.calls[0];
-    expect(key).toMatch(/^runs\/\d{4}-\d{2}-\d{2}\/.+\.json$/);
-    expect(JSON.parse(body as string).outcome).toBe("halted");
+    warnSpy.mockRestore();
   });
 
   // Prune + archived-repo tracking (#N) -------------------------------------
 
   /**
    * Builds a FakeD1 that drives runSync through the prune path:
-   *   isHalted=0 → lock acquired → allowlist=[Roxabi/roxabi-factory] →
-   *   ghGraphql returns live=[roxabi-factory] + archived=[roxabi-vault] →
+   *   discoverTenants → [{id:1, installation_id:139542392}] →
+   *   lock acquired → getInstallationToken → listInstallationRepos=[Roxabi/roxabi-factory] →
    *   DB SELECT DISTINCT queries return stale=[Roxabi/lyra] in issues/edges/pr_state/sync_state →
    *   batchChunked invoked with DELETE stmts for Roxabi/lyra
-   *
-   * Callers replace ghGraphql mocks before calling makeFullSyncDb.
    */
   function makeFullSyncDb(opts: {
     issueRepos?: string[];
@@ -1140,8 +1021,13 @@ describe("runSync", () => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      // discoverTenants
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 139542392 }]);
+      }
+      // tenant_repo_access (not used in prune path but respond gracefully)
+      if (sql.includes("FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ owner: "Roxabi", name: "roxabi-factory" }]);
       }
       // Prune SELECT DISTINCT queries
       if (sql.includes("SELECT DISTINCT repo FROM issues")) {
@@ -1165,34 +1051,14 @@ describe("runSync", () => {
   }
 
   it("prunes issues/edges/pr_state/sync_state for a deleted repo (Roxabi/lyra)", async () => {
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // listInstallationRepos returns only roxabi-factory (lyra is gone)
+    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → live: only roxabi-factory (lyra is gone)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // syncRepoBundle calls (REPO_BUNDLE_QUERY) for roxabi-factory — empty result
+    // syncRepoBundle calls for roxabi-factory — empty result
     mockGhGraphql.mockResolvedValue({
       data: {
         repository: {
@@ -1223,35 +1089,15 @@ describe("runSync", () => {
     expect(deletedEdgeStmts.length).toBeGreaterThan(0);
   });
 
-  it("does NOT prune rows for an archived repo (roxabi-vault stays)", async () => {
+  it("does NOT prune rows for a repo still accessible via installation (roxabi-vault stays)", async () => {
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // listInstallationRepos returns both repos — roxabi-vault is still accessible
+    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory", "Roxabi/roxabi-vault"]);
+
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → live: only roxabi-factory
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY → archived: roxabi-vault (it IS in archived, not stale)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // syncRepoBundle empty result for roxabi-factory
+    // syncRepoBundle empty result for each repo
     mockGhGraphql.mockResolvedValue({
       data: {
         repository: {
@@ -1263,7 +1109,7 @@ describe("runSync", () => {
       },
     });
 
-    // DB returns roxabi-vault as present in issues — but it's archived, so NOT stale
+    // DB returns roxabi-vault as present in issues — but it's still in live set, so NOT stale
     const db = makeFullSyncDb({
       issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
       edgeSrcRepos: [],
@@ -1283,41 +1129,18 @@ describe("runSync", () => {
     expect(deletedVaultStmts).toHaveLength(0);
   });
 
-  it("skips all prune logic (warn) when live repo enumeration returns 0 repos", async () => {
-    const { ghGraphql } = await import("./graphql");
-    const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → live: empty (transient error)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
+  it("skips all prune logic (warn) when listInstallationRepos returns 0 repos", async () => {
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // listInstallationRepos returns empty — transient error
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "Roxabi/roxabi-factory" }]);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 139542392 }]);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
@@ -1328,77 +1151,14 @@ describe("runSync", () => {
     const env = makeEnv({ DB: db });
     await expect(runSync(env)).resolves.toBeUndefined();
 
-    // Safety guard must have warned
+    // Safety guard must have warned — new flow emits the "nothing to sync" message
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("live repo enumeration returned 0 repos"),
+      expect.stringContaining("no repos discovered across all installations — nothing to sync"),
     );
 
     // No DELETE statements should have been issued
     const deleteStmts = db._recorded.filter((s) => s.sql.includes("DELETE"));
     expect(deleteStmts).toHaveLength(0);
-  });
-
-  it("upserts repos table with archived=1 when a repo moves live→archived", async () => {
-    const { ghGraphql } = await import("./graphql");
-    const mockGhGraphql = vi.mocked(ghGraphql);
-
-    // REPOS_QUERY → roxabi-factory live (roxabi-vault is now archived, not in live list)
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "roxabi-factory", owner: { login: "Roxabi" }, isArchived: false, isPrivate: false }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 5000, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // ARCHIVED_REPOS_QUERY → roxabi-vault is now archived
-    mockGhGraphql.mockResolvedValueOnce({
-      data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ nameWithOwner: "Roxabi/roxabi-vault" }],
-          },
-        },
-        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-    // syncRepoBundle empty result
-    mockGhGraphql.mockResolvedValue({
-      data: {
-        repository: {
-          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
-          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
-          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
-        },
-        rateLimit: { cost: 1, remaining: 4998, resetAt: "2026-01-01T00:00:00Z" },
-      },
-    });
-
-    const db = makeFullSyncDb({
-      issueRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
-      edgeSrcRepos: [],
-      edgeDstRepos: [],
-      prStateRepos: [],
-      syncStateRepos: ["Roxabi/roxabi-vault", "Roxabi/roxabi-factory"],
-    });
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    const env = makeEnv({ DB: db });
-    await expect(runSync(env)).resolves.toBeUndefined();
-
-    // The upsert INSERT stmt for Roxabi/roxabi-vault must use the archived=1 SQL variant
-    // (literal `1` is in the SQL text, not in bind args — only the repo name is bound)
-    const archivedUpsertStmts = db._recorded.filter(
-      (s) =>
-        s.sql.includes("INSERT INTO repos") &&
-        s.sql.includes("VALUES (?, 1)") &&
-        s.args.includes("Roxabi/roxabi-vault"),
-    );
-    expect(archivedUpsertStmts.length).toBeGreaterThan(0);
   });
 });
 
@@ -1482,95 +1242,124 @@ describe("writeRunAudit", () => {
 //      throws before syncRepoBundle. Add the mock when implementing #160.
 // ---------------------------------------------------------------------------
 
-describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-skip + fix in S3b)", () => {
+describe("runSync — multi-tenant installation sync (#160)", () => {
   // Local makeEnv scoped to this describe so it composes cleanly
   function makeEnv(overrides: Record<string, unknown> = {}): Env {
     return {
       DB: undefined as unknown as D1Database,
-      GITHUB_TOKEN: "tok",
       GITHUB_ORG: "Roxabi",
       ...overrides,
     } as unknown as Env;
   }
 
   it("deduplicates GraphQL bundle fetches: two tenants sharing repo o/r → exactly 1 REPO_BUNDLE_QUERY issued for o/r", async () => {
-    // Two tenants both have tenant_repo_access for "o/r".
-    // The future multi-tenant runSync must deduplicate: one fetch regardless of tenant count.
+    // Two tenants both have access to "o/r" via their install tokens.
+    // runSync must deduplicate: one syncRepoBundle call regardless of tenant count.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    // Both tenants enumerate the same repo "o/r"
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      // Future: tenants table → two rows
       if (sql.includes("FROM tenants")) {
         return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
-      }
-      // Future: tenant_repo_access for both tenants → same repo "o/r"
-      if (sql.includes("FROM tenant_repo_access")) {
-        return makeFakeStmt(sql, args, [{ owner: "o", name: "r" }, { owner: "o", name: "r" }]);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
 
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
-    // Future REPO_BUNDLE_QUERY path — stub returns minimal valid shape
+    // syncRepoBundle uses REPO_BUNDLE_QUERY — stub returns minimal valid shape
     mockGhGraphql.mockResolvedValue({
-      data: { repository: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] }, pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } },
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
     });
 
     const env = makeEnv({ DB: db });
+    vi.spyOn(console, "log").mockImplementation(() => {});
     await runSync(env);
 
-    // Exactly 1 ghGraphql call with REPO_BUNDLE_QUERY for owner="o", name="r"
+    // Exactly 1 ghGraphql call for repo o/r (deduplication)
     const bundleCalls = mockGhGraphql.mock.calls.filter(
-      (c) => c[0] === "REPO_BUNDLE_QUERY" && c[1]?.owner === "o" && c[1]?.name === "r",
+      (c) => (c[1] as Record<string, unknown>)?.owner === "o" && (c[1] as Record<string, unknown>)?.name === "r",
     );
     expect(bundleCalls).toHaveLength(1);
   });
 
   it("advances sync_slot per tick: seed sync_slot=0, after runSync the slot is updated", async () => {
-    // Future: sync_control row sync_slot tracks which window of repos was processed.
-    // The current impl has no windowing — this test will fail (RED) until slot logic is added.
+    // sync_control row sync_slot tracks which window of repos was processed.
+    // Discovery must yield ≥1 repo so Phase 2 runs and reaches the slot-advance write.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
     let syncSlotWritten = false;
+    let nextSlotValue: unknown;
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
       // Return sync_slot=0 on read
       if (sql.includes("sync_slot") && sql.includes("SELECT")) {
-        return makeFakeStmt(sql, args, [{ key: "sync_slot", value: "0" }]);
+        return makeFakeStmt(sql, args, [{ value: "0" }]);
       }
-      // Detect the slot-advance write (INSERT OR REPLACE / UPDATE with key=sync_slot)
-      if (sql.includes("sync_slot") && (sql.includes("INSERT") || sql.includes("UPDATE"))) {
+      // Detect the slot-advance write (UPDATE with key=sync_slot); capture bound value.
+      if (sql.includes("sync_slot") && sql.includes("UPDATE")) {
         syncSlotWritten = true;
+        nextSlotValue = args[0];
         return makeFakeStmt(sql, args, [], 1);
-      }
-      // repo_allowlist — empty → runSync short-circuits after acquiring lock
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, []);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const env = makeEnv({ DB: db });
     await runSync(env);
-    warnSpy.mockRestore();
 
-    // Assertion: the sync run must have written an updated sync_slot value.
-    // Currently no slot logic exists → syncSlotWritten stays false → RED.
+    // The sync run must advance sync_slot: 0 → (0+1) % NUM_SLOTS = 1.
     expect(syncSlotWritten).toBe(true);
+    expect(nextSlotValue).toBe("1");
   });
 
   it("per-tenant lock isolation: tenant A holding sync_running=1 does NOT prevent tenant B from syncing", async () => {
-    // Future: acquireSyncLock(db, tenantId) must be scoped per-tenant.
-    // Current impl: global lock (tenant_id=0 hardcoded) → tenant A's lock blocks everyone → RED.
+    // acquireSyncLock(db, tenantId) is per-tenant: tenant A's held lock (changes=0)
+    // must not stop discovery from attempting tenant B's own lock.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue([]);
+
     let tenantBLockAttempted = false;
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) {
-        // Lock for tenant A (id=1) is held → changes=0; lock for tenant B (id=2) is free → changes=1
-        const tenantArg = args.find((a) => typeof a === "number");
+        // Lock bound as [..., tenantId] — tenantId is last arg (a number)
+        const tenantArg = [...args].reverse().find((a) => typeof a === "number");
+        if (tenantArg === 0) return makeFakeStmt(sql, args, [], 1); // global tick lock: acquired
         if (tenantArg === 1) return makeFakeStmt(sql, args, [], 0); // tenant A: lock held
         if (tenantArg === 2) {
           tenantBLockAttempted = true;
@@ -1582,9 +1371,6 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
       if (sql.includes("FROM tenants")) {
         return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
       }
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, []);
-      }
       return makeFakeStmt(sql, args, [], 1);
     });
 
@@ -1593,25 +1379,25 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
     await runSync(env);
     warnSpy.mockRestore();
 
-    // Tenant B's lock attempt must have been made (i.e., runSync iterates tenants independently).
-    // With current single-tenant global lock this never happens → RED.
+    // Tenant B's lock attempt must have been made (runSync iterates tenants independently).
     expect(tenantBLockAttempted).toBe(true);
   });
 
   it("no PAT access: runSync completes via install tokens without reading env.GITHUB_TOKEN", async () => {
-    // Future: runSync must use resolveInstallToken() and never fall back to the PAT.
-    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos (line ~1161) → spy records it.
-    // The DB must return a non-empty allowlist so runSync advances past the early-return
-    // guard and actually reaches the PAT read site (enumerateOrgRepos / syncRepoBundle).
+    // runSync must use getInstallationToken() and never read env.GITHUB_TOKEN.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
+    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
       data: {
-        organization: {
-          repositories: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [{ name: "r", owner: { login: "o" }, isArchived: false, isPrivate: false }],
-          },
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
         },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
       },
     });
 
@@ -1619,9 +1405,8 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
       if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
       if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
-      // Non-empty allowlist — ensures runSync does NOT short-circuit before the PAT read
-      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
-        return makeFakeStmt(sql, args, [{ key: "o/r" }]);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 139542392 }]);
       }
       return makeFakeStmt(sql, args, [], 1);
     });
@@ -1633,15 +1418,15 @@ describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-
     Object.defineProperty(base, "GITHUB_TOKEN", {
       get() {
         patAccessCount++;
-        return "tok"; // still returns a value so runSync can proceed (error swallowing aside)
+        return "tok";
       },
       configurable: true,
     });
 
+    vi.spyOn(console, "log").mockImplementation(() => {});
     await runSync(base);
 
-    // Future impl: patAccessCount must be 0 (resolveInstallToken used instead).
-    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos + archivedRepos → count > 0 → RED.
+    // runSync must not read env.GITHUB_TOKEN — install token is used exclusively.
     expect(patAccessCount).toBe(0);
   });
 });

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1470,6 +1470,183 @@ describe("writeRunAudit", () => {
 });
 
 // ---------------------------------------------------------------------------
+// runSync — multi-tenant / per-installation tests
+// ---------------------------------------------------------------------------
+// DEFERRED to #160 (S3b — sync per-tenant cutover + PAT retirement). The runSync
+// rewrite was split out of #146 (S3a shipped the install-token infra + webhook
+// cutover). Skipped here because (a) these assert the not-yet-built per-tenant
+// runSync, and (b) two bugs must be fixed when un-skipping in #160:
+//   1. dedup assertion uses c[2]/c[3]; ghGraphql(query, variables, token) puts
+//      query at c[0], vars at c[1].
+//   2. no vi.mock("../auth/installToken") → a faithful impl's getInstallationToken
+//      throws before syncRepoBundle. Add the mock when implementing #160.
+// ---------------------------------------------------------------------------
+
+describe.skip("runSync — multi-tenant installation sync (DEFERRED #160 — un-skip + fix in S3b)", () => {
+  // Local makeEnv scoped to this describe so it composes cleanly
+  function makeEnv(overrides: Record<string, unknown> = {}): Env {
+    return {
+      DB: undefined as unknown as D1Database,
+      GITHUB_TOKEN: "tok",
+      GITHUB_ORG: "Roxabi",
+      ...overrides,
+    } as unknown as Env;
+  }
+
+  it("deduplicates GraphQL bundle fetches: two tenants sharing repo o/r → exactly 1 REPO_BUNDLE_QUERY issued for o/r", async () => {
+    // Two tenants both have tenant_repo_access for "o/r".
+    // The future multi-tenant runSync must deduplicate: one fetch regardless of tenant count.
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      // Future: tenants table → two rows
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
+      }
+      // Future: tenant_repo_access for both tenants → same repo "o/r"
+      if (sql.includes("FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ owner: "o", name: "r" }, { owner: "o", name: "r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+    // Future REPO_BUNDLE_QUERY path — stub returns minimal valid shape
+    mockGhGraphql.mockResolvedValue({
+      data: { repository: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] }, pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] } } },
+    });
+
+    const env = makeEnv({ DB: db });
+    await runSync(env);
+
+    // Exactly 1 ghGraphql call with REPO_BUNDLE_QUERY for owner="o", name="r"
+    const bundleCalls = mockGhGraphql.mock.calls.filter(
+      (c) => c[0] === "REPO_BUNDLE_QUERY" && c[1]?.owner === "o" && c[1]?.name === "r",
+    );
+    expect(bundleCalls).toHaveLength(1);
+  });
+
+  it("advances sync_slot per tick: seed sync_slot=0, after runSync the slot is updated", async () => {
+    // Future: sync_control row sync_slot tracks which window of repos was processed.
+    // The current impl has no windowing — this test will fail (RED) until slot logic is added.
+    let syncSlotWritten = false;
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      // Return sync_slot=0 on read
+      if (sql.includes("sync_slot") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ key: "sync_slot", value: "0" }]);
+      }
+      // Detect the slot-advance write (INSERT OR REPLACE / UPDATE with key=sync_slot)
+      if (sql.includes("sync_slot") && (sql.includes("INSERT") || sql.includes("UPDATE"))) {
+        syncSlotWritten = true;
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // repo_allowlist — empty → runSync short-circuits after acquiring lock
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, []);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = makeEnv({ DB: db });
+    await runSync(env);
+    warnSpy.mockRestore();
+
+    // Assertion: the sync run must have written an updated sync_slot value.
+    // Currently no slot logic exists → syncSlotWritten stays false → RED.
+    expect(syncSlotWritten).toBe(true);
+  });
+
+  it("per-tenant lock isolation: tenant A holding sync_running=1 does NOT prevent tenant B from syncing", async () => {
+    // Future: acquireSyncLock(db, tenantId) must be scoped per-tenant.
+    // Current impl: global lock (tenant_id=0 hardcoded) → tenant A's lock blocks everyone → RED.
+    let tenantBLockAttempted = false;
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        // Lock for tenant A (id=1) is held → changes=0; lock for tenant B (id=2) is free → changes=1
+        const tenantArg = args.find((a) => typeof a === "number");
+        if (tenantArg === 1) return makeFakeStmt(sql, args, [], 0); // tenant A: lock held
+        if (tenantArg === 2) {
+          tenantBLockAttempted = true;
+          return makeFakeStmt(sql, args, [], 1); // tenant B: lock acquired
+        }
+        return makeFakeStmt(sql, args, [], 0);
+      }
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }, { id: 2, installation_id: 20 }]);
+      }
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, []);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = makeEnv({ DB: db });
+    await runSync(env);
+    warnSpy.mockRestore();
+
+    // Tenant B's lock attempt must have been made (i.e., runSync iterates tenants independently).
+    // With current single-tenant global lock this never happens → RED.
+    expect(tenantBLockAttempted).toBe(true);
+  });
+
+  it("no PAT access: runSync completes via install tokens without reading env.GITHUB_TOKEN", async () => {
+    // Future: runSync must use resolveInstallToken() and never fall back to the PAT.
+    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos (line ~1161) → spy records it.
+    // The DB must return a non-empty allowlist so runSync advances past the early-return
+    // guard and actually reaches the PAT read site (enumerateOrgRepos / syncRepoBundle).
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        organization: {
+          repositories: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ name: "r", owner: { login: "o" }, isArchived: false, isPrivate: false }],
+          },
+        },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) return makeFakeStmt(sql, args, [], 1);
+      if (sql.includes("sync_started_at")) return makeFakeStmt(sql, args, [], 1);
+      // Non-empty allowlist — ensures runSync does NOT short-circuit before the PAT read
+      if (sql.includes("repo_allowlist") || (sql.includes("SELECT key") && sql.includes("sync_control"))) {
+        return makeFakeStmt(sql, args, [{ key: "o/r" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const base = makeEnv({ DB: db });
+    // Replace GITHUB_TOKEN with a spy getter that records every access.
+    let patAccessCount = 0;
+    delete (base as unknown as Record<string, unknown>)["GITHUB_TOKEN"];
+    Object.defineProperty(base, "GITHUB_TOKEN", {
+      get() {
+        patAccessCount++;
+        return "tok"; // still returns a value so runSync can proceed (error swallowing aside)
+      },
+      configurable: true,
+    });
+
+    await runSync(base);
+
+    // Future impl: patAccessCount must be 0 (resolveInstallToken used instead).
+    // Current impl reads env.GITHUB_TOKEN at enumerateOrgRepos + archivedRepos → count > 0 → RED.
+    expect(patAccessCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Teardown
 // ---------------------------------------------------------------------------
 

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BRANCH_ISSUE_RE,
+  UPSERT_ISSUE_SQL,
   batchChunked,
   canonicalKey,
   collectEdges,
@@ -449,6 +450,27 @@ describe("flushEdges", () => {
 });
 
 // ---------------------------------------------------------------------------
+// UPSERT_ISSUE_SQL shape (TF4)
+// ---------------------------------------------------------------------------
+
+describe("UPSERT_ISSUE_SQL", () => {
+  it("stores title inside json_object payload (not as a bare column)", () => {
+    // Assert the SQL uses json_object('title', ?) — not a raw title column
+    expect(UPSERT_ISSUE_SQL).toMatch(/json_object\('title', \?\)/);
+  });
+
+  it("updates payload via excluded.payload on conflict", () => {
+    // Match regardless of alignment whitespace between column name and = sign
+    expect(UPSERT_ISSUE_SQL).toMatch(/payload\s*=\s*excluded\.payload/);
+  });
+
+  it("does not expose title as a top-level excluded column", () => {
+    // title must not appear as `excluded.title` — it lives inside the JSON payload
+    expect(UPSERT_ISSUE_SQL).not.toMatch(/title\s*=\s*excluded\.title/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // acquireSyncLock
 // ---------------------------------------------------------------------------
 
@@ -467,6 +489,22 @@ describe("acquireSyncLock", () => {
     );
     const acquired = await acquireSyncLock(db);
     expect(acquired).toBe(false);
+  });
+
+  it("scopes UPDATE to tenant_id = 0 (TF3)", async () => {
+    // Arrange
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+    // Act
+    await acquireSyncLock(db);
+    // Assert
+    expect(capturedStmts).toHaveLength(1);
+    expect(capturedStmts[0].sql).toContain("key = 'sync_running'");
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
   });
 });
 
@@ -514,6 +552,8 @@ describe("haltSync", () => {
     // value='1' is a SQL literal, not a bound param — assert the SQL text
     expect(capturedStmts[0].sql).toContain("value='1'");
     expect(capturedStmts[0].sql).toContain("key='halted'");
+    // tenant isolation guard must be present (TF3)
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
     // only the ISO timestamp is bound
     expect(capturedStmts[0].args).toHaveLength(1);
     expect(typeof capturedStmts[0].args[0]).toBe("string");
@@ -549,6 +589,8 @@ describe("auth failure helpers", () => {
     // value='0' is a SQL literal, not a bound param — assert the SQL text
     expect(capturedStmts[0].sql).toContain("value='0'");
     expect(capturedStmts[0].sql).toContain("key='auth_failures'");
+    // tenant isolation guard must be present (TF3)
+    expect(capturedStmts[0].sql).toContain("AND tenant_id = 0");
     // only the ISO timestamp is bound
     expect(capturedStmts[0].args).toHaveLength(1);
     expect(String(capturedStmts[0].args[0])).toMatch(/^\d{4}-\d{2}-\d{2}T/);

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -25,7 +25,9 @@ import { getInstallationToken, listInstallationRepos } from "../auth/installToke
 // ---------------------------------------------------------------------------
 
 export const MAX_PAGES = 500;
+/** Repos synced per slot per tick. Coverage ceiling: WINDOW * NUM_SLOTS = 60 repos. */
 export const WINDOW = 20;
+/** Number of rotation slots. Coverage ceiling: WINDOW * NUM_SLOTS = 60 repos. */
 export const NUM_SLOTS = 3;
 
 /** Verbatim port of sync.py UPSERT_ISSUE_SQL — full sync path (sets status=null). */
@@ -1109,6 +1111,7 @@ export async function discoverTenants(
         repos = await listInstallationRepos(token);
       } catch (err) {
         console.error(`[sync] tenant ${tenantId} discovery failed:`, err);
+        await incrementAuthFailures(db, tenantId);
         continue;
       }
 
@@ -1198,6 +1201,9 @@ export async function runSync(env: Env): Promise<void> {
       return;
     }
 
+    if (allRepos.length > WINDOW * NUM_SLOTS)
+      console.warn(`[sync] ${allRepos.length} repos exceed window capacity ${WINDOW * NUM_SLOTS} — repos beyond index ${WINDOW * NUM_SLOTS} are not synced this cycle`);
+
     // Upsert repos table from the union.
     const repoUpsertStmts = allRepos.map((repo) =>
       db
@@ -1279,7 +1285,8 @@ export async function runSync(env: Env): Promise<void> {
     const slot = parseInt(slotRow?.value ?? "0", 10);
     const windowStart = slot * WINDOW;
     const windowEnd = windowStart + WINDOW;
-    const windowedRepos = allRepos.slice(windowStart, windowEnd);
+    // Windowing only engages past WINDOW repos; below that, sync everything hourly.
+    const windowedRepos = allRepos.length <= WINDOW ? allRepos : allRepos.slice(windowStart, windowEnd);
 
     console.log(
       `[sync] slot=${slot} window=[${windowStart},${windowEnd}) repos=${windowedRepos.length}/${allRepos.length}`,
@@ -1301,6 +1308,7 @@ export async function runSync(env: Env): Promise<void> {
 
     // Pass 1: bundled issues + refs + PRs per repo in window.
     const collectedEdges = new Map<string, EdgeData>();
+    let skippedCount = 0;
     for (const repo of windowedRepos) {
       const slash = repo.indexOf("/");
       const owner = repo.slice(0, slash);
@@ -1311,12 +1319,8 @@ export async function runSync(env: Env): Promise<void> {
         const token = await resolveToken();
         await syncRepoBundle(db, token, owner, name, collectedEdges);
       } catch (err) {
-        if (err instanceof GraphQLError && err.isAuth) {
-          // Auth failure already counted above; skip this repo, don't abort.
-          console.error(`[sync] skipping ${repo} — all tokens failed`);
-        } else {
-          console.error(`[sync] skipping ${repo}:`, err);
-        }
+        console.error(`[sync] skipping ${repo}:`, err);
+        skippedCount++;
       }
     }
 
@@ -1343,17 +1347,14 @@ export async function runSync(env: Env): Promise<void> {
       .bind(String(nextSlot), new Date().toISOString())
       .run();
 
-    await resetAuthFailures(db);
-    outcome = "success";
-  } catch (err) {
-    const isAuth = err instanceof GraphQLError && err.isAuth;
-    if (isAuth) {
-      const failures = await incrementAuthFailures(db);
-      console.error(`[sync] auth failure ${failures}/2`);
+    const systemicFailure = windowedRepos.length > 0 && skippedCount === windowedRepos.length;
+    if (systemicFailure) {
+      const failures = await incrementAuthFailures(db, 0);
+      console.error(`[sync] all ${windowedRepos.length} windowed repo(s) failed — systemic auth failure ${failures}/2`);
       outcome = failures >= 2 ? "halted" : "auth_error";
       if (failures >= 2) {
-        await haltSync(db);
-        console.error("[sync] HALTED: 2 consecutive auth failures");
+        await haltSync(db, 0);
+        console.error("[sync] HALTED: systemic token failure across all repos");
         const notifyUrl = env.NOTIFY_URL;
         if (notifyUrl) {
           await fetch(notifyUrl, {
@@ -1363,10 +1364,18 @@ export async function runSync(env: Env): Promise<void> {
           }).catch(() => {});
         }
       }
-    } else {
-      outcome = "error";
-      console.error("[sync] error:", err);
     }
+
+    if (!systemicFailure) {
+      const tenantIds = new Set<number>();
+      for (const list of repoTenantMap.values()) for (const e of list) tenantIds.add(e.tenantId);
+      await resetAuthFailures(db, 0);
+      for (const id of tenantIds) await resetAuthFailures(db, id);
+      outcome = "success";
+    }
+  } catch (err) {
+    outcome = "error";
+    console.error("[sync] error:", err);
   } finally {
     await releaseSyncLock(db);
     await writeRunAudit(env, db, {

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -30,15 +30,15 @@ export const MAX_PAGES = 500;
 /** Verbatim port of sync.py UPSERT_ISSUE_SQL — full sync path (sets status=null). */
 export const UPSERT_ISSUE_SQL = `
   INSERT INTO issues
-      (key, repo, number, title, state, url, created_at, updated_at,
+      (key, repo, number, payload, state, url, created_at, updated_at,
        closed_at, milestone, is_stub, lane, priority, size, status,
        has_active_branch)
   VALUES
-      (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (?, ?, ?, json_object('title', ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT(key) DO UPDATE SET
       repo              = excluded.repo,
       number            = excluded.number,
-      title             = excluded.title,
+      payload           = excluded.payload,
       state             = excluded.state,
       url               = excluded.url,
       created_at        = excluded.created_at,
@@ -216,6 +216,7 @@ export async function acquireSyncLock(db: D1Database): Promise<boolean> {
       `UPDATE sync_control
        SET value = '1', updated_at = ?
        WHERE key = 'sync_running'
+         AND tenant_id = 0
          AND (value = '0' OR (CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', updated_at) AS INTEGER)) > 900)`,
     )
     .bind(new Date().toISOString())
@@ -225,21 +226,21 @@ export async function acquireSyncLock(db: D1Database): Promise<boolean> {
 
 export async function releaseSyncLock(db: D1Database): Promise<void> {
   await db
-    .prepare(`UPDATE sync_control SET value='0', updated_at=? WHERE key='sync_running'`)
+    .prepare(`UPDATE sync_control SET value='0', updated_at=? WHERE key='sync_running' AND tenant_id = 0`)
     .bind(new Date().toISOString())
     .run();
 }
 
 export async function isHalted(db: D1Database): Promise<boolean> {
   const row = await db
-    .prepare(`SELECT value FROM sync_control WHERE key='halted'`)
+    .prepare(`SELECT value FROM sync_control WHERE key='halted' AND tenant_id = 0`)
     .first<{ value: string }>();
   return row?.value === "1";
 }
 
 export async function getAuthFailures(db: D1Database): Promise<number> {
   const row = await db
-    .prepare(`SELECT value FROM sync_control WHERE key='auth_failures'`)
+    .prepare(`SELECT value FROM sync_control WHERE key='auth_failures' AND tenant_id = 0`)
     .first<{ value: string }>();
   return parseInt(row?.value ?? "0", 10);
 }
@@ -248,7 +249,7 @@ export async function incrementAuthFailures(db: D1Database): Promise<number> {
   await db
     .prepare(
       `UPDATE sync_control SET value=CAST(CAST(value AS INTEGER)+1 AS TEXT), updated_at=?
-       WHERE key='auth_failures'`,
+       WHERE key='auth_failures' AND tenant_id = 0`,
     )
     .bind(new Date().toISOString())
     .run();
@@ -257,7 +258,7 @@ export async function incrementAuthFailures(db: D1Database): Promise<number> {
 
 export async function haltSync(db: D1Database): Promise<void> {
   await db
-    .prepare(`UPDATE sync_control SET value='1', updated_at=? WHERE key='halted'`)
+    .prepare(`UPDATE sync_control SET value='1', updated_at=? WHERE key='halted' AND tenant_id = 0`)
     .bind(new Date().toISOString())
     .run();
 }
@@ -265,7 +266,7 @@ export async function haltSync(db: D1Database): Promise<void> {
 export async function resetAuthFailures(db: D1Database): Promise<void> {
   await db
     .prepare(
-      `UPDATE sync_control SET value='0', updated_at=? WHERE key='auth_failures'`,
+      `UPDATE sync_control SET value='0', updated_at=? WHERE key='auth_failures' AND tenant_id = 0`,
     )
     .bind(new Date().toISOString())
     .run();
@@ -1093,7 +1094,7 @@ export async function writeRunAudit(
         .first<{ w: string | null }>(),
       db
         .prepare(
-          "SELECT key, value FROM sync_control WHERE key IN ('halted','auth_failures')",
+          "SELECT key, value FROM sync_control WHERE key IN ('halted','auth_failures') AND tenant_id = 0",
         )
         .all<{ key: string; value: string }>(),
     ]);
@@ -1145,7 +1146,7 @@ export async function runSync(env: Env): Promise<void> {
     const startedAt = new Date().toISOString();
     await db
       .prepare(
-        `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_started_at'`,
+        `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_started_at' AND tenant_id = 0`,
       )
       .bind(startedAt, startedAt)
       .run();

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -11,21 +11,22 @@
 
 import { ghGraphql, GraphQLError } from "./graphql";
 import {
-  ARCHIVED_REPOS_QUERY,
   ISSUES_QUERY,
   PRS_QUERY,
   REFS_QUERY,
   REPO_BUNDLE_QUERY,
-  REPOS_QUERY,
   STUB_ISSUE_QUERY,
 } from "./queries";
 import type { Env } from "../types";
+import { getInstallationToken, listInstallationRepos } from "../auth/installToken";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 export const MAX_PAGES = 500;
+export const WINDOW = 20;
+export const NUM_SLOTS = 3;
 
 /** Verbatim port of sync.py UPSERT_ISSUE_SQL — full sync path (sets status=null). */
 export const UPSERT_ISSUE_SQL = `
@@ -210,158 +211,68 @@ export async function batchChunked(
 // sync_control helpers
 // ---------------------------------------------------------------------------
 
-export async function acquireSyncLock(db: D1Database): Promise<boolean> {
+export async function acquireSyncLock(db: D1Database, tenantId: number = 0): Promise<boolean> {
   const result = await db
     .prepare(
       `UPDATE sync_control
        SET value = '1', updated_at = ?
        WHERE key = 'sync_running'
-         AND tenant_id = 0
+         AND tenant_id = ?
          AND (value = '0' OR (CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', updated_at) AS INTEGER)) > 900)`,
     )
-    .bind(new Date().toISOString())
+    .bind(new Date().toISOString(), tenantId)
     .run();
   return result.meta.changes > 0;
 }
 
-export async function releaseSyncLock(db: D1Database): Promise<void> {
+export async function releaseSyncLock(db: D1Database, tenantId: number = 0): Promise<void> {
   await db
-    .prepare(`UPDATE sync_control SET value='0', updated_at=? WHERE key='sync_running' AND tenant_id = 0`)
-    .bind(new Date().toISOString())
+    .prepare(`UPDATE sync_control SET value='0', updated_at=? WHERE key='sync_running' AND tenant_id = ?`)
+    .bind(new Date().toISOString(), tenantId)
     .run();
 }
 
-export async function isHalted(db: D1Database): Promise<boolean> {
+export async function isHalted(db: D1Database, tenantId: number = 0): Promise<boolean> {
   const row = await db
-    .prepare(`SELECT value FROM sync_control WHERE key='halted' AND tenant_id = 0`)
+    .prepare(`SELECT value FROM sync_control WHERE key='halted' AND tenant_id = ?`)
+    .bind(tenantId)
     .first<{ value: string }>();
   return row?.value === "1";
 }
 
-export async function getAuthFailures(db: D1Database): Promise<number> {
+export async function getAuthFailures(db: D1Database, tenantId: number = 0): Promise<number> {
   const row = await db
-    .prepare(`SELECT value FROM sync_control WHERE key='auth_failures' AND tenant_id = 0`)
+    .prepare(`SELECT value FROM sync_control WHERE key='auth_failures' AND tenant_id = ?`)
+    .bind(tenantId)
     .first<{ value: string }>();
   return parseInt(row?.value ?? "0", 10);
 }
 
-export async function incrementAuthFailures(db: D1Database): Promise<number> {
+export async function incrementAuthFailures(db: D1Database, tenantId: number = 0): Promise<number> {
   await db
     .prepare(
       `UPDATE sync_control SET value=CAST(CAST(value AS INTEGER)+1 AS TEXT), updated_at=?
-       WHERE key='auth_failures' AND tenant_id = 0`,
+       WHERE key='auth_failures' AND tenant_id = ?`,
     )
-    .bind(new Date().toISOString())
+    .bind(new Date().toISOString(), tenantId)
     .run();
-  return getAuthFailures(db);
+  return getAuthFailures(db, tenantId);
 }
 
-export async function haltSync(db: D1Database): Promise<void> {
+export async function haltSync(db: D1Database, tenantId: number = 0): Promise<void> {
   await db
-    .prepare(`UPDATE sync_control SET value='1', updated_at=? WHERE key='halted' AND tenant_id = 0`)
-    .bind(new Date().toISOString())
+    .prepare(`UPDATE sync_control SET value='1', updated_at=? WHERE key='halted' AND tenant_id = ?`)
+    .bind(new Date().toISOString(), tenantId)
     .run();
 }
 
-export async function resetAuthFailures(db: D1Database): Promise<void> {
+export async function resetAuthFailures(db: D1Database, tenantId: number = 0): Promise<void> {
   await db
     .prepare(
-      `UPDATE sync_control SET value='0', updated_at=? WHERE key='auth_failures' AND tenant_id = 0`,
+      `UPDATE sync_control SET value='0', updated_at=? WHERE key='auth_failures' AND tenant_id = ?`,
     )
-    .bind(new Date().toISOString())
+    .bind(new Date().toISOString(), tenantId)
     .run();
-}
-
-// ---------------------------------------------------------------------------
-// Repo allowlist
-// ---------------------------------------------------------------------------
-
-export async function getRepoAllowlist(db: D1Database): Promise<string[]> {
-  const result = await db.prepare(`SELECT repo FROM repo_allowlist`).all<{ repo: string }>();
-  return (result.results ?? []).map((r) => r.repo);
-}
-
-// ---------------------------------------------------------------------------
-// Org repo enumeration
-// ---------------------------------------------------------------------------
-
-interface RepoNode {
-  name: string;
-  owner: { login: string };
-  isArchived: boolean;
-  isPrivate: boolean;
-}
-interface ReposData {
-  organization: {
-    repositories: {
-      pageInfo: { hasNextPage: boolean; endCursor: string | null };
-      nodes: RepoNode[];
-    };
-  };
-  rateLimit: { cost: number; remaining: number; resetAt: string };
-}
-
-export async function enumerateOrgRepos(
-  org: string,
-  token: string,
-): Promise<Array<{ owner: string; name: string }>> {
-  const repos: Array<{ owner: string; name: string }> = [];
-  let cursor: string | null = null;
-
-  while (true) {
-    const response: { data: ReposData } & Record<string, unknown> = await ghGraphql<ReposData>(REPOS_QUERY, { org, cursor }, token);
-    const data: ReposData = response.data;
-    const rl = data.rateLimit;
-    console.log(`[sync] repos cost=${rl.cost} remaining=${rl.remaining}`);
-
-    for (const node of data.organization.repositories.nodes) {
-      repos.push({ owner: node.owner.login, name: node.name });
-    }
-
-    const pageInfo: { hasNextPage: boolean; endCursor: string | null } = data.organization.repositories.pageInfo;
-    if (!pageInfo.hasNextPage) break;
-    cursor = pageInfo.endCursor;
-    if (!cursor) break;
-  }
-
-  return repos;
-}
-
-interface ArchivedReposData {
-  organization: {
-    repositories: {
-      pageInfo: { hasNextPage: boolean; endCursor: string | null };
-      nodes: Array<{ nameWithOwner: string }>;
-    };
-  };
-  rateLimit: { cost: number; remaining: number; resetAt: string };
-}
-
-export async function enumerateArchivedOrgRepos(
-  org: string,
-  token: string,
-): Promise<string[]> {
-  const repos: string[] = [];
-  let cursor: string | null = null;
-
-  while (true) {
-    const response: { data: ArchivedReposData } & Record<string, unknown> =
-      await ghGraphql<ArchivedReposData>(ARCHIVED_REPOS_QUERY, { org, cursor }, token);
-    const data: ArchivedReposData = response.data;
-    const rl = data.rateLimit;
-    console.log(`[sync] archived-repos cost=${rl.cost} remaining=${rl.remaining}`);
-
-    for (const node of data.organization.repositories.nodes) {
-      repos.push(node.nameWithOwner);
-    }
-
-    const pageInfo = data.organization.repositories.pageInfo;
-    if (!pageInfo.hasNextPage) break;
-    cursor = pageInfo.endCursor;
-    if (!cursor) break;
-  }
-
-  return repos;
 }
 
 // ---------------------------------------------------------------------------
@@ -983,7 +894,10 @@ interface StubIssueData {
  * Find edge endpoints missing from issues, stub-fetch them.
  * Catches ANY GraphQLError → log as orphan + continue (matches Python behaviour).
  */
-export async function closedHopPass(db: D1Database, token: string): Promise<number> {
+export async function closedHopPass(
+  db: D1Database,
+  resolveToken: (owner: string, name: string) => Promise<string>,
+): Promise<number> {
   const missingRows = await db
     .prepare(
       `SELECT DISTINCT k FROM (
@@ -1008,6 +922,14 @@ export async function closedHopPass(db: D1Database, token: string): Promise<numb
     if (slashIdx < 0) continue;
     const owner = ownerRepo.slice(0, slashIdx);
     const name = ownerRepo.slice(slashIdx + 1);
+
+    let token: string;
+    try {
+      token = await resolveToken(owner, name);
+    } catch {
+      console.log(`[sync] no token for closed-hop ${key}`);
+      continue;
+    }
 
     let response: { data: StubIssueData } & Record<string, unknown>;
     try {
@@ -1124,6 +1046,119 @@ export async function writeRunAudit(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 1 — per-tenant discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover repos accessible to each installed tenant and build the global
+ * dedup map used by Phase 2 fan-out.
+ *
+ * For each tenant with an installation_id:
+ *   1. Seed sync_control rows (INSERT OR IGNORE) so acquireSyncLock can UPDATE.
+ *   2. Attempt acquireSyncLock(db, tenantId) as a within-tick skip-guard.
+ *   3. Under try/finally call getInstallationToken → listInstallationRepos.
+ *   4. Upsert tenant_repo_access; delete stale rows.
+ *   5. Accumulate Map<repo, Array<{tenantId, installationId}>> sorted by tenantId
+ *      (lowest = owning; used for token fallback in Phase 2).
+ */
+export async function discoverTenants(
+  db: D1Database,
+  env: Env,
+): Promise<Map<string, Array<{ tenantId: number; installationId: number }>>> {
+  const repoMap = new Map<string, Array<{ tenantId: number; installationId: number }>>();
+
+  const tenantRows = await db
+    .prepare(`SELECT id, installation_id FROM tenants WHERE installation_id IS NOT NULL ORDER BY id ASC`)
+    .all<{ id: number; installation_id: number }>();
+
+  for (const tenant of tenantRows.results ?? []) {
+    const tenantId = tenant.id;
+    const installationId = tenant.installation_id;
+
+    // Seed sync_control rows so acquireSyncLock UPDATE has a row to match.
+    const seedStmts: D1PreparedStatement[] = [
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO sync_control (tenant_id, key, value, updated_at) VALUES (?, 'sync_running', '0', ?)`,
+        )
+        .bind(tenantId, new Date().toISOString()),
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO sync_control (tenant_id, key, value, updated_at) VALUES (?, 'auth_failures', '0', ?)`,
+        )
+        .bind(tenantId, new Date().toISOString()),
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO sync_control (tenant_id, key, value, updated_at) VALUES (?, 'halted', '0', ?)`,
+        )
+        .bind(tenantId, new Date().toISOString()),
+    ];
+    await batchChunked(db, seedStmts);
+
+    const got = await acquireSyncLock(db, tenantId);
+    if (!got) {
+      console.log(`[sync] tenant ${tenantId} lock held — skipping discovery`);
+      continue;
+    }
+
+    try {
+      let repos: string[];
+      try {
+        const token = await getInstallationToken(db, env, tenantId, installationId);
+        repos = await listInstallationRepos(token);
+      } catch (err) {
+        console.error(`[sync] tenant ${tenantId} discovery failed:`, err);
+        continue;
+      }
+
+      // Upsert accessible repos into tenant_repo_access.
+      if (repos.length > 0) {
+        const upsertStmts = repos.map((repo) =>
+          db
+            .prepare(
+              `INSERT OR IGNORE INTO tenant_repo_access (tenant_id, repo) VALUES (?, ?)`,
+            )
+            .bind(tenantId, repo),
+        );
+        await batchChunked(db, upsertStmts);
+      }
+
+      // Delete stale rows: repos no longer returned by the installation.
+      const repoSet = new Set(repos);
+      const existing = await db
+        .prepare(`SELECT repo FROM tenant_repo_access WHERE tenant_id = ?`)
+        .bind(tenantId)
+        .all<{ repo: string }>();
+      const stale = (existing.results ?? []).map((r) => r.repo).filter((r) => !repoSet.has(r));
+      if (stale.length > 0) {
+        const deleteStmts = stale.map((repo) =>
+          db
+            .prepare(`DELETE FROM tenant_repo_access WHERE tenant_id = ? AND repo = ?`)
+            .bind(tenantId, repo),
+        );
+        await batchChunked(db, deleteStmts);
+        console.log(`[sync] tenant ${tenantId} removed ${stale.length} stale repo(s)`);
+      }
+
+      // Merge into global map (sorted ascending by tenantId — maintained by ORDER BY above).
+      for (const repo of repos) {
+        const entry = repoMap.get(repo);
+        if (entry) {
+          entry.push({ tenantId, installationId });
+        } else {
+          repoMap.set(repo, [{ tenantId, installationId }]);
+        }
+      }
+      console.log(`[sync] tenant ${tenantId} discovered ${repos.length} repo(s)`);
+    } finally {
+      await releaseSyncLock(db, tenantId);
+    }
+  }
+
+  return repoMap;
+}
+
 export async function runSync(env: Env): Promise<void> {
   const db = env.DB;
 
@@ -1151,142 +1186,162 @@ export async function runSync(env: Env): Promise<void> {
       .bind(startedAt, startedAt)
       .run();
 
-    const allowlist = await getRepoAllowlist(db);
-    if (allowlist.length === 0) {
-      console.warn("[sync] repo_allowlist empty — nothing to sync");
+    // Phase 1 — per-tenant discovery: build Map<repo, [{tenantId,installationId}]>.
+    const repoTenantMap = await discoverTenants(db, env);
+
+    // Union of all repos accessible across all tenants.
+    const allRepos = [...repoTenantMap.keys()].sort();
+
+    if (allRepos.length === 0) {
+      console.warn("[sync] no repos discovered across all installations — nothing to sync");
       outcome = "empty";
       return;
     }
 
-    const orgRepos = await enumerateOrgRepos(env.GITHUB_ORG, env.GITHUB_TOKEN);
-    const active = orgRepos.filter((r) => allowlist.includes(`${r.owner}/${r.name}`));
-
-    // Enumerate archived repos for tracking + prune safety.
-    const archivedRepoNames = await enumerateArchivedOrgRepos(
-      env.GITHUB_ORG,
-      env.GITHUB_TOKEN,
+    // Upsert repos table from the union.
+    const repoUpsertStmts = allRepos.map((repo) =>
+      db
+        .prepare(
+          `INSERT INTO repos (repo, archived) VALUES (?, 0) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived`,
+        )
+        .bind(repo),
     );
-    const liveRepoNames = orgRepos.map((r) => `${r.owner}/${r.name}`);
+    await batchChunked(db, repoUpsertStmts);
+    console.log(`[sync] upserted ${allRepos.length} repo(s) from tenant discovery`);
 
-    // SAFETY GUARD: if live enumeration returned 0 repos (transient API error),
-    // skip all prune logic to prevent wiping the entire DB. This is NOT a halt —
-    // sync continues with the (empty) active set, which means no issues are synced
-    // this run, but existing DB rows are preserved.
-    if (liveRepoNames.length === 0) {
-      console.warn("[sync] live repo enumeration returned 0 repos — skipping prune");
-    } else {
-      // Upsert repos table: live repos with archived=0, archived repos with archived=1.
-      const repoUpsertStmts: D1PreparedStatement[] = [
-        ...liveRepoNames.map((repo) =>
+    // Prune: delete data for repos absent from the union.
+    // SAFETY GUARD: skip prune if union is empty (already handled above, but be explicit).
+    const knownRepos = new Set(allRepos);
+    const CHUNK = 90;
+
+    const [issueRepos, edgeSrcRepos, edgeDstRepos, prStateRepos, syncStateRepos] =
+      await Promise.all([
+        db.prepare("SELECT DISTINCT repo FROM issues").all<{ repo: string }>(),
+        db.prepare("SELECT DISTINCT substr(src_key, 1, instr(src_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+        db.prepare("SELECT DISTINCT substr(dst_key, 1, instr(dst_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
+        db.prepare("SELECT DISTINCT repo FROM pr_state").all<{ repo: string }>(),
+        db.prepare("SELECT repo FROM sync_state").all<{ repo: string }>(),
+      ]);
+
+    const staleIssueRepos = (issueRepos.results ?? []).map((r) => r.repo).filter((r) => !knownRepos.has(r));
+    const staleEdgeRepos = [
+      ...(edgeSrcRepos.results ?? []).map((r) => r.repo),
+      ...(edgeDstRepos.results ?? []).map((r) => r.repo),
+    ].filter((r) => !knownRepos.has(r));
+    const stalePrStateRepos = (prStateRepos.results ?? []).map((r) => r.repo).filter((r) => !knownRepos.has(r));
+    const staleSyncStateRepos = (syncStateRepos.results ?? []).map((r) => r.repo).filter((r) => !knownRepos.has(r));
+
+    const pruneStmts: D1PreparedStatement[] = [];
+    for (let i = 0; i < staleIssueRepos.length; i += CHUNK) {
+      for (const repo of staleIssueRepos.slice(i, i + CHUNK)) {
+        pruneStmts.push(db.prepare("DELETE FROM issues WHERE repo=?").bind(repo));
+      }
+    }
+    const staleEdgeReposUniq = [...new Set(staleEdgeRepos)];
+    for (let i = 0; i < staleEdgeReposUniq.length; i += CHUNK) {
+      for (const repo of staleEdgeReposUniq.slice(i, i + CHUNK)) {
+        pruneStmts.push(
           db
             .prepare(
-              "INSERT INTO repos (repo, archived) VALUES (?, 0) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
+              "DELETE FROM edges WHERE substr(src_key,1,instr(src_key,'#')-1)=? OR substr(dst_key,1,instr(dst_key,'#')-1)=?",
             )
-            .bind(repo),
-        ),
-        ...archivedRepoNames.map((repo) =>
-          db
-            .prepare(
-              "INSERT INTO repos (repo, archived) VALUES (?, 1) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived",
-            )
-            .bind(repo),
-        ),
-      ];
-      if (repoUpsertStmts.length > 0) {
-        await batchChunked(db, repoUpsertStmts);
-        console.log(
-          `[sync] upserted ${liveRepoNames.length} live + ${archivedRepoNames.length} archived repo(s)`,
+            .bind(repo, repo),
         );
       }
-
-      // Full prune: delete issues (+ cascaded labels), edges, pr_state, sync_state
-      // for repos absent from live ∪ archived. Chunk at ≤90 to stay under D1 limits.
-      const knownRepos = new Set([...liveRepoNames, ...archivedRepoNames]);
-      const CHUNK = 90;
-
-      // Collect all repos currently in DB tables.
-      const [issueRepos, edgeSrcRepos, edgeDstRepos, prStateRepos, syncStateRepos] =
-        await Promise.all([
-          db.prepare("SELECT DISTINCT repo FROM issues").all<{ repo: string }>(),
-          db.prepare("SELECT DISTINCT substr(src_key, 1, instr(src_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
-          db.prepare("SELECT DISTINCT substr(dst_key, 1, instr(dst_key,'#')-1) AS repo FROM edges").all<{ repo: string }>(),
-          db.prepare("SELECT DISTINCT repo FROM pr_state").all<{ repo: string }>(),
-          db.prepare("SELECT repo FROM sync_state").all<{ repo: string }>(),
-        ]);
-
-      const staleIssueRepos = (issueRepos.results ?? [])
-        .map((r) => r.repo)
-        .filter((r) => !knownRepos.has(r));
-      const staleEdgeRepos = [
-        ...(edgeSrcRepos.results ?? []).map((r) => r.repo),
-        ...(edgeDstRepos.results ?? []).map((r) => r.repo),
-      ].filter((r) => !knownRepos.has(r));
-      const stalePrStateRepos = (prStateRepos.results ?? [])
-        .map((r) => r.repo)
-        .filter((r) => !knownRepos.has(r));
-      const staleSyncStateRepos = (syncStateRepos.results ?? [])
-        .map((r) => r.repo)
-        .filter((r) => !knownRepos.has(r));
-
-      const pruneStmts: D1PreparedStatement[] = [];
-      for (let i = 0; i < staleIssueRepos.length; i += CHUNK) {
-        for (const repo of staleIssueRepos.slice(i, i + CHUNK)) {
-          pruneStmts.push(db.prepare("DELETE FROM issues WHERE repo=?").bind(repo));
-        }
+    }
+    for (let i = 0; i < stalePrStateRepos.length; i += CHUNK) {
+      for (const repo of stalePrStateRepos.slice(i, i + CHUNK)) {
+        pruneStmts.push(db.prepare("DELETE FROM pr_state WHERE repo=?").bind(repo));
       }
-      // Deduplicate stale edge repos before chunking
-      const staleEdgeReposUniq = [...new Set(staleEdgeRepos)];
-      for (let i = 0; i < staleEdgeReposUniq.length; i += CHUNK) {
-        for (const repo of staleEdgeReposUniq.slice(i, i + CHUNK)) {
-          pruneStmts.push(
-            db
-              .prepare(
-                "DELETE FROM edges WHERE substr(src_key,1,instr(src_key,'#')-1)=? OR substr(dst_key,1,instr(dst_key,'#')-1)=?",
-              )
-              .bind(repo, repo),
-          );
-        }
-      }
-      for (let i = 0; i < stalePrStateRepos.length; i += CHUNK) {
-        for (const repo of stalePrStateRepos.slice(i, i + CHUNK)) {
-          pruneStmts.push(db.prepare("DELETE FROM pr_state WHERE repo=?").bind(repo));
-        }
-      }
-      for (let i = 0; i < staleSyncStateRepos.length; i += CHUNK) {
-        for (const repo of staleSyncStateRepos.slice(i, i + CHUNK)) {
-          pruneStmts.push(db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo));
-        }
-      }
-
-      if (pruneStmts.length > 0) {
-        await batchChunked(db, pruneStmts);
-        const totalStale = new Set([
-          ...staleIssueRepos,
-          ...staleEdgeReposUniq,
-          ...stalePrStateRepos,
-          ...staleSyncStateRepos,
-        ]).size;
-        console.log(`[sync] pruned data for ${totalStale} stale repo(s)`);
+    }
+    for (let i = 0; i < staleSyncStateRepos.length; i += CHUNK) {
+      for (const repo of staleSyncStateRepos.slice(i, i + CHUNK)) {
+        pruneStmts.push(db.prepare("DELETE FROM sync_state WHERE repo=?").bind(repo));
       }
     }
 
-    // Pass 1: bundled issues + refs + PRs per repo (1 subreq/repo instead of 3)
+    if (pruneStmts.length > 0) {
+      await batchChunked(db, pruneStmts);
+      const totalStale = new Set([
+        ...staleIssueRepos,
+        ...staleEdgeReposUniq,
+        ...stalePrStateRepos,
+        ...staleSyncStateRepos,
+      ]).size;
+      console.log(`[sync] pruned data for ${totalStale} stale repo(s)`);
+    }
+
+    // Phase 2 — deduped windowed fan-out.
+    // Read current slot (tenant_id=0).
+    const slotRow = await db
+      .prepare(`SELECT value FROM sync_control WHERE key='sync_slot' AND tenant_id = 0`)
+      .first<{ value: string }>();
+    const slot = parseInt(slotRow?.value ?? "0", 10);
+    const windowStart = slot * WINDOW;
+    const windowEnd = windowStart + WINDOW;
+    const windowedRepos = allRepos.slice(windowStart, windowEnd);
+
+    console.log(
+      `[sync] slot=${slot} window=[${windowStart},${windowEnd}) repos=${windowedRepos.length}/${allRepos.length}`,
+    );
+
+    // Per-repo token resolver: try owning tenant first, fall back down list.
+    const makeRepoResolver = (repoTenants: Array<{ tenantId: number; installationId: number }>) =>
+      async (): Promise<string> => {
+        for (const { tenantId, installationId } of repoTenants) {
+          try {
+            return await getInstallationToken(db, env, tenantId, installationId);
+          } catch (err) {
+            console.error(`[sync] token fallback: tenant ${tenantId} failed:`, err);
+            await incrementAuthFailures(db, tenantId);
+          }
+        }
+        throw new Error("all tenants failed to provide a token");
+      };
+
+    // Pass 1: bundled issues + refs + PRs per repo in window.
     const collectedEdges = new Map<string, EdgeData>();
-    for (const { owner, name } of active) {
+    for (const repo of windowedRepos) {
+      const slash = repo.indexOf("/");
+      const owner = repo.slice(0, slash);
+      const name = repo.slice(slash + 1);
+      const repoTenants = repoTenantMap.get(repo)!;
+      const resolveToken = makeRepoResolver(repoTenants);
       try {
-        await syncRepoBundle(db, env.GITHUB_TOKEN, owner, name, collectedEdges);
+        const token = await resolveToken();
+        await syncRepoBundle(db, token, owner, name, collectedEdges);
       } catch (err) {
-        if (err instanceof GraphQLError && err.isAuth) throw err;
-        console.error(`[sync] skipping ${owner}/${name}:`, err);
+        if (err instanceof GraphQLError && err.isAuth) {
+          // Auth failure already counted above; skip this repo, don't abort.
+          console.error(`[sync] skipping ${repo} — all tokens failed`);
+        } else {
+          console.error(`[sync] skipping ${repo}:`, err);
+        }
       }
     }
 
-    // Pass 2: flush all edges (deferred to avoid cross-repo FK hazard)
+    // Pass 2: flush all edges (deferred to avoid cross-repo FK hazard).
     await flushEdges(db, collectedEdges);
 
-    // Closed-hop pass
-    stubsCount = await closedHopPass(db, env.GITHUB_TOKEN);
+    // Closed-hop pass with per-(owner,name) resolver.
+    stubsCount = await closedHopPass(db, async (owner: string, name: string) => {
+      const repo = `${owner}/${name}`;
+      const repoTenants = repoTenantMap.get(repo);
+      if (!repoTenants || repoTenants.length === 0) {
+        throw new Error(`no tenant for ${repo}`);
+      }
+      return makeRepoResolver(repoTenants)();
+    });
     console.log(`[sync] completed — stubs=${stubsCount}`);
+
+    // Advance slot.
+    const nextSlot = (slot + 1) % NUM_SLOTS;
+    await db
+      .prepare(
+        `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_slot' AND tenant_id = 0`,
+      )
+      .bind(String(nextSlot), new Date().toISOString())
+      .run();
 
     await resetAuthFailures(db);
     outcome = "success";

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -6,8 +6,6 @@ export interface Env {
   DB: D1Database;
   /** Static-assets binding — serves the v6 frontend (wired in S7, #99). */
   ASSETS: Fetcher;
-  /** GitHub PAT for GraphQL sync (S3, #95). */
-  GITHUB_TOKEN: string;
   /** GitHub org to sync (e.g. "Roxabi"). */
   GITHUB_ORG: string;
   /** HMAC secret for webhook verification (S5, #97) — differs per env. */

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -32,4 +32,14 @@ export interface Env {
    * only guard). Set via `wrangler secret put ADMIN_TOKEN` to enable the gate.
    */
   ADMIN_TOKEN?: string;
+  // numeric App ID (App-JWT iss) — S3 consumes
+  GITHUB_APP_ID: string;
+  // OAuth client_id (login redirect)
+  GITHUB_APP_CLIENT_ID: string;
+  // OAuth client_secret (token exchange) — never logged
+  GITHUB_APP_CLIENT_SECRET: string;
+  // base64(PKCS#8 DER) of the App RSA key — importKey('pkcs8')
+  GITHUB_APP_PRIVATE_KEY: string;
+  // App webhook HMAC secret (distinct from org GITHUB_WEBHOOK_SECRET)
+  GITHUB_APP_WEBHOOK_SECRET: string;
 }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -42,4 +42,7 @@ export interface Env {
   GITHUB_APP_PRIVATE_KEY: string;
   // App webhook HMAC secret (distinct from org GITHUB_WEBHOOK_SECRET)
   GITHUB_APP_WEBHOOK_SECRET: string;
+  // base64 32-byte AES-GCM DEK for install-token encryption at rest (S3a, #146).
+  // Consumed by auth/tokenCrypto + auth/installToken. Set via `wrangler secret put INSTALL_TOKEN_KEY`.
+  INSTALL_TOKEN_KEY: string;
 }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -44,5 +44,6 @@ export interface Env {
   GITHUB_APP_WEBHOOK_SECRET: string;
   // base64 32-byte AES-GCM DEK for install-token encryption at rest (S3a, #146).
   // Consumed by auth/tokenCrypto + auth/installToken. Set via `wrangler secret put INSTALL_TOKEN_KEY`.
-  INSTALL_TOKEN_KEY: string;
+  // Optional at type-level (provisioned at deploy-time via CI); runtime guard in auth/installToken.ts getInstallTokenKey().
+  INSTALL_TOKEN_KEY?: string;
 }

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -35,8 +35,14 @@ vi.mock("../sync/sync", async (importOriginal) => {
   };
 });
 
+// RED (S3): resolveInstallToken does not exist yet — import fails at runtime → test fails
+vi.mock("../auth/installToken", () => ({
+  resolveInstallToken: vi.fn(),
+}));
+
 import { fetchIssueDeps } from "../sync/graphql";
 import { syncBranches } from "../sync/sync";
+import { resolveInstallToken } from "../auth/installToken";
 
 // ---------------------------------------------------------------------------
 // FakeD1 — cloned from mutations.test.ts / sync.test.ts pattern
@@ -173,6 +179,7 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_APP_CLIENT_SECRET: "placeholder",
     GITHUB_APP_PRIVATE_KEY: "placeholder",
     GITHUB_APP_WEBHOOK_SECRET: "placeholder",
+    INSTALL_TOKEN_KEY: "placeholder",
     ...overrides,
   };
 }
@@ -462,6 +469,56 @@ describe("handleDeps", () => {
       // Assert — catch swallows all errors, not just GraphQLError
       expect(result).toBe(0);
     });
+
+    // RED (S3 — future multi-tenant): handleDeps cross-repo path must use resolveInstallToken,
+    // NOT env.GITHUB_TOKEN. Current impl calls fetchIssueDeps(db, env.GITHUB_TOKEN, ...) at
+    // handlers.ts line ~209. Future impl must call resolveInstallToken(db, env, owner, name)
+    // and pass the resulting token to fetchIssueDeps.
+    it("cross-repo path resolves token via resolveInstallToken(db, env, owner, name) — NOT env.GITHUB_TOKEN", async () => {
+      // Arrange
+      const { db } = captureDb();
+      vi.mocked(fetchIssueDeps).mockResolvedValue({ blocked_by: [], blocking: [] });
+      // Future: resolveInstallToken returns an install token
+      vi.mocked(resolveInstallToken).mockResolvedValue("ghs_install_token");
+
+      // Use REPO which is "Roxabi/roxabi-live" → owner="Roxabi", name="roxabi-live"
+      const [owner, name] = REPO.split("/");
+
+      let patAccessCount = 0;
+      const envWithSpy: Env = { ...baseEnv, DB: db };
+      delete (envWithSpy as unknown as Record<string, unknown>)["GITHUB_TOKEN"];
+      Object.defineProperty(envWithSpy, "GITHUB_TOKEN", {
+        get() {
+          patAccessCount++;
+          return "ghp_test";
+        },
+        configurable: true,
+      });
+
+      const payload = {
+        action: "blocked_by_added",
+        blocked_issue: { number: 42 },
+        repository: { full_name: REPO },
+        // no blocking_issue key → cross-repo path
+      };
+
+      // Act
+      await handleDeps(payload, db, envWithSpy);
+
+      // Assert 1: resolveInstallToken called with the right db + env + owner/name.
+      // Compare via mock.calls indices, NOT toHaveBeenCalledWith(db, envWithSpy, ...): the
+      // structural matcher enumerates envWithSpy's own property names, which trips the
+      // GITHUB_TOKEN getter-spy and inflates patAccessCount. Reference-identity (toBe) and
+      // index access do not enumerate, so they measure the impl's access only.
+      const call = vi.mocked(resolveInstallToken).mock.calls[0];
+      expect(call?.[0]).toBe(db);
+      expect(call?.[1]).toBe(envWithSpy);
+      expect(call?.[2]).toBe(owner);
+      expect(call?.[3]).toBe(name);
+
+      // Assert 2: env.GITHUB_TOKEN must NOT be accessed by the impl (PAT bypass)
+      expect(patAccessCount).toBe(0);
+    });
   });
 });
 
@@ -622,6 +679,9 @@ describe("handleRefDelete", () => {
     // Arrange
     const { db } = captureDb();
     vi.mocked(syncBranches).mockResolvedValue(undefined);
+    // S3: handleRefDelete resolves the install token, then passes it to syncBranches
+    // (no longer env.GITHUB_TOKEN).
+    vi.mocked(resolveInstallToken).mockResolvedValue("ghs_install_token");
     const payload = {
       ref_type: "branch",
       ref: "42-done",
@@ -631,8 +691,8 @@ describe("handleRefDelete", () => {
     // Act
     await handleRefDelete(payload, db, { ...baseEnv, DB: db });
 
-    // Assert — syncBranches called with correct owner/name split
-    expect(vi.mocked(syncBranches)).toHaveBeenCalledWith(db, baseEnv.GITHUB_TOKEN, "Roxabi", "lyra");
+    // Assert — syncBranches called with the resolved install token + correct owner/name split
+    expect(vi.mocked(syncBranches)).toHaveBeenCalledWith(db, "ghs_install_token", "Roxabi", "lyra");
   });
 
   it("no-op for non-matching branch name", async () => {
@@ -665,6 +725,56 @@ describe("handleRefDelete", () => {
 
     // Assert
     expect(vi.mocked(syncBranches)).not.toHaveBeenCalled();
+  });
+
+  // RED (S3 — future multi-tenant): handleRefDelete must resolve the token for the
+  // deleted-branch repo via resolveInstallToken(db, env, owner, name), NOT env.GITHUB_TOKEN.
+  // Current impl calls syncBranches(db, env.GITHUB_TOKEN, owner, name) at handlers.ts line ~364.
+  // Future impl must call resolveInstallToken and pass the install token to syncBranches.
+  it("resolves token via resolveInstallToken for deleted-branch repo — NOT env.GITHUB_TOKEN", async () => {
+    // Arrange
+    const { db } = captureDb();
+    vi.mocked(syncBranches).mockResolvedValue(undefined);
+    // Future: resolveInstallToken returns an install token for this repo
+    vi.mocked(resolveInstallToken).mockResolvedValue("ghs_install_token");
+
+    // Use "Roxabi/lyra" so owner="Roxabi", name="lyra"
+    const repoFullName = "Roxabi/lyra";
+    const [owner, name] = repoFullName.split("/");
+
+    let patAccessCount = 0;
+    const envWithSpy: Env = { ...baseEnv, DB: db };
+    delete (envWithSpy as unknown as Record<string, unknown>)["GITHUB_TOKEN"];
+    Object.defineProperty(envWithSpy, "GITHUB_TOKEN", {
+      get() {
+        patAccessCount++;
+        return "ghp_test";
+      },
+      configurable: true,
+    });
+
+    const payload = {
+      ref_type: "branch",
+      ref: "42-done",
+      repository: { full_name: repoFullName },
+    };
+
+    // Act
+    await handleRefDelete(payload, db, envWithSpy);
+
+    // Assert 1: resolveInstallToken called with the right db + env + owner/name.
+    // Compare via mock.calls indices, NOT toHaveBeenCalledWith(db, envWithSpy, ...): the
+    // structural matcher enumerates envWithSpy's own property names, which trips the
+    // GITHUB_TOKEN getter-spy and inflates patAccessCount. Reference-identity (toBe) and
+    // index access do not enumerate, so they measure the impl's access only.
+    const call = vi.mocked(resolveInstallToken).mock.calls[0];
+    expect(call?.[0]).toBe(db);
+    expect(call?.[1]).toBe(envWithSpy);
+    expect(call?.[2]).toBe(owner);
+    expect(call?.[3]).toBe(name);
+
+    // Assert 2: env.GITHUB_TOKEN must NOT be accessed by the impl (PAT bypass)
+    expect(patAccessCount).toBe(0);
   });
 });
 

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -35,7 +35,7 @@ vi.mock("../sync/sync", async (importOriginal) => {
   };
 });
 
-// RED (S3): resolveInstallToken does not exist yet — import fails at runtime → test fails
+// Mocked to isolate webhook handler tests from the installation-token implementation.
 vi.mock("../auth/installToken", () => ({
   resolveInstallToken: vi.fn(),
 }));
@@ -411,6 +411,8 @@ describe("handleDeps", () => {
   });
 
   describe("cross-repo (blocking_issue absent)", () => {
+    beforeEach(() => vi.clearAllMocks());
+
     it("calls fetchIssueDeps then db.batch with upsertEdges stmts", async () => {
       // Arrange
       const { db } = captureDb();
@@ -671,6 +673,7 @@ describe("handleRefCreate", () => {
 // ---------------------------------------------------------------------------
 
 describe("handleRefDelete", () => {
+  beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.clearAllMocks());
 
   const baseEnv: Env = makeEnv();

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -170,7 +170,6 @@ function makeRequest(
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
     DB: captureDb().db,
-    GITHUB_TOKEN: "ghp_test",
     GITHUB_ORG: "Roxabi",
     GITHUB_WEBHOOK_SECRET: "test-secret",
     ASSETS: {} as Fetcher,

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -168,6 +168,11 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_ORG: "Roxabi",
     GITHUB_WEBHOOK_SECRET: "test-secret",
     ASSETS: {} as Fetcher,
+    GITHUB_APP_ID: "0",
+    GITHUB_APP_CLIENT_ID: "placeholder",
+    GITHUB_APP_CLIENT_SECRET: "placeholder",
+    GITHUB_APP_PRIVATE_KEY: "placeholder",
+    GITHUB_APP_WEBHOOK_SECRET: "placeholder",
     ...overrides,
   };
 }

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -28,6 +28,7 @@ import {
 } from "./mutations";
 import { BRANCH_ISSUE_RE, canonicalKey, extractFromLabels, syncBranches } from "../sync/sync";
 import { fetchIssueDeps, GraphQLError } from "../sync/graphql";
+import { resolveInstallToken } from "../auth/installToken";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -206,7 +207,24 @@ export async function handleDeps(
   // current dep graph and derive edges from the authoritative GitHub state.
   if (blockingIssue == null) {
     const repoObj = (payload["repository"] as Record<string, unknown> | undefined) ?? {};
-    return await pointFetchAndUpsertDeps(db, env.GITHUB_TOKEN, blockedIssue, repoObj);
+    const fullName = (repoObj["full_name"] as string | undefined) ?? "";
+    const slashIdx = fullName.indexOf("/");
+    if (slashIdx < 0 || slashIdx === fullName.length - 1) {
+      console.warn(
+        `[webhook] handle_deps: cannot resolve token — malformed repository.full_name=${JSON.stringify(fullName)}`,
+      );
+      return 0;
+    }
+    const owner = fullName.slice(0, slashIdx);
+    const name = fullName.slice(slashIdx + 1);
+    let token: string;
+    try {
+      token = await resolveInstallToken(db, env, owner, name);
+    } catch (err) {
+      console.warn(`[webhook] handle_deps: resolveInstallToken failed for ${fullName}`, err);
+      return 0;
+    }
+    return await pointFetchAndUpsertDeps(db, token, blockedIssue, repoObj);
   }
 
   // Same-repo fast path: both sides are in the payload — use them directly.
@@ -361,7 +379,8 @@ export async function handleRefDelete(
   const name = repo.slice(slashIdx + 1);
 
   try {
-    await syncBranches(db, env.GITHUB_TOKEN, owner, name);
+    const token = await resolveInstallToken(db, env, owner, name);
+    await syncBranches(db, token, owner, name);
   } catch (err) {
     console.error(
       `[webhook] handle_ref_delete: syncBranches failed for repo=${repo} ref=${ref}`,

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -383,7 +383,7 @@ export async function handleRefDelete(
     await syncBranches(db, token, owner, name);
   } catch (err) {
     console.error(
-      `[webhook] handle_ref_delete: syncBranches failed for repo=${repo} ref=${ref}`,
+      `[webhook] handle_ref_delete: token resolution or branch sync failed for repo=${repo} ref=${ref}`,
       err,
     );
   }

--- a/worker/src/webhook/mutations.test.ts
+++ b/worker/src/webhook/mutations.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  BUMP_DATA_VERSION_SQL,
   UPSERT_ISSUE_FROM_WEBHOOK_SQL,
   UPSERT_PR_STATE_SQL,
   addEdge,
+  bumpDataVersion,
   deleteIssue,
   removeEdge,
   renameMilestone,
@@ -173,6 +175,21 @@ describe("upsertIssueFromWebhook", () => {
     expect(args[10]).toBeNull(); // lane
     expect(args[11]).toBeNull(); // priority
     expect(args[12]).toBeNull(); // size
+  });
+
+  it("UPSERT_ISSUE_FROM_WEBHOOK_SQL uses json_object for title column", () => {
+    // Assert — SQL constant wraps title in json_object, not a bare column
+    expect(UPSERT_ISSUE_FROM_WEBHOOK_SQL).toMatch(/json_object\('title', \?\)/);
+  });
+
+  it("UPSERT_ISSUE_FROM_WEBHOOK_SQL sets payload = excluded.payload on conflict", () => {
+    // Assert — payload is updated via excluded alias on conflict
+    expect(UPSERT_ISSUE_FROM_WEBHOOK_SQL).toMatch(/payload\s*=\s*excluded\.payload/);
+  });
+
+  it("UPSERT_ISSUE_FROM_WEBHOOK_SQL does not set title = excluded.title on conflict", () => {
+    // Assert — title is not a direct column; it lives inside payload as json_object
+    expect(UPSERT_ISSUE_FROM_WEBHOOK_SQL).not.toMatch(/title\s*=\s*excluded\.title/);
   });
 });
 
@@ -500,5 +517,41 @@ describe("renameMilestone", () => {
     renameMilestone(db, "Roxabi/lyra", "Sprint 1", "Sprint 2");
     // Assert
     expect(stmts()[0].args).toEqual(["Sprint 2", "Roxabi/lyra", "Sprint 1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bumpDataVersion
+// ---------------------------------------------------------------------------
+
+describe("bumpDataVersion", () => {
+  const iso = "2024-06-10T12:00:00.000Z";
+
+  it("uses BUMP_DATA_VERSION_SQL constant", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    bumpDataVersion(db, iso);
+    // Assert
+    expect(stmts()[0].sql).toBe(BUMP_DATA_VERSION_SQL);
+  });
+
+  it("BUMP_DATA_VERSION_SQL has ON CONFLICT(tenant_id, key) clause", () => {
+    // Assert — conflict target must include tenant_id for multi-tenant correctness
+    expect(BUMP_DATA_VERSION_SQL).toContain("ON CONFLICT(tenant_id, key)");
+  });
+
+  it("BUMP_DATA_VERSION_SQL inserts literal 0 tenant_id and 'data_version' key", () => {
+    // Assert — VALUES row must start with (0, 'data_version', ...)
+    expect(BUMP_DATA_VERSION_SQL).toMatch(/VALUES\s*\(0, 'data_version'/);
+  });
+
+  it("binds iso twice — value and updated_at", () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    bumpDataVersion(db, iso);
+    // Assert — bind args are [iso, iso] (value = ?, updated_at = ?)
+    expect(stmts()[0].args).toEqual([iso, iso]);
   });
 });

--- a/worker/src/webhook/mutations.ts
+++ b/worker/src/webhook/mutations.ts
@@ -20,15 +20,15 @@
 /** Webhook upsert — preserves status (Project v2) and has_active_branch. */
 export const UPSERT_ISSUE_FROM_WEBHOOK_SQL = `
   INSERT INTO issues
-      (key, repo, number, title, state, url, created_at, updated_at, closed_at,
+      (key, repo, number, payload, state, url, created_at, updated_at, closed_at,
        milestone, is_stub, lane, priority, size, status, has_active_branch)
   VALUES
-      (?, ?, ?, ?, ?, ?, ?, ?, ?,
+      (?, ?, ?, json_object('title', ?), ?, ?, ?, ?, ?,
        ?, 0, ?, ?, ?, NULL, 0)
   ON CONFLICT(key) DO UPDATE SET
       repo       = excluded.repo,
       number     = excluded.number,
-      title      = excluded.title,
+      payload    = excluded.payload,
       state      = excluded.state,
       url        = excluded.url,
       created_at = excluded.created_at,
@@ -70,9 +70,9 @@ const RENAME_MILESTONE_SQL =
 
 /** Upsert the data_version key in sync_control with the given ISO-8601 timestamp. */
 export const BUMP_DATA_VERSION_SQL = `
-  INSERT INTO sync_control (key, value, updated_at)
-  VALUES ('data_version', ?, ?)
-  ON CONFLICT(key) DO UPDATE SET
+  INSERT INTO sync_control (tenant_id, key, value, updated_at)
+  VALUES (0, 'data_version', ?, ?)
+  ON CONFLICT(tenant_id, key) DO UPDATE SET
       value      = excluded.value,
       updated_at = excluded.updated_at
 `;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -80,6 +80,7 @@ binding     = "LOGS"
 bucket_name = "roxabi-live-logs-staging"
 
 # ── Dormant — activate when Workers Paid (Queues) is enabled ─────────────────
+# DORMANT — activate on Workers Paid + >30 repos (no consumer in Phase 1; uncommenting requires `wrangler queues create`)
 # [[queues.producers]]
 # binding = "SYNC_QUEUE"
 # queue   = "roxabi-live-sync"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -53,6 +53,7 @@ bucket_name = "roxabi-live-logs"
 
 [env.staging]
 name = "roxabi-live-staging"
+workers_dev = true
 # `routes` is inheritable — without this explicit empty override a staging
 # deploy would inherit the top-level live.roxabi.dev custom domain (#101) and
 # bind it to the staging Worker. Keep this even though staging has no routes.
@@ -73,6 +74,13 @@ enabled = true
 head_sampling_rate = 1
 
 # Named envs don't inherit top-level [[r2_buckets]] either — repeat for staging.
+# Separate bucket from prod to isolate staging/prod audit-log streams.
 [[env.staging.r2_buckets]]
 binding     = "LOGS"
-bucket_name = "roxabi-live-logs"
+bucket_name = "roxabi-live-logs-staging"
+
+# ── Dormant — activate when Workers Paid (Queues) is enabled ─────────────────
+# [[queues.producers]]
+# binding = "SYNC_QUEUE"
+# queue   = "roxabi-live-sync"
+# dormant — activate with Queues (Workers Paid) for per-repo sync fan-out, see #146


### PR DESCRIPTION
## Promotion: staging → main — Phase 1 (multi-tenant auth + install-token sync)

⚠️ **This is the full Phase 1 production cutover, not just #160.** main last synced 2026-06-09 (#138); staging is **47 commits ahead**. Merging promotes the entire repo-canonical rewrite to prod in one shot.

### What ships to prod
| Slice | What |
|---|---|
| #141 / #144 | Multi-tenant repo-canonical model — migration **0004** (10 tables, title→payload refactor) + **0005** (sync slot seed) |
| #145 | GitHub App JWT signer + OAuth login + D1 sessions |
| #146 (S3a) | Install-token infrastructure + webhook cutover |
| #160 (S3b) | Per-installation `runSync` cutover + PAT retirement (verified clean on staging, 2 ticks) |
| #164 | CI secret-inject path fix (`cd worker` so `--config ../wrangler.toml` resolves) |

### At-merge effects (IRREVERSIBLE — run automatically by `ci.yml` on push to `main`)
1. `wrangler d1 migrations apply DB --remote` → **0004 + 0005 applied to `roxabi-live-production` D1 (live data)**
2. `wrangler deploy` → new Worker live on `live.roxabi.dev` (~30–60s cutover blip)
3. Inject `GITHUB_APP_{ID,PRIVATE_KEY,WEBHOOK_SECRET}` + `INSTALL_TOKEN_KEY` to prod (source secrets confirmed present)

### Pre-flight
- [x] Staging CI green on `c43010e` (the promoted SHA)
- [x] #160 verified on staging — 2 consecutive install-token ticks clean (0 auth-fail, 0 halt, watermark fresh)
- [x] Prod inject secrets exist (`GH_APP_*`, `GH_INSTALL_TOKEN_KEY` @ 2026-06-12)
- [x] Migrations 0004+0005 battle-tested on staging since 2026-06-10 (incl. sync_control rebuild recovery guard)
- [ ] No open PRs targeting staging
- [ ] Deploy preview — N/A (no `deploy-preview.yml`; CF deploys via `ci.yml` on merge)

### Post-merge checklist
1. Watch the `main` CI run — confirm prod D1 migrate + deploy + secret-inject all green
2. Verify `https://live.roxabi.dev/health` → `db_reachable:true`, issue_count > 0
3. Verify prod cron tick (next `0 * * * *`) advances watermark on prod D1, `halted=0` / `auth_failures=0`
4. Register prod OAuth callback in the GitHub App settings if dashboard login is needed on prod (sync uses install tokens → unaffected)
5. Retire prod orphan PAT: `wrangler secret delete GITHUB_TOKEN` (prod) — same as staging RT3; new code never reads it
6. `release-please` will open a release PR on `main` → version + CHANGELOG
7. `/promote --finalize` (tag + GitHub Release) after the release PR, then `/cleanup`

---
⚠️ **MERGE WITH A MERGE COMMIT — never squash** (Release Convention; squash diverges histories → resurrected files next promotion).

Generated with [Claude Code](https://claude.com/claude-code) via `/promote`
