### PR TITLE
feat(api): tenant-filtered reads + active-tenant + private-repo authz

### DIFF
--- a/artifacts/plans/148-tenant-filtered-reads-plan.mdx
+++ b/artifacts/plans/148-tenant-filtered-reads-plan.mdx
@@ -1,0 +1,289 @@
+---
+title: "Plan: tenant-filtered reads + active-tenant + private-repo authz (Phase 1 S5)"
+issue: 148
+spec: artifacts/specs/148-tenant-filtered-reads-spec.mdx
+complexity: 7/10
+tier: F-full
+generated: 2026-06-13
+---
+
+## Summary
+
+Close the unauthenticated-graph IDOR gap: gate every `/api/*` read behind the existing fail-closed
+`requireSession` middleware, then scope all issue/graph/edge reads to a **per-request visible-repo
+set** (`tenant_repo_access` ∩ user-permitted private repos). Self-absorbs the minimal `is_private`
+enablers (migration 0007 + sync population) so criterion 4 ships without waiting on #147.
+
+**Design lock:** authorization is resolved **once per request** by `repoAccess.resolveVisibleRepos(c)`
+→ `string[]` of repos the session user may see (all public tenant repos ∪ private repos passing the
+24h-cached / live-fallback / fail-closed permission check). Every read query then filters
+`repo IN (…visible)`. One permission pass over ≤34 repos per request — never per-issue.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph req[Request path /api/*]
+    RS["requireSession (session.ts)\nNOT EXISTS suspended → 401 fail-closed\ninject session{userId,tenantId,githubId,githubLogin}"]
+    RV["resolveVisibleRepos (repoAccess.ts)"]
+    RD["read handler: issues.ts / graph.ts\nSQL filter repo IN (…visible)"]
+    SER["serialize → no tenant_id leak"]
+  end
+  subgraph authz[repoAccess.ts]
+    Q1["SELECT repo,is_private FROM tenant_repo_access WHERE tenant_id=?"]
+    PUB["public (is_private=0) → always visible"]
+    PRIV["private (is_private=1) → per-user check"]
+    CACHE["user_repo_permission_cache\nchecked_at < 24h ? has_access"]
+    LIVE["GET /repos/:o/:r/collaborators/:login\n204→1 · 404/403→0 · error→fail-closed(0)"]
+  end
+  subgraph ingest[Hourly cron — sync]
+    DT["discoverTenants (sync.ts)"]
+    LIR["listInstallationRepos (installToken.ts)\nsurfaces GitHub private flag"]
+    UP["UPSERT tenant_repo_access(tenant_id,repo,is_private)\nON CONFLICT DO UPDATE is_private"]
+  end
+  subgraph tenant[Active tenant]
+    AT["POST /api/active-tenant (active-tenant.ts)\nverify user_installations → setSessionTenant"]
+  end
+  RS --> RV --> RD --> SER
+  RV --> Q1 --> PUB & PRIV
+  PRIV --> CACHE -->|miss/stale| LIVE --> CACHE
+  DT --> LIR --> UP
+  AT -.updates.-> RS
+  UP -.feeds.-> Q1
+
+  style RS fill:#fde,stroke:#b27
+  style RV fill:#def,stroke:#27b
+  style LIVE fill:#ffd,stroke:#b92
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph mig[migrations/0007]
+    M0["+is_private INTEGER NOT NULL DEFAULT 1"]
+  end
+  subgraph it[auth/installToken.ts]
+    LIR2["listInstallationRepos(): {repo,isPrivate}[]"]
+  end
+  subgraph sy[sync/sync.ts]
+    DT2["discoverTenants() UPSERT is_private"]
+  end
+  subgraph ra[auth/repoAccess.ts NEW]
+    RVR["resolveVisibleRepos(c)"]
+    CPA["checkPrivateAccess(db,env,user,tenant,repo,login)"]
+  end
+  subgraph se[auth/session.ts]
+    REQ["requireSession (exists)"]
+    SST["setSessionTenant(db,token,tenantId) NEW"]
+  end
+  subgraph ap[api/]
+    IS["issues.ts list+get (AuthEnv)"]
+    GR["graph.ts 5 queries (AuthEnv)"]
+    ME["me.ts +active_tenant_id"]
+    ATR["active-tenant.ts NEW"]
+  end
+  subgraph rt[router.ts]
+    R1["use(requireSession) on issues/graph"]
+    R2["post /api/active-tenant"]
+  end
+  LIR2 --> DT2 --> M0
+  RVR --> CPA
+  RVR --> IS & GR
+  REQ --> R1
+  SST --> ATR --> R2
+  IS & GR & ME & ATR -.tested.-> T[(vitest + fake-D1)]
+```
+
+## Agents
+
+| Instance | Domain | Tasks | Files |
+|---|---|---|---|
+| backend-dev-A | ingest | T1, T3 | `migrations/0007`, `auth/installToken.ts`, `sync/sync.ts` |
+| backend-dev-B | authz + reads | T4, T6, T7 | `auth/repoAccess.ts` (new), `api/issues.ts`, `api/graph.ts` |
+| backend-dev-C | session + http | T5, T8, T9 | `api/active-tenant.ts` (new), `auth/session.ts`, `api/me.ts`, `router.ts` |
+| tester-A | shared + reads tests | T2, T10, T11, T12 | `src/test-utils.ts` (new), `auth/repoAccess.test.ts`, `api/issues.test.ts`, `api/graph.test.ts` |
+| tester-B | endpoint + sync tests | T13, T14, T15 | `api/active-tenant.test.ts`, `router-401` test, `sync/sync.test.ts` |
+| security-auditor | security | T16 | (read-only audit) |
+
+## Micro-Tasks
+
+### V1 — Privacy ingest
+
+**T1 — migration 0007: `tenant_repo_access.is_private`** · be-A · migrations · SC-trace: SC4 · diff 1
+- File: `worker/migrations/0007_repo_access_is_private.sql`
+- `ALTER TABLE tenant_repo_access ADD COLUMN is_private INTEGER NOT NULL DEFAULT 1;` (DEFAULT 1 = fail-closed; converges to 0 for public repos on first sync)
+- Verify: `grep -n is_private worker/migrations/0007_*.sql`
+
+**T3 — surface + populate `is_private`** · be-A · sync · SC-trace: SC4 · diff 3 · blockedBy T1
+- `auth/installToken.ts`: `GHRepository += private: boolean`; `listInstallationRepos` returns `Promise<Array<{repo:string; isPrivate:boolean}>>` (`{repo:r.full_name, isPrivate:r.private}`)
+- `sync/sync.ts` `discoverTenants`: consume `{repo,isPrivate}[]`; UPSERT `INSERT INTO tenant_repo_access (tenant_id,repo,is_private) VALUES (?,?,?) ON CONFLICT(tenant_id,repo) DO UPDATE SET is_private=excluded.is_private`; stale-prune + repoMap keyed by `.repo`
+- Verify: `cd worker && npm run typecheck`; `grep -n "ON CONFLICT" src/sync/sync.ts`
+
+### V2 — Authz + tenant-filtered reads
+
+**T4 — `repoAccess.ts` resolveVisibleRepos** · be-B · authz · SC-trace: SC2,SC3,SC4 · diff 4
+- File: `worker/src/auth/repoAccess.ts` (new)
+- `resolveVisibleRepos(c: Context<AuthEnv>): Promise<string[]>` — SELECT repo,is_private WHERE tenant_id=session.tenantId; public→keep; private→`checkPrivateAccess`
+- `checkPrivateAccess(db,env,userId,tenantId,repo,login)`: cache hit (`checked_at > datetime('now','-24 hours')`)→`has_access`; miss/stale→`getInstallationToken` + `GET /repos/{repo}/collaborators/{login}` (204→1 · 404/403→0); upsert cache; any error → fail-closed `false` (no cache write)
+- resolve installation_id once: `SELECT installation_id FROM tenants WHERE id=?`
+- Verify: `npm run typecheck`
+
+**T6 — `issues.ts` tenant filter + AuthEnv** · be-B · reads · SC-trace: SC2,SC3,SC5 · diff 3 · blockedBy T4
+- Upgrade both handlers to `Context<AuthEnv>`; `const visible = await resolveVisibleRepos(c)`
+- `listIssuesRoute`: `visible.length===0 → return {issues:[],total:0,limit,offset}`; prepend `issues.repo IN (${ph})` to conditions + params (count+data share `where`)
+- `getIssueRoute`: append `AND repo IN (${ph})` to `issueSql` → no row → 404 (IDOR closed); edge LEFT JOINs add `AND i.repo IN (${ph})` (foreign blockers fall back to parseKey, no metadata leak)
+- Verify: `npm run typecheck`; `npx vitest run src/api/issues.test.ts`
+
+**T7 — `graph.ts` tenant filter + AuthEnv + comment** · be-B · reads · SC-trace: SC3,SC5 · diff 3 · blockedBy T4
+- Upgrade signature to `Context<AuthEnv>`; `const visible = await resolveVisibleRepos(c)`; empty → `{nodes:[],edges:[],repos:[]}`
+- (c) issues `WHERE repo IN (ph)`; (a) labels `WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (ph))`; (d) edges `WHERE src_key IN (…) AND dst_key IN (…)` (both endpoints visible); (e) repos `WHERE repo IN (ph)`; (b) pr_state — scope by `repo` subquery if column exists, else leave with comment (consumed only via visible nodes → no output leak)
+- Fix header comment `Four D1 reads` → `Five D1 reads (a)-(e), tenant-scoped`
+- Verify: `npm run typecheck`; `npx vitest run src/api/graph.test.ts`
+
+### V3 — Active tenant
+
+**T5 — `active-tenant.ts` + `setSessionTenant`** · be-C · session · SC-trace: SC6 · diff 3
+- `auth/session.ts`: `setSessionTenant(db, rawToken, tenantId)` → `UPDATE sessions SET tenant_id=? WHERE token_hash=? AND revoked_at IS NULL AND expires_at > datetime('now')`
+- `api/active-tenant.ts` (new): POST; body `{tenant_id}`; `SELECT 1 FROM user_installations WHERE user_id=? AND tenant_id=?` → none → 403; else `setSessionTenant` → 200 `{active_tenant_id}`
+- Verify: `npm run typecheck`
+
+**T8 — `me.ts` active_tenant_id + account_type** · be-C · session · SC-trace: SC5,SC7 · diff 2
+- Add `active_tenant_id: s.tenantId`; installations query `+ t.account_type AS account_type`
+- Verify: `npm run typecheck`; `npx vitest run src/api/me.test.ts`
+
+**T9 — `router.ts` wiring** · be-C · http · SC-trace: SC1,SC6 · diff 2 · blockedBy T5,T6,T7
+- `app.use("/api/issues", requireSession)`, `app.use("/api/issues/*", requireSession)`, `app.use("/api/graph", requireSession)` (before the GET handlers)
+- `app.post("/api/active-tenant", requireSession, activeTenantRoute)`
+- Verify: `npm run typecheck`
+
+### Tests + audit
+
+**T2 — `test-utils.ts` extraction** · te-A · shared · diff 2
+- Extract `captureDb`/`makeFakeDb`/`makeFakeStmt` + `STUB_SESSION` from existing tests → `worker/src/test-utils.ts`; add SQL dispatch keys for `tenant_repo_access` + `user_repo_permission_cache`
+- Verify: `grep -n "export" src/test-utils.ts`
+
+**T10 — `repoAccess.test.ts`** · te-A · authz · blockedBy T4,T2 — cache hit/miss/stale, live 204/404, error→fail-closed, public skip, empty set
+**T11 — `issues.test.ts` updates** · te-A · reads · blockedBy T6,T2 — IDOR 404 on foreign repo, list scoped, edge no-leak
+**T12 — `graph.test.ts` updates** · te-A · reads · blockedBy T7,T2 — nodes/edges/repos scoped to visible, dangling edges pruned
+**T13 — `active-tenant.test.ts`** · te-B · endpoints · blockedBy T5,T2 — membership verified, switch persists, non-member 403
+**T14 — router 401 gating test** · te-B · endpoints · blockedBy T9,T2 — no session → 401 before any DB stmt on issues/graph
+**T15 — `sync.test.ts` is_private** · te-B · sync · blockedBy T3,T2 — UPSERT writes/flips is_private; private repo flag round-trips
+
+**T16 — security audit** · security-auditor · security · blockedBy T6,T7,T9,T4 — verify: fail-closed on every error path, IDOR closed (foreign repo→404), no `tenant_id` in any response shape, no cross-tenant UNION, live-API timeout → deny
+
+## Wave Structure
+
+5 waves, max 3 parallel agents. Elapsed ~3 units vs ~9 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | 2 ∥ | be-A: T1 · te-A: T2 |
+| 2 | Wave 1 done | 3 ∥ | be-A: T3 · be-B: T4 · be-C: T5 |
+| 3 | T4,T5 done | 2 ∥ | be-B: T6→T7 · be-C: T8→T9 |
+| 4 | Wave 3 done | 2 ∥ | te-A: T10,T11,T12 · te-B: T13,T14,T15 |
+| 5 | Wave 4 done | 1 | security-auditor: T16 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 migration | 1 | trivial | 2 | — |
+| T2 test-utils | 1 | bounded | 3 | — |
+| T3 sync is_private | 2 | judgmental | 8 | — |
+| T4 repoAccess.ts | 1 | exploratory | 10 | — |
+| T5 active-tenant | 2 | judgmental | 6 | — |
+| T6 issues filter | 1 | judgmental | 6 | — |
+| T7 graph filter | 1 | judgmental | 6 | — |
+| T8 me.ts | 1 | bounded | 3 | — |
+| T9 router | 1 | bounded | 3 | — |
+| T10–T15 tests | 6 | judgmental | ~30 | — |
+| T16 audit | 1 | judgmental | 8 | — |
+
+**Total estimated ops: ~96**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|---|---|---|---|---|
+| backend-dev-A | T1,T3 | 10 | migrations, sync | — |
+| backend-dev-B | T4,T6,T7 | 22 | authz, reads | — |
+| backend-dev-C | T5,T8,T9 | 12 | session, http | — |
+| tester-A | T2,T10,T11,T12 | 22 | shared, reads | — |
+| tester-B | T13,T14,T15 | 16 | endpoints, sync | — |
+| security-auditor | T16 | 8 | security | — |
+
+## Consistency Report
+
+- Criteria covered: 8/8 — SC1(T9,T14) · SC2(T4,T6,T16) · SC3(T4,T6,T7) · SC4(T1,T3,T4) · SC5(T6,T7,T8,T16) · SC6(T5,T9,T13) · SC7(T8) · SC8(T11,T12 + staging manual, public slice)
+- Untraced tasks: none
+- Deferred: webhook cache-invalidation + real-time `is_private` updates → #147 (out of scope, documented in spec amendment)
+- Exemptions: SC8 private-repo cross-account staging verification needs a 2nd test account — public slice automated; private slice = manual staging check post-merge
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T{n} | agent-instance | blockedBy | subject.
+     blockedBy refs T-numbers within this list. Seed in wave order; within a wave all rows ∥. -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | backend-dev-A | — | migrations |
+| T2 | tester-A | — | shared |
+
+### Wave 2 — after Wave 1, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T3 | backend-dev-A | T1 | sync |
+| T4 | backend-dev-B | T1 | authz |
+| T5 | backend-dev-C | — | session |
+
+### Wave 3 — after T4,T5, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T6 | backend-dev-B | T4 | reads |
+| T7 | backend-dev-B | T4,T6 | reads |
+| T8 | backend-dev-C | — | session |
+| T9 | backend-dev-C | T5,T6,T7 | http |
+
+### Wave 4 — after Wave 3, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T10 | tester-A | T4,T2 | authz |
+| T11 | tester-A | T6,T2 | reads |
+| T12 | tester-A | T7,T2 | reads |
+| T13 | tester-B | T5,T2 | endpoints |
+| T14 | tester-B | T9,T2 | endpoints |
+| T15 | tester-B | T3,T2 | sync |
+
+### Wave 5 — after Wave 4, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T16 | security-auditor | T4,T6,T7,T9 | security |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 8 — migrations (backend-dev-A)
+- T2: 9 — shared (tester-A)
+- T3: 10 — sync (backend-dev-A)
+- T4: 11 — authz (backend-dev-B)
+- T5: 12 — session (backend-dev-C)
+- T6: 13 — reads (backend-dev-B)
+- T7: 14 — reads (backend-dev-B)
+- T8: 15 — session (backend-dev-C)
+- T9: 16 — http (backend-dev-C)
+- T10: 17 — authz (tester-A)
+- T11: 18 — reads (tester-A)
+- T12: 19 — reads (tester-A)
+- T13: 20 — endpoints (tester-B)
+- T14: 21 — endpoints (tester-B)
+- T15: 22 — sync (tester-B)
+- T16: 23 — security (security-auditor)

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -93,7 +93,11 @@ populated by `discoverTenants` from the GitHub `private` flag):
    - 204 → `has_access=1`; upsert cache.
    - 404/403 → `has_access=0`; upsert cache.
    - API error / timeout → **fail-closed** (treat as no access, 404); do not cache.
-3. **Cache error** (D1 read failure): fail-closed → 404.
+3. **Cache error** (D1 read failure on the cache lookup): fall through to the live check
+   (step 2). The live check is itself fail-closed (any error/timeout/non-204 → no access), so
+   it stays authoritative; a transient D1 blip must not permanently deny a genuine collaborator.
+   _(Amended 2026-06-13 per PR #171 review — code is more resilient than the original
+   "fail-closed → 404"; no access can be granted without a definitive GitHub 204.)_
 
 Public repos (`is_private = 0`) skip the permission check entirely.
 
@@ -107,13 +111,15 @@ webhook handlers land in #147, the 24h TTL + live-API fallback is the sole fresh
 Returns authenticated user info and installation list:
 ```json
 {
-  "github_login": "...",
+  "user": { "github_id": 1001, "github_login": "..." },
   "active_tenant_id": 42,
   "installations": [
     { "tenant_id": 42, "account_login": "Roxabi", "account_type": "Organization" }
   ]
 }
 ```
+_(Amended 2026-06-13 per PR #171 review: identity is nested under `user`; `installation_id`
+is NOT surfaced — internal infra id, unnecessary client exposure removed.)_
 
 No `tenant_id` column exposed from `issues`/`edges` rows. Response shapes are identical to
 single-tenant responses — authorization is fully backend-side.

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -14,6 +14,24 @@ amended: 2026-06-10
 > `user_repo_permission_cache` check (24h TTL, live API fallback); session middleware includes
 > NOT-EXISTS suspended-tenant guard; no `tenant_id` in response shapes.
 
+> **Amendment (2026-06-13, recheck — Option 3 "self-absorb"):** drift-check vs the shipped
+> 0004 schema found `tenant_repo_access` has no `is_private` column, which criterion 4 needs.
+> Rather than block on #147 (S4), **this issue absorbs the minimal `is_private` enablers** so all
+> 8 criteria ship together. Concretely #148 now also: (a) migration **0007** adds
+> `tenant_repo_access.is_private INTEGER NOT NULL DEFAULT 0`; (b) `listInstallationRepos` surfaces
+> the `private` flag (already in the GitHub response, currently discarded); (c) `discoverTenants`
+> upserts `is_private` (real UPSERT, not `INSERT OR IGNORE`, so privacy flips propagate each
+> hourly sync). **#147 is NOT subsumed** — it keeps webhook event-routing, cross-tenant stub
+> policy, `repository.privatized/publicized` (real-time `is_private` updates), `member.removed`
+> cache invalidation, and retention-on-uninstall. The 24h TTL + live-API fallback is the
+> fail-safe until #147's webhook invalidation lands (this matches the original spec, which already
+> deferred invalidation to #147). **Coordination:** #147 must NOT re-add the `is_private` column.
+>
+> **Column/name fixes applied (shipped-schema drift):** `user_repo_permission_cache.cached_at`
+> → **`checked_at`** (0004:84); issue title reads → **`JSON_EXTRACT(payload,'$.title')`** (title
+> column dropped in 0004:123); edge columns → **`src_key`/`dst_key`** (0001); `graphRoute` has
+> **5** queries (nodes/labels/pr_state/edges/repos) — fix the stale "Four D1 reads" header.
+
 ## Scope
 
 Slice **S5** of #141. **This slice satisfies the epic acceptance criterion.**
@@ -64,10 +82,11 @@ This JOIN applies to:
 
 ### Private-repo permission check (`user_repo_permission_cache`)
 
-When `tenant_repo_access.is_private = 1`:
+When `tenant_repo_access.is_private = 1` (column added by **migration 0007**, this issue —
+populated by `discoverTenants` from the GitHub `private` flag):
 
 1. **Cache hit** (row in `user_repo_permission_cache` where `user_id=? AND repo=?` and
-   `cached_at > now - 24h`): use `has_access` value directly — **fail-closed** (if
+   `checked_at > now - 24h`): use `has_access` value directly — **fail-closed** (if
    `has_access=0`, 404, no data returned).
 2. **Cache miss** (no row, or row older than 24h): call GitHub API
    `GET /repos/:owner/:repo/collaborators/:username` with the installation token.
@@ -78,8 +97,10 @@ When `tenant_repo_access.is_private = 1`:
 
 Public repos (`is_private = 0`) skip the permission check entirely.
 
-TTL: 24 hours from `cached_at`. Cache is invalidated by webhook events
-(`member.removed` / `membership.removed` / `repository.privatized` — see #147).
+TTL: 24 hours from `checked_at`. Cache is invalidated by webhook events
+(`member.removed` / `membership.removed` / `repository.privatized` — see #147). Until those
+webhook handlers land in #147, the 24h TTL + live-API fallback is the sole freshness mechanism
+(acceptable: a removed collaborator loses access at next read after TTL expiry, ≤24h).
 
 ### `GET /api/me`
 
@@ -113,8 +134,11 @@ No cross-tenant UNION queries anywhere.
 - [ ] `getIssueRoute` issue/label/edge queries use `JOIN tenant_repo_access` (no
   `AND tenant_id=?`); foreign-tenant or unknown repo key → 404. [IDOR closed]
 - [ ] `listIssuesRoute` + all 5 `graphRoute` queries use `JOIN tenant_repo_access`.
-- [ ] Private-repo reads check `user_repo_permission_cache` (24h TTL); cache miss → live API
-  fallback; any error path → fail-closed (404).
+- [ ] Migration **0007** adds `tenant_repo_access.is_private` (DEFAULT 0); `listInstallationRepos`
+  surfaces the GitHub `private` flag; `discoverTenants` UPSERTs it each sync.
+- [ ] Private-repo reads (`is_private = 1`) check `user_repo_permission_cache` (24h TTL via
+  `checked_at`); cache miss → live API fallback (`GET /repos/:owner/:repo/collaborators/:user`,
+  204→access / 404→deny); any error path → fail-closed (404).
 - [ ] `GET /api/me` returns `installations` array; no `tenant_id` in issue/edge response shapes.
 - [ ] `POST /api/active-tenant` switches session tenant; membership verified before update.
 - [ ] >1 installation → org-picker flow works end-to-end.
@@ -123,8 +147,12 @@ No cross-tenant UNION queries anywhere.
 
 ## Dependencies
 
-Blocked by **#147** (S4 — `tenant_repo_access` populated by webhook; `user_repo_permission_cache`
-invalidation wired) and **#145** (S2 — sessions + `user_installations` table).
+- **#145** (S2 — sessions + `user_installations` table): **DONE** (shipped, closed).
+- ~~**#147** (S4)~~: **no longer a blocker** as of the 2026-06-13 Option-3 amendment — #148 self-absorbs
+  the `is_private` column + population. #147 retains its webhook scope (event routing, stub policy,
+  real-time privacy updates, cache invalidation, retention) and stays open; its later landing only
+  *improves freshness* of the permission cache, it does not gate this issue. #147 must NOT re-add
+  the `is_private` column (introduced here by migration 0007).
 
 ## Reference
 

--- a/worker/migrations/0007_repo_access_is_private.sql
+++ b/worker/migrations/0007_repo_access_is_private.sql
@@ -1,0 +1,12 @@
+-- migration: 0007_repo_access_is_private.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+
+-- Add is_private column to tenant_repo_access (fail-closed default).
+-- DEFAULT 1 = treat every repo as private until the hourly sync sets is_private=0
+-- for public repos. Defaulting to 0 (public) would expose private repos to
+-- unauthenticated graph reads (IDOR) before the first sync tick after apply.
+-- ALTER TABLE ... ADD COLUMN with a constant DEFAULT is valid in D1/SQLite.
+-- No backfill needed: existing rows correctly inherit DEFAULT 1 (fail-closed).
+-- No index added: is_private is used as a filter column in JOIN reads, not a
+-- primary lookup key; query planner will cover it via the (tenant_id, repo) PK scan.
+ALTER TABLE tenant_repo_access ADD COLUMN is_private INTEGER NOT NULL DEFAULT 1;

--- a/worker/src/api/active-tenant.test.ts
+++ b/worker/src/api/active-tenant.test.ts
@@ -4,7 +4,7 @@ import type { AuthEnv, SessionContext } from "../auth/session";
 import { activeTenantRoute } from "./active-tenant";
 import {
   captureDb,
-  captureDbWithRows,
+  dispatchByTable,
   makeEnv,
   STUB_SESSION,
 } from "../test-utils";
@@ -78,8 +78,13 @@ async function postActiveTenant(
 describe("activeTenantRoute", () => {
   describe("POST /api/active-tenant — member switch (200)", () => {
     it("returns 200 with active_tenant_id and issues UPDATE sessions", async () => {
-      // Arrange — membership SELECT returns a row; UPDATE sessions runs after.
-      const { db, stmts } = captureDbWithRows([{ 1: 1 }]);
+      // Arrange — membership row found AND target tenant not suspended → UPDATE runs.
+      const { db, stmts } = captureDb((sql) =>
+        dispatchByTable(sql, {
+          user_installations: [{ 1: 1 }],
+          tenants: [{ suspended_at: null }],
+        }),
+      );
       const app = makeApp(db);
 
       // Act
@@ -116,6 +121,34 @@ describe("activeTenantRoute", () => {
       expect(body.error).toBe("forbidden");
 
       // Assert — no UPDATE sessions was issued
+      const updateStmt = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("update sessions") &&
+          s.sql.toLowerCase().includes("tenant_id"),
+      );
+      expect(updateStmt).toBeUndefined();
+    });
+  });
+
+  describe("POST /api/active-tenant — suspended tenant (403)", () => {
+    it("returns 403 when the target tenant is suspended and issues NO UPDATE sessions", async () => {
+      // Arrange — user IS a member, but the tenant carries a suspended_at timestamp.
+      const { db, stmts } = captureDb((sql) =>
+        dispatchByTable(sql, {
+          user_installations: [{ 1: 1 }],
+          tenants: [{ suspended_at: "2026-01-01T00:00:00.000Z" }],
+        }),
+      );
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2 }, COOKIE_HEADER);
+
+      // Assert — switch rejected before any session mutation
+      expect(res.status).toBe(403);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("forbidden");
+
       const updateStmt = stmts().find(
         (s) =>
           s.sql.toLowerCase().includes("update sessions") &&

--- a/worker/src/api/active-tenant.test.ts
+++ b/worker/src/api/active-tenant.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv, SessionContext } from "../auth/session";
+import { activeTenantRoute } from "./active-tenant";
+import {
+  captureDb,
+  captureDbWithRows,
+  makeEnv,
+  STUB_SESSION,
+} from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// SESSION_COOKIE name — must match src/auth/session.ts SESSION_COOKIE constant.
+const SESSION_COOKIE_NAME = "__Host-session";
+const RAW_TOKEN = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+const COOKIE_HEADER = `${SESSION_COOKIE_NAME}=${RAW_TOKEN}`;
+
+// ---------------------------------------------------------------------------
+// App builders
+// ---------------------------------------------------------------------------
+
+/** App with STUB_SESSION injected — simulates requireSession middleware passing. */
+function makeApp(db: ReturnType<typeof captureDb>["db"]): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+
+  app.post("/api/active-tenant", activeTenantRoute);
+
+  return app;
+}
+
+/** App with NO session injected — simulates unauthenticated request. */
+function makeAppNoSession(db: ReturnType<typeof captureDb>["db"]): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.post("/api/active-tenant", activeTenantRoute);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: POST /api/active-tenant
+// ---------------------------------------------------------------------------
+
+async function postActiveTenant(
+  app: Hono<AuthEnv>,
+  db: D1Database,
+  body: unknown,
+  cookie?: string,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) {
+    headers["Cookie"] = cookie;
+  }
+
+  return app.request(
+    "/api/active-tenant",
+    {
+      method: "POST",
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    },
+    makeEnv(db),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("activeTenantRoute", () => {
+  describe("POST /api/active-tenant — member switch (200)", () => {
+    it("returns 200 with active_tenant_id and issues UPDATE sessions", async () => {
+      // Arrange — membership SELECT returns a row; UPDATE sessions runs after.
+      const { db, stmts } = captureDbWithRows([{ 1: 1 }]);
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2 }, COOKIE_HEADER);
+
+      // Assert — status + body
+      expect(res.status).toBe(200);
+      const body = await res.json() as { active_tenant_id: number };
+      expect(body.active_tenant_id).toBe(2);
+
+      // Assert — an UPDATE sessions SET tenant_id statement was issued
+      const updateStmt = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("update sessions") &&
+          s.sql.toLowerCase().includes("tenant_id"),
+      );
+      expect(updateStmt).toBeDefined();
+      expect(updateStmt!.sql).toMatch(/UPDATE sessions SET tenant_id/i);
+    });
+  });
+
+  describe("POST /api/active-tenant — non-member (403)", () => {
+    it("returns 403 when user has no membership row and issues NO UPDATE sessions", async () => {
+      // Arrange — membership SELECT returns nothing.
+      const { db, stmts } = captureDb(); // empty rows for every query
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 99 }, COOKIE_HEADER);
+
+      // Assert — status + body
+      expect(res.status).toBe(403);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("forbidden");
+
+      // Assert — no UPDATE sessions was issued
+      const updateStmt = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("update sessions") &&
+          s.sql.toLowerCase().includes("tenant_id"),
+      );
+      expect(updateStmt).toBeUndefined();
+    });
+  });
+
+  describe("POST /api/active-tenant — missing / invalid tenant_id (400)", () => {
+    it("returns 400 when body has no tenant_id field", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, {}, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+
+    it("returns 400 when tenant_id is a string", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: "two" }, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+
+    it("returns 400 when tenant_id is a float", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2.5 }, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+
+    it("returns 400 when body is not valid JSON", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act — send a raw non-JSON body
+      const res = await app.request(
+        "/api/active-tenant",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Cookie: COOKIE_HEADER },
+          body: "not-json",
+        },
+        makeEnv(db),
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+  });
+
+  describe("POST /api/active-tenant — no session (401)", () => {
+    it("returns 401 when no session is set on context", async () => {
+      // Arrange — app without session-injecting middleware
+      const { db } = captureDb();
+      const app = makeAppNoSession(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2 }, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+  });
+});

--- a/worker/src/api/active-tenant.ts
+++ b/worker/src/api/active-tenant.ts
@@ -47,6 +47,18 @@ export async function activeTenantRoute(c: Context<AuthEnv>): Promise<Response> 
     return c.json({ error: "forbidden" }, 403);
   }
 
