### PR TITLE
chore: promote staging → main — epic #141 Phase-1 cutover (#148, #149, #150)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,22 @@ jobs:
       - name: Test (vitest)
         run: cd plugins/roxabi-issues && bun run test
 
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install frontend deps
+        run: cd frontend && npm ci
+      - name: Test (vitest)
+        run: cd frontend && npm test
+
   deploy:
-    needs: [ci, worker]
+    needs: [ci, worker, frontend]
     if: github.event_name == 'push' && (github.ref_name == 'staging' || github.ref_name == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ reports/
 .dev.vars
 .dev.vars.*
 .wrangler/
+
+# frontend test harness (node_modules not committed)
+frontend/node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Let:
 ## Project
 
 **Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
-- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev** behind Cloudflare Access (Email-OTP, mickael@bouly.io)
+- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150)** — see docs/s7-access-cutover.md
 - Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
 - Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 * * * *` + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
 - Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Let:
 ## Project
 
 **Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
-- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150)** — see docs/s7-access-cutover.md
+- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150) — pending cutover, see docs/s7-access-cutover.md**
 - Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
 - Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 * * * *` + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
 - Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)

--- a/artifacts/plans/148-tenant-filtered-reads-plan.mdx
+++ b/artifacts/plans/148-tenant-filtered-reads-plan.mdx
@@ -1,0 +1,289 @@
+---
+title: "Plan: tenant-filtered reads + active-tenant + private-repo authz (Phase 1 S5)"
+issue: 148
+spec: artifacts/specs/148-tenant-filtered-reads-spec.mdx
+complexity: 7/10
+tier: F-full
+generated: 2026-06-13
+---
+
+## Summary
+
+Close the unauthenticated-graph IDOR gap: gate every `/api/*` read behind the existing fail-closed
+`requireSession` middleware, then scope all issue/graph/edge reads to a **per-request visible-repo
+set** (`tenant_repo_access` ∩ user-permitted private repos). Self-absorbs the minimal `is_private`
+enablers (migration 0007 + sync population) so criterion 4 ships without waiting on #147.
+
+**Design lock:** authorization is resolved **once per request** by `repoAccess.resolveVisibleRepos(c)`
+→ `string[]` of repos the session user may see (all public tenant repos ∪ private repos passing the
+24h-cached / live-fallback / fail-closed permission check). Every read query then filters
+`repo IN (…visible)`. One permission pass over ≤34 repos per request — never per-issue.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph req[Request path /api/*]
+    RS["requireSession (session.ts)\nNOT EXISTS suspended → 401 fail-closed\ninject session{userId,tenantId,githubId,githubLogin}"]
+    RV["resolveVisibleRepos (repoAccess.ts)"]
+    RD["read handler: issues.ts / graph.ts\nSQL filter repo IN (…visible)"]
+    SER["serialize → no tenant_id leak"]
+  end
+  subgraph authz[repoAccess.ts]
+    Q1["SELECT repo,is_private FROM tenant_repo_access WHERE tenant_id=?"]
+    PUB["public (is_private=0) → always visible"]
+    PRIV["private (is_private=1) → per-user check"]
+    CACHE["user_repo_permission_cache\nchecked_at < 24h ? has_access"]
+    LIVE["GET /repos/:o/:r/collaborators/:login\n204→1 · 404/403→0 · error→fail-closed(0)"]
+  end
+  subgraph ingest[Hourly cron — sync]
+    DT["discoverTenants (sync.ts)"]
+    LIR["listInstallationRepos (installToken.ts)\nsurfaces GitHub private flag"]
+    UP["UPSERT tenant_repo_access(tenant_id,repo,is_private)\nON CONFLICT DO UPDATE is_private"]
+  end
+  subgraph tenant[Active tenant]
+    AT["POST /api/active-tenant (active-tenant.ts)\nverify user_installations → setSessionTenant"]
+  end
+  RS --> RV --> RD --> SER
+  RV --> Q1 --> PUB & PRIV
+  PRIV --> CACHE -->|miss/stale| LIVE --> CACHE
+  DT --> LIR --> UP
+  AT -.updates.-> RS
+  UP -.feeds.-> Q1
+
+  style RS fill:#fde,stroke:#b27
+  style RV fill:#def,stroke:#27b
+  style LIVE fill:#ffd,stroke:#b92
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph mig[migrations/0007]
+    M0["+is_private INTEGER NOT NULL DEFAULT 1"]
+  end
+  subgraph it[auth/installToken.ts]
+    LIR2["listInstallationRepos(): {repo,isPrivate}[]"]
+  end
+  subgraph sy[sync/sync.ts]
+    DT2["discoverTenants() UPSERT is_private"]
+  end
+  subgraph ra[auth/repoAccess.ts NEW]
+    RVR["resolveVisibleRepos(c)"]
+    CPA["checkPrivateAccess(db,env,user,tenant,repo,login)"]
+  end
+  subgraph se[auth/session.ts]
+    REQ["requireSession (exists)"]
+    SST["setSessionTenant(db,token,tenantId) NEW"]
+  end
+  subgraph ap[api/]
+    IS["issues.ts list+get (AuthEnv)"]
+    GR["graph.ts 5 queries (AuthEnv)"]
+    ME["me.ts +active_tenant_id"]
+    ATR["active-tenant.ts NEW"]
+  end
+  subgraph rt[router.ts]
+    R1["use(requireSession) on issues/graph"]
+    R2["post /api/active-tenant"]
+  end
+  LIR2 --> DT2 --> M0
+  RVR --> CPA
+  RVR --> IS & GR
+  REQ --> R1
+  SST --> ATR --> R2
+  IS & GR & ME & ATR -.tested.-> T[(vitest + fake-D1)]
+```
+
+## Agents
+
+| Instance | Domain | Tasks | Files |
+|---|---|---|---|
+| backend-dev-A | ingest | T1, T3 | `migrations/0007`, `auth/installToken.ts`, `sync/sync.ts` |
+| backend-dev-B | authz + reads | T4, T6, T7 | `auth/repoAccess.ts` (new), `api/issues.ts`, `api/graph.ts` |
+| backend-dev-C | session + http | T5, T8, T9 | `api/active-tenant.ts` (new), `auth/session.ts`, `api/me.ts`, `router.ts` |
+| tester-A | shared + reads tests | T2, T10, T11, T12 | `src/test-utils.ts` (new), `auth/repoAccess.test.ts`, `api/issues.test.ts`, `api/graph.test.ts` |
+| tester-B | endpoint + sync tests | T13, T14, T15 | `api/active-tenant.test.ts`, `router-401` test, `sync/sync.test.ts` |
+| security-auditor | security | T16 | (read-only audit) |
+
+## Micro-Tasks
+
+### V1 — Privacy ingest
+
+**T1 — migration 0007: `tenant_repo_access.is_private`** · be-A · migrations · SC-trace: SC4 · diff 1
+- File: `worker/migrations/0007_repo_access_is_private.sql`
+- `ALTER TABLE tenant_repo_access ADD COLUMN is_private INTEGER NOT NULL DEFAULT 1;` (DEFAULT 1 = fail-closed; converges to 0 for public repos on first sync)
+- Verify: `grep -n is_private worker/migrations/0007_*.sql`
+
+**T3 — surface + populate `is_private`** · be-A · sync · SC-trace: SC4 · diff 3 · blockedBy T1
+- `auth/installToken.ts`: `GHRepository += private: boolean`; `listInstallationRepos` returns `Promise<Array<{repo:string; isPrivate:boolean}>>` (`{repo:r.full_name, isPrivate:r.private}`)
+- `sync/sync.ts` `discoverTenants`: consume `{repo,isPrivate}[]`; UPSERT `INSERT INTO tenant_repo_access (tenant_id,repo,is_private) VALUES (?,?,?) ON CONFLICT(tenant_id,repo) DO UPDATE SET is_private=excluded.is_private`; stale-prune + repoMap keyed by `.repo`
+- Verify: `cd worker && npm run typecheck`; `grep -n "ON CONFLICT" src/sync/sync.ts`
+
+### V2 — Authz + tenant-filtered reads
+
+**T4 — `repoAccess.ts` resolveVisibleRepos** · be-B · authz · SC-trace: SC2,SC3,SC4 · diff 4
+- File: `worker/src/auth/repoAccess.ts` (new)
+- `resolveVisibleRepos(c: Context<AuthEnv>): Promise<string[]>` — SELECT repo,is_private WHERE tenant_id=session.tenantId; public→keep; private→`checkPrivateAccess`
+- `checkPrivateAccess(db,env,userId,tenantId,repo,login)`: cache hit (`checked_at > datetime('now','-24 hours')`)→`has_access`; miss/stale→`getInstallationToken` + `GET /repos/{repo}/collaborators/{login}` (204→1 · 404/403→0); upsert cache; any error → fail-closed `false` (no cache write)
+- resolve installation_id once: `SELECT installation_id FROM tenants WHERE id=?`
+- Verify: `npm run typecheck`
+
+**T6 — `issues.ts` tenant filter + AuthEnv** · be-B · reads · SC-trace: SC2,SC3,SC5 · diff 3 · blockedBy T4
+- Upgrade both handlers to `Context<AuthEnv>`; `const visible = await resolveVisibleRepos(c)`
+- `listIssuesRoute`: `visible.length===0 → return {issues:[],total:0,limit,offset}`; prepend `issues.repo IN (${ph})` to conditions + params (count+data share `where`)
+- `getIssueRoute`: append `AND repo IN (${ph})` to `issueSql` → no row → 404 (IDOR closed); edge LEFT JOINs add `AND i.repo IN (${ph})` (foreign blockers fall back to parseKey, no metadata leak)
+- Verify: `npm run typecheck`; `npx vitest run src/api/issues.test.ts`
+
+**T7 — `graph.ts` tenant filter + AuthEnv + comment** · be-B · reads · SC-trace: SC3,SC5 · diff 3 · blockedBy T4
+- Upgrade signature to `Context<AuthEnv>`; `const visible = await resolveVisibleRepos(c)`; empty → `{nodes:[],edges:[],repos:[]}`
+- (c) issues `WHERE repo IN (ph)`; (a) labels `WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (ph))`; (d) edges `WHERE src_key IN (…) AND dst_key IN (…)` (both endpoints visible); (e) repos `WHERE repo IN (ph)`; (b) pr_state — scope by `repo` subquery if column exists, else leave with comment (consumed only via visible nodes → no output leak)
+- Fix header comment `Four D1 reads` → `Five D1 reads (a)-(e), tenant-scoped`
+- Verify: `npm run typecheck`; `npx vitest run src/api/graph.test.ts`
+
+### V3 — Active tenant
+
+**T5 — `active-tenant.ts` + `setSessionTenant`** · be-C · session · SC-trace: SC6 · diff 3
+- `auth/session.ts`: `setSessionTenant(db, rawToken, tenantId)` → `UPDATE sessions SET tenant_id=? WHERE token_hash=? AND revoked_at IS NULL AND expires_at > datetime('now')`
+- `api/active-tenant.ts` (new): POST; body `{tenant_id}`; `SELECT 1 FROM user_installations WHERE user_id=? AND tenant_id=?` → none → 403; else `setSessionTenant` → 200 `{active_tenant_id}`
+- Verify: `npm run typecheck`
+
+**T8 — `me.ts` active_tenant_id + account_type** · be-C · session · SC-trace: SC5,SC7 · diff 2
+- Add `active_tenant_id: s.tenantId`; installations query `+ t.account_type AS account_type`
+- Verify: `npm run typecheck`; `npx vitest run src/api/me.test.ts`
+
+**T9 — `router.ts` wiring** · be-C · http · SC-trace: SC1,SC6 · diff 2 · blockedBy T5,T6,T7
+- `app.use("/api/issues", requireSession)`, `app.use("/api/issues/*", requireSession)`, `app.use("/api/graph", requireSession)` (before the GET handlers)
+- `app.post("/api/active-tenant", requireSession, activeTenantRoute)`
+- Verify: `npm run typecheck`
+
+### Tests + audit
+
+**T2 — `test-utils.ts` extraction** · te-A · shared · diff 2
+- Extract `captureDb`/`makeFakeDb`/`makeFakeStmt` + `STUB_SESSION` from existing tests → `worker/src/test-utils.ts`; add SQL dispatch keys for `tenant_repo_access` + `user_repo_permission_cache`
+- Verify: `grep -n "export" src/test-utils.ts`
+
+**T10 — `repoAccess.test.ts`** · te-A · authz · blockedBy T4,T2 — cache hit/miss/stale, live 204/404, error→fail-closed, public skip, empty set
+**T11 — `issues.test.ts` updates** · te-A · reads · blockedBy T6,T2 — IDOR 404 on foreign repo, list scoped, edge no-leak
+**T12 — `graph.test.ts` updates** · te-A · reads · blockedBy T7,T2 — nodes/edges/repos scoped to visible, dangling edges pruned
+**T13 — `active-tenant.test.ts`** · te-B · endpoints · blockedBy T5,T2 — membership verified, switch persists, non-member 403
+**T14 — router 401 gating test** · te-B · endpoints · blockedBy T9,T2 — no session → 401 before any DB stmt on issues/graph
+**T15 — `sync.test.ts` is_private** · te-B · sync · blockedBy T3,T2 — UPSERT writes/flips is_private; private repo flag round-trips
+
+**T16 — security audit** · security-auditor · security · blockedBy T6,T7,T9,T4 — verify: fail-closed on every error path, IDOR closed (foreign repo→404), no `tenant_id` in any response shape, no cross-tenant UNION, live-API timeout → deny
+
+## Wave Structure
+
+5 waves, max 3 parallel agents. Elapsed ~3 units vs ~9 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | 2 ∥ | be-A: T1 · te-A: T2 |
+| 2 | Wave 1 done | 3 ∥ | be-A: T3 · be-B: T4 · be-C: T5 |
+| 3 | T4,T5 done | 2 ∥ | be-B: T6→T7 · be-C: T8→T9 |
+| 4 | Wave 3 done | 2 ∥ | te-A: T10,T11,T12 · te-B: T13,T14,T15 |
+| 5 | Wave 4 done | 1 | security-auditor: T16 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 migration | 1 | trivial | 2 | — |
+| T2 test-utils | 1 | bounded | 3 | — |
+| T3 sync is_private | 2 | judgmental | 8 | — |
+| T4 repoAccess.ts | 1 | exploratory | 10 | — |
+| T5 active-tenant | 2 | judgmental | 6 | — |
+| T6 issues filter | 1 | judgmental | 6 | — |
+| T7 graph filter | 1 | judgmental | 6 | — |
+| T8 me.ts | 1 | bounded | 3 | — |
+| T9 router | 1 | bounded | 3 | — |
+| T10–T15 tests | 6 | judgmental | ~30 | — |
+| T16 audit | 1 | judgmental | 8 | — |
+
+**Total estimated ops: ~96**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|---|---|---|---|---|
+| backend-dev-A | T1,T3 | 10 | migrations, sync | — |
+| backend-dev-B | T4,T6,T7 | 22 | authz, reads | — |
+| backend-dev-C | T5,T8,T9 | 12 | session, http | — |
+| tester-A | T2,T10,T11,T12 | 22 | shared, reads | — |
+| tester-B | T13,T14,T15 | 16 | endpoints, sync | — |
+| security-auditor | T16 | 8 | security | — |
+
+## Consistency Report
+
+- Criteria covered: 8/8 — SC1(T9,T14) · SC2(T4,T6,T16) · SC3(T4,T6,T7) · SC4(T1,T3,T4) · SC5(T6,T7,T8,T16) · SC6(T5,T9,T13) · SC7(T8) · SC8(T11,T12 + staging manual, public slice)
+- Untraced tasks: none
+- Deferred: webhook cache-invalidation + real-time `is_private` updates → #147 (out of scope, documented in spec amendment)
+- Exemptions: SC8 private-repo cross-account staging verification needs a 2nd test account — public slice automated; private slice = manual staging check post-merge
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T{n} | agent-instance | blockedBy | subject.
+     blockedBy refs T-numbers within this list. Seed in wave order; within a wave all rows ∥. -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | backend-dev-A | — | migrations |
+| T2 | tester-A | — | shared |
+
+### Wave 2 — after Wave 1, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T3 | backend-dev-A | T1 | sync |
+| T4 | backend-dev-B | T1 | authz |
+| T5 | backend-dev-C | — | session |
+
+### Wave 3 — after T4,T5, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T6 | backend-dev-B | T4 | reads |
+| T7 | backend-dev-B | T4,T6 | reads |
+| T8 | backend-dev-C | — | session |
+| T9 | backend-dev-C | T5,T6,T7 | http |
+
+### Wave 4 — after Wave 3, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T10 | tester-A | T4,T2 | authz |
+| T11 | tester-A | T6,T2 | reads |
+| T12 | tester-A | T7,T2 | reads |
+| T13 | tester-B | T5,T2 | endpoints |
+| T14 | tester-B | T9,T2 | endpoints |
+| T15 | tester-B | T3,T2 | sync |
+
+### Wave 5 — after Wave 4, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T16 | security-auditor | T4,T6,T7,T9 | security |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 8 — migrations (backend-dev-A)
+- T2: 9 — shared (tester-A)
+- T3: 10 — sync (backend-dev-A)
+- T4: 11 — authz (backend-dev-B)
+- T5: 12 — session (backend-dev-C)
+- T6: 13 — reads (backend-dev-B)
+- T7: 14 — reads (backend-dev-B)
+- T8: 15 — session (backend-dev-C)
+- T9: 16 — http (backend-dev-C)
+- T10: 17 — authz (tester-A)
+- T11: 18 — reads (tester-A)
+- T12: 19 — reads (tester-A)
+- T13: 20 — endpoints (tester-B)
+- T14: 21 — endpoints (tester-B)
+- T15: 22 — sync (tester-B)
+- T16: 23 — security (security-auditor)

--- a/artifacts/plans/149-login-consent-ui-plan.mdx
+++ b/artifacts/plans/149-login-consent-ui-plan.mdx
@@ -1,0 +1,254 @@
+---
+title: "Plan: feat(ui): login + account-link + operator-read consent (Phase 1 S6)"
+issue: 149
+spec: artifacts/specs/149-login-consent-ui-spec.mdx
+parent_spec: artifacts/specs/141-multi-tenant-github-app-auth-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-06-14
+---
+
+## Summary
+
+Add a frontend auth-state machine that gates the dep-graph dashboard behind GitHub login,
+GitHub-App install, and a one-time operator-read consent acknowledgement. Today
+`app.js init()` fetches `/api/graph` unconditionally; S6 inserts a gate that resolves the
+user via `/api/me` and renders one of four states (landing / install-CTA / consent / dashboard)
+before any issue data is loaded. Frontend-only — no backend or schema change (that is S7 #150).
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph idx[index.html]
+    boot[module load: state.js → auth.js → app.js → graph.js]
+  end
+  subgraph appjs[app.js]
+    init["init()"]
+    lar["loadAndRender()"]
+    poll["startPolling()"]
+  end
+  subgraph authjs[auth.js NEW]
+    gate["requireAuthGate()"]
+    apifn["api(path,opts) — 401 → AuthError"]
+    me["fetchMe() → /api/me"]
+    resolve["resolveView(me, hasConsent) PURE"]
+    landing["renderLanding()"]
+    install["renderInstallCta()"]
+    consent["renderConsentGate(me)"]
+    picker["renderOrgPicker(me)"]
+    notice["renderOperatorNotice()"]
+    logout["wireLogout() → POST /logout"]
+    cons["hasConsent/setConsent (localStorage)"]
+  end
+  subgraph be[worker backend — unchanged]
+    rme["/api/me"]
+    rgraph["/api/graph"]
+    rat["/api/active-tenant"]
+    rlogin["/login"]
+    rlogout["/logout"]
+  end
+
+  boot --> init
+  init --> gate
+  gate --> me --> rme
+  gate --> resolve
+  resolve -->|401| landing
+  landing -->|click| rlogin
+  resolve -->|installations:0| install --> ghinstall[(github.com/apps/roxabi-live/installations/new)]
+  resolve -->|!consent| consent
+  consent -->|I understand| cons
+  cons --> gate
+  resolve -->|consent ok| picker
+  picker -->|switch| rat --> reload[location.reload]
+  resolve --> notice
+  resolve --> logout --> rlogout
+  resolve -->|dashboard| lar --> rgraph
+  lar --> poll
+  poll -->|version 401| apifn -->|AuthError| landing
+```
+
+### File × function map
+
+```mermaid
+flowchart LR
+  subgraph authjs[auth.js NEW]
+    a_api[api]
+    a_me[fetchMe]
+    a_resolve[resolveView · PURE]
+    a_gate[requireAuthGate]
+    a_cons[hasConsent/setConsent]
+    a_render[renderLanding/InstallCta/ConsentGate/OrgPicker/OperatorNotice]
+    a_logout[wireLogout]
+  end
+  subgraph appjs[app.js]
+    p_init[init]
+    p_lar[loadAndRender]
+    p_poll[startPolling/fetchVersion]
+  end
+  subgraph test[auth.test.js NEW]
+    t1[resolveView cases]
+    t2[consent persistence]
+    t3[api 401 → AuthError]
+  end
+  p_init --> a_gate
+  a_gate --> a_me --> a_api
+  a_gate --> a_resolve
+  a_gate --> a_render
+  a_gate --> a_cons
+  a_gate --> a_logout
+  p_lar --> a_api
+  p_poll --> a_api
+  t1 --> a_resolve
+  t2 --> a_cons
+  t3 --> a_api
+```
+
+## Bootstrap Context
+
+- **Render chokepoint:** `frontend/app.js:293 init()` → `loadAndRender()` (`fetch('/api/graph')`, app.js:246) + `fetchVersion()` (app.js:277). No auth handling exists anywhere in `frontend/` today (operator-only, behind CF Access).
+- **Module pattern:** vanilla ES modules, no build step; `index.html` loads `<script type="module">` for state.js, pivot.js, app.js, graph.js. Add `auth.js` before `app.js`.
+- **State persistence:** sessionStorage (filters, `v6:*`), localStorage (`v6:theme`). Consent ack will use localStorage (`roxabi:consent:<login>`).
+- **Backend contract (verified at source — unchanged by S6):**
+  - `GET /api/me` (session-gated) → `{ user: { github_id, github_login }, active_tenant_id, installations: [{ tenant_id, account_login, account_type }] }`; `401 { error: "unauthorized" }` when no session. (`worker/src/api/me.ts:18`)
+  - `GET /login` → OAuth start. `POST /logout` (ungated) → 204 + clears `__Host-session`. `POST /api/active-tenant` `{tenant_id}` (session-gated) → `{active_tenant_id}`. (`worker/src/router.ts:68-75`)
+  - Frontend served via ASSETS fallback `app.all('*')` — ungated. (`router.ts:78`)
+  - Install URL hardcoded `https://github.com/apps/roxabi-live/installations/new`. (`worker/src/auth/oauth.ts:192`)
+
+## Decisions
+
+| # | Decision | Chosen | Rationale |
+|---|----------|--------|-----------|
+| A | Consent persistence | localStorage `roxabi:consent:<github_login>` = ISO ts | Spec: "frontend-enforced render block, no API-level gate". D1 column = backend+migration scope (S7 #150). Per-device re-ack acceptable for an acknowledgement. |
+| B | 401 handling (the deferred redirect #149 owns) | In-app flip to landing (① + login button); `api()` throws `AuthError` on 401, caught → `renderLanding()` | `/login` 302s straight to GitHub OAuth — a hard redirect gives the user no choice and no context. Landing satisfies "never blank/error". |
+| C | Org-picker | Non-blocking header switcher, shown when `installations.length > 1` | Backend always mints a session with one `active_tenant_id`; picker switches via POST /api/active-tenant + reload. A blocking modal would contradict the backend default. |
+| D | Test infra | Minimal vitest on extracted pure logic (`resolveView`, consent helpers, `api()` 401) + CI step | Highest value / lowest infra: covers the security-critical "no data before consent" decision without a full DOM harness. Browser flow (SC2) verified via `/verify`. |
+| E | Install-CTA | Implement defensively for `installations: []` | Spec lists the state; cheap. Note: current backend short-circuits zero-installation during OAuth callback (302 to GitHub) before a session exists, so this FE state is belt-and-suspanders / future-proofing. |
+
+**Flags (non-blocking):**
+- Consent gate is **not** an authz boundary — data is the user's own repos, and `/api/*` is already session+tenant-scoped (#148). Frontend-only is correct; document the rationale inline.
+- Install URL duplicated from `oauth.ts:192`; drift risk → follow-up to source from config (out of F-lite scope).
+- Suspended tenant → backend 401 → FE shows landing (indistinguishable from no-session). Dedicated suspended UX deferred (edge case follow-up).
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|----------------|-------|-------|
+| frontend-dev-A | T1, T2, T3, T4 | index.html, auth.css, auth.js, app.js |
+| tester-A | T5 | auth.test.js, package.json, vitest.config |
+| devops-A | T6 | .github/workflows |
+
+## Wave Structure
+
+2 waves, max 2 parallel agents in Wave 2. Elapsed ~1 cycle vs ~2 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | frontend-dev-A: T1→T2→T3→T4 (chained, one coherent UI surface — id/selector coupling forbids splitting) |
+| 2 | Wave 1 done | 2 ∥ | tester-A: T5 · devops-A: T6 (T6 after T5) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 index.html DOM | 1 | bounded | 3 | — |
+| T2 auth.css | 1 | bounded | 3 | — |
+| T3 auth.js core | 1 | judgmental | 6 | — |
+| T4 app.js wiring | 1 | judgmental | 5 | — |
+| T5 tests + vitest cfg | 1 | judgmental | 5 | — |
+| T6 CI step | 1 | bounded | 3 | — |
+
+**Total estimated ops: 25**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| frontend-dev-A | T1, T2, T3, T4 | 17 | auth-ui | — (|tasks|=4 ≤ 4, subjects=1) |
+| tester-A | T5 | 5 | testing | — |
+| devops-A | T6 | 3 | ci | — |
+
+## Consistency Report
+
+- Success criteria: 2/2 covered. SC1 (consent before data) → T1 (modal) + T3 (`resolveView` returns `consent` → gate) + T4 (init returns before `loadAndRender`) + T5 (test). SC2 (full flow) → T1–T4 (all states) + browser `/verify`.
+- Untraced tasks: none.
+- Exemptions: none.
+
+## Micro-Tasks
+
+### Slice — auth gate (SC1 + SC2)
+
+**T1 — index.html: gate DOM scaffolding** · `frontend/index.html` · frontend-dev-A · subject auth-ui · SC1+SC2 · difficulty 2
+- Add (hidden by default): `#auth-landing` (heading + `<a id="login-btn" href="/login">Log in with GitHub</a>`), `#auth-install` (copy + `<a id="install-btn">` → install URL), `#consent-gate` (overlay: heading "Before you continue", operator-read copy, `<button id="consent-ack">I understand</button>`), `#operator-notice` banner (persistent), `#org-picker` (header `<select>` / menu), `#logout-btn`.
+- Link `<link rel="stylesheet" href="auth.css">`; load `<script type="module" src="auth.js">` BEFORE app.js.
+- Keep existing `.sticky-head` / `<main>` dashboard markup; gates overlay/hide it.
+- Verify: `grep -c 'id="auth-landing"\|id="consent-gate"\|id="auth-install"\|id="operator-notice"\|id="org-picker"\|id="logout-btn"' frontend/index.html` → 6.
+
+**T2 — auth.css: gate styles** · `frontend/auth.css` (new) · frontend-dev-A · subject auth-ui · SC2 · difficulty 2
+- Style landing, login button, install CTA, consent modal overlay (full-screen, blocks dashboard), persistent notice banner, org-picker, logout — reuse app.css design tokens (`--accent`, fonts, dark/light via `[data-theme]`).
+- Verify: `test -f frontend/auth.css && grep -q 'consent-gate\|auth-landing' frontend/auth.css`.
+
+**T3 — auth.js: state machine + helpers** · `frontend/auth.js` (new) · frontend-dev-A · subject auth-ui · SC1+SC2 · difficulty 3
+- `class AuthError extends Error {}`; `api(path, opts)` → `fetch`; `if (r.status === 401) throw new AuthError()`; `if (!r.ok) throw new Error(...)`; return r.
+- `hasConsent(login)` / `setConsent(login)` via `localStorage['roxabi:consent:'+login]`.
+- `resolveView(me, consented)` **pure** → `'install'` (installations.length===0) | `'consent'` (!consented) | `'dashboard'`.
+- `fetchMe()` → `api('/api/me').then(r=>r.json())`.
+- `renderLanding()`, `renderInstallCta()`, `renderConsentGate(me, onAck)`, `renderOrgPicker(me)` (POST /api/active-tenant → reload), `renderOperatorNotice()`, `wireLogout()` (POST /logout → renderLanding).
+- `requireAuthGate()` async → `fetchMe()` (AuthError → renderLanding + return `{view:'landing'}`); compute `resolveView`; render install/consent gates (consent ack re-invokes gate); on `dashboard` → renderOrgPicker + renderOperatorNotice + wireLogout; return `{view, me}`. Export `requireAuthGate`, `api`, `AuthError`, `resolveView`, `hasConsent`, `setConsent`.
+- Verify: `node --check frontend/auth.js && grep -q 'export' frontend/auth.js`.
+
+**T4 — app.js: wire gate into init + wrap fetches** · `frontend/app.js` · frontend-dev-A · subject auth-ui · SC1+SC2 · difficulty 3
+- `import { requireAuthGate, api, AuthError } from './auth.js'`.
+- Rewrite `init()`: `const { view } = await requireAuthGate(); if (view !== 'dashboard') return;` THEN `restoreControls()` + `loadAndRender()` + polling.
+- `loadGraphData()` + `fetchVersion()` use `api()`; catch `AuthError` (in init + poll) → `renderLanding()` (import) instead of error msg.
+- Verify: `grep -q 'requireAuthGate' frontend/app.js && grep -q "api('/api/graph')" frontend/app.js`.
+
+**RED-GATE V1** — `node --check` passes on auth.js + app.js; manual: logged-out load shows landing, no `/api/graph` call fires (Network tab) until consent acked.
+
+### Slice — tests + CI
+
+**T5 — unit tests + frontend vitest** · `frontend/auth.test.js`, `frontend/package.json`, `frontend/vitest.config.js` (new) · tester-A · subject testing · SC1 · difficulty 3 · blockedBy T4
+- `resolveView`: install (0 installs) / consent (installs, !consented) / dashboard (installs, consented) — all branches.
+- consent: `setConsent('x')` then `hasConsent('x')===true`; `hasConsent('y')===false` (mock/jsdom localStorage).
+- `api()`: 401 → rejects `AuthError`; ok → returns response (mock fetch).
+- Minimal `frontend/package.json` (vitest devDep, `"test": "vitest run"`), jsdom env for localStorage.
+- Verify: `cd frontend && npm i && npm test` → all pass.
+
+**T6 — CI: run frontend tests** · `.github/workflows/*` · devops-A · subject ci · difficulty 2 · blockedBy T5
+- Add a step/job mirroring the worker pattern: `cd frontend && npm ci && npm test`. Keep CI green; do not touch the legacy python qg.conf gate.
+- Verify: workflow yaml includes the frontend test invocation; `gh workflow view` / local act dry-run if available.
+
+**RED-GATE V2** — T5 green locally; CI step added.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | frontend-dev-A | — | auth-ui |
+| T2 | frontend-dev-A | T1 | auth-ui |
+| T3 | frontend-dev-A | T2 | auth-ui |
+| T4 | frontend-dev-A | T3 | auth-ui |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | tester-A | T4 | testing |
+| T6 | devops-A | T5 | ci |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 10 — auth-ui (index.html DOM)
+- T2: 11 — auth-ui (auth.css)
+- T3: 12 — auth-ui (auth.js)
+- T4: 13 — auth-ui (app.js wiring)
+- T5: 14 — testing (auth.test.js + vitest)
+- T6: 15 — ci (frontend CI step)

--- a/artifacts/plans/150-not-null-access-cutover-plan.mdx
+++ b/artifacts/plans/150-not-null-access-cutover-plan.mdx
@@ -1,0 +1,112 @@
+---
+title: "S7 #150 — NOT-NULL migration + CF Access cutover + runbook (Phase-1 final slice)"
+issue: 150
+epic: 141
+tier: S
+status: implementing
+---
+
+# Plan — S7 #150 (epic #141 final slice)
+
+Closes Phase 1 of the multi-tenant rebuild: ship the deferred NOT-NULL migration (M-b)
+and flip CF Access from "gate the whole app" to "gate `/admin/*` only", so app-level
+sessions (built behind the Access wall in S2–S6) take over the public app. This is the
+slice that *actually opens the door to multi-tenancy* — until now every user other than
+`mickael@bouly.io` hit the Access wall.
+
+## Scope (from issue #150 / spec S7)
+
+1. Re-verify `COUNT(*) WHERE … IS NULL = 0` on `sync_control` + new-table required columns.
+2. Commit + apply **M-b `0008_tenant_not_null.sql`** (NOT-NULL ships HERE, never earlier).
+3. Staging smoke-test gate: app sessions return **401 unauth**.
+4. **CF Access narrowing**: App 1 (all-paths OTP) → `/admin/*` only; App 2 (`/webhook/*` bypass) unchanged.
+5. Prod cutover.
+6. Rollback (re-enable full-path Access) documented in a tracked runbook.
+
+## Re-evaluation of the M-b NO-OP candidate (S1 appendix)
+
+The S1 design (plan #144 appendix) flagged M-b as a **NO-OP candidate**: new tables were
+authored with `NOT NULL` inline in 0004, and `issues.payload` / `repos.repo_node_id` stay
+intentionally nullable. **Re-evaluated at S7 entry → not empty:** the 0004 `sync_control`
+rebuild silently dropped `value`'s `NOT NULL` (it was `NOT NULL` in 0001). That is the one
+genuine new-/rebuilt-table required column still loose, and the AC singles out
+"`COUNT NULL=0` on `sync_control`". M-b therefore re-tightens `sync_control.value`.
+
+Full new-table audit (current nullability vs. required):
+
+| Table | Loose required col? |
+|---|---|
+| tenants, users, user_installations, sessions, oauth_state, install_tokens | none (NOT NULL inline; `suspended_at`/`revoked_at`/`redirect_after` nullable by design) |
+| tenant_repo_access (`is_private` NOT NULL via 0007), user_repo_permission_cache, zk_payloads | none |
+| **sync_control** | **`value`** — `NOT NULL` (0001) → nullable (0004 rebuild). Re-tighten. |
+| issues / edges / labels / pr_state / repos | **excluded** — data tables, global PKs, no tenant_id; `payload`/`repo_node_id` stay nullable |
+
+### Write-path safety (verified, read-source not grep-assume)
+
+`sync_control.value` is never written NULL by any path:
+
+| Write | value bound | Non-NULL |
+|---|---|---|
+| `BUMP_DATA_VERSION_SQL` (mutations.ts) | `iso` (`new Date().toISOString()`) | ✓ |
+| `sync_started_at` UPDATE (sync.ts:1189) | `startedAt` ISO | ✓ |
+| `sync_slot` UPDATE (sync.ts:1347) | `String(nextSlot)` | ✓ |
+| lock/breaker UPDATES + seeds | literals `'0'`/`'1'`/`CAST(... AS TEXT)` | ✓ |
+
+→ Tightening cannot break a runtime write. The migration is also **self-guarding**: the
+`INSERT … SELECT` into a `NOT NULL` column throws *before any rename* if a stray NULL
+exists, so a bad state fails the CI migrate step loudly rather than corrupting data.
+
+## Migration design — `0008_tenant_not_null.sql`
+
+Mirror 0004's proven rename-swap (data survives every crash point; `DROP … IF EXISTS`
+recovery guard for partial re-runs). Preserve: `tenant_id INTEGER NOT NULL DEFAULT 0`
+(sentinel rows, **no FK** — deviation D-2), `key TEXT NOT NULL`, PK `(tenant_id, key)`,
+`updated_at` default. Only change: `value TEXT` → `value TEXT NOT NULL`. No secondary
+indexes to recreate (PK-only, same as 0001/0004).
+
+No unit test added: the worker suite mocks D1 (string-match), so a migration test would be
+theater. Validation = self-guard + `--local` apply + CI `--remote` apply + preflight COUNT.
+
+## CF Access cutover — safe ordering (add-specific-before-removing-general)
+
+Mirrors the S9 precedent ("App 2 before App 1"): never leave `/admin` unprotected.
+
+1. **Add** Access app "Roxabi Live Admin" → path `/admin`, policy Allow `mickael@bouly.io` OTP
+   (clone App 1's policy). Verify `/admin/sync` still OTP-challenged.
+2. Confirm staging smoke gate green: `/api/graph` unauth → **401** (Worker `requireSession`).
+3. **Remove** App 1 (the all-paths catch-all). Now: `/admin/*`→OTP (new app), `/webhook/*`→bypass
+   (App 2), everything else→edge-open → Worker `requireSession` (401 unauth / 200 with cookie).
+4. Verify post-flip: `/api/graph` unauth → 401 from Worker (NOT an Access redirect);
+   `/admin/sync` → Access OTP redirect; `/webhook/github` → no challenge.
+
+**Edge-exposed-after-flip routes** (intended): `/` + assets (frontend auth-gate redirects),
+`/api/version` (timestamp), `/health` (aggregate count), `/login`, `/oauth/callback`, `/logout`.
+All non-sensitive or auth-entry. Gated routes (`/api/graph,issues,me,active-tenant`) keep
+`requireSession`. → audited in the adversarial review (route-exposure check).
+
+**Rollback**: re-create App 1 (self-hosted, `live.roxabi.dev`, all paths, Allow
+`mickael@bouly.io` OTP) → whole app behind Access again. Exact policy in the runbook.
+
+## Deliverables
+
+| File | Owner | Notes |
+|---|---|---|
+| `worker/migrations/0008_tenant_not_null.sql` | (this slice) | guarded sync_control rebuild, value NOT NULL |
+| `docs/s7-access-cutover.md` | doc | preflight + smoke gate + Access narrowing + rollback runbook |
+| `CLAUDE.md` | doc | Access line: "behind CF Access (all paths)" → "/admin/* behind Access; public app = app sessions" |
+| this plan | — | artifact |
+
+## Go/No-Go (prod cutover — operator-gated, NOT autonomous)
+
+- [ ] `0008` merged to staging; staging D1 migrated green (CI)
+- [ ] staging preflight `SELECT COUNT(*) FROM sync_control WHERE value IS NULL` = 0
+- [ ] staging smoke: `/api/graph` unauth → 401; with valid cookie → 200
+- [ ] promote staging→main (CI applies `0008` to prod D1) — operator
+- [ ] **prod preflight** COUNT NULL = 0 confirmed before/at promote
+- [ ] CF Access narrowing executed (steps above) — operator, dashboard
+- [ ] post-flip verification curls pass
+- [ ] rollback runbook confirmed actionable
+
+Prod migration apply + CF Access change are **outward-facing / hard-to-reverse** → executed
+by the operator on explicit go, never autonomously. This slice ships the repo artifacts +
+runbook + a green staging PR.

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -93,7 +93,11 @@ populated by `discoverTenants` from the GitHub `private` flag):
    - 204 → `has_access=1`; upsert cache.
    - 404/403 → `has_access=0`; upsert cache.
    - API error / timeout → **fail-closed** (treat as no access, 404); do not cache.
-3. **Cache error** (D1 read failure): fail-closed → 404.
+3. **Cache error** (D1 read failure on the cache lookup): fall through to the live check
+   (step 2). The live check is itself fail-closed (any error/timeout/non-204 → no access), so
+   it stays authoritative; a transient D1 blip must not permanently deny a genuine collaborator.
+   _(Amended 2026-06-13 per PR #171 review — code is more resilient than the original
+   "fail-closed → 404"; no access can be granted without a definitive GitHub 204.)_
 
 Public repos (`is_private = 0`) skip the permission check entirely.
 
@@ -107,13 +111,15 @@ webhook handlers land in #147, the 24h TTL + live-API fallback is the sole fresh
 Returns authenticated user info and installation list:
 ```json
 {
-  "github_login": "...",
+  "user": { "github_id": 1001, "github_login": "..." },
   "active_tenant_id": 42,
   "installations": [
     { "tenant_id": 42, "account_login": "Roxabi", "account_type": "Organization" }
   ]
 }
 ```
+_(Amended 2026-06-13 per PR #171 review: identity is nested under `user`; `installation_id`
+is NOT surfaced — internal infra id, unnecessary client exposure removed.)_
 
 No `tenant_id` column exposed from `issues`/`edges` rows. Response shapes are identical to
 single-tenant responses — authorization is fully backend-side.

--- a/artifacts/specs/148-tenant-filtered-reads-spec.mdx
+++ b/artifacts/specs/148-tenant-filtered-reads-spec.mdx
@@ -14,6 +14,24 @@ amended: 2026-06-10
 > `user_repo_permission_cache` check (24h TTL, live API fallback); session middleware includes
 > NOT-EXISTS suspended-tenant guard; no `tenant_id` in response shapes.
 
+> **Amendment (2026-06-13, recheck — Option 3 "self-absorb"):** drift-check vs the shipped
+> 0004 schema found `tenant_repo_access` has no `is_private` column, which criterion 4 needs.
+> Rather than block on #147 (S4), **this issue absorbs the minimal `is_private` enablers** so all
+> 8 criteria ship together. Concretely #148 now also: (a) migration **0007** adds
+> `tenant_repo_access.is_private INTEGER NOT NULL DEFAULT 0`; (b) `listInstallationRepos` surfaces
+> the `private` flag (already in the GitHub response, currently discarded); (c) `discoverTenants`
+> upserts `is_private` (real UPSERT, not `INSERT OR IGNORE`, so privacy flips propagate each
+> hourly sync). **#147 is NOT subsumed** — it keeps webhook event-routing, cross-tenant stub
+> policy, `repository.privatized/publicized` (real-time `is_private` updates), `member.removed`
+> cache invalidation, and retention-on-uninstall. The 24h TTL + live-API fallback is the
+> fail-safe until #147's webhook invalidation lands (this matches the original spec, which already
+> deferred invalidation to #147). **Coordination:** #147 must NOT re-add the `is_private` column.
+>
+> **Column/name fixes applied (shipped-schema drift):** `user_repo_permission_cache.cached_at`
+> → **`checked_at`** (0004:84); issue title reads → **`JSON_EXTRACT(payload,'$.title')`** (title
+> column dropped in 0004:123); edge columns → **`src_key`/`dst_key`** (0001); `graphRoute` has
+> **5** queries (nodes/labels/pr_state/edges/repos) — fix the stale "Four D1 reads" header.
+
 ## Scope
 
 Slice **S5** of #141. **This slice satisfies the epic acceptance criterion.**
@@ -64,10 +82,11 @@ This JOIN applies to:
 
 ### Private-repo permission check (`user_repo_permission_cache`)
 
-When `tenant_repo_access.is_private = 1`:
+When `tenant_repo_access.is_private = 1` (column added by **migration 0007**, this issue —
+populated by `discoverTenants` from the GitHub `private` flag):
 
 1. **Cache hit** (row in `user_repo_permission_cache` where `user_id=? AND repo=?` and
-   `cached_at > now - 24h`): use `has_access` value directly — **fail-closed** (if
+   `checked_at > now - 24h`): use `has_access` value directly — **fail-closed** (if
    `has_access=0`, 404, no data returned).
 2. **Cache miss** (no row, or row older than 24h): call GitHub API
    `GET /repos/:owner/:repo/collaborators/:username` with the installation token.
@@ -78,8 +97,10 @@ When `tenant_repo_access.is_private = 1`:
 
 Public repos (`is_private = 0`) skip the permission check entirely.
 
-TTL: 24 hours from `cached_at`. Cache is invalidated by webhook events
-(`member.removed` / `membership.removed` / `repository.privatized` — see #147).
+TTL: 24 hours from `checked_at`. Cache is invalidated by webhook events
+(`member.removed` / `membership.removed` / `repository.privatized` — see #147). Until those
+webhook handlers land in #147, the 24h TTL + live-API fallback is the sole freshness mechanism
+(acceptable: a removed collaborator loses access at next read after TTL expiry, ≤24h).
 
 ### `GET /api/me`
 
@@ -113,8 +134,11 @@ No cross-tenant UNION queries anywhere.
 - [ ] `getIssueRoute` issue/label/edge queries use `JOIN tenant_repo_access` (no
   `AND tenant_id=?`); foreign-tenant or unknown repo key → 404. [IDOR closed]
 - [ ] `listIssuesRoute` + all 5 `graphRoute` queries use `JOIN tenant_repo_access`.
-- [ ] Private-repo reads check `user_repo_permission_cache` (24h TTL); cache miss → live API
-  fallback; any error path → fail-closed (404).
+- [ ] Migration **0007** adds `tenant_repo_access.is_private` (DEFAULT 0); `listInstallationRepos`
+  surfaces the GitHub `private` flag; `discoverTenants` UPSERTs it each sync.
+- [ ] Private-repo reads (`is_private = 1`) check `user_repo_permission_cache` (24h TTL via
+  `checked_at`); cache miss → live API fallback (`GET /repos/:owner/:repo/collaborators/:user`,
+  204→access / 404→deny); any error path → fail-closed (404).
 - [ ] `GET /api/me` returns `installations` array; no `tenant_id` in issue/edge response shapes.
 - [ ] `POST /api/active-tenant` switches session tenant; membership verified before update.
 - [ ] >1 installation → org-picker flow works end-to-end.
@@ -123,8 +147,12 @@ No cross-tenant UNION queries anywhere.
 
 ## Dependencies
 
-Blocked by **#147** (S4 — `tenant_repo_access` populated by webhook; `user_repo_permission_cache`
-invalidation wired) and **#145** (S2 — sessions + `user_installations` table).
+- **#145** (S2 — sessions + `user_installations` table): **DONE** (shipped, closed).
+- ~~**#147** (S4)~~: **no longer a blocker** as of the 2026-06-13 Option-3 amendment — #148 self-absorbs
+  the `is_private` column + population. #147 retains its webhook scope (event routing, stub policy,
+  real-time privacy updates, cache invalidation, retention) and stays open; its later landing only
+  *improves freshness* of the permission cache, it does not gate this issue. #147 must NOT re-add
+  the `is_private` column (introduced here by migration 0007).
 
 ## Reference
 

--- a/docs/s7-access-cutover.md
+++ b/docs/s7-access-cutover.md
@@ -1,0 +1,272 @@
+# S7 — NOT-NULL migration + CF Access narrowing (runbook)
+
+Issue [#150](https://github.com/Roxabi/roxabi-live/issues/150) · epic [#141](https://github.com/Roxabi/roxabi-live/issues/141).
+
+## Status: NOT YET EXECUTED
+
+This is the operator procedure for the S7 go. The repo PR + a green staging deploy are what ships now; the cutover below is operator-gated.
+
+---
+
+S7 flips CF Access from "gate the whole app" to "gate `/admin/*` only". Until this
+slice, every user other than `mickael@bouly.io` hits the Access Email-OTP wall before
+reaching any Worker route. App-level sessions (OAuth + session cookies, built in
+S2–S6, #144–#149) are the real auth gate for the public app — but they were unreachable
+behind the edge wall. S7 narrows Access to the admin surface only, so the Worker's own
+`requireSession` takes over. This is the slice that *actually opens the door to
+multi-tenancy*.
+
+---
+
+## What ships in this PR
+
+| File | Change |
+|---|---|
+| `worker/migrations/0008_tenant_not_null.sql` | M-b: `sync_control.value TEXT` → `TEXT NOT NULL`; rename-swap (data survives every crash point; self-guarding INSERT) |
+| `docs/s7-access-cutover.md` | This runbook |
+| `CLAUDE.md` | Access-line updated to reflect S7 end-state |
+| `frontend/.assetsignore` | Excludes `*.test.js`, `vitest.config.js`, `package.json`, `package-lock.json`, `node_modules/` from ASSETS bundle — confirm uploaded-asset count dropped / those URLs 404 in staging deploy log |
+
+CI auto-applies `0008` on merge: `wrangler d1 migrations apply DB --env staging --remote`
+(→ staging D1) and `wrangler d1 migrations apply DB --remote` on promote to main (→ prod
+D1). See `.github/workflows/ci.yml` deploy job.
+
+---
+
+## Go/No-Go checklist — **STOP if any item is unchecked**
+
+```
+[ ] 0008 merged to staging; CI migrations apply step green (staging D1)
+[ ] staging preflight COUNT NULL = 0  (Phase 1 below)
+[ ] staging smoke: /api/graph unauth → 401; /api/version → 200  (Phase 2 below)
+[ ] prod preflight COUNT NULL = 0  (Phase 1, prod variant — run BEFORE promote)
+[ ] promote staging → main; CI applies 0008 to prod D1 green
+[ ] CF Access: new /admin app added and /admin/sync OTP-challenged  (Phase 3, step 1–2)
+[ ] staging smoke confirmed green before removing App 1  (Phase 3, step 3)
+[ ] CF Access: App 1 (catch-all) removed  (Phase 3, step 4)
+[ ] post-flip verification curls pass  (Phase 3, step 5)
+[ ] SC2 browser-flow: private/incognito → live.roxabi.dev → frontend auth-gate (not raw 401)  (Phase 3, step 5)
+[ ] rollback confirmed actionable  (Rollback section)
+```
+
+---
+
+## Phase 1 — M-b NOT-NULL preflight + apply
+
+Run the preflight gate **before merge for staging** and **before promote for prod**.
+
+> **Account note:** `CLOUDFLARE_ACCOUNT_ID` must be exported. The token sees two accounts and `d1 execute --remote` 403s without an explicit account ID.
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=b5e90be971920ce406f7b679c4f1cd33
+cd worker
+
+# staging:
+npx wrangler d1 execute DB --env staging --remote --config ../wrangler.toml \
+  --command "SELECT COUNT(*) AS null_values FROM sync_control WHERE value IS NULL;"
+# expect: null_values = 0
+
+# prod (run BEFORE promote to main):
+npx wrangler d1 execute DB --remote --config ../wrangler.toml \
+  --command "SELECT COUNT(*) AS null_values FROM sync_control WHERE value IS NULL;"
+# expect: null_values = 0
+```
+
+**Self-guard property:** `0008`'s `INSERT … SELECT` into the new `value TEXT NOT NULL`
+column throws *before any rename* if a stray NULL exists. A bad state fails the CI
+migrate step loudly (red CI, `sync_control` still intact) rather than silently corrupting
+data. Locally validated: sqlite3 + `wrangler d1 migrations apply --local`, all 8
+migrations apply, 6 seeded rows preserved, NULL-insert correctly rejected.
+
+If COUNT > 0: do **not** proceed. Investigate which write path produced a NULL in
+`sync_control.value` (all known write paths bind a non-NULL string — see plan #150).
+
+### Migration re-apply recovery (theoretical)
+
+D1 wraps each migration file in an implicit transaction — a mid-file crash rolls back the
+whole migration. Two possible partial-crash states and their recovery commands:
+
+- **`no such table: sync_control`** (crash after first rename, before second):
+  ```sql
+  ALTER TABLE sync_control_new RENAME TO sync_control;
+  DROP TABLE IF EXISTS sync_control_old;
+  ```
+- **`table sync_control_old already exists`** (crash before first rename completed):
+  ```sql
+  DROP TABLE sync_control_old;
+  -- then re-apply migration 0008
+  ```
+
+In practice the implicit transaction makes these states unreachable in normal operation;
+the recovery block is here for completeness.
+
+---
+
+## Phase 2 — Staging smoke gate
+
+Staging (`roxabi-live-staging.mickael-b5e.workers.dev`) has no CF Access in front —
+requests go directly to the Worker. This isolates the Worker's own `requireSession` gate,
+proving the exact behavior prod must show once the edge Access wall is removed.
+
+```bash
+# unauthenticated graph request — Worker requireSession must reject:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://roxabi-live-staging.mickael-b5e.workers.dev/api/graph
+# expect: 401
+
+# version is public — no session required:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://roxabi-live-staging.mickael-b5e.workers.dev/api/version
+# expect: 200
+```
+
+A `200` on `/api/graph` without a session cookie is a **STOP** — do not remove App 1
+until this is resolved.
+
+**Recommended (not blocking):** confirm a valid session returns 200. Obtain a session
+cookie via interactive `/login` → OAuth on the staging Worker URL, then (the cookie name
+is `__Host-session` — copy it exactly; a wrong name false-fails as 401):
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -b '__Host-session=<cookie-value>' \
+  https://roxabi-live-staging.mickael-b5e.workers.dev/api/graph
+# expect: 200
+```
+
+If interactive login is not convenient at go-time, skip this curl and log it; the
+401-unauth check above is the hard gate.
+
+---
+
+## Phase 3 — CF Access narrowing (prod, dashboard)
+
+Account `b5e90be971920ce406f7b679c4f1cd33` (mickael@bouly.io). **Order is mandatory** —
+add the specific `/admin` app before removing the catch-all (mirror S9's "App 2 before
+App 1"). Never leave `/admin` unprotected between steps.
+
+**Before starting:** in the CF Access dashboard, open App 1 (catch-all) settings and
+record its current session duration. The default is **24 h** (per `docs/cloudflared-setup.md`
+Step A.4) — confirm and write down the live value. You will need it for rollback.
+
+### Step 1 — Add "Roxabi Live Admin" app
+
+Zero Trust → Access → Applications → Add → **Self-hosted**.
+
+- Name: `Roxabi Live Admin`
+- Domain: `live.roxabi.dev`, path: `/admin`
+  (CF Access uses prefix match — `/admin` covers `/admin/*`; do NOT enter `/admin*` or a wildcard)
+- Policy: **Allow**, include emails `mickael@bouly.io`, session duration: **24 h** (confirm
+  matches the value recorded above)
+- Auth method: One-time PIN
+
+Clone all other settings from the existing App 1 policy. App 2 (`/webhook` Bypass)
+remains untouched throughout.
+
+### Step 2 — Verify the new app gates `/admin`
+
+App 1 still guards everything else at this point — nothing is exposed yet.
+
+```bash
+curl -sS -D - -o /dev/null https://live.roxabi.dev/admin/sync \
+  | grep -iE 'HTTP/|^location'
+# expect: redirect to *.cloudflareaccess.com  (OTP challenge from new /admin app)
+```
+
+### Step 3 — Confirm staging smoke gate is green
+
+The Phase 2 check (`401` on `/api/graph` unauth) must be confirmed before proceeding.
+Do not remove App 1 until the Worker's `requireSession` is proven to hold on its own.
+
+### Step 4 — Remove App 1 (catch-all)
+
+Access → Applications → find the all-paths OTP app (`live.roxabi.dev`, no path) →
+Delete. Leave App 2 (`/webhook` Bypass) and the new `/admin` app.
+
+After removal:
+- `/admin/*` → OTP (new app)
+- `/webhook/*` → Bypass (App 2)
+- Everything else → edge-open → Worker `requireSession` (401 unauth / 200 with cookie)
+
+### Step 5 — Post-flip verification
+
+```bash
+# public-app path: gated by Worker, NOT edge — expect 401, no Access redirect:
+curl -sS -D - -o /dev/null https://live.roxabi.dev/api/graph \
+  | grep -iE 'HTTP/|^location|cf-access'
+# expect: HTTP 401  |  no Location: *.cloudflareaccess.com  |  no cf-access-* headers
+
+# issues endpoint: also Worker-gated — expect 401:
+curl -sS -D - -o /dev/null https://live.roxabi.dev/api/issues \
+  | grep -iE 'HTTP/|^location|cf-access'
+# expect: HTTP 401  |  no Location: *.cloudflareaccess.com  |  no cf-access-* headers
+
+# admin path: still OTP:
+curl -sS -D - -o /dev/null https://live.roxabi.dev/admin/sync \
+  | grep -iE 'HTTP/|^location'
+# expect: redirect to *.cloudflareaccess.com
+
+# webhook path: still Bypass (Worker response, no challenge):
+curl -sS -D - -o /dev/null https://live.roxabi.dev/webhook/github \
+  | grep -iE 'HTTP/|^location|cf-access'
+# expect: Worker response (4xx — missing HMAC body), no Access redirect, no cf-access headers
+```
+
+**SC2 browser-flow verification (manual):** open a private/incognito window →
+navigate to `https://live.roxabi.dev` without any session cookie → expect the frontend
+auth-gate (login/landing view from `frontend/auth.js`, #149), NOT a raw JSON `401` or
+blank page. A raw 401 here means the Worker's `requireSession` is firing on `/` or
+static assets — stop and investigate before declaring the flip done.
+
+---
+
+## Edge-exposed-after-flip routes (accepted)
+
+Once App 1 is removed these routes are reachable at the edge without an OTP challenge.
+Each is intentionally exposed:
+
+| Route | Why safe |
+|---|---|
+| `/` + static assets | Frontend auth-gate (`frontend/auth.js`, #149) redirects unauthenticated users to login before any data loads |
+| `/api/version` | Returns `data_version` timestamp only — no user or issue data |
+| `/health` | Returns aggregate issue `COUNT(*)` only — no tenant or user data |
+| `/login`, `/oauth/callback`, `/logout` | Auth-flow entry points — required to be reachable |
+
+Sensitive reads keep `requireSession` (→ 401 unauth):
+
+`/api/graph`, `/api/issues`, `/api/issues/:key`, `/api/me`, `/api/active-tenant`
+
+`/admin/*` keeps **both** the new edge OTP app **and** the `ADMIN_TOKEN` Bearer gate
+(#123, defense-in-depth).
+
+---
+
+## Rollback (re-enable Access on the full app)
+
+To restore the pre-S7 state (whole app behind Access):
+
+1. Zero Trust → Access → Applications → Add → **Self-hosted**.
+   - Domain: `live.roxabi.dev`, path: empty (all paths)
+   - Policy: **Allow**, include emails `mickael@bouly.io`, session duration: the value
+     you recorded before starting Phase 3 (default **24 h** — use the live value you
+     wrote down, not the default)
+2. Verify the catch-all OTP app gates `/api/graph`:
+   ```bash
+   curl -sS -D - -o /dev/null https://live.roxabi.dev/api/graph \
+     | grep -iE 'HTTP/|^location'
+   # expect: redirect to *.cloudflareaccess.com
+   ```
+3. Keep App 2 (`/webhook` Bypass) and the new `/admin` app — do not remove them.
+
+The public app is immediately behind Access again. The `0008` migration is independent of
+the Access state and is **not rolled back** — it is forward-safe (no code path writes NULL
+to `sync_control.value`).
+
+---
+
+## Honesty note
+
+- Operator retains full read access to user data at rest in D1 (Phase 1 of epic #141; no
+  encryption layer yet — carried as a known item).
+- After the flip, `/health` and `/api/version` are publicly reachable at the edge. Both
+  return non-sensitive aggregate data only (issue count, data-version timestamp).

--- a/docs/s7-access-cutover.md
+++ b/docs/s7-access-cutover.md
@@ -43,6 +43,7 @@ D1). See `.github/workflows/ci.yml` deploy job.
 [ ] promote staging → main; CI applies 0008 to prod D1 green
 [ ] CF Access: new /admin app added and /admin/sync OTP-challenged  (Phase 3, step 1–2)
 [ ] staging smoke confirmed green before removing App 1  (Phase 3, step 3)
+[ ] ADMIN_TOKEN verified set (wrangler secret list --env … shows it) OR edge-Access-only mode for /admin/* intentionally accepted  (Phase 3, before step 4)
 [ ] CF Access: App 1 (catch-all) removed  (Phase 3, step 4)
 [ ] post-flip verification curls pass  (Phase 3, step 5)
 [ ] SC2 browser-flow: private/incognito → live.roxabi.dev → frontend auth-gate (not raw 401)  (Phase 3, step 5)
@@ -86,15 +87,22 @@ If COUNT > 0: do **not** proceed. Investigate which write path produced a NULL i
 D1 wraps each migration file in an implicit transaction — a mid-file crash rolls back the
 whole migration. Two possible partial-crash states and their recovery commands:
 
+```bash
+export CLOUDFLARE_ACCOUNT_ID=b5e90be971920ce406f7b679c4f1cd33
+cd worker
+# staging (drop --env staging for prod):
+```
+
 - **`no such table: sync_control`** (crash after first rename, before second):
-  ```sql
-  ALTER TABLE sync_control_new RENAME TO sync_control;
-  DROP TABLE IF EXISTS sync_control_old;
+  ```bash
+  npx wrangler d1 execute DB --env staging --remote --config ../wrangler.toml \
+    --command "ALTER TABLE sync_control_new RENAME TO sync_control; DROP TABLE IF EXISTS sync_control_old;"
   ```
 - **`table sync_control_old already exists`** (crash before first rename completed):
-  ```sql
-  DROP TABLE sync_control_old;
-  -- then re-apply migration 0008
+  ```bash
+  npx wrangler d1 execute DB --env staging --remote --config ../wrangler.toml \
+    --command "DROP TABLE sync_control_old;"
+  # then re-apply migration 0008
   ```
 
 In practice the implicit transaction makes these states unreachable in normal operation;
@@ -165,7 +173,10 @@ remains untouched throughout.
 
 ### Step 2 — Verify the new app gates `/admin`
 
-App 1 still guards everything else at this point — nothing is exposed yet.
+App 1 still guards everything else at this point — nothing is exposed yet. Between Step 1
+and Step 4, BOTH Access apps cover `/admin`; CF Access resolves the most-specific path
+match, so the OTP challenge below is answered by the new `/admin`-scoped app — not App 1.
+Step 4 then removes App 1 (the legacy catch-all).
 
 ```bash
 curl -sS -D - -o /dev/null https://live.roxabi.dev/admin/sync \
@@ -230,7 +241,8 @@ Each is intentionally exposed:
 | `/` + static assets | Frontend auth-gate (`frontend/auth.js`, #149) redirects unauthenticated users to login before any data loads |
 | `/api/version` | Returns `data_version` timestamp only — no user or issue data |
 | `/health` | Returns aggregate issue `COUNT(*)` only — no tenant or user data |
-| `/login`, `/oauth/callback`, `/logout` | Auth-flow entry points — required to be reachable |
+| `/login`, `/oauth/callback` | Auth-flow entry points — required to be reachable |
+| `POST /logout` | Session invalidation — ungated by design (null-safe + idempotent, `SameSite=Strict` blocks cross-site submission); clears cookie, exposes no data |
 
 Sensitive reads keep `requireSession` (→ 401 unauth):
 

--- a/frontend/.assetsignore
+++ b/frontend/.assetsignore
@@ -1,0 +1,10 @@
+# Exclude dev/test files from the public ASSETS bundle.
+# After S7 (#150) narrows CF Access to /admin/* only, everything in frontend/ is
+# served edge-public via the Worker ASSETS binding. These files have no runtime
+# purpose for the frontend and would otherwise leak test logic + the dependency
+# tree to unauthenticated clients. Gitignore-style patterns (wrangler assets).
+*.test.js
+vitest.config.js
+package.json
+package-lock.json
+node_modules/

--- a/frontend/.assetsignore
+++ b/frontend/.assetsignore
@@ -4,7 +4,7 @@
 # purpose for the frontend and would otherwise leak test logic + the dependency
 # tree to unauthenticated clients. Gitignore-style patterns (wrangler assets).
 *.test.js
-vitest.config.js
+vitest.config.*
 package.json
 package-lock.json
 node_modules/

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6,6 +6,7 @@ import { initGraph, clearSearchHighlight }   from './graph.js';
 import { MultiSelect } from './multi_select.js';
 import { clearPinned } from './hover.js';
 import { repoTone } from './tone.js';
+import { api, AuthError, requireAuthGate } from './auth.js';
 
 const $ = id => document.getElementById(id);
 
@@ -243,8 +244,7 @@ function restoreControls() {
 }
 
 async function loadGraphData() {
-  const resp = await fetch('/api/graph');
-  if (!resp.ok) throw new Error(`/api/graph ${resp.status}`);
+  const resp = await api('/api/graph');
   return resp.json();
 }
 
@@ -274,8 +274,7 @@ const POLL_MS = 15000;
 let lastVersion = null;
 
 async function fetchVersion() {
-  const resp = await fetch('/api/version');
-  if (!resp.ok) throw new Error(`/api/version ${resp.status}`);
+  const resp = await api('/api/version');
   return (await resp.json()).version;
 }
 
@@ -291,6 +290,17 @@ function startPolling() {
 }
 
 async function init() {
+  // SC1: requireAuthGate() gates all data fetches behind resolveView === 'dashboard'.
+  // This is a render-block (UX), not an authz boundary — /api/* is already
+  // session+tenant-scoped on the server. The gate prevents confusing 401/empty-graph
+  // errors for unauthenticated or unconsented users.
+  try {
+    const view = await requireAuthGate();
+    if (view !== 'dashboard') return; // auth gate is showing; do not fetch data
+  } catch (e) {
+    if (e instanceof AuthError) return; // no session — landing view shown by requireAuthGate
+    throw e;
+  }
   restoreControls();
   try {
     await loadAndRender();

--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -102,6 +102,33 @@
   color: var(--text);
 }
 
+/* ─── Body gate — hide dashboard chrome until auth resolved ──────────────── */
+
+body.gated .sticky-head,
+body.gated #view-table,
+body.gated #view-list,
+body.gated #graph-panel,
+body.gated #error-msg {
+  display: none;
+}
+
+/* ─── Consent warning (beta / secrets notice) ────────────────────────────── */
+
+.consent-warning {
+  background: var(--accent-dim);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.6;
+  margin: 0;
+  padding: 10px 14px;
+}
+
+.consent-warning strong {
+  color: var(--text);
+}
+
 /* ─── Consent gate (full-viewport overlay) ───────────────────────────────── */
 
 /* Must exceed z-index 500 (.ms-panel uses 500) */

