### PR TITLE
fix(sync): seed sync_started_at sync_control row (0006)

### DIFF
--- a/worker/migrations/0006_sync_started_at_seed.sql
+++ b/worker/migrations/0006_sync_started_at_seed.sql
@@ -1,0 +1,12 @@
+-- migration: 0006_sync_started_at_seed.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+
+-- Seed the global sync_started_at row (tenant_id=0).
+-- runSync does `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_started_at'
+-- AND tenant_id=0` (worker/src/sync/sync.ts). SQLite UPDATE on a missing row is a silent
+-- no-op (0 rows changed, no error), so without this seed sync_started_at is never written
+-- and any reader (monitoring, dashboard) sees NULL forever. Surfaced by the #167 review.
+-- INSERT OR IGNORE: idempotent — no-op if the row already exists (re-applied migration, or
+-- a tick that already wrote it). sync_control PK is (tenant_id, key); tenant_id=0 is the
+-- global sentinel (no FK to tenants), same as the sync_slot seed in 0005.
+INSERT OR IGNORE INTO sync_control (tenant_id, key, value) VALUES (0, 'sync_started_at', '');


### PR DESCRIPTION
## Summary
Seed the global `sync_control(tenant_id=0, key='sync_started_at')` row via migration `0006`.

`runSync` writes this key with `UPDATE sync_control SET value=?, updated_at=? WHERE key='sync_started_at' AND tenant_id=0` (`worker/src/sync/sync.ts`). SQLite `UPDATE` on a missing row is a silent no-op → the key was never written and any reader (monitoring/dashboard) saw `NULL`. Seeded idempotently (`INSERT OR IGNORE`, composite PK), mirroring the `0005` sync_slot pattern.

## Origin
Surfaced by the **#167** promotion review (architect finding, 95%). Hardening pulled forward so the staging→main cutover carries the fix.

## Test plan
- [ ] CI green (lint/typecheck/test/worker build)
- [ ] On merge → staging deploy applies `0006`; verify `SELECT value FROM sync_control WHERE tenant_id=0 AND key='sync_started_at'` returns a row (then a subsequent tick sets it to an ISO ts)

No code change — migration-only, idempotent, no-op on any DB that already has the row.

---
Generated with [Claude Code](https://claude.com/claude-code)