+  // Suspended-tenant guard: a member must not switch into a suspended tenant.
+  // validateSession would 401 every subsequent request (NOT-EXISTS suspended guard),
+  // self-locking the session — reject the switch up-front instead.
+  const tenant = await c.env.DB
+    .prepare(`SELECT suspended_at FROM tenants WHERE id = ?`)
+    .bind(tenantId)
+    .first<{ suspended_at: string | null }>();
+
+  if (!tenant || tenant.suspended_at !== null) {
+    return c.json({ error: "forbidden" }, 403);
+  }
+
   // Read raw token from cookie for hashing inside setSessionTenant.
   const raw = readSessionToken(c);
   if (!raw) {

--- a/worker/src/api/active-tenant.ts
+++ b/worker/src/api/active-tenant.ts
@@ -1,0 +1,59 @@
+/**
+ * POST /api/active-tenant — switch the authenticated user's active tenant.
+ *
+ * Body: { tenant_id: number }
+ *
+ * The route is also placed behind requireSession middleware in router.ts
+ * (registered in T9). The explicit session check here is defense-in-depth.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/session";
+import { readSessionToken, setSessionTenant } from "../auth/session";
+
+export async function activeTenantRoute(c: Context<AuthEnv>): Promise<Response> {
+  // Defense-in-depth: requireSession already guards, but fail closed here too.
+  const s = c.get("session");
+  if (!s) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  // Parse + validate request body.
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "tenant_id required" }, 400);
+  }
+
+  const tenantId =
+    body !== null && typeof body === "object" && "tenant_id" in body
+      ? (body as Record<string, unknown>).tenant_id
+      : undefined;
+
+  if (typeof tenantId !== "number" || !Number.isInteger(tenantId)) {
+    return c.json({ error: "tenant_id required" }, 400);
+  }
+
+  // Membership check — user must belong to the requested tenant.
+  const membership = await c.env.DB
+    .prepare(
+      `SELECT 1 FROM user_installations WHERE user_id = ? AND tenant_id = ?`,
+    )
+    .bind(s.userId, tenantId)
+    .first<{ 1: number }>();
+
+  if (!membership) {
+    return c.json({ error: "forbidden" }, 403);
+  }
+
+  // Read raw token from cookie for hashing inside setSessionTenant.
+  const raw = readSessionToken(c);
+  if (!raw) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  await setSessionTenant(c.env.DB, raw, tenantId);
+
+  return c.json({ active_tenant_id: tenantId });
+}

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -1,18 +1,53 @@
 import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv } from "../auth/session";
 import type { Env } from "../types";
-import { app } from "../router";
+import { graphRoute } from "./graph";
+import {
+  STUB_SESSION,
+  makeEnv,
+  dispatchByTable,
+  makeFakeDb,
+  makeFakeStmt,
+  captureDb,
+  type FakeResult,
+} from "../test-utils";
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
+// ---------------------------------------------------------------------------
+// Test app with session middleware — mirrors me.test.ts pattern
+// ---------------------------------------------------------------------------
+
+function makeTestApp() {
+  const a = new Hono<AuthEnv>();
+  a.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  a.get("/api/graph", graphRoute);
+  return a;
+}
+
+const testApp = makeTestApp();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 /**
- * graph.ts fires 5 prepare().all() calls — dispatched by SQL content:
- *   "FROM labels"   → labels fixture
- *   "FROM pr_state" → pr_state fixture
- *   "FROM issues"   → issues fixture
- *   "FROM edges"    → edges fixture
- *   "FROM repos"    → repos fixture
+ * graph.ts fires 5 prepare().bind(...).all() calls — dispatched by SQL content:
+ *   "tenant_repo_access"  → visible repos (all public by default, derived from issues)
+ *   "from labels"         → labels fixture
+ *   "from pr_state"       → pr_state fixture
+ *   "from issues"         → issues fixture
+ *   "from edges"          → edges fixture
+ *   "from repos"          → repos fixture
+ *
+ * visibleRepos is derived from the issues fixture (all unique repos treated as public).
+ * Override `overrideVisible` to test a custom visibility set.
  */
 function makeGraphEnv(
   labels: unknown[],
@@ -20,24 +55,33 @@ function makeGraphEnv(
   issues: unknown[],
   edges: unknown[],
   repos: unknown[] = [],
+  overrideVisible?: string[],
 ): Env {
-  return {
-    DB: {
-      prepare: (sql: string) => ({
-        all: async () => {
-          if (sql.includes("FROM labels")) return { results: labels };
-          if (sql.includes("FROM pr_state")) return { results: prState };
-          if (sql.includes("FROM issues")) return { results: issues };
-          if (sql.includes("FROM edges")) return { results: edges };
-          if (sql.includes("FROM repos")) return { results: repos };
-          return { results: [] };
-        },
+  const visibleRepos =
+    overrideVisible ??
+    [...new Set((issues as Array<{ repo: string }>).map((i) => i.repo))];
+
+  const db = makeFakeDb((sql, args) =>
+    makeFakeStmt(
+      sql,
+      args,
+      dispatchByTable(sql, {
+        "tenant_repo_access": visibleRepos.map((repo) => ({
+          repo,
+          is_private: 0,
+        })),
+        "from labels": labels as FakeResult[],
+        "from pr_state": prState as FakeResult[],
+        // "from edges" MUST precede "from issues": edges SQL contains "FROM issues"
+        // as a subquery, so first-match-wins would otherwise misroute it.
+        "from edges": edges as FakeResult[],
+        "from repos": repos as FakeResult[],
+        "from issues": issues as FakeResult[],
       }),
-    },
-    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_ORG: "",
-    GITHUB_WEBHOOK_SECRET: "",
-  } as unknown as Env;
+    ),
+  );
+
+  return makeEnv(db);
 }
 
 /**
@@ -52,27 +96,28 @@ function makeGraphEnvWithCapture(
   repos: unknown[] = [],
 ): { env: Env; capturedSqls: string[] } {
   const capturedSqls: string[] = [];
-  const env = {
-    DB: {
-      prepare: (sql: string) => {
-        capturedSqls.push(sql);
-        return {
-          all: async () => {
-            if (sql.includes("FROM labels")) return { results: labels };
-            if (sql.includes("FROM pr_state")) return { results: prState };
-            if (sql.includes("FROM issues")) return { results: issues };
-            if (sql.includes("FROM edges")) return { results: edges };
-            if (sql.includes("FROM repos")) return { results: repos };
-            return { results: [] };
-          },
-        };
-      },
-    },
-    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_ORG: "",
-    GITHUB_WEBHOOK_SECRET: "",
-  } as unknown as Env;
-  return { env, capturedSqls };
+
+  const visibleRepos = [
+    ...new Set((issues as Array<{ repo: string }>).map((i) => i.repo)),
+  ];
+
+  const { db } = captureDb((sql, _args) => {
+    capturedSqls.push(sql);
+    return dispatchByTable(sql, {
+      "tenant_repo_access": visibleRepos.map((repo) => ({
+        repo,
+        is_private: 0,
+      })),
+      "from labels": labels as FakeResult[],
+      "from pr_state": prState as FakeResult[],
+      // "from edges" MUST precede "from issues": edges SQL subquery contains "FROM issues"
+      "from edges": edges as FakeResult[],
+      "from repos": repos as FakeResult[],
+      "from issues": issues as FakeResult[],
+    });
+  });
+
+  return { env: makeEnv(db), capturedSqls };
 }
 
 describe("GET /api/graph", () => {
@@ -82,7 +127,7 @@ describe("GET /api/graph", () => {
         key: "Roxabi/roxabi-live#1",
         repo: "Roxabi/roxabi-live",
         number: 1,
-        title: "Test issue",
+        title: "Fix the thing",
         state: "open",
         url: "https://github.com/Roxabi/roxabi-live/issues/1",
         milestone: null,
@@ -93,262 +138,273 @@ describe("GET /api/graph", () => {
         is_stub: 0,
         has_active_branch: 0,
       };
+      const edge = {
+        src_key: "Roxabi/roxabi-live#2",
+        dst_key: "Roxabi/roxabi-live#1",
+        kind: "blocks",
+      };
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [issue], [edge]),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        nodes: unknown[];
+        edges: unknown[];
+        repos: unknown[];
+      }>();
+      expect(Array.isArray(body.nodes)).toBe(true);
+      expect(Array.isArray(body.edges)).toBe(true);
+      expect(Array.isArray(body.repos)).toBe(true);
+    });
 
-      const res = await app.request(
+    it("maps IssueRow fields to Node shape", async () => {
+      const issue = {
+        key: "Roxabi/roxabi-live#42",
+        repo: "Roxabi/roxabi-live",
+        number: 42,
+        title: "Hello",
+        state: "open",
+        url: "https://github.com/Roxabi/roxabi-live/issues/42",
+        milestone: null,
+        lane: "backlog",
+        priority: "P1",
+        size: "M",
+        status: "in_progress",
+        is_stub: 0,
+        has_active_branch: 0,
+      };
+      const res = await testApp.request(
         "/api/graph",
         {},
         makeGraphEnv([], [], [issue], []),
       );
-
-      expect(res.status).toBe(200);
-      const body = await res.json<{ nodes: unknown[]; edges: unknown[] }>();
-      expect(body).toHaveProperty("nodes");
-      expect(body).toHaveProperty("edges");
-      expect(Array.isArray(body.nodes)).toBe(true);
-      expect(Array.isArray(body.edges)).toBe(true);
+      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
+      const node = body.nodes[0];
+      expect(node.key).toBe("Roxabi/roxabi-live#42");
+      expect(node.repo).toBe("Roxabi/roxabi-live");
+      expect(node.number).toBe(42);
+      expect(node.title).toBe("Hello");
+      expect(node.state).toBe("open");
+      expect(node.url).toBe(
+        "https://github.com/Roxabi/roxabi-live/issues/42",
+      );
+      expect(node.lane).toBe("backlog");
+      expect(node.priority).toBe("P1");
+      expect(node.size).toBe("M");
+      expect(node.status).toBe("in_progress");
+      expect(node.is_stub).toBe(false);
     });
 
-    it("maps node fields from issue row", async () => {
+    it("maps EdgeRow fields to Edge shape", async () => {
       const issue = {
-        key: "Roxabi/roxabi-live#7",
+        key: "Roxabi/roxabi-live#1",
         repo: "Roxabi/roxabi-live",
-        number: 7,
-        title: "My Issue",
+        number: 1,
+        title: null,
         state: "open",
-        url: "https://github.com/Roxabi/roxabi-live/issues/7",
-        milestone: "M1 — Foundation",
-        lane: "infra",
-        priority: "P1",
-        size: "M",
-        status: "In Progress",
+        url: null,
+        milestone: null,
+        lane: null,
+        priority: null,
+        size: null,
+        status: null,
         is_stub: 0,
         has_active_branch: 0,
       };
-
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
-      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      const node = body.nodes[0];
-
-      expect(node.key).toBe("Roxabi/roxabi-live#7");
-      expect(node.repo).toBe("Roxabi/roxabi-live");
-      expect(node.number).toBe(7);
-      expect(node.title).toBe("My Issue");
-      expect(node.state).toBe("open");
-      expect(node.url).toBe("https://github.com/Roxabi/roxabi-live/issues/7");
-      expect(node.milestone).toBe("M1 — Foundation");
-      expect(node.milestone_code).toBe("M1");
-      expect(node.milestone_name).toBe("Foundation");
-      expect(node.milestone_sort_key).toBe(1);
-      expect(node.lane).toBe("infra");
-      expect(node.priority).toBe("P1");
-      expect(node.size).toBe("M");
-      expect(node.status).toBe("In Progress");
-    });
-
-    it("maps edge fields correctly", async () => {
-      const edge = { src_key: "Roxabi/roxabi-live#1", dst_key: "Roxabi/roxabi-live#2", kind: "blocks" };
-
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], [edge]));
+      const edge = {
+        src_key: "Roxabi/roxabi-live#2",
+        dst_key: "Roxabi/roxabi-live#1",
+        kind: "blocks",
+      };
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [issue], [edge]),
+      );
       const body = await res.json<{ edges: Record<string, unknown>[] }>();
-      const e = body.edges[0];
-
-      expect(e.src).toBe("Roxabi/roxabi-live#1");
-      expect(e.dst).toBe("Roxabi/roxabi-live#2");
-      expect(e.kind).toBe("blocks");
+      expect(body.edges[0]).toEqual({
+        src: "Roxabi/roxabi-live#2",
+        dst: "Roxabi/roxabi-live#1",
+        kind: "blocks",
+      });
     });
   });
 
   describe("dev_state priority matrix", () => {
-    function makeIssue(
-      state: string,
-      hasActiveBranch: number,
-      key = "Roxabi/roxabi-live#1",
-    ) {
-      return {
-        key,
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state,
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: hasActiveBranch,
-      };
-    }
+    const baseIssue = {
+      key: "Roxabi/roxabi-live#1",
+      repo: "Roxabi/roxabi-live",
+      number: 1,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      is_stub: 0,
+      has_active_branch: 0,
+    };
 
-    it("returns idle for a closed issue regardless of branch/PRs", async () => {
-      const issue = makeIssue("closed", 1);
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+    it("idle when no branch and no open PR", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...baseIssue, has_active_branch: 0 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("idle");
     });
 
-    it("returns pr_reviewed when an open PR has has_reviewed_label=1", async () => {
-      const issue = makeIssue("open", 0);
-      const prState = [
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 1 },
-      ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
-      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].dev_state).toBe("pr_reviewed");
-    });
-
-    it("returns pr_open when an open PR exists without reviewed label", async () => {
-      const issue = makeIssue("open", 0);
-      const prState = [
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 0 },
-      ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
-      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].dev_state).toBe("pr_open");
-    });
-
-    it("returns dev when no open PRs but has_active_branch=1", async () => {
-      const issue = makeIssue("open", 1);
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+    it("dev when has_active_branch=1 and no open PR", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...baseIssue, has_active_branch: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("dev");
     });
 
-    it("returns idle when open, no PR, no active branch", async () => {
-      const issue = makeIssue("open", 0);
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+    it("pr_open when an open PR is linked but not reviewed", async () => {
+      const prState = [
+        {
+          closing_issue_keys: '["Roxabi/roxabi-live#1"]',
+          has_reviewed_label: 0,
+        },
+      ];
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [{ ...baseIssue, has_active_branch: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].dev_state).toBe("idle");
+      expect(body.nodes[0].dev_state).toBe("pr_open");
     });
 
-    it("pr_reviewed takes priority over pr_open when multiple PRs exist", async () => {
-      const issue = makeIssue("open", 0);
+    it("pr_reviewed when an open PR has has_reviewed_label=1", async () => {
       const prState = [
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 0 },
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 1 },
+        {
+          closing_issue_keys: '["Roxabi/roxabi-live#1"]',
+          has_reviewed_label: 1,
+        },
       ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [{ ...baseIssue, has_active_branch: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("pr_reviewed");
+    });
+
+    it("idle for a closed issue even when has_active_branch=1", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv(
+          [],
+          [],
+          [{ ...baseIssue, state: "closed", has_active_branch: 1 }],
+          [],
+        ),
+      );
+      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
+      expect(body.nodes[0].dev_state).toBe("idle");
     });
   });
 
   describe("lane fallback from labels", () => {
-    it("uses lane from DB row when set", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: "backend",
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const labels = [{ issue_key: issue.key, name: "graph:lane/frontend" }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+    const baseIssue = {
+      key: "Roxabi/roxabi-live#1",
+      repo: "Roxabi/roxabi-live",
+      number: 1,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      is_stub: 0,
+      has_active_branch: 0,
+    };
+
+    it("uses lane field when set", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...baseIssue, lane: "backlog" }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      // DB lane wins over label
-      expect(body.nodes[0].lane).toBe("backend");
+      expect(body.nodes[0].lane).toBe("backlog");
     });
 
-    it("falls back to graph:lane/ label when lane is null in DB", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const labels = [{ issue_key: issue.key, name: "graph:lane/infra" }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+    it("falls back to graph:lane/ label when lane field is null", async () => {
+      const labels = [{ issue_key: baseIssue.key, name: "graph:lane/active" }];
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv(labels, [], [baseIssue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].lane).toBe("infra");
+      expect(body.nodes[0].lane).toBe("active");
     });
 
-    it("returns null lane when no DB lane and no graph:lane/ label", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const labels = [{ issue_key: issue.key, name: "some-other-label" }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+    it("returns null lane when no lane field and no graph:lane/ label", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [baseIssue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].lane).toBeNull();
     });
   });
 
   describe("is_stub boolean coercion", () => {
+    const base = {
+      key: "Roxabi/roxabi-live#1",
+      repo: "Roxabi/roxabi-live",
+      number: 1,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      has_active_branch: 0,
+    };
+
     it("coerces is_stub=1 to true", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 1,
-        has_active_branch: 0,
-      };
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...base, is_stub: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].is_stub).toBe(true);
     });
 
     it("coerces is_stub=0 to false", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...base, is_stub: 0 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].is_stub).toBe(false);
     });
   });
 
   describe("invalid JSON in pr_state.closing_issue_keys", () => {
-    it("silently skips rows with invalid JSON", async () => {
+    it("falls back to idle dev_state on invalid closing_issue_keys JSON", async () => {
       const issue = {
         key: "Roxabi/roxabi-live#1",
         repo: "Roxabi/roxabi-live",
@@ -366,7 +422,11 @@ describe("GET /api/graph", () => {
       };
       // One row with invalid JSON — should not throw, issue gets idle dev_state
       const prState = [{ closing_issue_keys: "not-valid-json", has_reviewed_label: 1 }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [issue], []),
+      );
       expect(res.status).toBe(200);
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("idle");
@@ -389,7 +449,11 @@ describe("GET /api/graph", () => {
         has_active_branch: 0,
       };
       const prState = [{ closing_issue_keys: null, has_reviewed_label: 1 }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [issue], []),
+      );
       expect(res.status).toBe(200);
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("idle");
@@ -418,7 +482,11 @@ describe("GET /api/graph", () => {
         { issue_key: issue.key, name: "P1" },
         { issue_key: "other/repo#99", name: "enhancement" },
       ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv(labels, [], [issue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].labels).toEqual(["bug", "P1"]);
     });
@@ -439,7 +507,11 @@ describe("GET /api/graph", () => {
         is_stub: 0,
         has_active_branch: 0,
       };
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [issue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].labels).toEqual([]);
     });
@@ -447,7 +519,12 @@ describe("GET /api/graph", () => {
 
   describe("empty database", () => {
     it("returns {nodes:[], edges:[], repos:[]} when all tables empty", async () => {
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], []));
+      // Empty issues → no visible repos → resolveVisibleRepos short-circuits → {nodes:[],edges:[],repos:[]}
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [], []),
+      );
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual({ nodes: [], edges: [], repos: [] });
@@ -462,9 +539,14 @@ describe("GET /api/graph", () => {
         { repo: "Roxabi/roxabi-vault", archived: 1 },
       ];
       // SQL ORDER BY archived ASC, repo ASC — fixture already sorted correctly
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], [], repoRows));
+      // Use overrideVisible to inject visible repos (no issues needed)
+      const visibleList = repoRows.map((r) => r.repo);
+      const env = makeGraphEnv([], [], [], [], repoRows, visibleList);
+      const res = await testApp.request("/api/graph", {}, env);
       expect(res.status).toBe(200);
-      const body = await res.json<{ repos: { repo: string; archived: boolean }[] }>();
+      const body = await res.json<{
+        repos: { repo: string; archived: boolean }[];
+      }>();
       expect(body.repos).toEqual([
         { repo: "Roxabi/roxabi-factory", archived: false },
         { repo: "Roxabi/roxabi-live", archived: false },
@@ -477,11 +559,168 @@ describe("GET /api/graph", () => {
     it("issues SELECT uses JSON_EXTRACT(payload,'$.title') AS title", async () => {
       // Arrange
       const { env, capturedSqls } = makeGraphEnvWithCapture([], [], [], []);
-      // Act
-      await app.request("/api/graph", {}, env);
-      // Assert — the issues query must project title via JSON_EXTRACT
-      const issuesSql = capturedSqls.find((s) => s.includes("FROM issues"));
+      // Act — empty issues → resolveVisibleRepos returns [] → short-circuit.
+      // Use a non-empty issue to ensure issues query fires.
+      const issue = {
+        key: "Roxabi/roxabi-live#1",
+        repo: "Roxabi/roxabi-live",
+        number: 1,
+        title: null,
+        state: "open",
+        url: null,
+        milestone: null,
+        lane: null,
+        priority: null,
+        size: null,
+        status: null,
+        is_stub: 0,
+        has_active_branch: 0,
+      };
+      const { env: env2, capturedSqls: sqls2 } = makeGraphEnvWithCapture(
+        [],
+        [],
+        [issue],
+        [],
+      );
+      await testApp.request("/api/graph", {}, env2);
+      // Assert — the issues query must project title via JSON_EXTRACT.
+      // Use "json_extract" as the finder key so labels/edges subqueries (which also
+      // contain "from issues") don't accidentally win the find().
+      const issuesSql = sqls2.find((s) =>
+        s.toLowerCase().includes("json_extract"),
+      );
       expect(issuesSql).toContain("JSON_EXTRACT(payload,'$.title') AS title");
+      void env; // suppress unused warning
+      void capturedSqls;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tenant-scoped visibility tests (#148)
+  // ---------------------------------------------------------------------------
+
+  describe("tenant scoping", () => {
+    const visibleRepo = "Roxabi/roxabi-live";
+    const hiddenRepo = "Roxabi/private-repo";
+
+    const makeIssue = (repo: string, n: number) => ({
+      key: `${repo}#${n}`,
+      repo,
+      number: n,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      is_stub: 0,
+      has_active_branch: 0,
+    });
+
+    it("nodes scoped — issue in non-visible repo is absent from nodes", async () => {
+      // The hidden repo issue is in the issues fixture but NOT in tenant_repo_access.
+      // resolveVisibleRepos returns only [visibleRepo].
+      // graphRoute WHERE repo IN (?) scopes the issues query — DB stub simulates
+      // the filter by only returning the visible issue.
+      const visibleIssue = makeIssue(visibleRepo, 1);
+      // overrideVisible = only visibleRepo; issues stub returns only visibleIssue
+      const env = makeGraphEnv([], [], [visibleIssue], [], [], [visibleRepo]);
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{ nodes: { key: string }[] }>();
+      const keys = body.nodes.map((n) => n.key);
+      expect(keys).toContain(`${visibleRepo}#1`);
+      expect(keys).not.toContain(`${hiddenRepo}#99`);
+    });
+
+    it("edges scoped — edge with endpoint in non-visible repo is dropped", async () => {
+      // Both endpoints of the edge must be in visible repos.
+      // Our stub simulates the SQL filter: only edges where both endpoints are visible.
+      const visibleIssue = makeIssue(visibleRepo, 1);
+      const visibleEdge = {
+        src_key: `${visibleRepo}#2`,
+        dst_key: `${visibleRepo}#1`,
+        kind: "blocks",
+      };
+      // dangling edge has dst in hidden repo — DB stub does NOT return it
+      const env = makeGraphEnv(
+        [],
+        [],
+        [visibleIssue],
+        [visibleEdge], // only the fully-visible edge is returned by issues-scoped query
+        [],
+        [visibleRepo],
+      );
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        edges: { src: string; dst: string; kind: string }[];
+      }>();
+      // Visible edge is present
+      expect(body.edges).toContainEqual({
+        src: `${visibleRepo}#2`,
+        dst: `${visibleRepo}#1`,
+        kind: "blocks",
+      });
+      // No edge touching hidden repo
+      const touchesHidden = body.edges.some(
+        (e) => e.src.startsWith(hiddenRepo) || e.dst.startsWith(hiddenRepo),
+      );
+      expect(touchesHidden).toBe(false);
+    });
+
+    it("repos scoped — repos[] lists only visible repos", async () => {
+      const repoRows = [{ repo: visibleRepo, archived: 0 }];
+      // overrideVisible only includes visibleRepo; repos stub returns only that row
+      const env = makeGraphEnv([], [], [], [], repoRows, [visibleRepo]);
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        repos: { repo: string; archived: boolean }[];
+      }>();
+      expect(body.repos.map((r) => r.repo)).toEqual([visibleRepo]);
+      expect(body.repos.map((r) => r.repo)).not.toContain(hiddenRepo);
+    });
+
+    it("scopes the issues/edges/repos reads to the visible set via `repo IN` (#148)", async () => {
+      // Non-empty issues fixture → visible set non-empty → the data reads fire.
+      // This is the discriminating guard: strip the `repo IN` clauses from graphRoute
+      // and these assertions fail — i.e. the test actually exercises the scoping.
+      const issue = makeIssue(visibleRepo, 1);
+      const { env, capturedSqls } = makeGraphEnvWithCapture(
+        [],
+        [],
+        [issue],
+        [],
+        [{ repo: visibleRepo, archived: 0 }],
+      );
+      await testApp.request("/api/graph", {}, env);
+
+      const issuesSql = capturedSqls.find((s) => s.includes("has_active_branch"));
+      const edgesSql = capturedSqls.find((s) => s.includes("FROM edges"));
+      const reposSql = capturedSqls.find((s) => s.includes("FROM repos"));
+      expect(issuesSql).toBeDefined();
+      expect(edgesSql).toBeDefined();
+      expect(reposSql).toBeDefined();
+      // Without these filters the graph would expose issues/edges/repos from tenants
+      // the caller can't see.
+      expect(issuesSql).toContain("repo IN");
+      expect(edgesSql).toContain("repo IN");
+      expect(reposSql).toContain("repo IN");
+    });
+
+    it("empty visible set short-circuits to {nodes:[], edges:[], repos:[]} and issues NO data reads (#148)", async () => {
+      // issues fixture empty → tenant_repo_access empty → resolveVisibleRepos returns []
+      const { env, capturedSqls } = makeGraphEnvWithCapture([], [], [], [], []);
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ nodes: [], edges: [], repos: [] });
+      // The short-circuit must run BEFORE any data read — drop it and these fire.
+      expect(capturedSqls.some((s) => s.includes("has_active_branch"))).toBe(false);
+      expect(capturedSqls.some((s) => s.includes("FROM edges"))).toBe(false);
+      expect(capturedSqls.some((s) => s.includes("FROM repos"))).toBe(false);
     });
   });
 });

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -5,15 +5,17 @@
  * Response shape MUST stay { nodes: Node[], edges: Edge[] } — byte-compatible
  * with the Python source consumed by the v6 frontend (state.js).
  *
- * Four D1 reads (same logical queries as Python):
+ * Five D1 reads (a)-(e), tenant-scoped to resolveVisibleRepos(c):
  *   (a) labels — grouped into Map<issueKey, string[]>
  *   (b) open pr_state — build Map<issueKey, {has_reviewed_label:number}[]>
  *   (c) issues — one row per issue
  *   (d) edges — all src_key/dst_key/kind rows
+ *   (e) repos — live first (archived=0), then archived (archived=1), both alpha
  */
 
 import type { Context } from "hono";
-import type { Env } from "../types";
+import type { AuthEnv } from "../auth/session";
+import { resolveVisibleRepos } from "../auth/repoAccess";
 import { parseMilestone } from "../sync/parse";
 
 const LANE_LABEL_PREFIX = "graph:lane/";
@@ -113,11 +115,19 @@ interface EdgeRow {
   kind: string;
 }
 
-export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
-  // (a) labels → Map<issueKey, string[]>
+export const graphRoute = async (c: Context<AuthEnv>) => {
+  const visible = await resolveVisibleRepos(c);
+
+  if (visible.length === 0) {
+    return c.json({ nodes: [], edges: [], repos: [] });
+  }
+
+  const ph = visible.map(() => "?").join(",");
+
+  // (a) labels → Map<issueKey, string[]> — scoped to visible issues only
   const labelRows = await c.env.DB.prepare(
-    "SELECT issue_key, name FROM labels",
-  ).all<LabelRow>();
+    `SELECT issue_key, name FROM labels WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+  ).bind(...visible).all<LabelRow>();
   const labelsByIssue = new Map<string, string[]>();
   for (const row of labelRows.results) {
     const existing = labelsByIssue.get(row.issue_key);
@@ -129,9 +139,12 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
   }
 
   // (b) open pr_state → Map<issueKey, PrInfo[]>
+  // pr_state has a repo column; scope to visible repos so PR metadata for non-visible
+  // repos is excluded. openPrsByIssue is read by key only for visible issues, but
+  // scoping here prevents any row for non-visible repos from entering the map.
   const prRows = await c.env.DB.prepare(
-    "SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open'",
-  ).all<PrStateRow>();
+    `SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open' AND repo IN (${ph})`,
+  ).bind(...visible).all<PrStateRow>();
   const openPrsByIssue = new Map<string, PrInfo[]>();
   for (const row of prRows.results) {
     if (!row.closing_issue_keys) continue;
@@ -152,11 +165,11 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     }
   }
 
-  // (c) issues
+  // (c) issues — scoped to visible repos
   const issueRows = await c.env.DB.prepare(
     "SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone," +
-      " lane, priority, size, status, is_stub, has_active_branch FROM issues",
-  ).all<IssueRow>();
+      ` lane, priority, size, status, is_stub, has_active_branch FROM issues WHERE repo IN (${ph})`,
+  ).bind(...visible).all<IssueRow>();
 
   const nodes: Node[] = issueRows.results.map((row) => {
     const issueLabels = labelsByIssue.get(row.key) ?? [];
@@ -188,10 +201,13 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     };
   });
 
-  // (d) edges
+  // (d) edges — both endpoints must be in visible repos; dangling edges to invisible
+  // nodes are dropped (graph only draws an edge when both nodes are present)
   const edgeRows = await c.env.DB.prepare(
-    "SELECT src_key, dst_key, kind FROM edges",
-  ).all<EdgeRow>();
+    `SELECT src_key, dst_key, kind FROM edges` +
+      ` WHERE src_key IN (SELECT key FROM issues WHERE repo IN (${ph}))` +
+      ` AND dst_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+  ).bind(...visible, ...visible).all<EdgeRow>();
 
   const edges: Edge[] = edgeRows.results.map((row) => ({
     src: row.src_key,
@@ -205,8 +221,8 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     archived: number;
   }
   const repoRows = await c.env.DB.prepare(
-    "SELECT repo, archived FROM repos ORDER BY archived ASC, repo ASC",
-  ).all<RepoRow>();
+    `SELECT repo, archived FROM repos WHERE repo IN (${ph}) ORDER BY archived ASC, repo ASC`,
+  ).bind(...visible).all<RepoRow>();
   const repos = (repoRows.results ?? []).map((r) => ({
     repo: r.repo,
     archived: Boolean(r.archived),

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -1,9 +1,43 @@
-import { describe, expect, it, afterEach, vi } from "vitest";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 import type { Env } from "../types";
 import { app } from "../router";
+import { resolveVisibleRepos } from "../auth/repoAccess";
+
+// #148: these are handler unit tests — they exercise listIssuesRoute/getIssueRoute
+// logic (row mapping, filter SQL, limit/offset clamping). The auth middleware is
+// covered by router.test.ts + session.test.ts, and repo-permission resolution by
+// repoAccess.test.ts. So here we stub the auth boundary: requireSession becomes a
+// pass-through that injects a session, and resolveVisibleRepos returns a fixed
+// visible set (overridable per test).
+vi.mock("../auth/repoAccess", () => ({
+  resolveVisibleRepos: vi.fn(),
+}));
+
+vi.mock("../auth/session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auth/session")>();
+  return {
+    ...actual,
+    requireSession: (async (c, next) => {
+      c.set("session", {
+        userId: 1,
+        tenantId: 1,
+        githubId: 1001,
+        githubLogin: "octocat",
+      });
+      await next();
+    }) as typeof actual.requireSession,
+  };
+});
+
+const DEFAULT_VISIBLE = ["Roxabi/roxabi-live"];
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  // Default: the repo used by makeIssueRow fixtures is visible. Override per test.
+  vi.mocked(resolveVisibleRepos).mockResolvedValue(DEFAULT_VISIBLE);
 });
 
 // ── Env builders ─────────────────────────────────────────────────────────────
@@ -198,6 +232,38 @@ function makeGetEnvWithCapture(opts: GetEnvOptions): {
   } as unknown as Env;
 
   return { env, capturedSqls };
+}
+
+/**
+ * #148: like makeGetEnv but mimics the real `WHERE key = ? AND repo IN (...)` filter —
+ * the issue row is returned ONLY if its repo was bound into the statement (i.e. is in
+ * the visible set the handler passed). Lets us prove the IDOR 404 on a foreign repo.
+ */
+function makeRepoFilteredGetEnv(opts: {
+  issueRow: { repo: string } & Record<string, unknown>;
+}): Env {
+  const { issueRow } = opts;
+  return {
+    DB: {
+      prepare: (sql: string) => ({
+        bind: (...args: unknown[]) => ({
+          first: async () => {
+            if (sql.includes("FROM issues WHERE key") && args.includes(issueRow.repo)) {
+              return issueRow;
+            }
+            return null;
+          },
+          all: async () => ({ results: [] }),
+        }),
+        first: async () => null,
+        all: async () => ({ results: [] }),
+      }),
+      batch: async () => [],
+    },
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
 }
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -512,22 +578,23 @@ describe("GET /api/issues/:key", () => {
     });
   });
 
-  describe("edgeItem fallback when join returns null number/repo", () => {
-    it("parses number and repo from key when join columns are null", async () => {
-      const row = makeIssueRow();
-      // Edge join returned null for number+repo (orphan edge row)
-      const blocking = [
-        { key: "Roxabi/roxabi-live#5", number: null, repo: null },
-      ];
-      const res = await app.request(
-        "/api/issues/Roxabi/roxabi-live%231",
-        {},
-        makeGetEnv({ issueRow: row, blocking }),
+  describe("edge visibility (INNER JOIN, #148)", () => {
+    it("blocking/blocked_by queries INNER JOIN issues on the visible set", async () => {
+      vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/roxabi-live"]);
+      const { env, capturedSqls } = makeGetEnvWithCapture({ issueRow: makeIssueRow() });
+      await app.request("/api/issues/Roxabi/roxabi-live%231", {}, env);
+
+      const edgeSqls = capturedSqls.filter(
+        (s) => s.includes("e.src_key = ?") || s.includes("e.dst_key = ?"),
       );
-      const body = await res.json<{ blocking: Record<string, unknown>[] }>();
-      expect(body.blocking[0].key).toBe("Roxabi/roxabi-live#5");
-      expect(body.blocking[0].number).toBe(5);
-      expect(body.blocking[0].repo).toBe("Roxabi/roxabi-live");
+      expect(edgeSqls).toHaveLength(2);
+      // The protection: each edge query INNER-JOINs issues on `repo IN (visible)`, so a
+      // non-visible (or orphan) endpoint can never match → no parseKey fallback to leak it.
+      for (const sql of edgeSqls) {
+        expect(sql).not.toContain("LEFT JOIN");
+        expect(sql).toContain("JOIN issues");
+        expect(sql).toContain("repo IN");
+      }
     });
   });
 });
@@ -616,5 +683,94 @@ describe("GET /api/issues — filter SQL params and clamping (FIX 4)", () => {
       const body = await res.json<{ offset: number }>();
       expect(body.offset).toBe(0);
     });
+  });
+});
+
+// ── #148: tenant-scoped reads (IDOR + visibility) ────────────────────────────
+
+describe("#148 tenant scoping", () => {
+  it("IDOR: a foreign-repo issue is 404 when its repo is not in the visible set", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/alpha"]);
+    const env = makeRepoFilteredGetEnv({
+      issueRow: makeIssueRow({
+        key: "Roxabi/secret#42",
+        repo: "Roxabi/secret",
+        number: 42,
+      }),
+    });
+    const res = await app.request("/api/issues/Roxabi/secret%2342", {}, env);
+    // Indistinguishable from a missing issue — no existence/metadata leak.
+    expect(res.status).toBe(404);
+  });
+
+  it("the same issue is 200 when its repo IS visible", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/secret"]);
+    const env = makeRepoFilteredGetEnv({
+      issueRow: makeIssueRow({
+        key: "Roxabi/secret#42",
+        repo: "Roxabi/secret",
+        number: 42,
+      }),
+    });
+    const res = await app.request("/api/issues/Roxabi/secret%2342", {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("get-issue SQL carries repo IN (?) bound to the visible set", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/alpha", "Roxabi/beta"]);
+    const { env, capturedSqls } = makeGetEnvWithCapture({ issueRow: makeIssueRow() });
+    await app.request("/api/issues/Roxabi/roxabi-live%231", {}, env);
+    const issueSql = capturedSqls.find((s) => s.includes("FROM issues WHERE key"));
+    expect(issueSql).toContain("repo IN");
+  });
+
+  it("list: empty visible set short-circuits to an empty page (no DB rows leak)", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue([]);
+    const res = await app.request(
+      "/api/issues",
+      {},
+      // countN:99/rows present — must be ignored by the empty-set short-circuit
+      makeListEnv({ countN: 99, rows: [makeIssueRow()] }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ issues: unknown[]; total: number }>();
+    expect(body.issues).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it("edge no-leak: a blocker in a non-visible repo is dropped from blocked_by", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/roxabi-live"]);
+    // Faithful INNER-JOIN mock: the blocked_by query returns the hidden blocker ONLY if
+    // its repo was bound into the statement (i.e. is in the visible set). The handler
+    // binds `...visible, rawKey` = ["Roxabi/roxabi-live", key] — "SecretOrg/secret" is
+    // never bound, so the JOIN can't match it → the row never reaches the response.
+    const hiddenBlocker = { key: "SecretOrg/secret#9", number: 9, repo: "SecretOrg/secret" };
+    const env = {
+      DB: {
+        prepare: (sql: string) => ({
+          bind: (...args: unknown[]) => ({
+            first: async () =>
+              sql.includes("FROM issues WHERE key") ? makeIssueRow() : null,
+            all: async () => {
+              if (sql.includes("e.dst_key = ?")) {
+                return { results: args.includes(hiddenBlocker.repo) ? [hiddenBlocker] : [] };
+              }
+              return { results: [] };
+            },
+          }),
+          first: async () => null,
+          all: async () => ({ results: [] }),
+        }),
+        batch: async () => [],
+      },
+      ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
+      GITHUB_ORG: "",
+      GITHUB_WEBHOOK_SECRET: "",
+    } as unknown as Env;
+
+    const res = await app.request("/api/issues/Roxabi/roxabi-live%231", {}, env);
+    const body = await res.json<{ blocked_by: Record<string, unknown>[] }>();
+    // No key/number/repo of the non-visible blocker leaks — the relationship is omitted.
+    expect(body.blocked_by).toEqual([]);
   });
 });

--- a/worker/src/api/issues.ts
+++ b/worker/src/api/issues.ts
@@ -9,18 +9,10 @@
  */
 
 import type { Context } from "hono";
-import type { Env } from "../types";
+import type { AuthEnv } from "../auth/session";
+import { resolveVisibleRepos } from "../auth/repoAccess";
 
 const ISSUE_KEY_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+#[0-9]+$/;
-
-/** Parse 'owner/repo#N' → { repo, number }. Returns { repo: key, number: null } on failure. */
-function parseKey(key: string): { repo: string; number: number | null } {
-  const m = /^(.+)#(\d+)$/.exec(key);
-  if (m) {
-    return { repo: m[1], number: parseInt(m[2], 10) };
-  }
-  return { repo: key, number: null };
-}
 
 interface IssueListRow {
   key: string;
@@ -47,11 +39,13 @@ interface CountRow {
 
 interface EdgeJoinRow {
   key: string;
-  number: number | null;
-  repo: string | null;
+  number: number;
+  repo: string;
 }
 
-export const listIssuesRoute = async (c: Context<{ Bindings: Env }>) => {
+export const listIssuesRoute = async (c: Context<AuthEnv>) => {
+  const visible = await resolveVisibleRepos(c);
+
   const url = new URL(c.req.url);
   const repo = url.searchParams.get("repo");
   const state = url.searchParams.get("state");
@@ -65,8 +59,14 @@ export const listIssuesRoute = async (c: Context<{ Bindings: Env }>) => {
   const limit = Math.max(1, Math.min(rawLimitParsed, 500));
   const offset = Math.max(0, rawOffsetParsed);
 
-  const conditions: string[] = [];
-  const params: (string | number)[] = [];
+  if (visible.length === 0) {
+    return c.json({ issues: [], total: 0, limit, offset });
+  }
+
+  const ph = visible.map(() => "?").join(",");
+
+  const conditions: string[] = [`issues.repo IN (${ph})`];
+  const params: (string | number)[] = [...visible];
 
   if (repo !== null) {
     conditions.push("issues.repo = ?");
@@ -139,7 +139,9 @@ export const listIssuesRoute = async (c: Context<{ Bindings: Env }>) => {
   return c.json({ issues, total, limit, offset });
 };
 
-export const getIssueRoute = async (c: Context<{ Bindings: Env }>) => {
+export const getIssueRoute = async (c: Context<AuthEnv>) => {
+  const visible = await resolveVisibleRepos(c);
+
   // Extract key from path: /api/issues/<owner>/<repo>#<number>
   // The key contains a slash so a single :key param won't match — use wildcard.
   const rawKey = decodeURIComponent(c.req.path.slice("/api/issues/".length));
@@ -151,10 +153,16 @@ export const getIssueRoute = async (c: Context<{ Bindings: Env }>) => {
     );
   }
 
+  if (visible.length === 0) {
+    return c.json({ detail: "Issue not found" }, 404);
+  }
+
+  const ph = visible.map(() => "?").join(",");
+
   const issueSql =
     "SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, is_stub," +
-    " created_at, updated_at, closed_at FROM issues WHERE key = ?";
-  const row = await c.env.DB.prepare(issueSql).bind(rawKey).first<IssueListRow>();
+    ` created_at, updated_at, closed_at FROM issues WHERE key = ? AND repo IN (${ph})`;
+  const row = await c.env.DB.prepare(issueSql).bind(rawKey, ...visible).first<IssueListRow>();
 
   if (!row) {
     return c.json({ detail: "Issue not found" }, 404);
@@ -167,34 +175,38 @@ export const getIssueRoute = async (c: Context<{ Bindings: Env }>) => {
     .all<{ name: string }>();
   const labels = labelsResult.results.map((r) => r.name);
 
-  // blocking: edges where this issue is src (kind=blocks) → dst issues
+  // blocking: edges where this issue is src (kind=blocks) → dst issues.
+  // blocked_by: edges where this issue is dst (kind=blocks) → src issues.
+  // INNER JOIN + `i.repo IN (...)` keeps an edge only when its OTHER endpoint is also
+  // visible (the anchor issue is already confirmed visible above). A blocker in a repo
+  // the caller can't see is dropped entirely — no key/number disclosure — matching the
+  // both-endpoints-visible rule graph.ts enforces.
   const blockingResult = await c.env.DB.prepare(
     "SELECT e.dst_key AS key, i.number, i.repo" +
-      " FROM edges e LEFT JOIN issues i ON i.key = e.dst_key" +
+      ` FROM edges e JOIN issues i ON i.key = e.dst_key AND i.repo IN (${ph})` +
       " WHERE e.src_key = ? AND e.kind = 'blocks'",
   )
-    .bind(rawKey)
+    .bind(...visible, rawKey)
     .all<EdgeJoinRow>();
 
-  // blocked_by: edges where this issue is dst (kind=blocks) → src issues
   const blockedByResult = await c.env.DB.prepare(
     "SELECT e.src_key AS key, i.number, i.repo" +
-      " FROM edges e LEFT JOIN issues i ON i.key = e.src_key" +
+      ` FROM edges e JOIN issues i ON i.key = e.src_key AND i.repo IN (${ph})` +
       " WHERE e.dst_key = ? AND e.kind = 'blocks'",
   )
-    .bind(rawKey)
+    .bind(...visible, rawKey)
     .all<EdgeJoinRow>();
 
-  function edgeItem(edgeRow: EdgeJoinRow) {
-    if (edgeRow.number === null || edgeRow.repo === null) {
-      const parsed = parseKey(edgeRow.key);
-      return { key: edgeRow.key, number: parsed.number, repo: parsed.repo };
-    }
-    return { key: edgeRow.key, number: edgeRow.number, repo: edgeRow.repo };
-  }
-
-  const blocking = blockingResult.results.map(edgeItem);
-  const blocked_by = blockedByResult.results.map(edgeItem);
+  const blocking = blockingResult.results.map((e) => ({
+    key: e.key,
+    number: e.number,
+    repo: e.repo,
+  }));
+  const blocked_by = blockedByResult.results.map((e) => ({
+    key: e.key,
+    number: e.number,
+    repo: e.repo,
+  }));
 
   return c.json({
     key: row.key,

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -228,6 +228,34 @@ describe("meRoute", () => {
     });
   });
 
+  it("response includes active_tenant_id from the session (#148 SC7)", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — the active tenant is surfaced so the client can render the tenant switcher
+    expect(res.status).toBe(200);
+    const body = await res.json() as { active_tenant_id: number };
+    expect(body.active_tenant_id).toBe(STUB_SESSION.tenantId);
+  });
+
+  it("installations SELECT projects account_type (#148 SC7)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — account_type must be selected so User vs Organization tenants are distinguishable
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).toContain("account_type");
+  });
+
   it("returns 401 when requireSession finds no session cookie (negative guard test)", async () => {
     // Arrange — separate throwaway app mounting real requireSession, no stub session
     // This verifies the guard is not tautological: deleting requireSession would let

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -210,7 +210,7 @@ describe("meRoute", () => {
 
   it("surfaces installation rows returned by D1 in the response body", async () => {
     // Arrange — FakeD1 returns one installation row
-    const fakeRow = { tenant_id: 9, installation_id: 5, account_login: "Roxabi" };
+    const fakeRow = { tenant_id: 9, account_login: "Roxabi", account_type: "Organization" };
     const { db } = captureDbWithRows([fakeRow]);
     const app = makeApp(db);
 
@@ -223,9 +223,23 @@ describe("meRoute", () => {
     expect(body.installations).toHaveLength(1);
     expect(body.installations[0]).toMatchObject({
       tenant_id: 9,
-      installation_id: 5,
       account_login: "Roxabi",
+      account_type: "Organization",
     });
+  });
+
+  it("installations SELECT does NOT project installation_id (#171 — unnecessary exposure removed)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — installation_id is internal infra detail, not surfaced to clients
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).not.toContain("installation_id");
   });
 
   it("response includes active_tenant_id from the session (#148 SC7)", async () => {

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -23,11 +23,11 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
 
   const rows = await c.env.DB
     .prepare(
-      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login, t.account_type AS account_type
+      `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
        FROM user_installations ui JOIN tenants t ON t.id = ui.tenant_id WHERE ui.user_id = ?`,
     )
     .bind(s.userId)
-    .all<{ tenant_id: number; installation_id: number; account_login: string; account_type: string }>();
+    .all<{ tenant_id: number; account_login: string; account_type: string }>();
 
   return c.json({
     user: {

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -23,17 +23,18 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
 
   const rows = await c.env.DB
     .prepare(
-      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login
+      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login, t.account_type AS account_type
        FROM user_installations ui JOIN tenants t ON t.id = ui.tenant_id WHERE ui.user_id = ?`,
     )
     .bind(s.userId)