--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -1,0 +1,223 @@
+/* auth.css — Login gate, consent overlay, operator notice, org picker, logout btn */
+
+/* ─── Auth views (landing + install) ────────────────────────────────────────── */
+
+.auth-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 40px 24px;
+  gap: 24px;
+  text-align: center;
+}
+
+.auth-view h2 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.auth-view p {
+  color: var(--text-muted);
+  font-size: 14px;
+  max-width: 420px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ─── Login / install CTA button ─────────────────────────────────────────── */
+
+.auth-login-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 22px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+
+.auth-login-btn:hover {
+  opacity: 0.88;
+}
+
+.auth-login-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+/* ─── Org picker (select in header-actions) ──────────────────────────────── */
+
+.org-picker {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: 'Inter', system-ui, sans-serif;
+  padding: 5px 10px;
+  height: 30px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238b93a1' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  padding-right: 26px;
+}
+
+.org-picker:focus-visible {
+  border-color: var(--accent);
+}
+
+[data-theme="light"] .org-picker {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%235a6070' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+}
+
+/* ─── Operator notice (sticky banner below toolbar) ──────────────────────── */
+
+.operator-notice {
+  background: var(--accent-dim);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: 'Inter', system-ui, sans-serif;
+  padding: 6px 16px;
+  text-align: center;
+}
+
+.operator-notice strong {
+  color: var(--text);
+}
+
+/* ─── Consent gate (full-viewport overlay) ───────────────────────────────── */
+
+/* Must exceed z-index 500 (.ms-panel uses 500) */
+.consent-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 600;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+[data-theme="light"] .consent-gate {
+  background: rgba(0, 0, 0, 0.48);
+}
+
+.consent-dialog {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 12px;
+  box-shadow: var(--panel-shadow);
+  max-width: 480px;
+  width: 100%;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.consent-dialog h2 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.consent-dialog p {
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.65;
+  margin: 0;
+}
+
+.consent-scopes {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.consent-scope-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.consent-scope-item::before {
+  content: '•';
+  color: var(--accent);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.consent-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.consent-btn-primary {
+  padding: 9px 20px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.consent-btn-primary:hover {
+  opacity: 0.88;
+}
+
+.consent-btn-primary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.consent-btn-secondary {
+  padding: 9px 16px;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.consent-btn-secondary:hover {
+  border-color: var(--border-hi);
+  color: var(--text);
+}
+
+.consent-btn-secondary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -63,6 +63,7 @@ async function fetchMe() {
 // ─── Internal: render landing ─────────────────────────────────────────────────
 
 function renderLanding() {
+  document.body.classList.add('gated');
   const el = $('auth-landing');
   el.innerHTML = `
     <h2>Welcome to Roxabi Live</h2>
@@ -75,6 +76,7 @@ function renderLanding() {
 // ─── Internal: render install CTA ────────────────────────────────────────────
 
 function renderInstallCta() {
+  document.body.classList.add('gated');
   const el = $('auth-install');
   el.innerHTML = `
     <h2>Install the GitHub App</h2>
@@ -100,6 +102,7 @@ function renderInstallCta() {
  */
 function renderConsentGate(me) {
   return new Promise(resolve => {
+    document.body.classList.add('gated');
     const el = $('consent-gate');
     el.innerHTML = `
       <div class="consent-dialog" role="dialog" aria-modal="true" aria-labelledby="consent-title">
@@ -118,6 +121,10 @@ function renderConsentGate(me) {
           You can revoke access at any time from your
           <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">GitHub App settings</a>.
         </p>
+        <p class="consent-warning">
+          <strong>During this phase, the operator can read the issue data of the organisations you grant.</strong>
+          Don't paste secrets into issue bodies or titles.
+        </p>
         <div class="consent-actions">
           <button class="consent-btn-secondary" id="consent-logout">Sign out</button>
           <button class="consent-btn-primary" id="consent-ack">I understand — continue</button>
@@ -126,14 +133,37 @@ function renderConsentGate(me) {
     `;
     el.removeAttribute('hidden');
 
-    $('consent-ack').addEventListener('click', () => {
+    const ackBtn = $('consent-ack');
+    const logoutBtn = $('consent-logout');
+
+    // F3: focus first interactive element after show
+    ackBtn.focus();
+
+    // F3: Tab trap — cycle between logoutBtn and ackBtn only
+    el.addEventListener('keydown', e => {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey) {
+        if (document.activeElement === logoutBtn) {
+          e.preventDefault();
+          ackBtn.focus();
+        }
+      } else {
+        if (document.activeElement === ackBtn) {
+          e.preventDefault();
+          logoutBtn.focus();
+        }
+      }
+    });
+
+    ackBtn.addEventListener('click', () => {
       setConsent(me.user.github_login);
       el.setAttribute('hidden', '');
       resolve();
     });
 
-    $('consent-logout').addEventListener('click', async () => {
-      await fetch('/logout', { method: 'POST' });
+    // F6: route through api() instead of bare fetch
+    logoutBtn.addEventListener('click', async () => {
+      await api('/logout', { method: 'POST' }).catch(() => {});
       location.reload();
     });
   });
@@ -151,7 +181,7 @@ function renderOrgPicker(me) {
     opt.textContent = inst.account_login;
     sel.appendChild(opt);
   }
-  sel.value = String(me.active_tenant_id);
+  if (me.active_tenant_id != null) sel.value = String(me.active_tenant_id);
   sel.removeAttribute('hidden');
 
   sel.addEventListener('change', async () => {
@@ -164,7 +194,8 @@ function renderOrgPicker(me) {
       });
       location.reload();
     } catch {
-      // transient — user can retry
+      // revert selection to last known active tenant
+      if (me.active_tenant_id != null) sel.value = String(me.active_tenant_id);
     }
   });
 }
@@ -174,7 +205,8 @@ function renderOrgPicker(me) {
 function renderOperatorNotice() {
   const el = $('operator-notice');
   el.innerHTML = `
-    <strong>Operator read access:</strong> This tool reads your GitHub org data via the Roxabi Live App.
+    <strong>Operator read access (this phase):</strong> the operator can read the issue data of the organisations you grant.
+    Don't paste secrets into issue bodies or titles.
     <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">Manage</a>
   `;
   el.removeAttribute('hidden');
@@ -186,19 +218,20 @@ function wireLogout() {
   const btn = $('logout-btn');
   btn.removeAttribute('hidden');
   btn.addEventListener('click', async () => {
-    await fetch('/logout', { method: 'POST' });
+    await api('/logout', { method: 'POST' }).catch(() => {});
     location.reload();
   });
 }
 
 // ─── Internal: escape HTML ────────────────────────────────────────────────────
 
-function escHtml(str) {
+export function escHtml(str) {
   return String(str)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
 }
 
 // ─── requireAuthGate (async orchestrator) ─────────────────────────────────────
@@ -237,7 +270,8 @@ export async function requireAuthGate() {
 
   if (view === 'consent') {
     await renderConsentGate(me);
-    // After ACK, wire persistent UI before returning 'dashboard'
+    // After ACK, remove gate class and wire persistent UI before returning 'dashboard'
+    document.body.classList.remove('gated');
     renderOrgPicker(me);
     renderOperatorNotice();
     wireLogout();
@@ -245,6 +279,7 @@ export async function requireAuthGate() {
   }
 
   // view === 'dashboard': already consented, wire persistent UI immediately
+  document.body.classList.remove('gated');
   renderOrgPicker(me);
   renderOperatorNotice();
   wireLogout();

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,0 +1,252 @@
+// auth.js — Auth gate state machine, consent persistence, API wrapper
+// Exports: AuthError, api, hasConsent, setConsent, resolveView, requireAuthGate
+
+const $ = id => document.getElementById(id);
+
+// ─── AuthError ────────────────────────────────────────────────────────────────
+
+export class AuthError extends Error {
+  constructor(msg = 'Not authenticated') {
+    super(msg);
+    this.name = 'AuthError';
+  }
+}
+
+// ─── API wrapper ──────────────────────────────────────────────────────────────
+
+/** fetch wrapper — throws AuthError on 401, Error on other non-ok responses. */
+export async function api(path, opts) {
+  const resp = await fetch(path, opts);
+  if (resp.status === 401) throw new AuthError();
+  if (!resp.ok) throw new Error(`${path} ${resp.status}`);
+  return resp;
+}
+
+// ─── Consent persistence ──────────────────────────────────────────────────────
+
+const CONSENT_PREFIX = 'roxabi:consent:';
+
+/** Returns true if the user has previously acknowledged the operator-read consent. */
+export function hasConsent(login) {
+  return Boolean(localStorage.getItem(CONSENT_PREFIX + login));
+}
+
+/** Persists consent acknowledgement for this login (ISO timestamp). */
+export function setConsent(login) {
+  localStorage.setItem(CONSENT_PREFIX + login, new Date().toISOString());
+}
+
+// ─── View resolution (pure) ───────────────────────────────────────────────────
+
+/**
+ * Resolve which view to show.
+ * Pure: no DOM, no storage, no fetch — call sites handle side-effects.
+ *
+ * @param {{ user: { github_id: number, github_login: string }, active_tenant_id: number|null, installations: Array<{ tenant_id: number, account_login: string, account_type: string }> }} me
+ * @param {boolean} consented
+ * @returns {'install'|'consent'|'dashboard'}
+ */
+export function resolveView(me, consented) {
+  if (me.installations.length === 0) return 'install';
+  if (!consented) return 'consent';
+  return 'dashboard';
+}
+
+// ─── Internal: /api/me ────────────────────────────────────────────────────────
+
+/** Fetches /api/me. Throws AuthError if 401 (no session). */
+async function fetchMe() {
+  const resp = await api('/api/me');
+  return resp.json();
+}
+
+// ─── Internal: render landing ─────────────────────────────────────────────────
+
+function renderLanding() {
+  const el = $('auth-landing');
+  el.innerHTML = `
+    <h2>Welcome to Roxabi Live</h2>
+    <p>Sign in with GitHub to view your organisation's dependency graph.</p>
+    <a href="/login" class="auth-login-btn" aria-label="Sign in with GitHub">Sign in with GitHub</a>
+  `;
+  el.removeAttribute('hidden');
+}
+
+// ─── Internal: render install CTA ────────────────────────────────────────────
+
+function renderInstallCta() {
+  const el = $('auth-install');
+  el.innerHTML = `
+    <h2>Install the GitHub App</h2>
+    <p>No GitHub App installation found for your account. Install the Roxabi Live app on your organisation to get started.</p>
+    <a
+      href="https://github.com/apps/roxabi-live/installations/new"
+      class="auth-login-btn"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Install GitHub App"
+    >Install GitHub App</a>
+    <p><small>After installing, reload this page.</small></p>
+  `;
+  el.removeAttribute('hidden');
+}
+
+// ─── Internal: render consent gate ───────────────────────────────────────────
+
+/**
+ * Renders the consent overlay and resolves when the user acknowledges.
+ * @param {{ user: { github_id: number, github_login: string }, active_tenant_id: number|null, installations: Array<{ tenant_id: number, account_login: string, account_type: string }> }} me
+ * @returns {Promise<void>} resolves on ACK
+ */
+function renderConsentGate(me) {
+  return new Promise(resolve => {
+    const el = $('consent-gate');
+    el.innerHTML = `
+      <div class="consent-dialog" role="dialog" aria-modal="true" aria-labelledby="consent-title">
+        <h2 id="consent-title">Operator data access</h2>
+        <p>
+          Roxabi Live reads your GitHub organisation data on your behalf to build
+          the dependency graph. The following access is required:
+        </p>
+        <div class="consent-scopes">
+          <div class="consent-scope-item">Read issues, labels, milestones, and sub-issue relationships</div>
+          <div class="consent-scope-item">Read repository metadata (name, visibility, archived status)</div>
+          <div class="consent-scope-item">Data is stored in Cloudflare D1 and scoped to your organisation</div>
+        </div>
+        <p>
+          Signed in as <strong>${escHtml(me.user.github_login)}</strong>.
+          You can revoke access at any time from your
+          <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">GitHub App settings</a>.
+        </p>
+        <div class="consent-actions">
+          <button class="consent-btn-secondary" id="consent-logout">Sign out</button>
+          <button class="consent-btn-primary" id="consent-ack">I understand — continue</button>
+        </div>
+      </div>
+    `;
+    el.removeAttribute('hidden');
+
+    $('consent-ack').addEventListener('click', () => {
+      setConsent(me.user.github_login);
+      el.setAttribute('hidden', '');
+      resolve();
+    });
+
+    $('consent-logout').addEventListener('click', async () => {
+      await fetch('/logout', { method: 'POST' });
+      location.reload();
+    });
+  });
+}
+
+// ─── Internal: render org picker ─────────────────────────────────────────────
+
+function renderOrgPicker(me) {
+  const sel = $('org-picker');
+  if (me.installations.length <= 1) { sel.setAttribute('hidden', ''); return; }
+  sel.innerHTML = '';
+  for (const inst of me.installations) {
+    const opt = document.createElement('option');
+    opt.value = inst.tenant_id;
+    opt.textContent = inst.account_login;
+    sel.appendChild(opt);
+  }
+  sel.value = String(me.active_tenant_id);
+  sel.removeAttribute('hidden');
+
+  sel.addEventListener('change', async () => {
+    const id = Number(sel.value);
+    try {
+      await api('/api/active-tenant', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tenant_id: id }),
+      });
+      location.reload();
+    } catch {
+      // transient — user can retry
+    }
+  });
+}
+
+// ─── Internal: render operator notice ────────────────────────────────────────
+
+function renderOperatorNotice() {
+  const el = $('operator-notice');
+  el.innerHTML = `
+    <strong>Operator read access:</strong> This tool reads your GitHub org data via the Roxabi Live App.
+    <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">Manage</a>
+  `;
+  el.removeAttribute('hidden');
+}
+
+// ─── Internal: wire logout ────────────────────────────────────────────────────
+
+function wireLogout() {
+  const btn = $('logout-btn');
+  btn.removeAttribute('hidden');
+  btn.addEventListener('click', async () => {
+    await fetch('/logout', { method: 'POST' });
+    location.reload();
+  });
+}
+
+// ─── Internal: escape HTML ────────────────────────────────────────────────────
+
+function escHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ─── requireAuthGate (async orchestrator) ─────────────────────────────────────
+
+/**
+ * Runs the full auth gate flow.
+ *
+ * SC1 render-block: callers MUST check the returned view and skip
+ * fetch('/api/graph') (and all other /api/* data calls) until this returns
+ * 'dashboard'. This is a frontend render-gate, NOT an authz boundary — the
+ * server already scopes /api/* to the active session+tenant. The gate here
+ * exists so the UI never fires graph data fetches for unauthenticated or
+ * unconsented users, which would produce confusing 401/empty-graph errors.
+ *
+ * @returns {Promise<'landing'|'install'|'consent'|'dashboard'>}
+ */
+export async function requireAuthGate() {
+  let me;
+  try {
+    me = await fetchMe();
+  } catch (e) {
+    if (e instanceof AuthError) {
+      renderLanding();
+      return 'landing';
+    }
+    throw e;
+  }
+
+  const consented = hasConsent(me.user.github_login);
+  const view = resolveView(me, consented);
+
+  if (view === 'install') {
+    renderInstallCta();
+    return 'install';
+  }
+
+  if (view === 'consent') {
+    await renderConsentGate(me);
+    // After ACK, wire persistent UI before returning 'dashboard'
+    renderOrgPicker(me);
+    renderOperatorNotice();
+    wireLogout();
+    return 'dashboard';
+  }
+
+  // view === 'dashboard': already consented, wire persistent UI immediately
+  renderOrgPicker(me);
+  renderOperatorNotice();
+  wireLogout();
+  return 'dashboard';
+}

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthError, api, hasConsent, setConsent, resolveView } from './auth.js';
+
+// ─── resolveView (pure) ───────────────────────────────────────────────────────
+
+describe('resolveView', () => {
+  const installationFixture = {
+    tenant_id: 1,
+    account_login: 'roxabi',
+    account_type: 'Organization',
+  };
+
+  describe('when installations is empty', () => {
+    it("returns 'install' regardless of consent", () => {
+      // Arrange
+      const me = {
+        user: { github_id: 42, github_login: 'alice' },
+        active_tenant_id: null,
+        installations: [],
+      };
+      const consented = true;
+
+      // Act
+      const result = resolveView(me, consented);
+
+      // Assert
+      expect(result).toBe('install');
+    });
+  });
+
+  describe('when installations is non-empty and not consented', () => {
+    it("returns 'consent'", () => {
+      // Arrange
+      const me = {
+        user: { github_id: 42, github_login: 'alice' },
+        active_tenant_id: 1,
+        installations: [installationFixture],
+      };
+      const consented = false;
+
+      // Act
+      const result = resolveView(me, consented);
+
+      // Assert
+      expect(result).toBe('consent');
+    });
+  });
+
+  describe('when installations is non-empty and consented', () => {
+    it("returns 'dashboard'", () => {
+      // Arrange
+      const me = {
+        user: { github_id: 42, github_login: 'alice' },
+        active_tenant_id: 1,
+        installations: [installationFixture],
+      };
+      const consented = true;
+
+      // Act
+      const result = resolveView(me, consented);
+
+      // Assert
+      expect(result).toBe('dashboard');
+    });
+  });
+});
+
+// ─── consent persistence ──────────────────────────────────────────────────────
+
+describe('consent persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('hasConsent returns false before setConsent is called', () => {
+    // Arrange — localStorage cleared in beforeEach
+
+    // Act
+    const result = hasConsent('alice');
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it('hasConsent returns true after setConsent is called for that login', () => {
+    // Arrange
+    setConsent('alice');
+
+    // Act
+    const result = hasConsent('alice');
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it('consent is scoped per-login: setConsent for alice does not affect bob', () => {
+    // Arrange
+    setConsent('alice');
+
+    // Act
+    const result = hasConsent('bob');
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+// ─── api() ────────────────────────────────────────────────────────────────────
+
+describe('api()', () => {
+  let fetchSpy;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws AuthError on HTTP 401', async () => {
+    // Arrange
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+
+    // Act + Assert
+    await expect(api('/x')).rejects.toBeInstanceOf(AuthError);
+    expect(fetchSpy).toHaveBeenCalledWith('/x', undefined);
+  });
+
+  it('resolves to the Response object on HTTP 200', async () => {
+    // Arrange
+    const mockResponse = new Response('{}', { status: 200 });
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse);
+
+    // Act
+    const result = await api('/x');
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(result).toBe(mockResponse);
+  });
+
+  it('throws a generic Error (not AuthError) on HTTP 500', async () => {
+    // Arrange
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    // Act
+    const rejection = api('/x');
+
+    // Assert
+    await expect(rejection).rejects.toBeInstanceOf(Error);
+    await expect(rejection).rejects.not.toBeInstanceOf(AuthError);
+  });
+});

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AuthError, api, hasConsent, setConsent, resolveView } from './auth.js';
+import { AuthError, api, hasConsent, setConsent, resolveView, escHtml } from './auth.js';
 
 // ─── resolveView (pure) ───────────────────────────────────────────────────────
 
@@ -150,5 +150,51 @@ describe('api()', () => {
     // Assert
     await expect(rejection).rejects.toBeInstanceOf(Error);
     await expect(rejection).rejects.not.toBeInstanceOf(AuthError);
+  });
+
+  it('forwards opts to fetch', async () => {
+    // Arrange
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 200 }),
+    );
+
+    // Act
+    await api('/y', { method: 'POST' });
+
+    // Assert
+    expect(fetchSpy).toHaveBeenCalledWith('/y', { method: 'POST' });
+  });
+});
+
+// ─── escHtml ──────────────────────────────────────────────────────────────────
+
+describe('escHtml', () => {
+  it('escapes &', () => {
+    expect(escHtml('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes <', () => {
+    expect(escHtml('a<b')).toBe('a&lt;b');
+  });
+
+  it('escapes >', () => {
+    expect(escHtml('a>b')).toBe('a&gt;b');
+  });
+
+  it('escapes "', () => {
+    expect(escHtml('a"b')).toBe('a&quot;b');
+  });
+
+  it("escapes '", () => {
+    expect(escHtml("a'b")).toBe('a&#x27;b');
+  });
+
+  it('escapes a combined multi-char string', () => {
+    expect(escHtml('a<b>&"\''))
+      .toBe('a&lt;b&gt;&amp;&quot;&#x27;');
+  });
+
+  it('returns a plain string unchanged', () => {
+    expect(escHtml('hello world')).toBe('hello world');
   });
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@500;600;700&display=swap">
 <link rel="stylesheet" href="app.css">
+<link rel="stylesheet" href="auth.css">
 <link rel="stylesheet" href="graph.css">
 </head>
 <body>
@@ -22,6 +23,8 @@
         <button id="btn-list"  class="seg"    data-v="list"  aria-pressed="false" title="List"><span class="ico">≡</span> List</button>
         <button id="btn-graph" class="seg"    data-v="graph" aria-pressed="false" title="Graph"><span class="ico">⋈</span> Graph</button>
       </div>
+      <select id="org-picker" class="org-picker" aria-label="Active organisation" hidden></select>
+      <button id="logout-btn" class="theme-btn" type="button" hidden>Sign out</button>
       <button id="theme-btn" class="theme-btn" type="button" title="Toggle theme" aria-label="Toggle theme">🌙</button>
     </div>
   </header>
@@ -95,6 +98,7 @@
       <div class="segs" id="graph-edge-segs" role="group" aria-label="Parent visibility"></div>
     </span>
   </div>
+  <div id="operator-notice" class="operator-notice" hidden></div>
 </div>
 
 <main>
@@ -102,14 +106,19 @@
   <div id="view-list"  class="view"             role="region" aria-label="List view"></div>
   <section id="graph-panel" class="view"        role="region" aria-label="Graph view" hidden></section>
   <div id="error-msg" class="error-msg" hidden></div>
+  <div id="auth-landing" class="auth-view" hidden></div>
+  <div id="auth-install" class="auth-view" hidden></div>
 </main>
 
 <footer class="page-footer">
   <span>v6</span>
 </footer>
 
+<div id="consent-gate" class="consent-gate" hidden></div>
+
 <script type="module" src="state.js"></script>
 <script type="module" src="pivot.js"></script>
+<script type="module" src="auth.js"></script>
 <script type="module" src="app.js"></script>
 <script type="module" src="graph.js"></script>
 </body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,2234 @@
+{
+  "name": "roxabi-live-frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "roxabi-live-frontend",
+      "devDependencies": {
+        "jsdom": "^25.0.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "roxabi-live-frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "jsdom": "^25.0.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});

--- a/worker/migrations/0007_repo_access_is_private.sql
+++ b/worker/migrations/0007_repo_access_is_private.sql
@@ -1,0 +1,12 @@
+-- migration: 0007_repo_access_is_private.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+
+-- Add is_private column to tenant_repo_access (fail-closed default).
+-- DEFAULT 1 = treat every repo as private until the hourly sync sets is_private=0
+-- for public repos. Defaulting to 0 (public) would expose private repos to
+-- unauthenticated graph reads (IDOR) before the first sync tick after apply.
+-- ALTER TABLE ... ADD COLUMN with a constant DEFAULT is valid in D1/SQLite.
+-- No backfill needed: existing rows correctly inherit DEFAULT 1 (fail-closed).
+-- No index added: is_private is used as a filter column in JOIN reads, not a
+-- primary lookup key; query planner will cover it via the (tenant_id, repo) PK scan.
+ALTER TABLE tenant_repo_access ADD COLUMN is_private INTEGER NOT NULL DEFAULT 1;

--- a/worker/migrations/0008_tenant_not_null.sql
+++ b/worker/migrations/0008_tenant_not_null.sql
@@ -1,0 +1,51 @@
+-- migration: 0008_tenant_not_null.sql  (M-b — epic #141 / S7 #150)
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+--
+-- The deferred NOT-NULL migration. Authored in S1's design (plan #144 appendix),
+-- committed HERE (S7) so CI never tightens before the auth tables proved out.
+--
+-- SCOPE — new/rebuilt tables ONLY. Data tables (issues, edges, labels, pr_state,
+-- repos) keep their global PKs and are untouched (repo-canonical pivot: no
+-- tenant_id on data tables → no backfill, no NOT-NULL changes there). The
+-- intentionally-nullable seams stay nullable: issues.payload (NULL in Phase 1,
+-- ciphertext in Phase 2) and repos.repo_node_id (filled lazily by sync).
+--
+-- The new auth tables (0004) were already authored with NOT NULL inline, and
+-- 0007 added tenant_repo_access.is_private NOT NULL. The S1 appendix flagged M-b
+-- as a NO-OP candidate "if still empty at S7 entry". Re-evaluated at S7: it is
+-- NOT empty — the 0004 sync_control rebuild silently dropped value's NOT NULL
+-- (it was NOT NULL in 0001; the rebuild recreated it as `value TEXT`). This
+-- migration restores that single invariant. No other column needs tightening.
+--
+-- SAFE: no code path writes NULL to sync_control.value — every write binds an
+-- ISO timestamp / String(slot) / literal '0'|'1'|CAST(... AS TEXT) (verified
+-- across mutations.ts + sync.ts). SELF-GUARDING: the INSERT … SELECT into a
+-- NOT NULL column throws BEFORE any rename if a stray NULL exists, so a bad
+-- state fails this migration loudly (sync_control still intact) rather than
+-- corrupting data. Pre-req gate (docs/s7-access-cutover.md): re-verify
+--   SELECT COUNT(*) FROM sync_control WHERE value IS NULL;  -- expect 0
+-- on staging and prod before apply.
+
+-- D1 enforces FKs by default; belt-and-braces for local/vanilla SQLite runs.
+PRAGMA foreign_keys = ON;
+
+-- sync_control rebuild — value TEXT → value TEXT NOT NULL. Mirrors the 0004
+-- rename-swap (data exists in at least one table at every crash point). NO FK on
+-- tenant_id (deviation D-2: sentinel rows use tenant_id=0, not a real tenant).
+-- recovery guard — if a prior partial run failed between CREATE and first RENAME,
+-- re-apply starts clean.
+DROP TABLE IF EXISTS sync_control_new;
+CREATE TABLE sync_control_new (
+  tenant_id  INTEGER NOT NULL DEFAULT 0,
+  key        TEXT NOT NULL,
+  value      TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, key)
+);
+-- Copy tenant_id directly (post-0004 sync_control already has the column — unlike
+-- 0004, which hardcoded 0 because the pre-rebuild table had no tenant_id).
+INSERT INTO sync_control_new (tenant_id, key, value, updated_at)
+  SELECT tenant_id, key, value, updated_at FROM sync_control;
+ALTER TABLE sync_control RENAME TO sync_control_old;
+ALTER TABLE sync_control_new RENAME TO sync_control;
+DROP TABLE sync_control_old;

--- a/worker/migrations/0008_tenant_not_null.sql
+++ b/worker/migrations/0008_tenant_not_null.sql
@@ -48,4 +48,7 @@ INSERT INTO sync_control_new (tenant_id, key, value, updated_at)
   SELECT tenant_id, key, value, updated_at FROM sync_control;
 ALTER TABLE sync_control RENAME TO sync_control_old;
 ALTER TABLE sync_control_new RENAME TO sync_control;
-DROP TABLE sync_control_old;
+-- IF EXISTS for defensive symmetry with the top guard (reached only after the
+-- rename above creates sync_control_old, so a no-op divergence under D1's
+-- implicit per-migration transaction; harmless under a non-transactional re-run).
+DROP TABLE IF EXISTS sync_control_old;

--- a/worker/src/api/active-tenant.test.ts
+++ b/worker/src/api/active-tenant.test.ts
@@ -4,7 +4,7 @@ import type { AuthEnv, SessionContext } from "../auth/session";
 import { activeTenantRoute } from "./active-tenant";
 import {
   captureDb,
-  captureDbWithRows,
+  dispatchByTable,
   makeEnv,
   STUB_SESSION,
 } from "../test-utils";
@@ -78,8 +78,13 @@ async function postActiveTenant(
 describe("activeTenantRoute", () => {
   describe("POST /api/active-tenant — member switch (200)", () => {
     it("returns 200 with active_tenant_id and issues UPDATE sessions", async () => {
-      // Arrange — membership SELECT returns a row; UPDATE sessions runs after.
-      const { db, stmts } = captureDbWithRows([{ 1: 1 }]);
+      // Arrange — membership row found AND target tenant not suspended → UPDATE runs.
+      const { db, stmts } = captureDb((sql) =>
+        dispatchByTable(sql, {
+          user_installations: [{ 1: 1 }],
+          tenants: [{ suspended_at: null }],
+        }),
+      );
       const app = makeApp(db);
 
       // Act
@@ -116,6 +121,34 @@ describe("activeTenantRoute", () => {
       expect(body.error).toBe("forbidden");
 
       // Assert — no UPDATE sessions was issued
+      const updateStmt = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("update sessions") &&
+          s.sql.toLowerCase().includes("tenant_id"),
+      );
+      expect(updateStmt).toBeUndefined();
+    });
+  });
+
+  describe("POST /api/active-tenant — suspended tenant (403)", () => {
+    it("returns 403 when the target tenant is suspended and issues NO UPDATE sessions", async () => {
+      // Arrange — user IS a member, but the tenant carries a suspended_at timestamp.
+      const { db, stmts } = captureDb((sql) =>
+        dispatchByTable(sql, {
+          user_installations: [{ 1: 1 }],
+          tenants: [{ suspended_at: "2026-01-01T00:00:00.000Z" }],
+        }),
+      );
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2 }, COOKIE_HEADER);
+
+      // Assert — switch rejected before any session mutation
+      expect(res.status).toBe(403);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("forbidden");
+
       const updateStmt = stmts().find(
         (s) =>
           s.sql.toLowerCase().includes("update sessions") &&

--- a/worker/src/api/active-tenant.test.ts
+++ b/worker/src/api/active-tenant.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv, SessionContext } from "../auth/session";
+import { activeTenantRoute } from "./active-tenant";
+import {
+  captureDb,
+  captureDbWithRows,
+  makeEnv,
+  STUB_SESSION,
+} from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// SESSION_COOKIE name — must match src/auth/session.ts SESSION_COOKIE constant.
+const SESSION_COOKIE_NAME = "__Host-session";
+const RAW_TOKEN = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+const COOKIE_HEADER = `${SESSION_COOKIE_NAME}=${RAW_TOKEN}`;
+
+// ---------------------------------------------------------------------------
+// App builders
+// ---------------------------------------------------------------------------
+
+/** App with STUB_SESSION injected — simulates requireSession middleware passing. */
+function makeApp(db: ReturnType<typeof captureDb>["db"]): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+
+  app.post("/api/active-tenant", activeTenantRoute);
+
+  return app;
+}
+
+/** App with NO session injected — simulates unauthenticated request. */
+function makeAppNoSession(db: ReturnType<typeof captureDb>["db"]): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.post("/api/active-tenant", activeTenantRoute);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: POST /api/active-tenant
+// ---------------------------------------------------------------------------
+
+async function postActiveTenant(
+  app: Hono<AuthEnv>,
+  db: D1Database,
+  body: unknown,
+  cookie?: string,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) {
+    headers["Cookie"] = cookie;
+  }
+
+  return app.request(
+    "/api/active-tenant",
+    {
+      method: "POST",
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    },
+    makeEnv(db),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("activeTenantRoute", () => {
+  describe("POST /api/active-tenant — member switch (200)", () => {
+    it("returns 200 with active_tenant_id and issues UPDATE sessions", async () => {
+      // Arrange — membership SELECT returns a row; UPDATE sessions runs after.
+      const { db, stmts } = captureDbWithRows([{ 1: 1 }]);
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2 }, COOKIE_HEADER);
+
+      // Assert — status + body
+      expect(res.status).toBe(200);
+      const body = await res.json() as { active_tenant_id: number };
+      expect(body.active_tenant_id).toBe(2);
+
+      // Assert — an UPDATE sessions SET tenant_id statement was issued
+      const updateStmt = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("update sessions") &&
+          s.sql.toLowerCase().includes("tenant_id"),
+      );
+      expect(updateStmt).toBeDefined();
+      expect(updateStmt!.sql).toMatch(/UPDATE sessions SET tenant_id/i);
+    });
+  });
+
+  describe("POST /api/active-tenant — non-member (403)", () => {
+    it("returns 403 when user has no membership row and issues NO UPDATE sessions", async () => {
+      // Arrange — membership SELECT returns nothing.
+      const { db, stmts } = captureDb(); // empty rows for every query
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 99 }, COOKIE_HEADER);
+
+      // Assert — status + body
+      expect(res.status).toBe(403);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("forbidden");
+
+      // Assert — no UPDATE sessions was issued
+      const updateStmt = stmts().find(
+        (s) =>
+          s.sql.toLowerCase().includes("update sessions") &&
+          s.sql.toLowerCase().includes("tenant_id"),
+      );
+      expect(updateStmt).toBeUndefined();
+    });
+  });
+
+  describe("POST /api/active-tenant — missing / invalid tenant_id (400)", () => {
+    it("returns 400 when body has no tenant_id field", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, {}, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+
+    it("returns 400 when tenant_id is a string", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: "two" }, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+
+    it("returns 400 when tenant_id is a float", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2.5 }, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+
+    it("returns 400 when body is not valid JSON", async () => {
+      // Arrange
+      const { db } = captureDb();
+      const app = makeApp(db);
+
+      // Act — send a raw non-JSON body
+      const res = await app.request(
+        "/api/active-tenant",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Cookie: COOKIE_HEADER },
+          body: "not-json",
+        },
+        makeEnv(db),
+      );
+
+      // Assert
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("tenant_id required");
+    });
+  });
+
+  describe("POST /api/active-tenant — no session (401)", () => {
+    it("returns 401 when no session is set on context", async () => {
+      // Arrange — app without session-injecting middleware
+      const { db } = captureDb();
+      const app = makeAppNoSession(db);
+
+      // Act
+      const res = await postActiveTenant(app, db, { tenant_id: 2 }, COOKIE_HEADER);
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+  });
+});

--- a/worker/src/api/active-tenant.ts
+++ b/worker/src/api/active-tenant.ts
@@ -47,6 +47,18 @@ export async function activeTenantRoute(c: Context<AuthEnv>): Promise<Response> 
     return c.json({ error: "forbidden" }, 403);
   }
 
+  // Suspended-tenant guard: a member must not switch into a suspended tenant.
+  // validateSession would 401 every subsequent request (NOT-EXISTS suspended guard),
+  // self-locking the session — reject the switch up-front instead.
+  const tenant = await c.env.DB
+    .prepare(`SELECT suspended_at FROM tenants WHERE id = ?`)
+    .bind(tenantId)
+    .first<{ suspended_at: string | null }>();
+
+  if (!tenant || tenant.suspended_at !== null) {
+    return c.json({ error: "forbidden" }, 403);
+  }
+
   // Read raw token from cookie for hashing inside setSessionTenant.
   const raw = readSessionToken(c);
   if (!raw) {

--- a/worker/src/api/active-tenant.ts
+++ b/worker/src/api/active-tenant.ts
@@ -1,0 +1,59 @@
+/**
+ * POST /api/active-tenant — switch the authenticated user's active tenant.
+ *
+ * Body: { tenant_id: number }
+ *
+ * The route is also placed behind requireSession middleware in router.ts
+ * (registered in T9). The explicit session check here is defense-in-depth.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/session";
+import { readSessionToken, setSessionTenant } from "../auth/session";
+
+export async function activeTenantRoute(c: Context<AuthEnv>): Promise<Response> {
+  // Defense-in-depth: requireSession already guards, but fail closed here too.
+  const s = c.get("session");
+  if (!s) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  // Parse + validate request body.
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "tenant_id required" }, 400);
+  }
+
+  const tenantId =
+    body !== null && typeof body === "object" && "tenant_id" in body
+      ? (body as Record<string, unknown>).tenant_id
+      : undefined;
+
+  if (typeof tenantId !== "number" || !Number.isInteger(tenantId)) {
+    return c.json({ error: "tenant_id required" }, 400);
+  }
+
+  // Membership check — user must belong to the requested tenant.
+  const membership = await c.env.DB
+    .prepare(
+      `SELECT 1 FROM user_installations WHERE user_id = ? AND tenant_id = ?`,
+    )
+    .bind(s.userId, tenantId)
+    .first<{ 1: number }>();
+
+  if (!membership) {
+    return c.json({ error: "forbidden" }, 403);
+  }
+
+  // Read raw token from cookie for hashing inside setSessionTenant.
+  const raw = readSessionToken(c);
+  if (!raw) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  await setSessionTenant(c.env.DB, raw, tenantId);
+
+  return c.json({ active_tenant_id: tenantId });
+}

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -1,18 +1,53 @@
 import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv } from "../auth/session";
 import type { Env } from "../types";
-import { app } from "../router";
+import { graphRoute } from "./graph";
+import {
+  STUB_SESSION,
+  makeEnv,
+  dispatchByTable,
+  makeFakeDb,
+  makeFakeStmt,
+  captureDb,
+  type FakeResult,
+} from "../test-utils";
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
+// ---------------------------------------------------------------------------
+// Test app with session middleware — mirrors me.test.ts pattern
+// ---------------------------------------------------------------------------
+
+function makeTestApp() {
+  const a = new Hono<AuthEnv>();
+  a.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  a.get("/api/graph", graphRoute);
+  return a;
+}
+
+const testApp = makeTestApp();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 /**
- * graph.ts fires 5 prepare().all() calls — dispatched by SQL content:
- *   "FROM labels"   → labels fixture
- *   "FROM pr_state" → pr_state fixture
- *   "FROM issues"   → issues fixture
- *   "FROM edges"    → edges fixture
- *   "FROM repos"    → repos fixture
+ * graph.ts fires 5 prepare().bind(...).all() calls — dispatched by SQL content:
+ *   "tenant_repo_access"  → visible repos (all public by default, derived from issues)
+ *   "from labels"         → labels fixture
+ *   "from pr_state"       → pr_state fixture
+ *   "from issues"         → issues fixture
+ *   "from edges"          → edges fixture
+ *   "from repos"          → repos fixture
+ *
+ * visibleRepos is derived from the issues fixture (all unique repos treated as public).
+ * Override `overrideVisible` to test a custom visibility set.
  */
 function makeGraphEnv(
   labels: unknown[],
@@ -20,24 +55,33 @@ function makeGraphEnv(
   issues: unknown[],
   edges: unknown[],
   repos: unknown[] = [],
+  overrideVisible?: string[],
 ): Env {
-  return {
-    DB: {
-      prepare: (sql: string) => ({
-        all: async () => {
-          if (sql.includes("FROM labels")) return { results: labels };
-          if (sql.includes("FROM pr_state")) return { results: prState };
-          if (sql.includes("FROM issues")) return { results: issues };
-          if (sql.includes("FROM edges")) return { results: edges };
-          if (sql.includes("FROM repos")) return { results: repos };
-          return { results: [] };
-        },
+  const visibleRepos =
+    overrideVisible ??
+    [...new Set((issues as Array<{ repo: string }>).map((i) => i.repo))];
+
+  const db = makeFakeDb((sql, args) =>
+    makeFakeStmt(
+      sql,
+      args,
+      dispatchByTable(sql, {
+        "tenant_repo_access": visibleRepos.map((repo) => ({
+          repo,
+          is_private: 0,
+        })),
+        "from labels": labels as FakeResult[],
+        "from pr_state": prState as FakeResult[],
+        // "from edges" MUST precede "from issues": edges SQL contains "FROM issues"
+        // as a subquery, so first-match-wins would otherwise misroute it.
+        "from edges": edges as FakeResult[],
+        "from repos": repos as FakeResult[],
+        "from issues": issues as FakeResult[],
       }),
-    },
-    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_ORG: "",
-    GITHUB_WEBHOOK_SECRET: "",
-  } as unknown as Env;
+    ),
+  );
+
+  return makeEnv(db);
 }
 
 /**
@@ -52,27 +96,28 @@ function makeGraphEnvWithCapture(
   repos: unknown[] = [],
 ): { env: Env; capturedSqls: string[] } {
   const capturedSqls: string[] = [];
-  const env = {
-    DB: {
-      prepare: (sql: string) => {
-        capturedSqls.push(sql);
-        return {
-          all: async () => {
-            if (sql.includes("FROM labels")) return { results: labels };
-            if (sql.includes("FROM pr_state")) return { results: prState };
-            if (sql.includes("FROM issues")) return { results: issues };
-            if (sql.includes("FROM edges")) return { results: edges };
-            if (sql.includes("FROM repos")) return { results: repos };
-            return { results: [] };
-          },
-        };
-      },
-    },
-    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
-    GITHUB_ORG: "",
-    GITHUB_WEBHOOK_SECRET: "",
-  } as unknown as Env;
-  return { env, capturedSqls };
+
+  const visibleRepos = [
+    ...new Set((issues as Array<{ repo: string }>).map((i) => i.repo)),
+  ];
+
+  const { db } = captureDb((sql, _args) => {
+    capturedSqls.push(sql);
+    return dispatchByTable(sql, {
+      "tenant_repo_access": visibleRepos.map((repo) => ({
+        repo,
+        is_private: 0,
+      })),
+      "from labels": labels as FakeResult[],
+      "from pr_state": prState as FakeResult[],
+      // "from edges" MUST precede "from issues": edges SQL subquery contains "FROM issues"
+      "from edges": edges as FakeResult[],
+      "from repos": repos as FakeResult[],
+      "from issues": issues as FakeResult[],
+    });
+  });
+
+  return { env: makeEnv(db), capturedSqls };
 }
 
 describe("GET /api/graph", () => {
@@ -82,7 +127,7 @@ describe("GET /api/graph", () => {
         key: "Roxabi/roxabi-live#1",
         repo: "Roxabi/roxabi-live",
         number: 1,
-        title: "Test issue",
+        title: "Fix the thing",
         state: "open",
         url: "https://github.com/Roxabi/roxabi-live/issues/1",
         milestone: null,
@@ -93,262 +138,273 @@ describe("GET /api/graph", () => {
         is_stub: 0,
         has_active_branch: 0,
       };
+      const edge = {
+        src_key: "Roxabi/roxabi-live#2",
+        dst_key: "Roxabi/roxabi-live#1",
+        kind: "blocks",
+      };
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [issue], [edge]),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        nodes: unknown[];
+        edges: unknown[];
+        repos: unknown[];
+      }>();
+      expect(Array.isArray(body.nodes)).toBe(true);
+      expect(Array.isArray(body.edges)).toBe(true);
+      expect(Array.isArray(body.repos)).toBe(true);
+    });
 
-      const res = await app.request(
+    it("maps IssueRow fields to Node shape", async () => {
+      const issue = {
+        key: "Roxabi/roxabi-live#42",
+        repo: "Roxabi/roxabi-live",
+        number: 42,
+        title: "Hello",
+        state: "open",
+        url: "https://github.com/Roxabi/roxabi-live/issues/42",
+        milestone: null,
+        lane: "backlog",
+        priority: "P1",
+        size: "M",
+        status: "in_progress",
+        is_stub: 0,
+        has_active_branch: 0,
+      };
+      const res = await testApp.request(
         "/api/graph",
         {},
         makeGraphEnv([], [], [issue], []),
       );
-
-      expect(res.status).toBe(200);
-      const body = await res.json<{ nodes: unknown[]; edges: unknown[] }>();
-      expect(body).toHaveProperty("nodes");
-      expect(body).toHaveProperty("edges");
-      expect(Array.isArray(body.nodes)).toBe(true);
-      expect(Array.isArray(body.edges)).toBe(true);
+      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
+      const node = body.nodes[0];
+      expect(node.key).toBe("Roxabi/roxabi-live#42");
+      expect(node.repo).toBe("Roxabi/roxabi-live");
+      expect(node.number).toBe(42);
+      expect(node.title).toBe("Hello");
+      expect(node.state).toBe("open");
+      expect(node.url).toBe(
+        "https://github.com/Roxabi/roxabi-live/issues/42",
+      );
+      expect(node.lane).toBe("backlog");
+      expect(node.priority).toBe("P1");
+      expect(node.size).toBe("M");
+      expect(node.status).toBe("in_progress");
+      expect(node.is_stub).toBe(false);
     });
 
-    it("maps node fields from issue row", async () => {
+    it("maps EdgeRow fields to Edge shape", async () => {
       const issue = {
-        key: "Roxabi/roxabi-live#7",
+        key: "Roxabi/roxabi-live#1",
         repo: "Roxabi/roxabi-live",
-        number: 7,
-        title: "My Issue",
+        number: 1,
+        title: null,
         state: "open",
-        url: "https://github.com/Roxabi/roxabi-live/issues/7",
-        milestone: "M1 — Foundation",
-        lane: "infra",
-        priority: "P1",
-        size: "M",
-        status: "In Progress",
+        url: null,
+        milestone: null,
+        lane: null,
+        priority: null,
+        size: null,
+        status: null,
         is_stub: 0,
         has_active_branch: 0,
       };
-
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
-      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      const node = body.nodes[0];
-
-      expect(node.key).toBe("Roxabi/roxabi-live#7");
-      expect(node.repo).toBe("Roxabi/roxabi-live");
-      expect(node.number).toBe(7);
-      expect(node.title).toBe("My Issue");
-      expect(node.state).toBe("open");
-      expect(node.url).toBe("https://github.com/Roxabi/roxabi-live/issues/7");
-      expect(node.milestone).toBe("M1 — Foundation");
-      expect(node.milestone_code).toBe("M1");
-      expect(node.milestone_name).toBe("Foundation");
-      expect(node.milestone_sort_key).toBe(1);
-      expect(node.lane).toBe("infra");
-      expect(node.priority).toBe("P1");
-      expect(node.size).toBe("M");
-      expect(node.status).toBe("In Progress");
-    });
-
-    it("maps edge fields correctly", async () => {
-      const edge = { src_key: "Roxabi/roxabi-live#1", dst_key: "Roxabi/roxabi-live#2", kind: "blocks" };
-
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], [edge]));
+      const edge = {
+        src_key: "Roxabi/roxabi-live#2",
+        dst_key: "Roxabi/roxabi-live#1",
+        kind: "blocks",
+      };
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [issue], [edge]),
+      );
       const body = await res.json<{ edges: Record<string, unknown>[] }>();
-      const e = body.edges[0];
-
-      expect(e.src).toBe("Roxabi/roxabi-live#1");
-      expect(e.dst).toBe("Roxabi/roxabi-live#2");
-      expect(e.kind).toBe("blocks");
+      expect(body.edges[0]).toEqual({
+        src: "Roxabi/roxabi-live#2",
+        dst: "Roxabi/roxabi-live#1",
+        kind: "blocks",
+      });
     });
   });
 
   describe("dev_state priority matrix", () => {
-    function makeIssue(
-      state: string,
-      hasActiveBranch: number,
-      key = "Roxabi/roxabi-live#1",
-    ) {
-      return {
-        key,
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state,
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: hasActiveBranch,
-      };
-    }
+    const baseIssue = {
+      key: "Roxabi/roxabi-live#1",
+      repo: "Roxabi/roxabi-live",
+      number: 1,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      is_stub: 0,
+      has_active_branch: 0,
+    };
 
-    it("returns idle for a closed issue regardless of branch/PRs", async () => {
-      const issue = makeIssue("closed", 1);
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+    it("idle when no branch and no open PR", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...baseIssue, has_active_branch: 0 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("idle");
     });
 
-    it("returns pr_reviewed when an open PR has has_reviewed_label=1", async () => {
-      const issue = makeIssue("open", 0);
-      const prState = [
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 1 },
-      ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
-      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].dev_state).toBe("pr_reviewed");
-    });
-
-    it("returns pr_open when an open PR exists without reviewed label", async () => {
-      const issue = makeIssue("open", 0);
-      const prState = [
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 0 },
-      ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
-      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].dev_state).toBe("pr_open");
-    });
-
-    it("returns dev when no open PRs but has_active_branch=1", async () => {
-      const issue = makeIssue("open", 1);
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+    it("dev when has_active_branch=1 and no open PR", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...baseIssue, has_active_branch: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("dev");
     });
 
-    it("returns idle when open, no PR, no active branch", async () => {
-      const issue = makeIssue("open", 0);
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+    it("pr_open when an open PR is linked but not reviewed", async () => {
+      const prState = [
+        {
+          closing_issue_keys: '["Roxabi/roxabi-live#1"]',
+          has_reviewed_label: 0,
+        },
+      ];
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [{ ...baseIssue, has_active_branch: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].dev_state).toBe("idle");
+      expect(body.nodes[0].dev_state).toBe("pr_open");
     });
 
-    it("pr_reviewed takes priority over pr_open when multiple PRs exist", async () => {
-      const issue = makeIssue("open", 0);
+    it("pr_reviewed when an open PR has has_reviewed_label=1", async () => {
       const prState = [
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 0 },
-        { closing_issue_keys: JSON.stringify([issue.key]), has_reviewed_label: 1 },
+        {
+          closing_issue_keys: '["Roxabi/roxabi-live#1"]',
+          has_reviewed_label: 1,
+        },
       ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [{ ...baseIssue, has_active_branch: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("pr_reviewed");
+    });
+
+    it("idle for a closed issue even when has_active_branch=1", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv(
+          [],
+          [],
+          [{ ...baseIssue, state: "closed", has_active_branch: 1 }],
+          [],
+        ),
+      );
+      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
+      expect(body.nodes[0].dev_state).toBe("idle");
     });
   });
 
   describe("lane fallback from labels", () => {
-    it("uses lane from DB row when set", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: "backend",
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const labels = [{ issue_key: issue.key, name: "graph:lane/frontend" }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+    const baseIssue = {
+      key: "Roxabi/roxabi-live#1",
+      repo: "Roxabi/roxabi-live",
+      number: 1,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      is_stub: 0,
+      has_active_branch: 0,
+    };
+
+    it("uses lane field when set", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...baseIssue, lane: "backlog" }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      // DB lane wins over label
-      expect(body.nodes[0].lane).toBe("backend");
+      expect(body.nodes[0].lane).toBe("backlog");
     });
 
-    it("falls back to graph:lane/ label when lane is null in DB", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const labels = [{ issue_key: issue.key, name: "graph:lane/infra" }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+    it("falls back to graph:lane/ label when lane field is null", async () => {
+      const labels = [{ issue_key: baseIssue.key, name: "graph:lane/active" }];
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv(labels, [], [baseIssue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
-      expect(body.nodes[0].lane).toBe("infra");
+      expect(body.nodes[0].lane).toBe("active");
     });
 
-    it("returns null lane when no DB lane and no graph:lane/ label", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const labels = [{ issue_key: issue.key, name: "some-other-label" }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+    it("returns null lane when no lane field and no graph:lane/ label", async () => {
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [baseIssue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].lane).toBeNull();
     });
   });
 
   describe("is_stub boolean coercion", () => {
+    const base = {
+      key: "Roxabi/roxabi-live#1",
+      repo: "Roxabi/roxabi-live",
+      number: 1,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      has_active_branch: 0,
+    };
+
     it("coerces is_stub=1 to true", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 1,
-        has_active_branch: 0,
-      };
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...base, is_stub: 1 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].is_stub).toBe(true);
     });
 
     it("coerces is_stub=0 to false", async () => {
-      const issue = {
-        key: "Roxabi/roxabi-live#1",
-        repo: "Roxabi/roxabi-live",
-        number: 1,
-        title: null,
-        state: "open",
-        url: null,
-        milestone: null,
-        lane: null,
-        priority: null,
-        size: null,
-        status: null,
-        is_stub: 0,
-        has_active_branch: 0,
-      };
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [{ ...base, is_stub: 0 }], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].is_stub).toBe(false);
     });
   });
 
   describe("invalid JSON in pr_state.closing_issue_keys", () => {
-    it("silently skips rows with invalid JSON", async () => {
+    it("falls back to idle dev_state on invalid closing_issue_keys JSON", async () => {
       const issue = {
         key: "Roxabi/roxabi-live#1",
         repo: "Roxabi/roxabi-live",
@@ -366,7 +422,11 @@ describe("GET /api/graph", () => {
       };
       // One row with invalid JSON — should not throw, issue gets idle dev_state
       const prState = [{ closing_issue_keys: "not-valid-json", has_reviewed_label: 1 }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [issue], []),
+      );
       expect(res.status).toBe(200);
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("idle");
@@ -389,7 +449,11 @@ describe("GET /api/graph", () => {
         has_active_branch: 0,
       };
       const prState = [{ closing_issue_keys: null, has_reviewed_label: 1 }];
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], prState, [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], prState, [issue], []),
+      );
       expect(res.status).toBe(200);
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].dev_state).toBe("idle");
@@ -418,7 +482,11 @@ describe("GET /api/graph", () => {
         { issue_key: issue.key, name: "P1" },
         { issue_key: "other/repo#99", name: "enhancement" },
       ];
-      const res = await app.request("/api/graph", {}, makeGraphEnv(labels, [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv(labels, [], [issue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].labels).toEqual(["bug", "P1"]);
     });
@@ -439,7 +507,11 @@ describe("GET /api/graph", () => {
         is_stub: 0,
         has_active_branch: 0,
       };
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [issue], []));
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [issue], []),
+      );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].labels).toEqual([]);
     });
@@ -447,7 +519,12 @@ describe("GET /api/graph", () => {
 
   describe("empty database", () => {
     it("returns {nodes:[], edges:[], repos:[]} when all tables empty", async () => {
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], []));
+      // Empty issues → no visible repos → resolveVisibleRepos short-circuits → {nodes:[],edges:[],repos:[]}
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [], []),
+      );
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual({ nodes: [], edges: [], repos: [] });
@@ -462,9 +539,14 @@ describe("GET /api/graph", () => {
         { repo: "Roxabi/roxabi-vault", archived: 1 },
       ];
       // SQL ORDER BY archived ASC, repo ASC — fixture already sorted correctly
-      const res = await app.request("/api/graph", {}, makeGraphEnv([], [], [], [], repoRows));
+      // Use overrideVisible to inject visible repos (no issues needed)
+      const visibleList = repoRows.map((r) => r.repo);
+      const env = makeGraphEnv([], [], [], [], repoRows, visibleList);
+      const res = await testApp.request("/api/graph", {}, env);
       expect(res.status).toBe(200);
-      const body = await res.json<{ repos: { repo: string; archived: boolean }[] }>();
+      const body = await res.json<{
+        repos: { repo: string; archived: boolean }[];
+      }>();
       expect(body.repos).toEqual([
         { repo: "Roxabi/roxabi-factory", archived: false },
         { repo: "Roxabi/roxabi-live", archived: false },
@@ -477,11 +559,168 @@ describe("GET /api/graph", () => {
     it("issues SELECT uses JSON_EXTRACT(payload,'$.title') AS title", async () => {
       // Arrange
       const { env, capturedSqls } = makeGraphEnvWithCapture([], [], [], []);
-      // Act
-      await app.request("/api/graph", {}, env);
-      // Assert — the issues query must project title via JSON_EXTRACT
-      const issuesSql = capturedSqls.find((s) => s.includes("FROM issues"));
+      // Act — empty issues → resolveVisibleRepos returns [] → short-circuit.
+      // Use a non-empty issue to ensure issues query fires.
+      const issue = {
+        key: "Roxabi/roxabi-live#1",
+        repo: "Roxabi/roxabi-live",
+        number: 1,
+        title: null,
+        state: "open",
+        url: null,
+        milestone: null,
+        lane: null,
+        priority: null,
+        size: null,
+        status: null,
+        is_stub: 0,
+        has_active_branch: 0,
+      };
+      const { env: env2, capturedSqls: sqls2 } = makeGraphEnvWithCapture(
+        [],
+        [],
+        [issue],
+        [],
+      );
+      await testApp.request("/api/graph", {}, env2);
+      // Assert — the issues query must project title via JSON_EXTRACT.
+      // Use "json_extract" as the finder key so labels/edges subqueries (which also
+      // contain "from issues") don't accidentally win the find().
+      const issuesSql = sqls2.find((s) =>
+        s.toLowerCase().includes("json_extract"),
+      );
       expect(issuesSql).toContain("JSON_EXTRACT(payload,'$.title') AS title");
+      void env; // suppress unused warning
+      void capturedSqls;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tenant-scoped visibility tests (#148)
+  // ---------------------------------------------------------------------------
+
+  describe("tenant scoping", () => {
+    const visibleRepo = "Roxabi/roxabi-live";
+    const hiddenRepo = "Roxabi/private-repo";
+
+    const makeIssue = (repo: string, n: number) => ({
+      key: `${repo}#${n}`,
+      repo,
+      number: n,
+      title: null,
+      state: "open",
+      url: null,
+      milestone: null,
+      lane: null,
+      priority: null,
+      size: null,
+      status: null,
+      is_stub: 0,
+      has_active_branch: 0,
+    });
+
+    it("nodes scoped — issue in non-visible repo is absent from nodes", async () => {
+      // The hidden repo issue is in the issues fixture but NOT in tenant_repo_access.
+      // resolveVisibleRepos returns only [visibleRepo].
+      // graphRoute WHERE repo IN (?) scopes the issues query — DB stub simulates
+      // the filter by only returning the visible issue.
+      const visibleIssue = makeIssue(visibleRepo, 1);
+      // overrideVisible = only visibleRepo; issues stub returns only visibleIssue
+      const env = makeGraphEnv([], [], [visibleIssue], [], [], [visibleRepo]);
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{ nodes: { key: string }[] }>();
+      const keys = body.nodes.map((n) => n.key);
+      expect(keys).toContain(`${visibleRepo}#1`);
+      expect(keys).not.toContain(`${hiddenRepo}#99`);
+    });
+
+    it("edges scoped — edge with endpoint in non-visible repo is dropped", async () => {
+      // Both endpoints of the edge must be in visible repos.
+      // Our stub simulates the SQL filter: only edges where both endpoints are visible.
+      const visibleIssue = makeIssue(visibleRepo, 1);
+      const visibleEdge = {
+        src_key: `${visibleRepo}#2`,
+        dst_key: `${visibleRepo}#1`,
+        kind: "blocks",
+      };
+      // dangling edge has dst in hidden repo — DB stub does NOT return it
+      const env = makeGraphEnv(
+        [],
+        [],
+        [visibleIssue],
+        [visibleEdge], // only the fully-visible edge is returned by issues-scoped query
+        [],
+        [visibleRepo],
+      );
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        edges: { src: string; dst: string; kind: string }[];
+      }>();
+      // Visible edge is present
+      expect(body.edges).toContainEqual({
+        src: `${visibleRepo}#2`,
+        dst: `${visibleRepo}#1`,
+        kind: "blocks",
+      });
+      // No edge touching hidden repo
+      const touchesHidden = body.edges.some(
+        (e) => e.src.startsWith(hiddenRepo) || e.dst.startsWith(hiddenRepo),
+      );
+      expect(touchesHidden).toBe(false);
+    });
+
+    it("repos scoped — repos[] lists only visible repos", async () => {
+      const repoRows = [{ repo: visibleRepo, archived: 0 }];
+      // overrideVisible only includes visibleRepo; repos stub returns only that row
+      const env = makeGraphEnv([], [], [], [], repoRows, [visibleRepo]);
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        repos: { repo: string; archived: boolean }[];
+      }>();
+      expect(body.repos.map((r) => r.repo)).toEqual([visibleRepo]);
+      expect(body.repos.map((r) => r.repo)).not.toContain(hiddenRepo);
+    });
+
+    it("scopes the issues/edges/repos reads to the visible set via `repo IN` (#148)", async () => {
+      // Non-empty issues fixture → visible set non-empty → the data reads fire.
+      // This is the discriminating guard: strip the `repo IN` clauses from graphRoute
+      // and these assertions fail — i.e. the test actually exercises the scoping.
+      const issue = makeIssue(visibleRepo, 1);
+      const { env, capturedSqls } = makeGraphEnvWithCapture(
+        [],
+        [],
+        [issue],
+        [],
+        [{ repo: visibleRepo, archived: 0 }],
+      );
+      await testApp.request("/api/graph", {}, env);
+
+      const issuesSql = capturedSqls.find((s) => s.includes("has_active_branch"));
+      const edgesSql = capturedSqls.find((s) => s.includes("FROM edges"));
+      const reposSql = capturedSqls.find((s) => s.includes("FROM repos"));
+      expect(issuesSql).toBeDefined();
+      expect(edgesSql).toBeDefined();
+      expect(reposSql).toBeDefined();
+      // Without these filters the graph would expose issues/edges/repos from tenants
+      // the caller can't see.
+      expect(issuesSql).toContain("repo IN");
+      expect(edgesSql).toContain("repo IN");
+      expect(reposSql).toContain("repo IN");
+    });
+
+    it("empty visible set short-circuits to {nodes:[], edges:[], repos:[]} and issues NO data reads (#148)", async () => {
+      // issues fixture empty → tenant_repo_access empty → resolveVisibleRepos returns []
+      const { env, capturedSqls } = makeGraphEnvWithCapture([], [], [], [], []);
+      const res = await testApp.request("/api/graph", {}, env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ nodes: [], edges: [], repos: [] });
+      // The short-circuit must run BEFORE any data read — drop it and these fire.
+      expect(capturedSqls.some((s) => s.includes("has_active_branch"))).toBe(false);
+      expect(capturedSqls.some((s) => s.includes("FROM edges"))).toBe(false);
+      expect(capturedSqls.some((s) => s.includes("FROM repos"))).toBe(false);
     });
   });
 });

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -5,15 +5,17 @@
  * Response shape MUST stay { nodes: Node[], edges: Edge[] } — byte-compatible
  * with the Python source consumed by the v6 frontend (state.js).
  *
- * Four D1 reads (same logical queries as Python):
+ * Five D1 reads (a)-(e), tenant-scoped to resolveVisibleRepos(c):
  *   (a) labels — grouped into Map<issueKey, string[]>
  *   (b) open pr_state — build Map<issueKey, {has_reviewed_label:number}[]>
  *   (c) issues — one row per issue
  *   (d) edges — all src_key/dst_key/kind rows
+ *   (e) repos — live first (archived=0), then archived (archived=1), both alpha
  */
 
 import type { Context } from "hono";
-import type { Env } from "../types";
+import type { AuthEnv } from "../auth/session";
+import { resolveVisibleRepos } from "../auth/repoAccess";
 import { parseMilestone } from "../sync/parse";
 
 const LANE_LABEL_PREFIX = "graph:lane/";
@@ -113,11 +115,19 @@ interface EdgeRow {
   kind: string;
 }
 
-export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
-  // (a) labels → Map<issueKey, string[]>
+export const graphRoute = async (c: Context<AuthEnv>) => {
+  const visible = await resolveVisibleRepos(c);
+
+  if (visible.length === 0) {
+    return c.json({ nodes: [], edges: [], repos: [] });
+  }
+
+  const ph = visible.map(() => "?").join(",");
+
+  // (a) labels → Map<issueKey, string[]> — scoped to visible issues only
   const labelRows = await c.env.DB.prepare(
-    "SELECT issue_key, name FROM labels",
-  ).all<LabelRow>();
+    `SELECT issue_key, name FROM labels WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+  ).bind(...visible).all<LabelRow>();
   const labelsByIssue = new Map<string, string[]>();
   for (const row of labelRows.results) {
     const existing = labelsByIssue.get(row.issue_key);
@@ -129,9 +139,12 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
   }
 
   // (b) open pr_state → Map<issueKey, PrInfo[]>
+  // pr_state has a repo column; scope to visible repos so PR metadata for non-visible
+  // repos is excluded. openPrsByIssue is read by key only for visible issues, but
+  // scoping here prevents any row for non-visible repos from entering the map.
   const prRows = await c.env.DB.prepare(
-    "SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open'",
-  ).all<PrStateRow>();
+    `SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open' AND repo IN (${ph})`,
+  ).bind(...visible).all<PrStateRow>();
   const openPrsByIssue = new Map<string, PrInfo[]>();
   for (const row of prRows.results) {
     if (!row.closing_issue_keys) continue;
@@ -152,11 +165,11 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     }
   }
 
-  // (c) issues
+  // (c) issues — scoped to visible repos
   const issueRows = await c.env.DB.prepare(
     "SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone," +
-      " lane, priority, size, status, is_stub, has_active_branch FROM issues",
-  ).all<IssueRow>();
+      ` lane, priority, size, status, is_stub, has_active_branch FROM issues WHERE repo IN (${ph})`,
+  ).bind(...visible).all<IssueRow>();
 
   const nodes: Node[] = issueRows.results.map((row) => {
     const issueLabels = labelsByIssue.get(row.key) ?? [];
@@ -188,10 +201,13 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     };
   });
 
-  // (d) edges
+  // (d) edges — both endpoints must be in visible repos; dangling edges to invisible
+  // nodes are dropped (graph only draws an edge when both nodes are present)
   const edgeRows = await c.env.DB.prepare(
-    "SELECT src_key, dst_key, kind FROM edges",
-  ).all<EdgeRow>();
+    `SELECT src_key, dst_key, kind FROM edges` +
+      ` WHERE src_key IN (SELECT key FROM issues WHERE repo IN (${ph}))` +
+      ` AND dst_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+  ).bind(...visible, ...visible).all<EdgeRow>();
 
   const edges: Edge[] = edgeRows.results.map((row) => ({
     src: row.src_key,
@@ -205,8 +221,8 @@ export const graphRoute = async (c: Context<{ Bindings: Env }>) => {
     archived: number;
   }
   const repoRows = await c.env.DB.prepare(
-    "SELECT repo, archived FROM repos ORDER BY archived ASC, repo ASC",
-  ).all<RepoRow>();
+    `SELECT repo, archived FROM repos WHERE repo IN (${ph}) ORDER BY archived ASC, repo ASC`,
+  ).bind(...visible).all<RepoRow>();
   const repos = (repoRows.results ?? []).map((r) => ({
     repo: r.repo,
     archived: Boolean(r.archived),

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -1,9 +1,43 @@
-import { describe, expect, it, afterEach, vi } from "vitest";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 import type { Env } from "../types";
 import { app } from "../router";
+import { resolveVisibleRepos } from "../auth/repoAccess";
+
+// #148: these are handler unit tests — they exercise listIssuesRoute/getIssueRoute
+// logic (row mapping, filter SQL, limit/offset clamping). The auth middleware is
+// covered by router.test.ts + session.test.ts, and repo-permission resolution by
+// repoAccess.test.ts. So here we stub the auth boundary: requireSession becomes a
+// pass-through that injects a session, and resolveVisibleRepos returns a fixed
+// visible set (overridable per test).
+vi.mock("../auth/repoAccess", () => ({
+  resolveVisibleRepos: vi.fn(),
+}));
+
+vi.mock("../auth/session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auth/session")>();
+  return {
+    ...actual,
+    requireSession: (async (c, next) => {
+      c.set("session", {
+        userId: 1,
+        tenantId: 1,
+        githubId: 1001,
+        githubLogin: "octocat",
+      });
+      await next();
+    }) as typeof actual.requireSession,
+  };
+});
+
+const DEFAULT_VISIBLE = ["Roxabi/roxabi-live"];
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  // Default: the repo used by makeIssueRow fixtures is visible. Override per test.
+  vi.mocked(resolveVisibleRepos).mockResolvedValue(DEFAULT_VISIBLE);
 });
 
 // ── Env builders ─────────────────────────────────────────────────────────────
@@ -198,6 +232,38 @@ function makeGetEnvWithCapture(opts: GetEnvOptions): {
   } as unknown as Env;
 
   return { env, capturedSqls };
+}
+
+/**
+ * #148: like makeGetEnv but mimics the real `WHERE key = ? AND repo IN (...)` filter —
+ * the issue row is returned ONLY if its repo was bound into the statement (i.e. is in
+ * the visible set the handler passed). Lets us prove the IDOR 404 on a foreign repo.
+ */
+function makeRepoFilteredGetEnv(opts: {
+  issueRow: { repo: string } & Record<string, unknown>;
+}): Env {
+  const { issueRow } = opts;
+  return {
+    DB: {
+      prepare: (sql: string) => ({
+        bind: (...args: unknown[]) => ({
+          first: async () => {
+            if (sql.includes("FROM issues WHERE key") && args.includes(issueRow.repo)) {
+              return issueRow;
+            }
+            return null;
+          },
+          all: async () => ({ results: [] }),
+        }),
+        first: async () => null,
+        all: async () => ({ results: [] }),
+      }),
+      batch: async () => [],
+    },
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
 }
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -512,22 +578,23 @@ describe("GET /api/issues/:key", () => {
     });
   });
 
-  describe("edgeItem fallback when join returns null number/repo", () => {
-    it("parses number and repo from key when join columns are null", async () => {
-      const row = makeIssueRow();
-      // Edge join returned null for number+repo (orphan edge row)
-      const blocking = [
-        { key: "Roxabi/roxabi-live#5", number: null, repo: null },
-      ];
-      const res = await app.request(
-        "/api/issues/Roxabi/roxabi-live%231",
-        {},
-        makeGetEnv({ issueRow: row, blocking }),
+  describe("edge visibility (INNER JOIN, #148)", () => {
+    it("blocking/blocked_by queries INNER JOIN issues on the visible set", async () => {
+      vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/roxabi-live"]);
+      const { env, capturedSqls } = makeGetEnvWithCapture({ issueRow: makeIssueRow() });
+      await app.request("/api/issues/Roxabi/roxabi-live%231", {}, env);
+
+      const edgeSqls = capturedSqls.filter(
+        (s) => s.includes("e.src_key = ?") || s.includes("e.dst_key = ?"),
       );
-      const body = await res.json<{ blocking: Record<string, unknown>[] }>();
-      expect(body.blocking[0].key).toBe("Roxabi/roxabi-live#5");
-      expect(body.blocking[0].number).toBe(5);
-      expect(body.blocking[0].repo).toBe("Roxabi/roxabi-live");
+      expect(edgeSqls).toHaveLength(2);
+      // The protection: each edge query INNER-JOINs issues on `repo IN (visible)`, so a
+      // non-visible (or orphan) endpoint can never match → no parseKey fallback to leak it.
+      for (const sql of edgeSqls) {
+        expect(sql).not.toContain("LEFT JOIN");
+        expect(sql).toContain("JOIN issues");
+        expect(sql).toContain("repo IN");
+      }
     });
   });
 });
@@ -616,5 +683,94 @@ describe("GET /api/issues — filter SQL params and clamping (FIX 4)", () => {
       const body = await res.json<{ offset: number }>();
       expect(body.offset).toBe(0);
     });
+  });
+});
+
+// ── #148: tenant-scoped reads (IDOR + visibility) ────────────────────────────
+
+describe("#148 tenant scoping", () => {
+  it("IDOR: a foreign-repo issue is 404 when its repo is not in the visible set", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/alpha"]);
+    const env = makeRepoFilteredGetEnv({
+      issueRow: makeIssueRow({
+        key: "Roxabi/secret#42",
+        repo: "Roxabi/secret",
+        number: 42,
+      }),
+    });
+    const res = await app.request("/api/issues/Roxabi/secret%2342", {}, env);
+    // Indistinguishable from a missing issue — no existence/metadata leak.
+    expect(res.status).toBe(404);
+  });
+
+  it("the same issue is 200 when its repo IS visible", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/secret"]);
+    const env = makeRepoFilteredGetEnv({
+      issueRow: makeIssueRow({
+        key: "Roxabi/secret#42",
+        repo: "Roxabi/secret",
+        number: 42,
+      }),
+    });
+    const res = await app.request("/api/issues/Roxabi/secret%2342", {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("get-issue SQL carries repo IN (?) bound to the visible set", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/alpha", "Roxabi/beta"]);
+    const { env, capturedSqls } = makeGetEnvWithCapture({ issueRow: makeIssueRow() });
+    await app.request("/api/issues/Roxabi/roxabi-live%231", {}, env);
+    const issueSql = capturedSqls.find((s) => s.includes("FROM issues WHERE key"));
+    expect(issueSql).toContain("repo IN");
+  });
+
+  it("list: empty visible set short-circuits to an empty page (no DB rows leak)", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue([]);
+    const res = await app.request(
+      "/api/issues",
+      {},
+      // countN:99/rows present — must be ignored by the empty-set short-circuit
+      makeListEnv({ countN: 99, rows: [makeIssueRow()] }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ issues: unknown[]; total: number }>();
+    expect(body.issues).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it("edge no-leak: a blocker in a non-visible repo is dropped from blocked_by", async () => {
+    vi.mocked(resolveVisibleRepos).mockResolvedValue(["Roxabi/roxabi-live"]);
+    // Faithful INNER-JOIN mock: the blocked_by query returns the hidden blocker ONLY if
+    // its repo was bound into the statement (i.e. is in the visible set). The handler
+    // binds `...visible, rawKey` = ["Roxabi/roxabi-live", key] — "SecretOrg/secret" is
+    // never bound, so the JOIN can't match it → the row never reaches the response.
+    const hiddenBlocker = { key: "SecretOrg/secret#9", number: 9, repo: "SecretOrg/secret" };
+    const env = {
+      DB: {
+        prepare: (sql: string) => ({
+          bind: (...args: unknown[]) => ({
+            first: async () =>
+              sql.includes("FROM issues WHERE key") ? makeIssueRow() : null,
+            all: async () => {
+              if (sql.includes("e.dst_key = ?")) {
+                return { results: args.includes(hiddenBlocker.repo) ? [hiddenBlocker] : [] };
+              }
+              return { results: [] };
+            },
+          }),
+          first: async () => null,
+          all: async () => ({ results: [] }),
+        }),
+        batch: async () => [],
+      },
+      ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
+      GITHUB_ORG: "",
+      GITHUB_WEBHOOK_SECRET: "",
+    } as unknown as Env;
+
+    const res = await app.request("/api/issues/Roxabi/roxabi-live%231", {}, env);
+    const body = await res.json<{ blocked_by: Record<string, unknown>[] }>();
+    // No key/number/repo of the non-visible blocker leaks — the relationship is omitted.
+    expect(body.blocked_by).toEqual([]);
   });
 });

--- a/worker/src/api/issues.ts
+++ b/worker/src/api/issues.ts
@@ -9,18 +9,10 @@
  */
 
 import type { Context } from "hono";
-import type { Env } from "../types";
+import type { AuthEnv } from "../auth/session";
+import { resolveVisibleRepos } from "../auth/repoAccess";
 
 const ISSUE_KEY_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+#[0-9]+$/;
-
-/** Parse 'owner/repo#N' → { repo, number }. Returns { repo: key, number: null } on failure. */
-function parseKey(key: string): { repo: string; number: number | null } {
-  const m = /^(.+)#(\d+)$/.exec(key);
-  if (m) {
-    return { repo: m[1], number: parseInt(m[2], 10) };
-  }
-  return { repo: key, number: null };
-}
 
 interface IssueListRow {
   key: string;
@@ -47,11 +39,13 @@ interface CountRow {
 
 interface EdgeJoinRow {
   key: string;
-  number: number | null;
-  repo: string | null;
+  number: number;
+  repo: string;
 }
 
-export const listIssuesRoute = async (c: Context<{ Bindings: Env }>) => {
+export const listIssuesRoute = async (c: Context<AuthEnv>) => {
+  const visible = await resolveVisibleRepos(c);
+
   const url = new URL(c.req.url);
   const repo = url.searchParams.get("repo");
   const state = url.searchParams.get("state");
@@ -65,8 +59,14 @@ export const listIssuesRoute = async (c: Context<{ Bindings: Env }>) => {
   const limit = Math.max(1, Math.min(rawLimitParsed, 500));
   const offset = Math.max(0, rawOffsetParsed);
 
-  const conditions: string[] = [];
-  const params: (string | number)[] = [];
+  if (visible.length === 0) {
+    return c.json({ issues: [], total: 0, limit, offset });
+  }
+
+  const ph = visible.map(() => "?").join(",");
+
+  const conditions: string[] = [`issues.repo IN (${ph})`];
+  const params: (string | number)[] = [...visible];
 
   if (repo !== null) {
     conditions.push("issues.repo = ?");
@@ -139,7 +139,9 @@ export const listIssuesRoute = async (c: Context<{ Bindings: Env }>) => {
   return c.json({ issues, total, limit, offset });
 };
 
-export const getIssueRoute = async (c: Context<{ Bindings: Env }>) => {
+export const getIssueRoute = async (c: Context<AuthEnv>) => {
+  const visible = await resolveVisibleRepos(c);
+
   // Extract key from path: /api/issues/<owner>/<repo>#<number>
   // The key contains a slash so a single :key param won't match — use wildcard.
   const rawKey = decodeURIComponent(c.req.path.slice("/api/issues/".length));
@@ -151,10 +153,16 @@ export const getIssueRoute = async (c: Context<{ Bindings: Env }>) => {
     );
   }
 
+  if (visible.length === 0) {
+    return c.json({ detail: "Issue not found" }, 404);
+  }
+
+  const ph = visible.map(() => "?").join(",");
+
   const issueSql =
     "SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, is_stub," +
-    " created_at, updated_at, closed_at FROM issues WHERE key = ?";
-  const row = await c.env.DB.prepare(issueSql).bind(rawKey).first<IssueListRow>();
+    ` created_at, updated_at, closed_at FROM issues WHERE key = ? AND repo IN (${ph})`;
+  const row = await c.env.DB.prepare(issueSql).bind(rawKey, ...visible).first<IssueListRow>();
 
   if (!row) {
     return c.json({ detail: "Issue not found" }, 404);
@@ -167,34 +175,38 @@ export const getIssueRoute = async (c: Context<{ Bindings: Env }>) => {
     .all<{ name: string }>();
   const labels = labelsResult.results.map((r) => r.name);
 
-  // blocking: edges where this issue is src (kind=blocks) → dst issues
+  // blocking: edges where this issue is src (kind=blocks) → dst issues.
+  // blocked_by: edges where this issue is dst (kind=blocks) → src issues.
+  // INNER JOIN + `i.repo IN (...)` keeps an edge only when its OTHER endpoint is also
+  // visible (the anchor issue is already confirmed visible above). A blocker in a repo
+  // the caller can't see is dropped entirely — no key/number disclosure — matching the
+  // both-endpoints-visible rule graph.ts enforces.
   const blockingResult = await c.env.DB.prepare(
     "SELECT e.dst_key AS key, i.number, i.repo" +
-      " FROM edges e LEFT JOIN issues i ON i.key = e.dst_key" +
+      ` FROM edges e JOIN issues i ON i.key = e.dst_key AND i.repo IN (${ph})` +
       " WHERE e.src_key = ? AND e.kind = 'blocks'",
   )
-    .bind(rawKey)
+    .bind(...visible, rawKey)
     .all<EdgeJoinRow>();
 
-  // blocked_by: edges where this issue is dst (kind=blocks) → src issues
   const blockedByResult = await c.env.DB.prepare(
     "SELECT e.src_key AS key, i.number, i.repo" +
-      " FROM edges e LEFT JOIN issues i ON i.key = e.src_key" +
+      ` FROM edges e JOIN issues i ON i.key = e.src_key AND i.repo IN (${ph})` +
       " WHERE e.dst_key = ? AND e.kind = 'blocks'",
   )
-    .bind(rawKey)
+    .bind(...visible, rawKey)
     .all<EdgeJoinRow>();
 
-  function edgeItem(edgeRow: EdgeJoinRow) {
-    if (edgeRow.number === null || edgeRow.repo === null) {
-      const parsed = parseKey(edgeRow.key);
-      return { key: edgeRow.key, number: parsed.number, repo: parsed.repo };
-    }
-    return { key: edgeRow.key, number: edgeRow.number, repo: edgeRow.repo };
-  }
-
-  const blocking = blockingResult.results.map(edgeItem);
-  const blocked_by = blockedByResult.results.map(edgeItem);
+  const blocking = blockingResult.results.map((e) => ({
+    key: e.key,
+    number: e.number,
+    repo: e.repo,
+  }));
+  const blocked_by = blockedByResult.results.map((e) => ({
+    key: e.key,
+    number: e.number,
+    repo: e.repo,
+  }));
 
   return c.json({
     key: row.key,

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -228,6 +228,34 @@ describe("meRoute", () => {
     });
   });
 
+  it("response includes active_tenant_id from the session (#148 SC7)", async () => {
+    // Arrange
+    const { db } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    const res = await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — the active tenant is surfaced so the client can render the tenant switcher
+    expect(res.status).toBe(200);
+    const body = await res.json() as { active_tenant_id: number };
+    expect(body.active_tenant_id).toBe(STUB_SESSION.tenantId);
+  });
+
+  it("installations SELECT projects account_type (#148 SC7)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — account_type must be selected so User vs Organization tenants are distinguishable
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).toContain("account_type");
+  });
+
   it("returns 401 when requireSession finds no session cookie (negative guard test)", async () => {
     // Arrange — separate throwaway app mounting real requireSession, no stub session
     // This verifies the guard is not tautological: deleting requireSession would let

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -210,7 +210,7 @@ describe("meRoute", () => {
 
   it("surfaces installation rows returned by D1 in the response body", async () => {
     // Arrange — FakeD1 returns one installation row
-    const fakeRow = { tenant_id: 9, installation_id: 5, account_login: "Roxabi" };
+    const fakeRow = { tenant_id: 9, account_login: "Roxabi", account_type: "Organization" };
     const { db } = captureDbWithRows([fakeRow]);
     const app = makeApp(db);
 
@@ -223,9 +223,23 @@ describe("meRoute", () => {
     expect(body.installations).toHaveLength(1);
     expect(body.installations[0]).toMatchObject({
       tenant_id: 9,
-      installation_id: 5,
       account_login: "Roxabi",
+      account_type: "Organization",
     });
+  });
+
+  it("installations SELECT does NOT project installation_id (#171 — unnecessary exposure removed)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+
+    // Act
+    await app.request("/api/me", {}, makeEnv(db));
+
+    // Assert — installation_id is internal infra detail, not surfaced to clients
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt).toBeDefined();
+    expect(installStmt!.sql).not.toContain("installation_id");
   });
 
   it("response includes active_tenant_id from the session (#148 SC7)", async () => {

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -23,11 +23,11 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
 
   const rows = await c.env.DB
     .prepare(
-      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login, t.account_type AS account_type
+      `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
        FROM user_installations ui JOIN tenants t ON t.id = ui.tenant_id WHERE ui.user_id = ?`,
     )
     .bind(s.userId)
-    .all<{ tenant_id: number; installation_id: number; account_login: string; account_type: string }>();
+    .all<{ tenant_id: number; account_login: string; account_type: string }>();
 
   return c.json({
     user: {

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -23,17 +23,18 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
 
   const rows = await c.env.DB
     .prepare(
-      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login
+      `SELECT ui.tenant_id AS tenant_id, t.installation_id AS installation_id, t.account_login AS account_login, t.account_type AS account_type
        FROM user_installations ui JOIN tenants t ON t.id = ui.tenant_id WHERE ui.user_id = ?`,
     )
     .bind(s.userId)
-    .all<{ tenant_id: number; installation_id: number; account_login: string }>();
+    .all<{ tenant_id: number; installation_id: number; account_login: string; account_type: string }>();
 
   return c.json({
     user: {
       github_id: s.githubId,
       github_login: s.githubLogin,
     },
+    active_tenant_id: s.tenantId,
     installations: rows.results,
   });
 }

--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -593,10 +593,13 @@ describe("listInstallationRepos — W2 pagination bound", () => {
 
   it("stops early on a short final page and does NOT warn (normal case)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ repositories: [{ full_name: "o/only" }] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+      new Response(
+        JSON.stringify({ repositories: [{ full_name: "o/only", private: true }] }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
     );
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -604,7 +607,7 @@ describe("listInstallationRepos — W2 pagination bound", () => {
     const repos = await listInstallationRepos("fake-token");
 
     expect(fetchMock).toHaveBeenCalledTimes(1); // short page → single fetch
-    expect(repos).toEqual(["o/only"]);
+    expect(repos).toEqual([{ repo: "o/only", isPrivate: true }]);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -208,6 +208,7 @@ export async function resolveInstallToken(
 
 interface GHRepository {
   full_name: string;
+  private: boolean;
 }
 
 interface GHInstallationReposResponse {
@@ -221,11 +222,13 @@ interface GHInstallationReposResponse {
  * Paginates automatically (100 per page) until all repos are collected.
  *
  * @param token - GitHub installation access token (from getInstallationToken).
- * @returns Array of `"owner/name"` full_name strings.
+ * @returns Array of `{ repo: "owner/name", isPrivate: boolean }` entries.
  */
-export async function listInstallationRepos(token: string): Promise<string[]> {
+export async function listInstallationRepos(
+  token: string,
+): Promise<Array<{ repo: string; isPrivate: boolean }>> {
   const MAX_PAGES = 10;
-  const repos: string[] = [];
+  const repos: Array<{ repo: string; isPrivate: boolean }> = [];
   let lastPageFull = false;
 
   for (let page = 1; page <= MAX_PAGES; page++) {
@@ -258,7 +261,7 @@ export async function listInstallationRepos(token: string): Promise<string[]> {
     const pageRepos = body.repositories ?? [];
 
     for (const r of pageRepos) {
-      repos.push(r.full_name);
+      repos.push({ repo: r.full_name, isPrivate: r.private });
     }
 
     lastPageFull = pageRepos.length === 100;

--- a/worker/src/auth/repoAccess.test.ts
+++ b/worker/src/auth/repoAccess.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Context } from "hono";
+import type { AuthEnv } from "./session";
+import {
+  resolveVisibleRepos,
+  checkPrivateAccess,
+} from "./repoAccess";
+import {
+  captureDb,
+  dispatchByTable,
+  STUB_SESSION,
+  makeEnv,
+} from "../test-utils";
+
+// ---------------------------------------------------------------------------
+// Mock installToken module
+// ---------------------------------------------------------------------------
+
+vi.mock("./installToken", () => ({
+  getInstallationToken: vi.fn().mockResolvedValue("tok"),
+  encryptToken: vi.fn(),
+  decryptToken: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal Hono Context stub carrying a session and DB env. */
+function makeCtx(
+  db: D1Database,
+  session: AuthEnv["Variables"]["session"],
+): Context<AuthEnv> {
+  const env = makeEnv(db);
+  return {
+    get: (key: string) => (key === "session" ? session : undefined),
+    env,
+  } as unknown as Context<AuthEnv>;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  // Reset global fetch after each test
+  (globalThis as Record<string, unknown>).fetch = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// checkPrivateAccess — cache HIT
+// ---------------------------------------------------------------------------
+
+describe("checkPrivateAccess", () => {
+  it("returns true from cache (has_access=1, fresh) without calling fetch", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [{ has_access: 1 }],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false from cache (has_access=0, fresh) without calling fetch", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [{ has_access: 0 }],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // cache MISS → fetch 204 → granted + UPSERT
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch 204 → returns true and issues a cache UPSERT", async () => {
+    // Arrange
+    const { db, stmts } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [], // miss
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 204 }) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert — access granted
+    expect(result).toBe(true);
+
+    // Assert — a cache UPSERT statement was issued (INSERT INTO user_repo_permission_cache)
+    const upsertStmt = stmts().find((s) =>
+      s.sql.toLowerCase().includes("insert into user_repo_permission_cache"),
+    );
+    expect(upsertStmt).toBeDefined();
+    expect(upsertStmt?.run).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // fetch 404 → denied
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch 404 → returns false", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 404 }) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // fetch 403 → denied
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch 403 → returns false", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 403 }) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // fetch throws (network) → denied AND no cache UPSERT
+  // -------------------------------------------------------------------------
+
+  it("cache miss: fetch throws → returns false and does NOT issue a cache UPSERT", async () => {
+    // Arrange
+    const { db, stmts } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_repo_permission_cache: [],
+        tenants: [{ id: 1 }],
+      }),
+    );
+    const env = makeEnv(db);
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network error")) as typeof fetch;
+
+    // Act
+    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+
+    // Assert — denied
+    expect(result).toBe(false);
+
+    // Assert — no UPSERT issued
+    const upsertStmt = stmts().find((s) =>
+      s.sql.toLowerCase().includes("insert into user_repo_permission_cache"),
+    );
+    expect(upsertStmt).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVisibleRepos
+// ---------------------------------------------------------------------------
+
+describe("resolveVisibleRepos", () => {
+  // -------------------------------------------------------------------------
+  // Public repo — always visible, no fetch
+  // -------------------------------------------------------------------------
+
+  it("public repo (is_private=0) → visible without getInstallationToken or fetch", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        tenant_repo_access: [{ repo: "Roxabi/public", is_private: 0 }],
+      }),
+    );
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+    const ctx = makeCtx(db, STUB_SESSION);
+
+    // Act
+    const visible = await resolveVisibleRepos(ctx);
+
+    // Assert
+    expect(visible).toEqual(["Roxabi/public"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty tenant_repo_access → []
+  // -------------------------------------------------------------------------
+
+  it("empty tenant_repo_access → resolveVisibleRepos returns []", async () => {
+    // Arrange
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        tenant_repo_access: [],
+      }),
+    );
+    const ctx = makeCtx(db, STUB_SESSION);
+
+    // Act
+    const visible = await resolveVisibleRepos(ctx);
+
+    // Assert
+    expect(visible).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // No session on context → []
+  // -------------------------------------------------------------------------
+
+  it("no session on context → resolveVisibleRepos returns []", async () => {
+    // Arrange
+    const { db } = captureDb(() => []);
+    const ctx = makeCtx(db, undefined);
+
+    // Act
+    const visible = await resolveVisibleRepos(ctx);
+
+    // Assert
+    expect(visible).toEqual([]);
+  });
+});

--- a/worker/src/auth/repoAccess.test.ts
+++ b/worker/src/auth/repoAccess.test.ts
@@ -62,7 +62,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = fetchMock as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(true);
@@ -82,7 +82,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = fetchMock as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(false);
@@ -105,7 +105,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ status: 204 }) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert — access granted
     expect(result).toBe(true);
@@ -134,7 +134,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ status: 404 }) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(false);
@@ -156,7 +156,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ status: 403 }) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert
     expect(result).toBe(false);
@@ -178,7 +178,7 @@ describe("checkPrivateAccess", () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("network error")) as typeof fetch;
 
     // Act
-    const result = await checkPrivateAccess(db, env, 1, 42, "Roxabi/secret", "octocat");
+    const result = await checkPrivateAccess(db, env, 1, 1, 42, "Roxabi/secret", "octocat");
 
     // Assert — denied
     expect(result).toBe(false);

--- a/worker/src/auth/repoAccess.ts
+++ b/worker/src/auth/repoAccess.ts
@@ -1,0 +1,252 @@
+/**
+ * Per-request visible-repo resolver and private-repo permission check.
+ *
+ * Security invariant: every uncertain / error path returns false (deny).
+ * This is the IDOR-closing primitive — fail-closed on all branches.
+ *
+ * Never throws out to the caller. All errors are caught internally and
+ * resolved as a denial so transient failures cannot leak private data.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "./session";
+import type { Env } from "../types";
+import { getInstallationToken } from "./installToken";
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface RepoAccessRow {
+  repo: string;
+  is_private: number;
+}
+
+interface TenantInstallRow {
+  installation_id: number;
+}
+
+interface PermCacheRow {
+  has_access: number;
+}
+
+// ---------------------------------------------------------------------------
+// resolveVisibleRepos
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the list of repo full-names visible to the authenticated session user.
+ *
+ * Public repos (is_private = 0) are always included.
+ * Private repos (is_private = 1) are included only if checkPrivateAccess returns true.
+ *
+ * Fail-closed: missing session, DB errors, or any per-repo check error → deny that repo.
+ * installation_id is resolved once before the loop; never re-queried per repo.
+ *
+ * @param c - Hono context carrying AuthEnv (DB binding + session variable).
+ * @returns Array of visible repo full-names ("owner/name").
+ */
+export async function resolveVisibleRepos(
+  c: Context<AuthEnv>,
+): Promise<string[]> {
+  const s = c.get("session");
+  // Middleware guarantees session; guard defensively — fail-closed.
+  if (!s) {
+    return [];
+  }
+
+  const db = c.env.DB;
+  const env = c.env;
+
+  // Fetch all repos registered for this tenant.
+  let rows: RepoAccessRow[];
+  try {
+    const result = await db
+      .prepare(
+        `SELECT repo, is_private FROM tenant_repo_access WHERE tenant_id = ?`,
+      )
+      .bind(s.tenantId)
+      .all<RepoAccessRow>();
+    rows = result.results ?? [];
+  } catch {
+    // DB error — fail-closed, no repos visible.
+    return [];
+  }
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  // Resolve installation_id ONCE for this tenant before iterating private repos.
+  // We only need it if there are private repos, but resolve eagerly to keep the
+  // loop simple and avoid conditional re-queries.
+  let installationId: number | null = null;
+  const hasPrivate = rows.some((r) => r.is_private !== 0);
+  if (hasPrivate) {
+    try {
+      const tenantRow = await db
+        .prepare(
+          `SELECT installation_id FROM tenants WHERE id = ?`,
+        )
+        .bind(s.tenantId)
+        .first<TenantInstallRow>();
+      installationId = tenantRow?.installation_id ?? null;
+    } catch {
+      // DB error — treat all private repos as denied below (installationId = null).
+    }
+  }
+
+  const visible: string[] = [];
+
+  for (const row of rows) {
+    if (row.is_private === 0) {
+      // Public repo — always visible.
+      visible.push(row.repo);
+    } else {
+      // Private repo — check per-user permission.
+      if (installationId === null) {
+        // Could not resolve installation — deny (fail-closed).
+        continue;
+      }
+      const allowed = await checkPrivateAccess(
+        db,
+        env,
+        s.userId,
+        installationId,
+        row.repo,
+        s.githubLogin,
+      );
+      if (allowed) {
+        visible.push(row.repo);
+      }
+    }
+  }
+
+  return visible;
+}
+
+// ---------------------------------------------------------------------------
+// checkPrivateAccess
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a user has read access to a private repository.
+ *
+ * Cache path (24 h TTL): reads user_repo_permission_cache. Hit → return cached value.
+ * Live path (cache miss / stale):
+ *   - Mints an installation access token via getInstallationToken.
+ *   - Calls GET /repos/{repo}/collaborators/{login} with the token.
+ *   - HTTP 204 → access granted. HTTP 404 or 403 → access denied.
+ *   - On 204/404/403: UPSERTs result into cache, then returns boolean.
+ *   - Any other status, network error, or thrown exception → fail-closed (false),
+ *     cache is NOT written (transient failure must not poison future cache hits).
+ *
+ * @param db             - D1 database binding.
+ * @param env            - Worker env bindings (for getInstallationToken).
+ * @param userId         - users.id of the authenticated user.
+ * @param installationId - GitHub App installation_id (resolved by the caller).
+ * @param repo           - Full repo name "owner/name" (already validated by caller).
+ * @param login          - GitHub login of the user (for the collaborator check URL).
+ * @returns true if the user has access, false in all other cases (deny-by-default).
+ */
+export async function checkPrivateAccess(
+  db: D1Database,
+  env: Env,
+  userId: number,
+  installationId: number,
+  repo: string,
+  login: string,
+): Promise<boolean> {
+  // Step 1 — Cache check (24 h TTL).
+  try {
+    const cached = await db
+      .prepare(
+        `SELECT has_access FROM user_repo_permission_cache
+         WHERE user_id = ? AND repo = ? AND checked_at > datetime('now','-24 hours')`,
+      )
+      .bind(userId, repo)
+      .first<PermCacheRow>();
+
+    if (cached !== null && cached !== undefined) {
+      // Cache hit — return stored value.
+      return Boolean(cached.has_access);
+    }
+  } catch {
+    // Cache read failure — proceed to live check; do not short-circuit to false
+    // (a DB read error should not permanently deny a user; live check can clarify).
+  }
+
+  // Step 2 — Live check via GitHub Collaborators API.
+  // Any error in this block must return false without writing cache.
+  let access: boolean;
+  try {
+    // Resolve installation access token (tenant_id not needed by caller-side contract;
+    // installToken.ts requires it for cache keying — we use tenantId=0 sentinel is wrong;
+    // instead we need the actual tenantId). However, getInstallationToken's signature
+    // requires tenantId. The caller (resolveVisibleRepos) has it, but checkPrivateAccess
+    // receives only installationId. To keep this function self-contained and the interface
+    // clean, we look up the tenantId from the tenants table using installationId.
+    const tenantRow = await db
+      .prepare(`SELECT id FROM tenants WHERE installation_id = ?`)
+      .bind(installationId)
+      .first<{ id: number }>();
+
+    if (!tenantRow) {
+      // No matching tenant — fail-closed.
+      return false;
+    }
+
+    const token = await getInstallationToken(
+      db,
+      env,
+      tenantRow.id,
+      installationId,
+    );
+
+    // GET /repos/{owner}/{name}/collaborators/{login}
+    // repo is already "owner/name" — use directly.
+    const url = `https://api.github.com/repos/${repo}/collaborators/${encodeURIComponent(login)}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "roxabi-live-worker",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (res.status === 204) {
+      access = true;
+    } else if (res.status === 404 || res.status === 403) {
+      access = false;
+    } else {
+      // Unexpected status (5xx, 429, etc.) — fail-closed, do NOT cache.
+      return false;
+    }
+  } catch {
+    // Network failure, token mint error, or any thrown exception — fail-closed.
+    // Do NOT write cache: a transient failure must not poison future reads.
+    return false;
+  }
+
+  // Step 3 — UPSERT result into cache (only reached on 204 / 404 / 403).
+  try {
+    await db
+      .prepare(
+        `INSERT INTO user_repo_permission_cache (user_id, repo, has_access, checked_at)
+         VALUES (?, ?, ?, datetime('now'))
+         ON CONFLICT(user_id, repo) DO UPDATE SET
+           has_access = excluded.has_access,
+           checked_at = excluded.checked_at`,
+      )
+      .bind(userId, repo, access ? 1 : 0)
+      .run();
+  } catch {
+    // Cache write failure — log-only concern; return the live result regardless.
+    // A failed upsert means the next request re-checks live; it does not affect
+    // the current request's answer.
+  }
+
+  return access;
+}

--- a/worker/src/auth/repoAccess.ts
+++ b/worker/src/auth/repoAccess.ts
@@ -112,6 +112,7 @@ export async function resolveVisibleRepos(
         db,
         env,
         s.userId,
+        s.tenantId,
         installationId,
         row.repo,
         s.githubLogin,
@@ -144,6 +145,7 @@ export async function resolveVisibleRepos(
  * @param db             - D1 database binding.
  * @param env            - Worker env bindings (for getInstallationToken).
  * @param userId         - users.id of the authenticated user.
+ * @param tenantId       - tenants.id (supplied by the caller, which already holds it).
  * @param installationId - GitHub App installation_id (resolved by the caller).
  * @param repo           - Full repo name "owner/name" (already validated by caller).
  * @param login          - GitHub login of the user (for the collaborator check URL).
@@ -153,6 +155,7 @@ export async function checkPrivateAccess(
   db: D1Database,
   env: Env,
   userId: number,
+  tenantId: number,
   installationId: number,
   repo: string,
   login: string,
@@ -180,26 +183,12 @@ export async function checkPrivateAccess(
   // Any error in this block must return false without writing cache.
   let access: boolean;
   try {
-    // Resolve installation access token (tenant_id not needed by caller-side contract;
-    // installToken.ts requires it for cache keying — we use tenantId=0 sentinel is wrong;
-    // instead we need the actual tenantId). However, getInstallationToken's signature
-    // requires tenantId. The caller (resolveVisibleRepos) has it, but checkPrivateAccess
-    // receives only installationId. To keep this function self-contained and the interface
-    // clean, we look up the tenantId from the tenants table using installationId.
-    const tenantRow = await db
-      .prepare(`SELECT id FROM tenants WHERE installation_id = ?`)
-      .bind(installationId)
-      .first<{ id: number }>();
-
-    if (!tenantRow) {
-      // No matching tenant — fail-closed.
-      return false;
-    }
-
+    // tenantId + installationId are both supplied by the caller (resolveVisibleRepos),
+    // which already holds them on the session — no reverse lookup needed.
     const token = await getInstallationToken(
       db,
       env,
-      tenantRow.id,
+      tenantId,
       installationId,
     );
 

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -149,6 +149,30 @@ export async function validateSession(
 }
 
 /**
+ * Switch the active tenant for an existing session.
+ * Hashes the raw token, then updates sessions.tenant_id in place.
+ * The UPDATE is a no-op if the session has expired or been revoked,
+ * which is safe — the caller (activeTenantRoute) guards membership first.
+ */
+export async function setSessionTenant(
+  db: D1Database,
+  rawToken: string,
+  tenantId: number,
+): Promise<void> {
+  const hash = await sha256hex(rawToken);
+
+  await db
+    .prepare(
+      `UPDATE sessions SET tenant_id = ?
+       WHERE token_hash = ?
+         AND revoked_at IS NULL
+         AND expires_at > datetime('now')`,
+    )
+    .bind(tenantId, hash)
+    .run();
+}
+
+/**
  * Delete a session by raw token (hashes before querying).
  */
 export async function deleteSession(

--- a/worker/src/router.test.ts
+++ b/worker/src/router.test.ts
@@ -1,0 +1,262 @@
+/**
+ * router.test.ts — auth gate fires before DB work.
+ *
+ * Verifies that requireSession short-circuits the /api/issues, /api/issues/*,
+ * and /api/graph routes before any D1 access when no session cookie is present.
+ * Also provides a positive control confirming the gate admits a valid session.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Env } from "./types";
+import type { SessionContext } from "./auth/session";
+import { app } from "./router";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// DB stub helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a D1Database stub whose .prepare throws if called.
+ * Use this to assert the DB is never touched on the 401 path.
+ */
+function makeDbThatMustNotBeCalled(): D1Database {
+  const errorMsg = "DB must not be touched on 401 path";
+  return {
+    prepare: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+    batch: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+    dump: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+    exec: vi.fn(() => {
+      throw new Error(errorMsg);
+    }),
+  } as unknown as D1Database;
+}
+
+/**
+ * Returns a D1Database stub that answers validateSession's query with a
+ * valid session row, so requireSession admits the request.
+ *
+ * validateSession calls:
+ *   db.prepare(SELECT … FROM sessions s JOIN users …).bind(hash).first()
+ *
+ * We intercept via bind().first() returning the stub row.
+ */
+function makeSessionDb(session: SessionContext): D1Database {
+  const validRow = {
+    userId: session.userId,
+    tenantId: session.tenantId,
+    githubId: session.githubId,
+    githubLogin: session.githubLogin,
+  };
+
+  const bindStmt = {
+    first: vi.fn().mockResolvedValue(validRow),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+    bind: vi.fn(function (this: unknown) { return this; }),
+  };
+
+  const stmt = {
+    first: vi.fn().mockResolvedValue(validRow),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+    bind: vi.fn(() => bindStmt),
+  };
+
+  return {
+    prepare: vi.fn(() => stmt),
+    batch: vi.fn().mockResolvedValue([]),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+// ---------------------------------------------------------------------------
+// Env builder
+// ---------------------------------------------------------------------------
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: {
+      fetch: async () => new Response("asset", { status: 200 }),
+    } as unknown as Fetcher,
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+// Canonical stub session for positive control
+const STUB_SESSION: SessionContext = {
+  userId: 1,
+  tenantId: 1,
+  githubId: 1001,
+  githubLogin: "octocat",
+};
+
+// A plausible raw session token (64-char hex)
+const VALID_RAW_TOKEN = "a".repeat(64);
+
+// ---------------------------------------------------------------------------
+// Negative tests — no Cookie header → 401, DB must not be touched
+// ---------------------------------------------------------------------------
+
+describe("requireSession auth gate", () => {
+  describe("GET /api/issues — no cookie", () => {
+    it("returns 401 with {error: unauthorized}", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request("/api/issues", {}, env);
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+
+    it("never calls DB.prepare on 401 path", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act — must not throw (DB.prepare is guarded by requireSession returning early)
+      const res = await app.request("/api/issues", {}, env);
+
+      // Assert — 401 means requireSession returned before touching DB
+      expect(res.status).toBe(401);
+      expect(db.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/issues/:key — no cookie", () => {
+    it("returns 401 with {error: unauthorized}", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act — encoded Roxabi/alpha#42
+      const res = await app.request(
+        "/api/issues/Roxabi%2Falpha%2342",
+        {},
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+
+    it("never calls DB.prepare on 401 path", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request(
+        "/api/issues/Roxabi%2Falpha%2342",
+        {},
+        env,
+      );
+
+      // Assert
+      expect(res.status).toBe(401);
+      expect(db.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/graph — no cookie", () => {
+    it("returns 401 with {error: unauthorized}", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request("/api/graph", {}, env);
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+
+    it("never calls DB.prepare on 401 path", async () => {
+      // Arrange
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request("/api/graph", {}, env);
+
+      // Assert
+      expect(res.status).toBe(401);
+      expect(db.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Positive control — valid session cookie must NOT produce 401
+  // -------------------------------------------------------------------------
+
+  describe("positive control — valid session cookie", () => {
+    it("GET /api/issues with valid session does not return 401", async () => {
+      // Arrange — DB answers validateSession's query with a valid row
+      const db = makeSessionDb(STUB_SESSION);
+      const env = makeEnv(db);
+
+      // Act — send a plausible raw token in the __Host-session cookie
+      const res = await app.request(
+        "/api/issues",
+        { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+
+      // Assert — gate passed; handler ran (may be 200 or non-401 error from handler)
+      expect(res.status).not.toBe(401);
+    });
+
+    it("GET /api/graph with valid session does not return 401", async () => {
+      // Arrange
+      const db = makeSessionDb(STUB_SESSION);
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request(
+        "/api/graph",
+        { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+
+      // Assert
+      expect(res.status).not.toBe(401);
+    });
+
+    it("GET /api/issues/:key with valid session does not return 401", async () => {
+      // Arrange
+      const db = makeSessionDb(STUB_SESSION);
+      const env = makeEnv(db);
+
+      // Act
+      const res = await app.request(
+        "/api/issues/Roxabi%2Falpha%2342",
+        { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+
+      // Assert
+      expect(res.status).not.toBe(401);
+    });
+  });
+});

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -9,6 +9,7 @@ import { checkAdminAuth } from "./api/auth";
 import { loginRoute, callbackRoute } from "./auth/oauth";
 import { meRoute, logoutRoute } from "./api/me";
 import { requireSession, type AuthEnv } from "./auth/session";
+import { activeTenantRoute } from "./api/active-tenant";
 
 const app = new Hono<AuthEnv>();
 
@@ -20,12 +21,16 @@ app.get("/api/version", versionRoute);
 // POST /webhook/github — HMAC-verified GitHub org webhooks (S5, #97).
 app.post("/webhook/github", webhookRoute);
 
-// GET /api/graph — v6 graph payload: nodes + edges (S6, #98).
+// GET /api/graph — v6 graph payload: nodes + edges (S6, #98). Session-gated (#148).
+app.use("/api/graph", requireSession);
 app.get("/api/graph", graphRoute);
 
 // GET /api/issues — list with optional repo/state/label/limit/offset filters (S6, #98).
 // GET /api/issues/* — single issue by key (key contains owner/repo#N slash) (S6, #98).
 // List route MUST be registered before the wildcard so Hono's first-match wins.
+// Both paths need their own use() — /api/issues/* does NOT match bare /api/issues (#148).
+app.use("/api/issues", requireSession);
+app.use("/api/issues/*", requireSession);
 app.get("/api/issues", listIssuesRoute);
 app.get("/api/issues/*", getIssueRoute);
 
@@ -64,6 +69,7 @@ app.get("/login", loginRoute);
 app.get("/oauth/callback", callbackRoute);
 app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
+app.post("/api/active-tenant", requireSession, activeTenantRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1054,7 +1054,7 @@ describe("runSync", () => {
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
     // listInstallationRepos returns only roxabi-factory (lyra is gone)
-    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "Roxabi/roxabi-factory", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
@@ -1093,7 +1093,7 @@ describe("runSync", () => {
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
     // listInstallationRepos returns both repos — roxabi-vault is still accessible
-    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory", "Roxabi/roxabi-vault"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "Roxabi/roxabi-factory", isPrivate: false }, { repo: "Roxabi/roxabi-vault", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     const mockGhGraphql = vi.mocked(ghGraphql);
@@ -1258,7 +1258,7 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
     // Both tenants enumerate the same repo "o/r"
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("key='halted'")) return makeFakeStmt(sql, args, [{ value: "0" }], 0);
@@ -1300,7 +1300,7 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
     // Discovery must yield ≥1 repo so Phase 2 runs and reaches the slot-advance write.
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1387,7 +1387,7 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
     // runSync must use getInstallationToken() and never read env.GITHUB_TOKEN.
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("fake-token");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["Roxabi/roxabi-factory"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "Roxabi/roxabi-factory", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1501,7 +1501,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     // Arrange
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("tok");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/keep"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/keep", isPrivate: true }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1555,10 +1555,12 @@ describe("runSync — breaker + discovery (#160)", () => {
     const recorded = db._recorded;
     const insertKeep = recorded.find(
       (s) =>
-        s.sql.includes("INSERT OR IGNORE INTO tenant_repo_access") &&
+        s.sql.includes("INSERT INTO tenant_repo_access") &&
         s.args.includes("o/keep"),
     );
     expect(insertKeep).toBeDefined();
+    // #148: is_private written (o/keep mocked private → bound 1; args = [tenantId, repo, is_private])
+    expect(insertKeep?.args[2]).toBe(1);
 
     // Assert — DELETE for "o/stale" (not for "o/keep")
     const deleteStale = recorded.find(
@@ -1576,11 +1578,77 @@ describe("runSync — breaker + discovery (#160)", () => {
     expect(deleteKeep).toBeUndefined();
   });
 
+  it("B3b: discoverTenants writes is_private=0 for a public repo", async () => {
+    // Arrange
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("tok");
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/pub", isPrivate: false }]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      // Global tick lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // Tenant lock → acquired
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      // halted guard
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // auth_failures SELECT → not halted
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      // tenants discovery → 1 tenant
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      // existing tenant_repo_access rows → same as current (no stale)
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/pub" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — INSERT for "o/pub" with is_private=0
+    const recorded = db._recorded;
+    const insertPub = recorded.find(
+      (s) =>
+        s.sql.includes("INSERT INTO tenant_repo_access") &&
+        s.args.includes("o/pub"),
+    );
+    expect(insertPub).toBeDefined();
+    // #148: is_private=0 for public repo (args = [tenantId, repo, is_private])
+    expect(insertPub?.args[2]).toBe(0);
+  });
+
   it("B4: token-exhausted repo is skipped, runSync resolves without throwing", async () => {
     // Arrange — getInstallationToken always rejects for Phase 2 lookups
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockRejectedValue(new Error("no-token"));
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/a"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/a", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({
@@ -1641,7 +1709,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     vi.mocked(getInstallationToken)
       .mockResolvedValueOnce("tok-discovery") // Phase 1 success
       .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
@@ -1703,7 +1771,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     vi.mocked(getInstallationToken)
       .mockResolvedValueOnce("tok-discovery") // Phase 1 success
       .mockRejectedValue(new Error("systemic-error")); // Phase 2 failures
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/r"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/r", isPrivate: false }]);
 
     const db = makeFakeDb((sql, args) => {
       if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
@@ -1759,7 +1827,7 @@ describe("runSync — breaker + discovery (#160)", () => {
     // Arrange — 1 tenant id=7, 1 repo synced OK
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
     vi.mocked(getInstallationToken).mockResolvedValue("tok-7");
-    vi.mocked(listInstallationRepos).mockResolvedValue(["o/ok"]);
+    vi.mocked(listInstallationRepos).mockResolvedValue([{ repo: "o/ok", isPrivate: false }]);
 
     const { ghGraphql } = await import("./graphql");
     vi.mocked(ghGraphql).mockResolvedValue({

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -1105,7 +1105,7 @@ export async function discoverTenants(
     }
 
     try {
-      let repos: string[];
+      let repos: Array<{ repo: string; isPrivate: boolean }>;
       try {
         const token = await getInstallationToken(db, env, tenantId, installationId);
         repos = await listInstallationRepos(token);
@@ -1115,20 +1115,22 @@ export async function discoverTenants(
         continue;
       }
 
-      // Upsert accessible repos into tenant_repo_access.
+      // Upsert accessible repos into tenant_repo_access (sets is_private on every sync
+      // so public repos converge to is_private=0; DEFAULT 1 = fail-closed for new rows).
       if (repos.length > 0) {
-        const upsertStmts = repos.map((repo) =>
+        const upsertStmts = repos.map((r) =>
           db
             .prepare(
-              `INSERT OR IGNORE INTO tenant_repo_access (tenant_id, repo) VALUES (?, ?)`,
+              `INSERT INTO tenant_repo_access (tenant_id, repo, is_private) VALUES (?, ?, ?)
+               ON CONFLICT(tenant_id, repo) DO UPDATE SET is_private = excluded.is_private`,
             )
-            .bind(tenantId, repo),
+            .bind(tenantId, r.repo, r.isPrivate ? 1 : 0),
         );
         await batchChunked(db, upsertStmts);
       }
 
       // Delete stale rows: repos no longer returned by the installation.
-      const repoSet = new Set(repos);
+      const repoSet = new Set(repos.map((r) => r.repo));
       const existing = await db
         .prepare(`SELECT repo FROM tenant_repo_access WHERE tenant_id = ?`)
         .bind(tenantId)
@@ -1145,7 +1147,7 @@ export async function discoverTenants(
       }
 
       // Merge into global map (sorted ascending by tenantId — maintained by ORDER BY above).
-      for (const repo of repos) {
+      for (const { repo } of repos) {
         const entry = repoMap.get(repo);
         if (entry) {
           entry.push({ tenantId, installationId });

--- a/worker/src/test-utils.ts
+++ b/worker/src/test-utils.ts
@@ -1,0 +1,199 @@
+/**
+ * test-utils.ts — shared FakeD1 harness for Worker vitest suites.
+ *
+ * NOT a test file — no `describe`/`it`/`expect`. Imported by *.test.ts files.
+ * Sources consolidated from: me.test.ts, session.test.ts, installToken.test.ts
+ */
+
+import { vi } from "vitest";
+import type { Env } from "./types";
+import type { SessionContext } from "./auth/session";
+
+// ---------------------------------------------------------------------------
+// Core FakeD1 types
+// ---------------------------------------------------------------------------
+
+export type FakeResult = { [k: string]: unknown };
+
+export interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level primitives
+// ---------------------------------------------------------------------------
+
+export function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+export function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Higher-level capture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a FakeD1 that records every prepared statement.
+ *
+ * Optional `handler` receives (sql, args) and returns rows for that query.
+ * When omitted, every query returns empty rows (same as original captureDb()).
+ */
+export function captureDb(
+  handler?: (sql: string, args: unknown[]) => FakeResult[],
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const rows = handler ? handler(sql, args) : [];
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/** Every query returns the same fixed rows. */
+export function captureDbWithRows(
+  rows: FakeResult[],
+): { db: D1Database; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+/**
+ * Every query returns the single provided row (or null).
+ * Sourced from session.test.ts — useful for single-row lookups (SELECT … LIMIT 1).
+ */
+export function fixedFirstDb(row: FakeResult | null): D1Database {
+  return makeFakeDb((sql, args) =>
+    makeFakeStmt(sql, args, row !== null ? [row] : [], 0),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SQL-dispatch helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Route a SQL string to a row set by matching table-name keywords.
+ *
+ * Keys in `map` are matched against `sql.toLowerCase()` via `includes()`.
+ * First match wins. Returns `[]` when no key matches.
+ *
+ * Typical use inside a `captureDb` handler:
+ *
+ *   const { db } = captureDb((sql) =>
+ *     dispatchByTable(sql, {
+ *       "tenant_repo_access":          [{ repo_id: 1, tenant_id: 1 }],
+ *       "user_repo_permission_cache":  [{ permission: "read" }],
+ *       "tenants":                     [{ id: 1, github_org: "Roxabi" }],
+ *     }),
+ *   );
+ *
+ * Keys for the two new #148 tables (`tenant_repo_access`, `user_repo_permission_cache`)
+ * are deliberately called out in the example above.
+ */
+export function dispatchByTable(
+  sql: string,
+  map: Record<string, FakeResult[]>,
+): FakeResult[] {
+  const lower = sql.toLowerCase();
+  for (const [key, rows] of Object.entries(map)) {
+    if (lower.includes(key.toLowerCase())) {
+      return rows;
+    }
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical stub session for #148 tests.
+ * Values differ from per-file stubs in older tests (alice/7/9/42) — use these
+ * for all new Wave-1 / Wave-2 tests unless a specific scenario requires custom values.
+ */
+export const STUB_SESSION: SessionContext = {
+  userId: 1,
+  tenantId: 1,
+  githubId: 1001,
+  githubLogin: "octocat",
+};
+
+/**
+ * Minimal Env builder — only fields required by most route handlers.
+ * Cast via `unknown as Env` so callers do not need to satisfy optional fields.
+ */
+export function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: {
+      fetch: async () => new Response("asset", { status: 200 }),
+    } as unknown as Fetcher,
+    GITHUB_ORG: "",
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}


### PR DESCRIPTION
Promote staging → main to complete **epic #141 Phase 1** on prod. **This is the mandatory prerequisite for the CF Access narrowing** (S7 #150): it deploys the Worker-side session gate to prod so that, once CF Access is narrowed to `/admin/*`, the public app is protected by `requireSession` — not left open.

## ⚠️ Why this must land before the Access flip
On `main` today, `/api/graph` + `/api/issues` are `app.get(...)` with **no `requireSession`** — they are protected **only** by the edge CF Access wall. `#148` added the session middleware on staging but it was never promoted. Narrowing Access without this promote = `/api/*` open to the internet (IDOR). This PR closes that gap.

## Delta (11 commits)
- **#148** — tenant-filtered reads: `requireSession` on `/api/graph,issues,me,active-tenant`; per-user private-repo authz; `0007_repo_access_is_private` (fail-closed `DEFAULT 1`)
- **#149** — frontend login + consent gate (`frontend/auth.js`); org-picker; consent overlay
- **#150** — `0008_tenant_not_null` (`sync_control.value` → NOT NULL, self-guarding); `frontend/.assetsignore`; CF Access cutover runbook (`docs/s7-access-cutover.md`)

## Prod effects on merge (CI deploy job)
- `wrangler d1 migrations apply DB --remote` → applies **0007 + 0008** to prod D1 (0004-0006 already applied). Both validated on staging; 0008 self-guards on NULL.
- `wrangler deploy` → prod Worker gains `requireSession` on `/api/*` + the `#149` frontend gate + `.assetsignore`.
- Prod stays **double-gated** (CF Access wall still in front) until the operator narrows Access — i.e. **no exposure window** is created by this merge.
- Known: `is_private` defaults to 1 (fail-closed) until the hourly sync / `/admin/sync` converges public repos to 0.

## After merge (operator)
Run `docs/s7-access-cutover.md` Phase 3 — add the `/admin` Access app, verify, remove the catch-all. Then post-flip verification curls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)