### PR TITLE
fix(ui): consent-gate overlay always painted — hidden overridden by display:flex

### DIFF
--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -1,5 +1,18 @@
 /* auth.css — Login gate, consent overlay, operator notice, org picker, logout btn */
 
+/* ─── hidden-attribute guard (MUST precede the display rules below in intent) ──
+   The `hidden` HTML attribute is UA `[hidden]{display:none}` at specificity
+   (0,1,0) — which TIES with the `.auth-view` / `.consent-gate` class rules that
+   set `display:flex`, and author rules win the tie. Without this, the EMPTY
+   #consent-gate (position:fixed, inset:0, z-index:600, dark backdrop) is painted
+   on page load and buries the landing/install views under a full-screen dark
+   overlay (the user cannot reach "Sign in"). Raising specificity to (0,2,0) via
+   the attribute selector lets `hidden` win until JS removes it. */
+.auth-view[hidden],
+.consent-gate[hidden] {
+  display: none;
+}
+
 /* ─── Auth views (landing + install) ────────────────────────────────────────── */
 
 .auth-view {


### PR DESCRIPTION
**Prod hotfix.** After the #150 promote deployed the #149 frontend auth-gate to prod, the first real-browser load showed a **dark page blocking sign-in**.

## Root cause
`.auth-view { display:flex }` and `.consent-gate { display:flex }` (auth.css) **tie** the UA `[hidden]{display:none}` at specificity `(0,1,0)` — and author rules win the tie. So the `hidden` HTML attribute was **ignored**, and the empty `#consent-gate` (`position:fixed; inset:0; z-index:600; background:rgba(0,0,0,.72)`) was painted on load, burying the landing/install views under a full-screen dark overlay. The user can't reach "Sign in with GitHub".

The **consent step itself** renders fine (`renderConsentGate` fills the overlay with the dialog) — only the **landing/install** views were buried. That's why it looked like "consent doesn't work" when it's actually the empty consent overlay covering the landing.

## Why it shipped unseen
jsdom unit tests don't evaluate CSS cascade/layout, and **SC2 (real-browser flow) was deferred to manual /verify and never executed** (`ui-manual-only`, no e2e harness). This PR is the first browser load.

## Fix
```css
.auth-view[hidden],
.consent-gate[hidden] { display: none; }
```
Specificity `(0,2,0)` (class+attribute) beats the `(0,1,0)` class display rule → `hidden` wins until JS removes it. Other hidden elements (`org-picker`, `logout-btn .theme-btn`, `operator-notice`) set no `display` rule → unaffected.

## Verification (SC2 — this time for real)
After merge → staging deploy, load `https://roxabi-live-staging.mickael-b5e.workers.dev` in a browser (no Access in front): expect the **landing / "Sign in with GitHub"** view, not a dark page. Then promote to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)