-    .all<{ tenant_id: number; installation_id: number; account_login: string }>();
+    .all<{ tenant_id: number; installation_id: number; account_login: string; account_type: string }>();
 
   return c.json({
     user: {
       github_id: s.githubId,
       github_login: s.githubLogin,
     },
+    active_tenant_id: s.tenantId,
     installations: rows.results,
   });
 }

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -593,10 +593,13 @@ describe("listInstallationRepos — W2 pagination bound", () => {
 
   it("stops early on a short final page and does NOT warn (normal case)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ repositories: [{ full_name: "o/only" }] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+      new Response(
+        JSON.stringify({ repositories: [{ full_name: "o/only", private: true }] }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
     );
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -604,7 +607,7 @@ describe("listInstallationRepos — W2 pagination bound", () => {
     const repos = await listInstallationRepos("fake-token");
 
     expect(fetchMock).toHaveBeenCalledTimes(1); // short page → single fetch
-    expect(repos).toEqual(["o/only"]);
+    expect(repos).toEqual([{ repo: "o/only", isPrivate: true }]);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -208,6 +208,7 @@ export async function resolveInstallToken(
 
 interface GHRepository {
   full_name: string;
+  private: boolean;
 }
 
 interface GHInstallationReposResponse {
@@ -221,11 +222,13 @@ interface GHInstallationReposResponse {
  * Paginates automatically (100 per page) until all repos are collected.
  *
  * @param token - GitHub installation access token (from getInstallationToken).
- * @returns Array of `"owner/name"` full_name strings.
+ * @returns Array of `{ repo: "owner/name", isPrivate: boolean }` entries.
  */
-export async function listInstallationRepos(token: string): Promise<string[]> {
+export async function listInstallationRepos(
+  token: string,
+): Promise<Array<{ repo: string; isPrivate: boolean }>> {
   const MAX_PAGES = 10;
-  const repos: string[] = [];
+  const repos: Array<{ repo: string; isPrivate: boolean }> = [];
   let lastPageFull = false;
 
   for (let page = 1; page <= MAX_PAGES; page++) {
@@ -258,7 +261,7 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
     const pageRepos = body.repositories ?? [];
 
     for (const r of pageRepos) {
-      repos.push(r.full_name);
+      repos.push({ repo: r.full_name, isPrivate: r.private });
     }
 
     lastPageFull = pageRepos.length === 100;

--- a/worker/src/auth/repoAccess.test.ts
+++ b/worker/src/auth/repoAccess.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Context } from "hono";
+import type { AuthEnv } from "./session";
+import {
+  resolveVisibleRepos,
+  checkPrivateAccess,
+} from "./repoAccess";
+import {
+  captureDb,
+  dispatchByTable,
+  STUB_SESSION,
+  makeEnv,
+} from "../test-utils";
+
+// ---------------------------------------------------------------------------
+// Mock installToken module
+// ---------------------------------------------------------------------------
+
+vi.mock("./installToken", () => ({
+  getInstallationToken: vi.fn().mockResolvedValue("tok"),
+  encryptToken: vi.fn(),
+  decryptToken: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal Hono Context stub carrying a session and DB env. */
+function makeCtx(
+  db: D1Database,
+  session: AuthEnv["Variables"]["session"],
+): Context<AuthEnv> {
+  const env = makeEnv(db);
+  return {
+    get: (key: string) => (key === "session" ? session : undefined),
+    env,
+  } as unknown as Context<AuthEnv>;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  // Reset global fetch after each test
+  (globalThis as Record<string, unknown>).fetch = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// checkPrivateAccess — cache HIT
+// ---------------------------------------------------------------------------
+
+describe("checkPrivateAccess", () => {
+  it("returns true from cache (has_access=1, fresh) without calling fetch", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [{ has_access: 1 }],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false from cache (has_access=0, fresh) without calling fetch", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [{ has_access: 0 }],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // cache MISS → fetch 204 → granted + UPSERT
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch 204 → returns true and issues a cache UPSERT", async () => {
+    // Arrange
+    const { db, stmts } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [], // miss
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 204 }) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert — access granted
+    expect(result).toBe(true);
+
+    // Assert — a cache UPSERT statement was issued (INSERT INTO user_repo_permission_cache)
+    const upsertStmt = stmts().find((s) =>
+      s.sql.toLowerCase().includes("insert into user_repo_permission_cache"),
+    );
+    expect(upsertStmt).toBeDefined();
+    expect(upsertStmt?.run).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // fetch 404 → denied
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch 404 → returns false", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 404 }) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // fetch 403 → denied
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch 403 → returns false", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 403 }) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // fetch throws (network) → denied AND no cache UPSERT
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch throws → returns false and does NOT issue a cache UPSERT", async () => {
+    // Arrange
+    const { db, stmts } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network error")) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert — denied
+    expect(result).toBe(false);
+
+    // Assert — no UPSERT issued
+    const upsertStmt = stmts().find((s) =>
+      s.sql.toLowerCase().includes("insert into user_repo_permission_cache"),
+    );
+    expect(upsertStmt).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVisibleRepos
+// ---------------------------------------------------------------------------
+
+describe("resolveVisibleRepos", () => {
+  // -------------------------------------------------------------------------
+  // Public repo — always visible, no fetch
+  // -------------------------------------------------------------------------
+
+  it("public repo (is_private=0) → visible without getInstallationToken or fetch", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        tenant_repo_access: [{ repo: "Roxabi/public", is_private: 0 }],
+      }),
+    );
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+    const ctx = makeCtx(db, STUB_SESSION);
+
+    // Act
+    const visible = await resolveVisibleRepos(ctx);
+
+    // Assert
+    expect(visible).toEqual(["Roxabi/public"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty tenant_repo_access → []
+  // -------------------------------------------------------------------------
+
+  it("empty tenant_repo_access → resolveVisibleRepos returns []", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        tenant_repo_access: [],
+      }),
+    );
+    const ctx = makeCtx(db, STUB_SESSION);
+
+    // Act
+    const visible = await resolveVisibleRepos(ctx);
+
+    // Assert
+    expect(visible).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // No session on context → []
+  // -------------------------------------------------------------------------
+
+  it("no session on context → resolveVisibleRepos returns []", async () => {
+    // Arrange
+    const { db } = captureDb(() => []);
+    const ctx = makeCtx(db, undefined);
+
+    // Act
+    const visible = await resolveVisibleRepos(ctx);
+
+    // Assert
+    expect(visible).toEqual([]);
+  });
+});

--- a/worker/src/auth/repoAccess.test.ts
+++ b/worker/src/auth/repoAccess.test.ts
@@ -62,7 +62,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = fetchMock as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(true);
@@ -82,7 +82,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = fetchMock as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(false);
@@ -105,7 +105,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ status: 204 }) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert — access granted
     expect(result).toBe(true);
@@ -134,7 +134,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ status: 404 }) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(false);
@@ -156,7 +156,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ status: 403 }) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(false);
@@ -178,7 +178,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("network error")) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert — denied
     expect(result).toBe(false);

--- a/worker/src/auth/repoAccess.ts
+++ b/worker/src/auth/repoAccess.ts
@@ -1,0 +1,252 @@
+/**
+ * Per-request visible-repo resolver and private-repo permission check.
+ *
+ * Security invariant: every uncertain / error path returns false (deny).
+ * This is the IDOR-closing primitive — fail-closed on all branches.
+ *
+ * Never throws out to the caller. All errors are caught internally and
+ * resolved as a denial so transient failures cannot leak private data.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "./session";
+import type { Env } from "../types";
+import { getInstallationToken } from "./installToken";
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface RepoAccessRow {
+  repo: string;
+  is_private: number;
+}
+
+interface TenantInstallRow {
+  installation_id: number;
+}
+
+interface PermCacheRow {
+  has_access: number;
+}
+
+// ---------------------------------------------------------------------------
+// resolveVisibleRepos
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the list of repo full-names visible to the authenticated session user.
+ *
+ * Public repos (is_private = 0) are always included.
+ * Private repos (is_private = 1) are included only if checkPrivateAccess returns true.
+ *
+ * Fail-closed: missing session, DB errors, or any per-repo check error → deny that repo.
+ * installation_id is resolved once before the loop; never re-queried per repo.
+ *
+ * @param c - Hono context carrying AuthEnv (DB binding + session variable).
+ * @returns Array of visible repo full-names ("owner/name").
+ */
+export async function resolveVisibleRepos(
+  c: Context<AuthEnv>,
+): Promise<string[]> {
+  const s = c.get("session");
+  // Middleware guarantees session; guard defensively — fail-closed.
+  if (!s) {
+    return [];
+  }
+
+  const db = c.env.DB;
+  const env = c.env;
+
+  // Fetch all repos registered for this tenant.
+  let rows: RepoAccessRow[];
+  try {
+    const result = await db
+      .prepare(
+        `SELECT repo, is_private FROM tenant_repo_access WHERE tenant_id = ?`,
+      )
+      .bind(s.tenantId)
+      .all<RepoAccessRow>();
+    rows = result.results ?? [];
+  } catch {
+    // DB error — fail-closed, no repos visible.
+    return [];
+  }
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  // Resolve installation_id ONCE for this tenant before iterating private repos.
+  // We only need it if there are private repos, but resolve eagerly to keep the
+  // loop simple and avoid conditional re-queries.
+  let installationId: number | null = null;
+  const hasPrivate = rows.some((r) => r.is_private !== 0);
+  if (hasPrivate) {
+    try {
+      const tenantRow = await db
+        .prepare(
+          `SELECT installation_id FROM tenants WHERE id = ?`,
+        )
+        .bind(s.tenantId)
+        .first<TenantInstallRow>();
+      installationId = tenantRow?.installation_id ?? null;
+    } catch {
+      // DB error — treat all private repos as denied below (installationId = null).
+    }
+  }
+
+  const visible: string[] = [];
+
+  for (const row of rows) {
+    if (row.is_private === 0) {
+      // Public repo — always visible.
+      visible.push(row.repo);
+    } else {
+      // Private repo — check per-user permission.
+      if (installationId === null) {
+        // Could not resolve installation — deny (fail-closed).
+        continue;
+      }
+      const allowed = await checkPrivateAccess(
+        db,
+        env,
+        s.userId,
+        installationId,
+        row.repo,
+        s.githubLogin,
+      );
+      if (allowed) {
+        visible.push(row.repo);
+      }
+    }
+  }
+
+  return visible;
+}
+
+// ---------------------------------------------------------------------------
+// checkPrivateAccess
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a user has read access to a private repository.
+ *
+ * Cache path (24 h TTL): reads user_repo_permission_cache. Hit → return cached value.
+ * Live path (cache miss / stale):
+ *   - Mints an installation access token via getInstallationToken.
+ *   - Calls GET /repos/{repo}/collaborators/{login} with the token.
+ *   - HTTP 204 → access granted. HTTP 404 or 403 → access denied.
+ *   - On 204/404/403: UPSERTs result into cache, then returns boolean.
+ *   - Any other status, network error, or thrown exception → fail-closed (false),
+ *     cache is NOT written (transient failure must not poison future cache hits).
+ *
+ * @param db             - D1 database binding.
+ * @param env            - Worker env bindings (for getInstallationToken).
+ * @param userId         - users.id of the authenticated user.
+ * @param installationId - GitHub App installation_id (resolved by the caller).
+ * @param repo           - Full repo name "owner/name" (already validated by caller).
+ * @param login          - GitHub login of the user (for the collaborator check URL).
+ * @returns true if the user has access, false in all other cases (deny-by-default).
+ */
+export async function checkPrivateAccess(
+  db: D1Database,
+  env: Env,
+  userId: number,
+  installationId: number,
+  repo: string,
+  login: string,
+): Promise<boolean> {
+  // Step 1 — Cache check (24 h TTL).
+  try {
+    const cached = await db
+      .prepare(
+        `SELECT has_access FROM user_repo_permission_cache
+         WHERE user_id = ? AND repo = ? AND checked_at > datetime('now','-24 hours')`,
+      )
+      .bind(userId, repo)
+      .first<PermCacheRow>();
+
+    if (cached !== null && cached !== undefined) {
+      // Cache hit — return stored value.
+      return Boolean(cached.has_access);
+    }
+  } catch {
+    // Cache read failure — proceed to live check; do not short-circuit to false
+    // (a DB read error should not permanently deny a user; live check can clarify).
+  }
+
+  // Step 2 — Live check via GitHub Collaborators API.
+  // Any error in this block must return false without writing cache.
+  let access: boolean;
+  try {
+    // Resolve installation access token (tenant_id not needed by caller-side contract;
+    // installToken.ts requires it for cache keying — we use tenantId=0 sentinel is wrong;
+    // instead we need the actual tenantId). However, getInstallationToken's signature
+    // requires tenantId. The caller (resolveVisibleRepos) has it, but checkPrivateAccess
+    // receives only installationId. To keep this function self-contained and the interface
+    // clean, we look up the tenantId from the tenants table using installationId.
+    const tenantRow = await db
+      .prepare(`SELECT id FROM tenants WHERE installation_id = ?`)
+      .bind(installationId)
+      .first<{ id: number }>();
+
+    if (!tenantRow) {
+      // No matching tenant — fail-closed.
+      return false;
+    }
+
+    const token = await getInstallationToken(
+      db,
+      env,
+      tenantRow.id,
+      installationId,
+    );
+
+    // GET /repos/{owner}/{name}/collaborators/{login}
+    // repo is already "owner/name" — use directly.
+    const url = `https://api.github.com/repos/${repo}/collaborators/${encodeURIComponent(login)}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "roxabi-live-worker",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (res.status === 204) {
+      access = true;
+    } else if (res.status === 404 || res.status === 403) {
+      access = false;
+    } else {
+      // Unexpected status (5xx, 429, etc.) — fail-closed, do NOT cache.
+      return false;
+    }
+  } catch {
+    // Network failure, token mint error, or any thrown exception — fail-closed.
+    // Do NOT write cache: a transient failure must not poison future reads.
+    return false;
+  }
+
+  // Step 3 — UPSERT result into cache (only reached on 204 / 404 / 403).
+  try {
+    await db
+      .prepare(
+        `INSERT INTO user_repo_permission_cache (user_id, repo, has_access, checked_at)
+         VALUES (?, ?, ?, datetime('now'))
+         ON CONFLICT(user_id, repo) DO UPDATE SET
+           has_access = excluded.has_access,
+           checked_at = excluded.checked_at`,
+      )
+      .bind(userId, repo, access ? 1 : 0)
+      .run();
+  } catch {
+    // Cache write failure — log-only concern; return the live result regardless.
+    // A failed upsert means the next request re-checks live; it does not affect
+    // the current request's answer.
+  }
+
+  return access;
+}

--- a/worker/src/auth/repoAccess.ts
+++ b/worker/src/auth/repoAccess.ts
@@ -112,6 +112,7 @@ export async function resolveVisibleRepos(
         db,
         env,
         s.userId,
+        s.tenantId,
         installationId,
         row.repo,
         s.githubLogin,
@@ -144,6 +145,7 @@ export async function resolveVisibleRepos(
  * @param db             - D1 database binding.
  * @param env            - Worker env bindings (for getInstallationToken).
  * @param userId         - users.id of the authenticated user.
+ * @param tenantId       - tenants.id (supplied by the caller, which already holds it).
  * @param installationId - GitHub App installation_id (resolved by the caller).
  * @param repo           - Full repo name "owner/name" (already validated by caller).
  * @param login          - GitHub login of the user (for the collaborator check URL).
@@ -153,6 +155,7 @@ export async function checkPrivateAccess(
   db: D1Database,
   env: Env,
   userId: number,
+  tenantId: number,
   installationId: number,
   repo: string,
   login: string,
@@ -180,26 +183,12 @@ export async function checkPrivateAccess(
   // Any error in this block must return false without writing cache.
   let access: boolean;
   try {
-    // Resolve installation access token (tenant_id not needed by caller-side contract;
-    // installToken.ts requires it for cache keying — we use tenantId=0 sentinel is wrong;
-    // instead we need the actual tenantId). However, getInstallationToken's signature
-    // requires tenantId. The caller (resolveVisibleRepos) has it, but checkPrivateAccess
-    // receives only installationId. To keep this function self-contained and the interface
-    // clean, we look up the tenantId from the tenants table using installationId.
-    const tenantRow = await db
-      .prepare(`SELECT id FROM tenants WHERE installation_id = ?`)
-      .bind(installationId)
-      .first<{ id: number }>();
-
-    if (!tenantRow) {
-      // No matching tenant — fail-closed.
-      return false;
-    }
-
+    // tenantId + installationId are both supplied by the caller (resolveVisibleRepos),
+    // which already holds them on the session — no reverse lookup needed.
     const token = await getInstallationToken(
       db,
       env,
-      tenantRow.id,
+      tenantId,
       installationId,
     );
 

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -149,6 +149,30 @@ export async function validateSession(
 }
 
 /**
+ * Switch the active tenant for an existing session.
+ * Hashes the raw token, then updates sessions.tenant_id in place.
+ * The UPDATE is a no-op if the session has expired or been revoked,
+ * which is safe — the caller (activeTenantRoute) guards membership first.
+ */
+export async function setSessionTenant(
+  db: D1Database,
+  rawToken: string,
+  tenantId: number,
+): Promise<void> {
+  const hash = await sha256hex(rawToken);
+
+  await db
+    .prepare(
+      `UPDATE sessions SET tenant_id = ?
+       WHERE token_hash = ?
+         AND revoked_at IS NULL
+         AND expires_at > datetime('now')`,
+    )
+    .bind(tenantId, hash)
+    .run();
+}
+
+/**
  * Delete a session by raw token (hashes before querying).
  */
 export async function deleteSession(

--- a/worker/src/router.test.ts
+++ b/worker/src/router.test.ts
@@ -1,0 +1,262 @@
+/**
+ * router.test.ts — auth gate fires before DB work.
+ *
+ * Verifies that requireSession short-circuits the /api/issues, /api/issues/*,
+ * and /api/graph routes before any D1 access when no session cookie is present.
+ * Also provides a positive control confirming the gate admits a valid session.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Env } from "./types";
+import type { SessionContext } from "./auth/session";
+import { app } from "./router";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// DB stub helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a D1Database stub whose .prepare throws if called.
+ * Use this to assert the DB is never touched on the 401 path.
+ */
+function makeDbThatMustNotBeCalled(): D1Database {
+  const errorMsg = "DB must not be touched on 401 path";
+  return {
+    prepare: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+    batch: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+    dump: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+    exec: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+  } as unknown as D1Database;
+}
+
+/**
+ * Returns a D1Database stub that answers validateSession's query with a
+ * valid session row, so requireSession admits the request.
+ *
+ * validateSession calls:
+ *   db.prepare(SELECT … FROM sessions s JOIN users …).bind(hash).first()
+ *
+ * We intercept via bind().first() returning the stub row.
+ */
+function makeSessionDb(session: SessionContext): D1Database {
+  const validRow = {
+    userId: session.userId,
+    tenantId: session.tenantId,
+    githubId: session.githubId,
+    githubLogin: session.githubLogin,
+  };
+
+  const bindStmt = {
+    first: vi.fn().mockResolvedValue(validRow),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+    bind: vi.fn(function (this: unknown) { return this; }),
+  };
+
+  const stmt = {
+    first: vi.fn().mockResolvedValue(validRow),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+    bind: vi.fn(() => bindStmt),
+  };
+
+  return {
+    prepare: vi.fn(() => stmt),
+    batch: vi.fn().mockResolvedValue([]),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+// ---------------------------------------------------------------------------
+// Env builder
+// ---------------------------------------------------------------------------
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: {
+      fetch: async () => new Response("asset", { status: 200 }),
+    } as unknown as Fetcher,
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+// Canonical stub session for positive control
+const STUB_SESSION: SessionContext = {
+  userId: 1,
+  tenantId: 1,
+  githubId: 1001,
+  githubLogin: "octocat",
+};
+
+// A plausible raw session token (64-char hex)
+const VALID_RAW_TOKEN = "a".repeat(64);
+
+// ---------------------------------------------------------------------------
+// Negative tests — no Cookie header → 401, DB must not be touched
+// ---------------------------------------------------------------------------
+
+describe("requireSession auth gate", () => {
+  describe("GET /api/issues — no cookie", () => {
+    it("returns 401 with {error: unauthorized}", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request("/api/issues", {}, env);
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+
+    it("never calls DB.prepare on 401 path", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act — must not throw (DB.prepare is guarded by requireSession returning early)
+      const res = await app.request("/api/issues", {}, env);
+
+      // Assert — 401 means requireSession returned before touching DB
+      expect(res.status).toBe(401);
+      expect(db.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/issues/:key — no cookie", () => {
+    it("returns 401 with {error: unauthorized}", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act — encoded Roxabi/alpha#42
+      const res = await app.request(
+        "/api/issues/Roxabi%2Falpha%2342",
+        {},
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+
+    it("never calls DB.prepare on 401 path", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request(
+        "/api/issues/Roxabi%2Falpha%2342",
+        {},
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(401);
+      expect(db.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/graph — no cookie", () => {
+    it("returns 401 with {error: unauthorized}", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request("/api/graph", {}, env);
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+
+    it("never calls DB.prepare on 401 path", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request("/api/graph", {}, env);
+
+      // Assert
+      expect(res.status).toBe(401);
+      expect(db.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Positive control — valid session cookie must NOT produce 401
+  // -------------------------------------------------------------------------
+
+  describe("positive control — valid session cookie", () => {
+    it("GET /api/issues with valid session does not return 401", async () => {
+      // Arrange — DB answers validateSession's query with a valid row
+      const db = makeSessionDb(STUB_SESSION);
+      const env = makeEnv(db);
+
+      // Act — send a plausible raw token in the __Host-session cookie
+      const res = await app.request(
+        "/api/issues",
+        { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+
+      // Assert — gate passed; handler ran (may be 200 or non-401 error from handler)
+      expect(res.status).not.toBe(401);
+    });
+
+    it("GET /api/graph with valid session does not return 401", async () => {
+      // Arrange
+      const db = makeSessionDb(STUB_SESSION);
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request(
+        "/api/graph",
+        { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+
+      // Assert
+      expect(res.status).not.toBe(401);
+    });
+
+    it("GET /api/issues/:key with valid session does not return 401", async () => {
+      // Arrange
+      const db = makeSessionDb(STUB_SESSION);
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request(
+        "/api/issues/Roxabi%2Falpha%2342",
+        { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+
+      // Assert
+      expect(res.status).not.toBe(401);
+    });
+  });
+});

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -9,6 +9,7 @@ import { checkAdminAuth } from "./api/auth";
 import { loginRoute, callbackRoute } from "./auth/oauth";
 import { meRoute, logoutRoute } from "./api/me";
 import { requireSession, type AuthEnv } from "./auth/session";
+import { activeTenantRoute } from "./api/active-tenant";
 
 const app = new Hono<AuthEnv>();
 
@@ -20,12 +21,16 @@ app.get("/api/version", versionRoute);
 // POST /webhook/github — HMAC-verified GitHub org webhooks (S5, #97).
 app.post("/webhook/github", webhookRoute);
 
-// GET /api/graph — v6 graph payload: nodes + edges (S6, #98).
+// GET /api/graph — v6 graph payload: nodes + edges (S6, #98). Session-gated (#148).
+app.use("/api/graph", requireSession);
 app.get("/api/graph", graphRoute);
 
 // GET /api/issues — list with optional repo/state/label/limit/offset filters (S6, #98).
 // GET /api/issues/* — single issue by key (key contains owner/repo#N slash) (S6, #98).
 // List route MUST be registered before the wildcard so Hono's first-match wins.
+// Both paths need their own use() — /api/issues/* does NOT match bare /api/issues (#148).
+app.use("/api/issues", requireSession);
+app.use("/api/issues/*", requireSession);
 app.get("/api/issues", listIssuesRoute);
 app.get("/api/issues/*", getIssueRoute);
 
@@ -64,6 +69,7 @@ app.get("/login", loginRoute);
 app.get("/oauth/callback", callbackRoute);
 app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
+app.post("/api/active-tenant", requireSession, activeTenantRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1054,7 +1054,7 @@ describe("runSync", () => {
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
     // listInstallationRepos returns only roxabi-factory (lyra is gone)
-    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "Roxabi/roxabi-factory", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
@@ -1093,7 +1093,7 @@ describe("runSync", () => {
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
     // listInstallationRepos returns both repos — roxabi-vault is still accessible
-    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory", "Roxabi/roxabi-vault"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "Roxabi/roxabi-factory", isPrivate: false }, { repo: "Roxabi/roxabi-vault", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
@@ -1258,7 +1258,7 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
     // Both tenants enumerate the same repo "o/r"
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
@@ -1300,7 +1300,7 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
     // Discovery must yield ≥1 repo so Phase 2 runs and reaches the slot-advance write.
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1387,7 +1387,7 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
     // runSync must use getInstallationToken() and never read env.GITHUB_TOKEN.
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "Roxabi/roxabi-factory", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1501,7 +1501,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     // Arrange
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("tok");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/keep"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/keep", isPrivate: true }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1555,10 +1555,12 @@ describe("runSync — breaker + discovery (#160)", () => {
     const recorded = db._recorded;
     const insertKeep = recorded.find(
       (s) =>
-        s.sql.includes("INSERT OR IGNORE INTO tenant_repo_access") &&
+        s.sql.includes("INSERT INTO tenant_repo_access") &&
         s.args.includes("o/keep"),
     );
     expect(insertKeep).toBeDefined();
+    // #148: is_private written (o/keep mocked private → bound 1; args = [tenantId, repo, is_private])
+    expect(insertKeep?.args[2]).toBe(1);
 
     // Assert — DELETE for "o/stale" (not for "o/keep")
     const deleteStale = recorded.find(
@@ -1576,11 +1578,77 @@ describe("runSync — breaker + discovery (#160)", () => {
     expect(deleteKeep).toBeUndefined();
   });
 
+  it("B3b: discoverTenants writes is_private=0 for a public repo", async () => {
+    // Arrange
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("tok");
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/pub", isPrivate: false }]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      // Global tick lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // Tenant lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // halted guard
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT → not halted
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // tenants discovery → 1 tenant
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      // existing tenant_repo_access rows → same as current (no stale)
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/pub" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — INSERT for "o/pub" with is_private=0
+    const recorded = db._recorded;
+    const insertPub = recorded.find(
+      (s) =>
+        s.sql.includes("INSERT INTO tenant_repo_access") &&
+        s.args.includes("o/pub"),
+    );
+    expect(insertPub).toBeDefined();
+    // #148: is_private=0 for public repo (args = [tenantId, repo, is_private])
+    expect(insertPub?.args[2]).toBe(0);
+  });
+
   it("B4: token-exhausted repo is skipped, runSync resolves without throwing", async () => {
     // Arrange — getInstallationToken always rejects for Phase 2 lookups
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockRejectedValue(new Error("no-token"));
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/a"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/a", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1641,7 +1709,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     vi.mocked(getInstallationToken)
       .mockResolvedValueOnce("tok-discovery") // Phase 1 success
       .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
@@ -1703,7 +1771,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     vi.mocked(getInstallationToken)
       .mockResolvedValueOnce("tok-discovery") // Phase 1 success
       .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
@@ -1759,7 +1827,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     // Arrange — 1 tenant id=7, 1 repo synced OK
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("tok-7");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/ok"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/ok", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -1105,7 +1105,7 @@ export async function discoverTenants(
     }
 
     try {
-      let repos: string[];
+      let repos: Array<{ repo: string; isPrivate: boolean }>;
       try {
         const token = await getInstallationToken(db, env, tenantId, installationId);
         repos = await listInstallationRepos(token);
@@ -1115,20 +1115,22 @@ export async function discoverTenants(
         continue;
       }
 
-      // Upsert accessible repos into tenant_repo_access.
+      // Upsert accessible repos into tenant_repo_access (sets is_private on every sync
+      // so public repos converge to is_private=0; DEFAULT 1 = fail-closed for new rows).
       if (repos.length > 0) {
-        const upsertStmts = repos.map((repo) =>
+        const upsertStmts = repos.map((r) =>
           db
             .prepare(
-              `INSERT OR IGNORE INTO tenant_repo_access (tenant_id, repo) VALUES (?, ?)`,
+              `INSERT INTO tenant_repo_access (tenant_id, repo, is_private) VALUES (?, ?, ?)
+               ON CONFLICT(tenant_id, repo) DO UPDATE SET is_private = excluded.is_private`,
             )
-            .bind(tenantId, repo),
+            .bind(tenantId, r.repo, r.isPrivate ? 1 : 0),
         );
         await batchChunked(db, upsertStmts);
       }
 
       // Delete stale rows: repos no longer returned by the installation.
-      const repoSet = new Set(repos);
+      const repoSet = new Set(repos.map((r) => r.repo));
       const existing = await db
         .prepare(`SELECT repo FROM tenant_repo_access WHERE tenant_id = ?`)
         .bind(tenantId)
@@ -1145,7 +1147,7 @@ export async function discoverTenants(
       }
 
       // Merge into global map (sorted ascending by tenantId — maintained by ORDER BY above).
-      for (const repo of repos) {
+      for (const { repo } of repos) {
         const entry = repoMap.get(repo);
         if (entry) {
           entry.push({ tenantId, installationId });

--- a/worker/src/test-utils.ts
+++ b/worker/src/test-utils.ts
@@ -1,0 +1,199 @@
+/**
+ * test-utils.ts — shared FakeD1 harness for Worker vitest suites.
+ *
+ * NOT a test file — no `describe`/`it`/`expect`. Imported by *.test.ts files.
+ * Sources consolidated from: me.test.ts, session.test.ts, installToken.test.ts
+ */
+
+import { vi } from "vitest";
+import type { Env } from "./types";
+import type { SessionContext } from "./auth/session";
+
+// ---------------------------------------------------------------------------
+// Core FakeD1 types
+// ---------------------------------------------------------------------------
+
+export type FakeResult = { [k: string]: unknown };
+
+export interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level primitives
+// ---------------------------------------------------------------------------
+
+export function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+export function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Higher-level capture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a FakeD1 that records every prepared statement.
+ *
+ * Optional `handler` receives (sql, args) and returns rows for that query.
+ * When omitted, every query returns empty rows (same as original captureDb()).
+ */
+export function captureDb(
+  handler?: (sql: string, args: unknown[]) => FakeResult[],
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const rows = handler ? handler(sql, args) : [];
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/** Every query returns the same fixed rows. */
+export function captureDbWithRows(
+  rows: FakeResult[],
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/**
+ * Every query returns the single provided row (or null).
+ * Sourced from session.test.ts — useful for single-row lookups (SELECT … LIMIT 1).
+ */
+export function fixedFirstDb(row: FakeResult | null): D1Database {
+  return makeFakeDb((sql, args) =>
+    makeFakeStmt(sql, args, row !== null ? [row] : [], 0),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SQL-dispatch helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Route a SQL string to a row set by matching table-name keywords.
+ *
+ * Keys in `map` are matched against `sql.toLowerCase()` via `includes()`.
+ * First match wins. Returns `[]` when no key matches.
+ *
+ * Typical use inside a `captureDb` handler:
+ *
+ *   const { db } = captureDb((sql) =>
+ *     dispatchByTable(sql, {
+ *       "tenant_repo_access":          [{ repo_id: 1, tenant_id: 1 }],
+ *       "user_repo_permission_cache":  [{ permission: "read" }],
+ *       "tenants":                     [{ id: 1, github_org: "Roxabi" }],
+ *     }),
+ *   );
+ *
+ * Keys for the two new #148 tables (`tenant_repo_access`, `user_repo_permission_cache`)
+ * are deliberately called out in the example above.
+ */
+export function dispatchByTable(
+  sql: string,
+  map: Record<string, FakeResult[]>,
+): FakeResult[] {
+  const lower = sql.toLowerCase();
+  for (const [key, rows] of Object.entries(map)) {
+    if (lower.includes(key.toLowerCase())) {
+      return rows;
+    }
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical stub session for #148 tests.
+ * Values differ from per-file stubs in older tests (alice/7/9/42) — use these
+ * for all new Wave-1 / Wave-2 tests unless a specific scenario requires custom values.
+ */
+export const STUB_SESSION: SessionContext = {
+  userId: 1,
+  tenantId: 1,
+  githubId: 1001,
+  githubLogin: "octocat",
+};
+
+/**
+ * Minimal Env builder — only fields required by most route handlers.
+ * Cast via `unknown as Env` so callers do not need to satisfy optional fields.
+ */
+export function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: {
+      fetch: async () => new Response("asset", { status: 200 }),
+    } as unknown as Fetcher,
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}


### PR DESCRIPTION
## Summary
- Closes the unauthenticated-graph IDOR (#148, Phase-1 S5): every `/api/*` read is now gated by fail-closed `requireSession`, and all issue/graph/edge/repo reads are scoped to a per-request visible-repo set (`tenant_repo_access` ∩ user-permitted private repos).
- Self-absorbs the `is_private` column (migration **0007**) + sync population, so criterion 4 ships without waiting on #147 (Option-3 amendment, 2026-06-13).
- Single-issue blocker edges use INNER JOIN + `repo IN (visible)` → a blocker in a repo the caller can't see is dropped entirely (no key/number disclosure), matching `graph.ts`'s both-endpoints-visible rule.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #148: tenant-filtered reads + active-tenant + org-picker (Phase 1 S5) | OPEN |
| Analysis | — | Absent |
| Spec | [148-tenant-filtered-reads-spec.mdx](artifacts/specs/148-tenant-filtered-reads-spec.mdx) | Present |
| Implementation | 2 commits on `feat/148-tenant-filtered-reads` | Complete |
| Verification | Lint n/a · Typecheck ✅ · Tests ✅ (424 / 20 files, 8 new) | Passed |

## Test Plan
- [ ] Unauthed `GET /api/issues`, `/api/issues/:key`, `/api/graph` → **401** before any DB statement
- [ ] Logged-in user sees only their tenant's issues + graph; foreign/unknown repo key → **404** (IDOR closed)
- [ ] Private repo (`is_private=1`) hidden unless live collaborator check passes; any error path → fail-closed
- [ ] `POST /api/active-tenant` switches tenant for a member; non-member → **403**
- [ ] **Post-deploy:** run `/admin/sync` → `is_private` converges to 0 for public repos; 2nd-account staging isolation (SC9)

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC1: every `/api/*` 401 before any DB; suspended→401 | `router.test.ts` 401 on issues/`:key`/graph + `never calls DB.prepare`; suspended via `validateSession` (S2) | ✓ proven |
| SC2: `getIssueRoute` scoped; foreign/unknown→404 [IDOR] | `issues.test.ts` IDOR-404, 200-when-visible, `repo IN`, INNER-JOIN edge, edge no-leak | ✓ proven |
| SC3: `listIssuesRoute` + 5 `graphRoute` reads scoped | `issues.test.ts` empty-visible short-circuit; `graph.test.ts` reads-carry-`repo IN` + empty-visible-no-reads | ✓ proven |
| SC4: 0007 `is_private`; surfaced + UPSERTed | `sync.test.ts` priv=1/pub=0 UPSERT; `installToken.test.ts` private round-trip | ✓ proven |
| SC5: private read → 24h cache → live API → fail-closed | `repoAccess.test.ts` cache / 204-grant / 404-deny / error-fail-closed / no-session-[] | ✓ proven |
| SC6: `/api/me` installations; no tenant_id in shapes | `me.test.ts` installations + JOIN tenants; issue/graph exact-key-set shape tests | ✓ proven |
| SC7: `/api/active-tenant` switch + membership guard | `active-tenant.test.ts` member-200 / non-member-403 / 401 / 400; `me.test.ts` active_tenant_id | ✓ proven |
| SC8: >1 installation → org-picker E2E | — | ⚠ NO TEST — ui-manual-only |
| SC9: 2nd account sees only own repos — staging | — | ⚠ NO TEST — infra-not-wired (2nd account + deploy) |

> Every mapped test was adversarially falsified (#280 gate): stashing each source file turns its test(s) RED. The gate caught a real tautology in `graph.test.ts` (passed with `graph.ts` gutted) — rewritten to SQL-shape + short-circuit-suppression guards.

**Notes for review:**
- Migration 0007 uses `DEFAULT 1` (fail-closed) vs the spec's `DEFAULT 0` — deliberate hardening (unknown rows stay private until sync proves public).
- SC2/SC3 satisfied via `resolveVisibleRepos` (resolve-once → bind `repo IN`), not a literal per-query `JOIN tenant_repo_access` — recheck-approved refinement (keeps private-repo authz out of every read query).

Fixes #148

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
