### PR TITLE
feat(deploy): NOT-NULL migration + CF Access cutover + runbook (#150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Let:
 ## Project
 
 **Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
-- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev** behind Cloudflare Access (Email-OTP, mickael@bouly.io)
+- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150)** — see docs/s7-access-cutover.md
 - Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
 - Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 * * * *` + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
 - Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Let:
 ## Project
 
 **Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
-- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150)** — see docs/s7-access-cutover.md
+- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150) — pending cutover, see docs/s7-access-cutover.md**
 - Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
 - Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 * * * *` + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
 - Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)

--- a/artifacts/plans/150-not-null-access-cutover-plan.mdx
+++ b/artifacts/plans/150-not-null-access-cutover-plan.mdx
@@ -1,0 +1,112 @@
+---
+title: "S7 #150 — NOT-NULL migration + CF Access cutover + runbook (Phase-1 final slice)"
+issue: 150
+epic: 141
+tier: S
+status: implementing
+---
+
+# Plan — S7 #150 (epic #141 final slice)
+
+Closes Phase 1 of the multi-tenant rebuild: ship the deferred NOT-NULL migration (M-b)
+and flip CF Access from "gate the whole app" to "gate `/admin/*` only", so app-level
+sessions (built behind the Access wall in S2–S6) take over the public app. This is the
+slice that *actually opens the door to multi-tenancy* — until now every user other than
+`mickael@bouly.io` hit the Access wall.
+
+## Scope (from issue #150 / spec S7)
+
+1. Re-verify `COUNT(*) WHERE … IS NULL = 0` on `sync_control` + new-table required columns.
+2. Commit + apply **M-b `0008_tenant_not_null.sql`** (NOT-NULL ships HERE, never earlier).
+3. Staging smoke-test gate: app sessions return **401 unauth**.
+4. **CF Access narrowing**: App 1 (all-paths OTP) → `/admin/*` only; App 2 (`/webhook/*` bypass) unchanged.
+5. Prod cutover.
+6. Rollback (re-enable full-path Access) documented in a tracked runbook.
+
+## Re-evaluation of the M-b NO-OP candidate (S1 appendix)
+
+The S1 design (plan #144 appendix) flagged M-b as a **NO-OP candidate**: new tables were
+authored with `NOT NULL` inline in 0004, and `issues.payload` / `repos.repo_node_id` stay
+intentionally nullable. **Re-evaluated at S7 entry → not empty:** the 0004 `sync_control`
+rebuild silently dropped `value`'s `NOT NULL` (it was `NOT NULL` in 0001). That is the one
+genuine new-/rebuilt-table required column still loose, and the AC singles out
+"`COUNT NULL=0` on `sync_control`". M-b therefore re-tightens `sync_control.value`.
+
+Full new-table audit (current nullability vs. required):
+
+| Table | Loose required col? |
+|---|---|
+| tenants, users, user_installations, sessions, oauth_state, install_tokens | none (NOT NULL inline; `suspended_at`/`revoked_at`/`redirect_after` nullable by design) |
+| tenant_repo_access (`is_private` NOT NULL via 0007), user_repo_permission_cache, zk_payloads | none |
+| **sync_control** | **`value`** — `NOT NULL` (0001) → nullable (0004 rebuild). Re-tighten. |
+| issues / edges / labels / pr_state / repos | **excluded** — data tables, global PKs, no tenant_id; `payload`/`repo_node_id` stay nullable |
+
+### Write-path safety (verified, read-source not grep-assume)
+
+`sync_control.value` is never written NULL by any path:
+
+| Write | value bound | Non-NULL |
+|---|---|---|
+| `BUMP_DATA_VERSION_SQL` (mutations.ts) | `iso` (`new Date().toISOString()`) | ✓ |
+| `sync_started_at` UPDATE (sync.ts:1189) | `startedAt` ISO | ✓ |
+| `sync_slot` UPDATE (sync.ts:1347) | `String(nextSlot)` | ✓ |
+| lock/breaker UPDATES + seeds | literals `'0'`/`'1'`/`CAST(... AS TEXT)` | ✓ |
+
+→ Tightening cannot break a runtime write. The migration is also **self-guarding**: the
+`INSERT … SELECT` into a `NOT NULL` column throws *before any rename* if a stray NULL
+exists, so a bad state fails the CI migrate step loudly rather than corrupting data.
+
+## Migration design — `0008_tenant_not_null.sql`
+
+Mirror 0004's proven rename-swap (data survives every crash point; `DROP … IF EXISTS`
+recovery guard for partial re-runs). Preserve: `tenant_id INTEGER NOT NULL DEFAULT 0`
+(sentinel rows, **no FK** — deviation D-2), `key TEXT NOT NULL`, PK `(tenant_id, key)`,
+`updated_at` default. Only change: `value TEXT` → `value TEXT NOT NULL`. No secondary
+indexes to recreate (PK-only, same as 0001/0004).
+
+No unit test added: the worker suite mocks D1 (string-match), so a migration test would be
+theater. Validation = self-guard + `--local` apply + CI `--remote` apply + preflight COUNT.
+
+## CF Access cutover — safe ordering (add-specific-before-removing-general)
+
+Mirrors the S9 precedent ("App 2 before App 1"): never leave `/admin` unprotected.
+
+1. **Add** Access app "Roxabi Live Admin" → path `/admin`, policy Allow `mickael@bouly.io` OTP
+   (clone App 1's policy). Verify `/admin/sync` still OTP-challenged.
+2. Confirm staging smoke gate green: `/api/graph` unauth → **401** (Worker `requireSession`).
+3. **Remove** App 1 (the all-paths catch-all). Now: `/admin/*`→OTP (new app), `/webhook/*`→bypass
+   (App 2), everything else→edge-open → Worker `requireSession` (401 unauth / 200 with cookie).
+4. Verify post-flip: `/api/graph` unauth → 401 from Worker (NOT an Access redirect);
+   `/admin/sync` → Access OTP redirect; `/webhook/github` → no challenge.
+
+**Edge-exposed-after-flip routes** (intended): `/` + assets (frontend auth-gate redirects),
+`/api/version` (timestamp), `/health` (aggregate count), `/login`, `/oauth/callback`, `/logout`.
+All non-sensitive or auth-entry. Gated routes (`/api/graph,issues,me,active-tenant`) keep
+`requireSession`. → audited in the adversarial review (route-exposure check).
+
+**Rollback**: re-create App 1 (self-hosted, `live.roxabi.dev`, all paths, Allow
+`mickael@bouly.io` OTP) → whole app behind Access again. Exact policy in the runbook.
+
+## Deliverables
+
+| File | Owner | Notes |
+|---|---|---|
+| `worker/migrations/0008_tenant_not_null.sql` | (this slice) | guarded sync_control rebuild, value NOT NULL |
+| `docs/s7-access-cutover.md` | doc | preflight + smoke gate + Access narrowing + rollback runbook |
+| `CLAUDE.md` | doc | Access line: "behind CF Access (all paths)" → "/admin/* behind Access; public app = app sessions" |
+| this plan | — | artifact |
+
+## Go/No-Go (prod cutover — operator-gated, NOT autonomous)
+
+- [ ] `0008` merged to staging; staging D1 migrated green (CI)
+- [ ] staging preflight `SELECT COUNT(*) FROM sync_control WHERE value IS NULL` = 0
+- [ ] staging smoke: `/api/graph` unauth → 401; with valid cookie → 200
+- [ ] promote staging→main (CI applies `0008` to prod D1) — operator
+- [ ] **prod preflight** COUNT NULL = 0 confirmed before/at promote
+- [ ] CF Access narrowing executed (steps above) — operator, dashboard
+- [ ] post-flip verification curls pass
+- [ ] rollback runbook confirmed actionable
+
+Prod migration apply + CF Access change are **outward-facing / hard-to-reverse** → executed
+by the operator on explicit go, never autonomously. This slice ships the repo artifacts +
+runbook + a green staging PR.

--- a/docs/s7-access-cutover.md
+++ b/docs/s7-access-cutover.md
@@ -1,0 +1,272 @@
+# S7 — NOT-NULL migration + CF Access narrowing (runbook)
+
+Issue [#150](https://github.com/Roxabi/roxabi-live/issues/150) · epic [#141](https://github.com/Roxabi/roxabi-live/issues/141).
+
+## Status: NOT YET EXECUTED
+
+This is the operator procedure for the S7 go. The repo PR + a green staging deploy are what ships now; the cutover below is operator-gated.
+
+---
+
+S7 flips CF Access from "gate the whole app" to "gate `/admin/*` only". Until this
+slice, every user other than `mickael@bouly.io` hits the Access Email-OTP wall before
+reaching any Worker route. App-level sessions (OAuth + session cookies, built in
+S2–S6, #144–#149) are the real auth gate for the public app — but they were unreachable
+behind the edge wall. S7 narrows Access to the admin surface only, so the Worker's own
+`requireSession` takes over. This is the slice that *actually opens the door to
+multi-tenancy*.
+
+---
+
+## What ships in this PR
+
+| File | Change |
+|---|---|
+| `worker/migrations/0008_tenant_not_null.sql` | M-b: `sync_control.value TEXT` → `TEXT NOT NULL`; rename-swap (data survives every crash point; self-guarding INSERT) |
+| `docs/s7-access-cutover.md` | This runbook |
+| `CLAUDE.md` | Access-line updated to reflect S7 end-state |
+| `frontend/.assetsignore` | Excludes `*.test.js`, `vitest.config.js`, `package.json`, `package-lock.json`, `node_modules/` from ASSETS bundle — confirm uploaded-asset count dropped / those URLs 404 in staging deploy log |
+
+CI auto-applies `0008` on merge: `wrangler d1 migrations apply DB --env staging --remote`
+(→ staging D1) and `wrangler d1 migrations apply DB --remote` on promote to main (→ prod
+D1). See `.github/workflows/ci.yml` deploy job.
+
+---
+
+## Go/No-Go checklist — **STOP if any item is unchecked**
+
+```
+[ ] 0008 merged to staging; CI migrations apply step green (staging D1)
+[ ] staging preflight COUNT NULL = 0  (Phase 1 below)
+[ ] staging smoke: /api/graph unauth → 401; /api/version → 200  (Phase 2 below)
+[ ] prod preflight COUNT NULL = 0  (Phase 1, prod variant — run BEFORE promote)
+[ ] promote staging → main; CI applies 0008 to prod D1 green
+[ ] CF Access: new /admin app added and /admin/sync OTP-challenged  (Phase 3, step 1–2)
+[ ] staging smoke confirmed green before removing App 1  (Phase 3, step 3)
+[ ] CF Access: App 1 (catch-all) removed  (Phase 3, step 4)
+[ ] post-flip verification curls pass  (Phase 3, step 5)
+[ ] SC2 browser-flow: private/incognito → live.roxabi.dev → frontend auth-gate (not raw 401)  (Phase 3, step 5)
+[ ] rollback confirmed actionable  (Rollback section)
+```
+
+---
+
+## Phase 1 — M-b NOT-NULL preflight + apply
+
+Run the preflight gate **before merge for staging** and **before promote for prod**.
+
+> **Account note:** `CLOUDFLARE_ACCOUNT_ID` must be exported. The token sees two accounts and `d1 execute --remote` 403s without an explicit account ID.
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=b5e90be971920ce406f7b679c4f1cd33
+cd worker
+
+# staging:
+npx wrangler d1 execute DB --env staging --remote --config ../wrangler.toml \
+  --command "SELECT COUNT(*) AS null_values FROM sync_control WHERE value IS NULL;"
+# expect: null_values = 0
+
+# prod (run BEFORE promote to main):
+npx wrangler d1 execute DB --remote --config ../wrangler.toml \
+  --command "SELECT COUNT(*) AS null_values FROM sync_control WHERE value IS NULL;"
+# expect: null_values = 0
+```
+
+**Self-guard property:** `0008`'s `INSERT … SELECT` into the new `value TEXT NOT NULL`
+column throws *before any rename* if a stray NULL exists. A bad state fails the CI
+migrate step loudly (red CI, `sync_control` still intact) rather than silently corrupting
+data. Locally validated: sqlite3 + `wrangler d1 migrations apply --local`, all 8
+migrations apply, 6 seeded rows preserved, NULL-insert correctly rejected.
+
+If COUNT > 0: do **not** proceed. Investigate which write path produced a NULL in
+`sync_control.value` (all known write paths bind a non-NULL string — see plan #150).
+
+### Migration re-apply recovery (theoretical)
+
+D1 wraps each migration file in an implicit transaction — a mid-file crash rolls back the
+whole migration. Two possible partial-crash states and their recovery commands:
+
+- **`no such table: sync_control`** (crash after first rename, before second):
+  ```sql
+  ALTER TABLE sync_control_new RENAME TO sync_control;
+  DROP TABLE IF EXISTS sync_control_old;
+  ```
+- **`table sync_control_old already exists`** (crash before first rename completed):
+  ```sql
+  DROP TABLE sync_control_old;
+  -- then re-apply migration 0008
+  ```
+
+In practice the implicit transaction makes these states unreachable in normal operation;
+the recovery block is here for completeness.
+
+---
+
+## Phase 2 — Staging smoke gate
+
+Staging (`roxabi-live-staging.mickael-b5e.workers.dev`) has no CF Access in front —
+requests go directly to the Worker. This isolates the Worker's own `requireSession` gate,
+proving the exact behavior prod must show once the edge Access wall is removed.
+
+```bash
+# unauthenticated graph request — Worker requireSession must reject:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://roxabi-live-staging.mickael-b5e.workers.dev/api/graph
+# expect: 401
+
+# version is public — no session required:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://roxabi-live-staging.mickael-b5e.workers.dev/api/version
+# expect: 200
+```
+
+A `200` on `/api/graph` without a session cookie is a **STOP** — do not remove App 1
+until this is resolved.
+
+**Recommended (not blocking):** confirm a valid session returns 200. Obtain a session
+cookie via interactive `/login` → OAuth on the staging Worker URL, then (the cookie name
+is `__Host-session` — copy it exactly; a wrong name false-fails as 401):
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -b '__Host-session=<cookie-value>' \
+  https://roxabi-live-staging.mickael-b5e.workers.dev/api/graph
+# expect: 200
+```
+
+If interactive login is not convenient at go-time, skip this curl and log it; the
+401-unauth check above is the hard gate.
+
+---
+
+## Phase 3 — CF Access narrowing (prod, dashboard)
+
+Account `b5e90be971920ce406f7b679c4f1cd33` (mickael@bouly.io). **Order is mandatory** —
+add the specific `/admin` app before removing the catch-all (mirror S9's "App 2 before
+App 1"). Never leave `/admin` unprotected between steps.
+
+**Before starting:** in the CF Access dashboard, open App 1 (catch-all) settings and
+record its current session duration. The default is **24 h** (per `docs/cloudflared-setup.md`
+Step A.4) — confirm and write down the live value. You will need it for rollback.
+
+### Step 1 — Add "Roxabi Live Admin" app
+
+Zero Trust → Access → Applications → Add → **Self-hosted**.
+
+- Name: `Roxabi Live Admin`
+- Domain: `live.roxabi.dev`, path: `/admin`
+  (CF Access uses prefix match — `/admin` covers `/admin/*`; do NOT enter `/admin*` or a wildcard)
+- Policy: **Allow**, include emails `mickael@bouly.io`, session duration: **24 h** (confirm
+  matches the value recorded above)
+- Auth method: One-time PIN
+
+Clone all other settings from the existing App 1 policy. App 2 (`/webhook` Bypass)
+remains untouched throughout.
+
+### Step 2 — Verify the new app gates `/admin`
+
+App 1 still guards everything else at this point — nothing is exposed yet.
+
+```bash
+curl -sS -D - -o /dev/null https://live.roxabi.dev/admin/sync \
+  | grep -iE 'HTTP/|^location'
+# expect: redirect to *.cloudflareaccess.com  (OTP challenge from new /admin app)
+```
+
+### Step 3 — Confirm staging smoke gate is green
+
+The Phase 2 check (`401` on `/api/graph` unauth) must be confirmed before proceeding.
+Do not remove App 1 until the Worker's `requireSession` is proven to hold on its own.
+
+### Step 4 — Remove App 1 (catch-all)
+
+Access → Applications → find the all-paths OTP app (`live.roxabi.dev`, no path) →
+Delete. Leave App 2 (`/webhook` Bypass) and the new `/admin` app.
+
+After removal:
+- `/admin/*` → OTP (new app)
+- `/webhook/*` → Bypass (App 2)
+- Everything else → edge-open → Worker `requireSession` (401 unauth / 200 with cookie)
+
+### Step 5 — Post-flip verification
+
+```bash
+# public-app path: gated by Worker, NOT edge — expect 401, no Access redirect:
+curl -sS -D - -o /dev/null https://live.roxabi.dev/api/graph \
+  | grep -iE 'HTTP/|^location|cf-access'
+# expect: HTTP 401  |  no Location: *.cloudflareaccess.com  |  no cf-access-* headers
+
+# issues endpoint: also Worker-gated — expect 401:
+curl -sS -D - -o /dev/null https://live.roxabi.dev/api/issues \
+  | grep -iE 'HTTP/|^location|cf-access'
+# expect: HTTP 401  |  no Location: *.cloudflareaccess.com  |  no cf-access-* headers
+
+# admin path: still OTP:
+curl -sS -D - -o /dev/null https://live.roxabi.dev/admin/sync \
+  | grep -iE 'HTTP/|^location'
+# expect: redirect to *.cloudflareaccess.com
+
+# webhook path: still Bypass (Worker response, no challenge):
+curl -sS -D - -o /dev/null https://live.roxabi.dev/webhook/github \
+  | grep -iE 'HTTP/|^location|cf-access'
+# expect: Worker response (4xx — missing HMAC body), no Access redirect, no cf-access headers
+```
+
+**SC2 browser-flow verification (manual):** open a private/incognito window →
+navigate to `https://live.roxabi.dev` without any session cookie → expect the frontend
+auth-gate (login/landing view from `frontend/auth.js`, #149), NOT a raw JSON `401` or
+blank page. A raw 401 here means the Worker's `requireSession` is firing on `/` or
+static assets — stop and investigate before declaring the flip done.
+
+---
+
+## Edge-exposed-after-flip routes (accepted)
+
+Once App 1 is removed these routes are reachable at the edge without an OTP challenge.
+Each is intentionally exposed:
+
+| Route | Why safe |
+|---|---|
+| `/` + static assets | Frontend auth-gate (`frontend/auth.js`, #149) redirects unauthenticated users to login before any data loads |
+| `/api/version` | Returns `data_version` timestamp only — no user or issue data |
+| `/health` | Returns aggregate issue `COUNT(*)` only — no tenant or user data |
+| `/login`, `/oauth/callback`, `/logout` | Auth-flow entry points — required to be reachable |
+
+Sensitive reads keep `requireSession` (→ 401 unauth):
+
+`/api/graph`, `/api/issues`, `/api/issues/:key`, `/api/me`, `/api/active-tenant`
+
+`/admin/*` keeps **both** the new edge OTP app **and** the `ADMIN_TOKEN` Bearer gate
+(#123, defense-in-depth).
+
+---
+
+## Rollback (re-enable Access on the full app)
+
+To restore the pre-S7 state (whole app behind Access):
+
+1. Zero Trust → Access → Applications → Add → **Self-hosted**.
+   - Domain: `live.roxabi.dev`, path: empty (all paths)
+   - Policy: **Allow**, include emails `mickael@bouly.io`, session duration: the value
+     you recorded before starting Phase 3 (default **24 h** — use the live value you
+     wrote down, not the default)
+2. Verify the catch-all OTP app gates `/api/graph`:
+   ```bash
+   curl -sS -D - -o /dev/null https://live.roxabi.dev/api/graph \
+     | grep -iE 'HTTP/|^location'
+   # expect: redirect to *.cloudflareaccess.com
+   ```
+3. Keep App 2 (`/webhook` Bypass) and the new `/admin` app — do not remove them.
+
+The public app is immediately behind Access again. The `0008` migration is independent of
+the Access state and is **not rolled back** — it is forward-safe (no code path writes NULL
+to `sync_control.value`).
+
+---
+
+## Honesty note
+
+- Operator retains full read access to user data at rest in D1 (Phase 1 of epic #141; no
+  encryption layer yet — carried as a known item).
+- After the flip, `/health` and `/api/version` are publicly reachable at the edge. Both
+  return non-sensitive aggregate data only (issue count, data-version timestamp).

--- a/docs/s7-access-cutover.md
+++ b/docs/s7-access-cutover.md
@@ -43,6 +43,7 @@ D1). See `.github/workflows/ci.yml` deploy job.
 [ ] promote staging → main; CI applies 0008 to prod D1 green
 [ ] CF Access: new /admin app added and /admin/sync OTP-challenged  (Phase 3, step 1–2)
 [ ] staging smoke confirmed green before removing App 1  (Phase 3, step 3)
+[ ] ADMIN_TOKEN verified set (wrangler secret list --env … shows it) OR edge-Access-only mode for /admin/* intentionally accepted  (Phase 3, before step 4)
 [ ] CF Access: App 1 (catch-all) removed  (Phase 3, step 4)
 [ ] post-flip verification curls pass  (Phase 3, step 5)
 [ ] SC2 browser-flow: private/incognito → live.roxabi.dev → frontend auth-gate (not raw 401)  (Phase 3, step 5)
@@ -86,15 +87,22 @@ If COUNT > 0: do **not** proceed. Investigate which write path produced a NULL i
 D1 wraps each migration file in an implicit transaction — a mid-file crash rolls back the
 whole migration. Two possible partial-crash states and their recovery commands:
 
+```bash
+export CLOUDFLARE_ACCOUNT_ID=b5e90be971920ce406f7b679c4f1cd33
+cd worker
+# staging (drop --env staging for prod):
+```
+
 - **`no such table: sync_control`** (crash after first rename, before second):
-  ```sql
-  ALTER TABLE sync_control_new RENAME TO sync_control;
-  DROP TABLE IF EXISTS sync_control_old;
+  ```bash
+  npx wrangler d1 execute DB --env staging --remote --config ../wrangler.toml \
+    --command "ALTER TABLE sync_control_new RENAME TO sync_control; DROP TABLE IF EXISTS sync_control_old;"
   ```
 - **`table sync_control_old already exists`** (crash before first rename completed):
-  ```sql
-  DROP TABLE sync_control_old;
-  -- then re-apply migration 0008
+  ```bash
+  npx wrangler d1 execute DB --env staging --remote --config ../wrangler.toml \
+    --command "DROP TABLE sync_control_old;"
+  # then re-apply migration 0008
   ```
 
 In practice the implicit transaction makes these states unreachable in normal operation;
@@ -165,7 +173,10 @@ remains untouched throughout.
 
 ### Step 2 — Verify the new app gates `/admin`
 
-App 1 still guards everything else at this point — nothing is exposed yet.
+App 1 still guards everything else at this point — nothing is exposed yet. Between Step 1
+and Step 4, BOTH Access apps cover `/admin`; CF Access resolves the most-specific path
+match, so the OTP challenge below is answered by the new `/admin`-scoped app — not App 1.
+Step 4 then removes App 1 (the legacy catch-all).
 
 ```bash
 curl -sS -D - -o /dev/null https://live.roxabi.dev/admin/sync \
@@ -230,7 +241,8 @@ Each is intentionally exposed:
 | `/` + static assets | Frontend auth-gate (`frontend/auth.js`, #149) redirects unauthenticated users to login before any data loads |
 | `/api/version` | Returns `data_version` timestamp only — no user or issue data |
 | `/health` | Returns aggregate issue `COUNT(*)` only — no tenant or user data |
-| `/login`, `/oauth/callback`, `/logout` | Auth-flow entry points — required to be reachable |
+| `/login`, `/oauth/callback` | Auth-flow entry points — required to be reachable |
+| `POST /logout` | Session invalidation — ungated by design (null-safe + idempotent, `SameSite=Strict` blocks cross-site submission); clears cookie, exposes no data |
 
 Sensitive reads keep `requireSession` (→ 401 unauth):
 

--- a/frontend/.assetsignore
+++ b/frontend/.assetsignore
@@ -1,0 +1,10 @@
+# Exclude dev/test files from the public ASSETS bundle.
+# After S7 (#150) narrows CF Access to /admin/* only, everything in frontend/ is
+# served edge-public via the Worker ASSETS binding. These files have no runtime
+# purpose for the frontend and would otherwise leak test logic + the dependency
+# tree to unauthenticated clients. Gitignore-style patterns (wrangler assets).
+*.test.js
+vitest.config.js
+package.json
+package-lock.json
+node_modules/

--- a/frontend/.assetsignore
+++ b/frontend/.assetsignore
@@ -4,7 +4,7 @@
 # purpose for the frontend and would otherwise leak test logic + the dependency
 # tree to unauthenticated clients. Gitignore-style patterns (wrangler assets).
 *.test.js
-vitest.config.js
+vitest.config.*
 package.json
 package-lock.json
 node_modules/

--- a/worker/migrations/0008_tenant_not_null.sql
+++ b/worker/migrations/0008_tenant_not_null.sql
@@ -1,0 +1,51 @@
+-- migration: 0008_tenant_not_null.sql  (M-b — epic #141 / S7 #150)
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+--
+-- The deferred NOT-NULL migration. Authored in S1's design (plan #144 appendix),
+-- committed HERE (S7) so CI never tightens before the auth tables proved out.
+--
+-- SCOPE — new/rebuilt tables ONLY. Data tables (issues, edges, labels, pr_state,
+-- repos) keep their global PKs and are untouched (repo-canonical pivot: no
+-- tenant_id on data tables → no backfill, no NOT-NULL changes there). The
+-- intentionally-nullable seams stay nullable: issues.payload (NULL in Phase 1,
+-- ciphertext in Phase 2) and repos.repo_node_id (filled lazily by sync).
+--
+-- The new auth tables (0004) were already authored with NOT NULL inline, and
+-- 0007 added tenant_repo_access.is_private NOT NULL. The S1 appendix flagged M-b
+-- as a NO-OP candidate "if still empty at S7 entry". Re-evaluated at S7: it is
+-- NOT empty — the 0004 sync_control rebuild silently dropped value's NOT NULL
+-- (it was NOT NULL in 0001; the rebuild recreated it as `value TEXT`). This
+-- migration restores that single invariant. No other column needs tightening.
+--
+-- SAFE: no code path writes NULL to sync_control.value — every write binds an
+-- ISO timestamp / String(slot) / literal '0'|'1'|CAST(... AS TEXT) (verified
+-- across mutations.ts + sync.ts). SELF-GUARDING: the INSERT … SELECT into a
+-- NOT NULL column throws BEFORE any rename if a stray NULL exists, so a bad
+-- state fails this migration loudly (sync_control still intact) rather than
+-- corrupting data. Pre-req gate (docs/s7-access-cutover.md): re-verify
+--   SELECT COUNT(*) FROM sync_control WHERE value IS NULL;  -- expect 0
+-- on staging and prod before apply.
+
+-- D1 enforces FKs by default; belt-and-braces for local/vanilla SQLite runs.
+PRAGMA foreign_keys = ON;
+
+-- sync_control rebuild — value TEXT → value TEXT NOT NULL. Mirrors the 0004
+-- rename-swap (data exists in at least one table at every crash point). NO FK on
+-- tenant_id (deviation D-2: sentinel rows use tenant_id=0, not a real tenant).
+-- recovery guard — if a prior partial run failed between CREATE and first RENAME,
+-- re-apply starts clean.
+DROP TABLE IF EXISTS sync_control_new;
+CREATE TABLE sync_control_new (
+  tenant_id  INTEGER NOT NULL DEFAULT 0,
+  key        TEXT NOT NULL,
+  value      TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, key)
+);
+-- Copy tenant_id directly (post-0004 sync_control already has the column — unlike
+-- 0004, which hardcoded 0 because the pre-rebuild table had no tenant_id).
+INSERT INTO sync_control_new (tenant_id, key, value, updated_at)
+  SELECT tenant_id, key, value, updated_at FROM sync_control;
+ALTER TABLE sync_control RENAME TO sync_control_old;
+ALTER TABLE sync_control_new RENAME TO sync_control;
+DROP TABLE sync_control_old;

--- a/worker/migrations/0008_tenant_not_null.sql
+++ b/worker/migrations/0008_tenant_not_null.sql
@@ -48,4 +48,7 @@ INSERT INTO sync_control_new (tenant_id, key, value, updated_at)
   SELECT tenant_id, key, value, updated_at FROM sync_control;
 ALTER TABLE sync_control RENAME TO sync_control_old;
 ALTER TABLE sync_control_new RENAME TO sync_control;
-DROP TABLE sync_control_old;
+-- IF EXISTS for defensive symmetry with the top guard (reached only after the
+-- rename above creates sync_control_old, so a no-op divergence under D1's
+-- implicit per-migration transaction; harmless under a non-transactional re-run).
+DROP TABLE IF EXISTS sync_control_old;


### PR DESCRIPTION
Closes #150 — epic #141 Phase-1 **final slice** (S7). Ships the deferred M-b NOT-NULL migration + the runbook to narrow CF Access to `/admin/*` only, so the Worker's `requireSession` takes over the public app. **This is the slice that actually opens roxabi-live to multi-tenancy** — until now every user except `mickael@bouly.io` hit the CF Access wall.

## What ships (repo)
| File | Role |
|---|---|
| `worker/migrations/0008_tenant_not_null.sql` | M-b: re-tighten `sync_control.value` → `NOT NULL` (guarded rename-swap) |
| `docs/s7-access-cutover.md` | preflight + smoke gate + Access narrowing + **rollback** runbook (operator-executed) |
| `frontend/.assetsignore` | exclude test/dev files from the edge-public ASSETS bundle |
| `CLAUDE.md` | Access line → `/admin/*` only; public app on app sessions |
| `artifacts/plans/150-…-plan.mdx` | slice plan |

## Migration content — decision flagged ⚠️
New auth tables were already `NOT NULL` inline (0004/0007). The **only** loose required column is `sync_control.value` — it was `NOT NULL` in 0001 but the 0004 rebuild silently dropped it. The AC singles out "COUNT NULL=0 on **sync_control**", and the S1 NO-OP-candidate guidance was conditional ("if still empty") — it isn't.
- **Option 1 (shipped):** tighten `value` → `NOT NULL` via guarded rebuild. Self-guarding `INSERT…SELECT` (throws on NULL before any rename); code never writes NULL (verified across `mutations.ts`/`sync.ts`). Same risk profile as 0004's accepted rebuild.
- **Option 2:** no-op/assertion migration. → flip is a 1-file change before promote if you prefer it.

## Validation
- `0008` applies cleanly: `sqlite3` 0001→0008 **and** `wrangler d1 migrations apply --local`. All 6 `sync_control` rows preserved, NULL-insert rejects, `issues.payload` stays nullable.
- `npm run typecheck` + **426 tests** green (no regression).
- **Adversarial review** (migration-safety / route-exposure security / runbook-AC + reconcile): verdict `ship-with-fixes`, **no blockers**. `requireSession` confirmed fail-closed; HMAC sound; OAuth replay/open-redirect closed. 7 runbook fixes + the `.assetsignore` applied; a dangerous suggested migration "fix" (double-DROP → data loss) was **rejected** and the theoretical recovery documented instead.

## Acceptance criteria
- [x] new-table required columns re-verified; M-b NOT-NULL applied (new tables only — no data-table schema changes)
- [x] app sessions return 401 unauth (staging smoke gate documented) → Access scoped to `/admin/*`; `/webhook/*` bypass kept (runbook)
- [x] rollback (re-enable Access) documented in a tracked runbook

## NOT done here (operator-gated — outward-facing / hard-to-reverse)
Per the runbook go/no-go: prod migration apply (auto on promote→main), **CF Access narrowing** (dashboard), prod preflight, and the SC2 browser-flow check are executed by the operator on explicit go. This PR ships repo artifacts + a green staging deploy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)