### PR TITLE
docs: self-hosting deploy guide + CF-era doc refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,162 @@
-# Roxabi Dashboard — environment variables
-# Copy to .env and fill in values. Never commit .env.
+# roxabi-live — configuration reference
+#
+# THIS PROJECT IS A CLOUDFLARE WORKER.
+# Runtime secrets are NOT loaded from a .env file.
+#
+# How secrets are set:
+#   Production/staging : wrangler secret put <KEY> [--env staging]
+#   Local dev          : worker/.dev.vars  (KEY=VALUE, one per line; gitignored; read
+#                        automatically by `wrangler dev` — do NOT commit this file)
+#
+# This file is a CHECKLIST only — not a file you source or copy.
+# Remove this comment block before using the commands below.
 
-# Path to the corpus SQLite database (default: ~/.roxabi/corpus.db)
-CORPUS_DB_PATH=
+# ── Worker secrets (wrangler secret put) ─────────────────────────────────────
+#
+# Set each secret with:
+#   printf %s 'VALUE' | wrangler secret put KEY               # prod
+#   printf %s 'VALUE' | wrangler secret put KEY --env staging # staging
+#
+# For local dev: add KEY=VALUE lines to worker/.dev.vars instead.
 
-# GitHub webhook HMAC secret (set when configuring the org webhook)
+# GITHUB_WEBHOOK_SECRET
+#   HMAC-SHA256 secret for GitHub org-level webhook → POST /webhook/github
+#   (X-Hub-Signature-256 header verification in worker/src/webhook/hmac.ts)
+#   Obtain: set when configuring the org webhook in GitHub → Settings → Webhooks
+#   wrangler secret put GITHUB_WEBHOOK_SECRET [--env staging]
 GITHUB_WEBHOOK_SECRET=
 
-# Cloudflare tunnel name (for cloudflared supervisor program)
-CLOUDFLARED_TUNNEL_NAME=
+# GITHUB_APP_ID
+#   GitHub App numeric ID — used for App-JWT generation (install-token flow)
+#   Obtain: GitHub → Settings → Developer settings → GitHub Apps → your app → App ID
+#   wrangler secret put GITHUB_APP_ID [--env staging]
+#   Note: also injected post-deploy by CI from repo secret GH_APP_ID
+GITHUB_APP_ID=
 
-# Corpus reconciler interval in seconds (default: 3600)
-CORPUS_SYNC_INTERVAL_SECONDS=3600
+# GITHUB_APP_CLIENT_ID
+#   GitHub App OAuth client ID — used in GET /login → GET /oauth/callback flow
+#   Obtain: GitHub App settings → Client ID
+#   wrangler secret put GITHUB_APP_CLIENT_ID [--env staging]
+#   Note: NOT injected by CI — set it manually. There is no GH_APP_CLIENT_ID repo
+#         secret and no injection step in ci.yml (do not confuse with GH_APP_ID,
+#         which maps to the numeric GITHUB_APP_ID).
+GITHUB_APP_CLIENT_ID=
 
-# ── Cloudflare Worker secrets (set via `wrangler secret put <KEY>`) ─────────
-# Defense-in-depth token for /admin/* endpoints (#123).
-# Unset = no Worker-side gate (Cloudflare Access edge is the only guard).
-# Set to a strong random value to enable the gate:
-#   wrangler secret put ADMIN_TOKEN            # prod
-#   wrangler secret put ADMIN_TOKEN --env staging
+# GITHUB_APP_CLIENT_SECRET
+#   GitHub App OAuth client secret — used in /oauth/callback token exchange
+#   Obtain: GitHub App settings → Generate a client secret
+#   wrangler secret put GITHUB_APP_CLIENT_SECRET [--env staging]
+#   Note: NOT injected by CI — set it manually. No repo secret and no injection
+#         step in ci.yml; skipping this breaks the /oauth/callback token exchange.
+GITHUB_APP_CLIENT_SECRET=
+
+# GITHUB_APP_PRIVATE_KEY
+#   base64-encoded PKCS#8 DER RSA private key for signing App-JWTs
+#   Used for install-token generation (worker/src/sync/graphql.ts)
+#   Obtain: GitHub App settings → Generate a private key → convert to PKCS#8 DER → base64
+#   wrangler secret put GITHUB_APP_PRIVATE_KEY [--env staging]
+#   Note: CI injects post-deploy from repo secret GH_APP_PRIVATE_KEY
+GITHUB_APP_PRIVATE_KEY=
+
+# GITHUB_APP_WEBHOOK_SECRET
+#   App-level webhook HMAC secret (distinct from the org-level GITHUB_WEBHOOK_SECRET)
+#   Obtain: GitHub App settings → Webhook secret field
+#   wrangler secret put GITHUB_APP_WEBHOOK_SECRET [--env staging]
+#   Note: CI injects post-deploy from repo secret GH_APP_WEBHOOK_SECRET
+#   Note: this is present in the Env interface but the live /webhook/github handler
+#         reads GITHUB_WEBHOOK_SECRET (org-level), not this one
+GITHUB_APP_WEBHOOK_SECRET=
+
+# INSTALL_TOKEN_KEY
+#   base64-encoded 32-byte AES-GCM DEK for encrypting GitHub App installation tokens
+#   stored at rest in D1 table install_tokens
+#   Obtain: generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+#   wrangler secret put INSTALL_TOKEN_KEY [--env staging]
+#   Note: CI injects post-deploy from repo secret GH_INSTALL_TOKEN_KEY
+INSTALL_TOKEN_KEY=
+
+# ADMIN_TOKEN
+#   Optional Bearer token for POST /admin/sync — defense-in-depth gate at Worker level
+#   in addition to the Cloudflare Access Email-OTP edge policy on /admin/*
+#   Unset = Worker-level gate disabled; CF Access edge alone guards /admin/*
+#   Obtain: generate any strong random string (e.g. openssl rand -hex 32)
+#   wrangler secret put ADMIN_TOKEN [--env staging]
 ADMIN_TOKEN=
+
+# NOTIFY_URL
+#   Optional webhook URL for halt/auth-failure alerts from the sync circuit breaker
+#   Unset = no notifications sent on halt
+#   wrangler secret put NOTIFY_URL [--env staging]
+NOTIFY_URL=
+
+
+# ── wrangler.toml [vars] (NOT secrets — set in wrangler.toml, not here) ──────
+#
+# GITHUB_ORG
+#   GitHub org slug to sync (e.g. "YourOrg")
+#   In practice treated as a secret — set via:
+#   wrangler secret put GITHUB_ORG [--env staging]
+#
+#   <!-- TODO: confirm whether GITHUB_ORG is in [vars] or always secret put in your fork -->
+
+
+# ── CI repo secrets (GitHub Actions → Settings → Secrets → Actions) ──────────
+#
+# These are NOT Worker runtime secrets — they are used by the deploy workflow
+# (push to staging → staging deploy; push to main → prod deploy).
+#
+# CF_API_TOKEN
+#   Cloudflare API token with Worker deploy + D1 migrations + secret write permissions
+#   Obtain: Cloudflare dashboard → My Profile → API Tokens → Create Token
+#           <!-- TODO: minimum required permissions: Workers Scripts:Edit, D1:Edit, Workers Secrets:Edit -->
+#
+# CLOUDFLARE_ACCOUNT_ID
+#   Required because the CF API token may be scoped to multiple accounts
+#   Obtain: Cloudflare dashboard → right sidebar when in an account → Account ID
+#   <!-- TODO: replace with your own account ID: <YOUR_CF_ACCOUNT_ID> -->
+#
+# GH_APP_ID
+#   GitHub App numeric ID (injected post-deploy as Worker secret GITHUB_APP_ID)
+#   Note: GitHub Actions forbids GITHUB_-prefixed secret names; GH_APP_* prefix used instead
+#
+# GH_APP_PRIVATE_KEY
+#   base64 PKCS#8 DER RSA private key (injected post-deploy as GITHUB_APP_PRIVATE_KEY)
+#
+# GH_APP_WEBHOOK_SECRET
+#   App webhook secret (injected post-deploy as GITHUB_APP_WEBHOOK_SECRET)
+#
+# GH_INSTALL_TOKEN_KEY
+#   AES-GCM DEK (injected post-deploy as INSTALL_TOKEN_KEY)
+
+
+# ── Bindings (wrangler.toml — replace IDs per fork) ──────────────────────────
+#
+# DB  (D1 database)
+#   prod    : database_name = "YOUR-D1-DB-PROD"    database_id = "<YOUR_D1_PROD_ID>"
+#   staging : database_name = "YOUR-D1-DB-STAGING" database_id = "<YOUR_D1_STAGING_ID>"
+#   Obtain: wrangler d1 create YOUR-DB-NAME  → copy the id printed
+#   <!-- TODO: replace roxabi-live-production / roxabi-live-staging IDs in wrangler.toml -->
+#
+# LOGS  (R2 bucket)
+#   prod    : bucket_name = "YOUR-R2-BUCKET-PROD"
+#   staging : bucket_name = "YOUR-R2-BUCKET-STAGING"
+#   Obtain: wrangler r2 bucket create YOUR-BUCKET-NAME
+#   <!-- TODO: replace roxabi-live-logs / roxabi-live-logs-staging in wrangler.toml -->
+#
+# ASSETS  (static files) — no replacement needed; always bound to ./frontend
+
+
+# ── Routes / Worker names (wrangler.toml — replace per fork) ─────────────────
+#
+# Prod Worker name  : name = "YOUR-WORKER-NAME"   (replace roxabi-live)
+# Staging Worker    : [env.staging] name = "YOUR-WORKER-NAME-staging"
+# Custom domain     : routes = [{pattern = "your.domain.com", custom_domain = true}]
+#                     <!-- TODO: replace live.roxabi.dev with your domain -->
+#
+# IMPORTANT: wrangler inherits the top-level `routes` key into named envs.
+# [env.staging] MUST explicitly set routes = [] to prevent the staging Worker
+# from binding your production custom domain.
+#
+# Install URL (frontend/auth.js + /oauth/callback redirect):
+#   Replace: https://github.com/apps/roxabi-live/installations/new
+#   With:    https://github.com/apps/YOUR-APP-SLUG/installations/new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Let:
 - `/admin/*` gated by `ADMIN_TOKEN` secret (defense-in-depth, #123) in addition to edge Access
 - M₁ (roxabituwer) **decommissioned 2026-06-08**: `live.service` stopped+disabled, Tailscale Funnel retired, `~/.roxabi/corpus.db` archived
 
-→ `docs/ARCHITECTURE.md` (to be created)
+→ `docs/ARCHITECTURE.md`
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Roxabi Live pulls GitHub issues from the entire org into a [Cloudflare D1](https://developers.cloudflare.com/d1/) database and serves a multi-view dashboard at **[live.roxabi.dev](https://live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via a GitHub org webhook, and re-syncs hourly via a Cron Trigger — all on a single Cloudflare Worker.
 
+**Multi-user:** any GitHub user with access to the installed GitHub App can sign in via OAuth (`GET /login`). The app is session-gated — `/api/*` requires an active session cookie. `/admin/*` additionally sits behind Cloudflare Access (Email-OTP) as a defense-in-depth layer.
+
 ## Why
 
 GitHub Projects and the default issue list give no cross-repo dependency view. Roxabi Live solves three specific gaps:
@@ -18,7 +20,7 @@ GitHub Projects and the default issue list give no cross-repo dependency view. R
 
 ## Quick Start
 
-Roxabi Live runs as a **Cloudflare Worker** at **[live.roxabi.dev](https://live.roxabi.dev)** (behind Cloudflare Access) — nothing to install to use it.
+Roxabi Live runs as a **Cloudflare Worker** at **[live.roxabi.dev](https://live.roxabi.dev)** — nothing to install to use it. Sign in with your GitHub account via `GET /login`.
 
 Local development:
 
@@ -28,6 +30,8 @@ cd roxabi-live/worker
 npm ci
 npx wrangler dev          # local Worker + D1 → http://localhost:8787
 ```
+
+Create a `worker/.dev.vars` file (wrangler reads it automatically, never commit it) with the secrets listed in the [Configuration](#configuration) section.
 
 Deploys are CI-driven: push to `staging` → staging Worker; push to `main` → production (`live.roxabi.dev`).
 
@@ -71,37 +75,76 @@ flowchart LR
 
 ## API Reference
 
-| Endpoint | Method | Description |
-|---|---|---|
-| `/health` | GET | DB reachability + issue count |
-| `/api/version` | GET | Build/version info |
-| `/api/issues` | GET | List issues (`repo`, `state`, `label`, `limit`, `offset` query params) |
-| `/api/issues/{key}` | GET | Single issue by key, e.g. `Roxabi/lyra#123` |
-| `/api/graph` | GET | Full dependency graph JSON (nodes + edges) |
-| `/admin/sync` | POST | Out-of-band sync trigger (`Authorization: Bearer <ADMIN_TOKEN>`) |
-| `/webhook/github` | POST | GitHub webhook receiver (HMAC-verified) |
-| `/` | Static | Dep-graph dashboard (served via ASSETS) |
+| Endpoint | Method | Auth | Description |
+|---|---|---|---|
+| `/health` | GET | public | DB reachability + issue count |
+| `/api/version` | GET | public | Build/version info |
+| `/login` | GET | public | Start GitHub App OAuth flow; redirects to GitHub |
+| `/oauth/callback` | GET | public (validates D1 state) | OAuth callback; sets `__Host-session` cookie |
+| `/logout` | POST | public (idempotent) | Clear session cookie |
+| `/api/me` | GET | session | Current authenticated user info |
+| `/api/active-tenant` | POST | session | Set active org when user has >1 GitHub App installation |
+| `/api/issues` | GET | session | List issues (`repo`, `state`, `label`, `limit`, `offset` query params) |
+| `/api/issues/{key}` | GET | session | Single issue by key, e.g. `Roxabi/lyra#123` |
+| `/api/graph` | GET | session | Full dependency graph JSON (nodes + edges), scoped to tenant |
+| `/admin/sync` | POST | CF Access + ADMIN_TOKEN Bearer | Out-of-band sync trigger |
+| `/webhook/github` | POST | HMAC-SHA256 (`X-Hub-Signature-256`) | GitHub org webhook receiver; CF Access Bypass at edge |
+| `/*` | GET | public | Static frontend (ASSETS binding) |
+
+**session** = `__Host-session` cookie validated against D1 `sessions` table (`requireSession` middleware).
 
 ## Configuration
 
 Bindings live in [`wrangler.toml`](wrangler.toml); secrets are set per-environment via `wrangler secret put`.
 
-| Binding / Secret | Type | Description |
+### Bindings
+
+| Binding | Type | Description |
 |---|---|---|
-| `DB` | D1 | Issue corpus (`roxabi-live-production` / `roxabi-live-staging`) |
-| `ASSETS` | Static | Serves `frontend/` |
-| `LOGS` | R2 | Per-run sync audit (`roxabi-live-logs`) |
-| `GITHUB_TOKEN` | secret | GitHub GraphQL auth |
-| `GITHUB_ORG` | var | Org to sync |
-| `GITHUB_WEBHOOK_SECRET` | secret | HMAC verification for `/webhook/github` |
-| `ADMIN_TOKEN` | secret (optional) | Bearer gate for `/admin/*` |
+| `DB` | D1 | Issue corpus + sessions (`roxabi-live-production` / `roxabi-live-staging`) |
+| `ASSETS` | Static | Serves `frontend/` via ASSETS binding |
+| `LOGS` | R2 | Per-run sync audit (`roxabi-live-logs` / `roxabi-live-logs-staging`) |
 | Cron | trigger | `0 * * * *` — hourly sync |
 
+### Secrets
+
+| Secret | Required | Description |
+|---|---|---|
+| `GITHUB_WEBHOOK_SECRET` | yes | HMAC-SHA256 secret matching your GitHub org webhook (`X-Hub-Signature-256`) |
+| `GITHUB_APP_ID` | yes | GitHub App numeric ID (App-JWT generation for install-token flow) |
+| `GITHUB_APP_CLIENT_ID` | yes | GitHub App OAuth client ID (`/login` → `/oauth/callback` flow) |
+| `GITHUB_APP_CLIENT_SECRET` | yes | GitHub App OAuth client secret (token exchange in `/oauth/callback`) |
+| `GITHUB_APP_PRIVATE_KEY` | yes | base64-encoded PKCS#8 DER RSA private key for signing App-JWTs |
+| `GITHUB_APP_WEBHOOK_SECRET` | yes | App-level webhook HMAC secret (distinct from org `GITHUB_WEBHOOK_SECRET`) |
+| `INSTALL_TOKEN_KEY` | yes | base64-encoded 32-byte AES-GCM DEK for encrypting installation tokens at rest |
+| `GITHUB_ORG` | yes | GitHub org slug to sync (e.g. `Roxabi`); set via `wrangler secret put` |
+| `ADMIN_TOKEN` | optional | Bearer gate for `POST /admin/sync`; if unset, CF Access alone guards `/admin/*` |
+| `NOTIFY_URL` | optional | Webhook URL for sync circuit-breaker halt/auth-failure alerts |
+
 ```bash
-# set a secret (prod, then staging)
-printf %s '<value>' | wrangler secret put GITHUB_TOKEN
-printf %s '<value>' | wrangler secret put GITHUB_TOKEN --env staging
+# wrangler.toml lives at the repo root, so run from worker/ with --config
+# set a secret (prod)
+cd worker && printf %s '<value>' | npx wrangler secret put GITHUB_APP_ID --config ../wrangler.toml
+
+# same secret on staging
+cd worker && printf %s '<value>' | npx wrangler secret put GITHUB_APP_ID --env staging --config ../wrangler.toml
 ```
+
+For local dev, put secrets in `worker/.dev.vars` (one `KEY=VALUE` per line; never commit this file).
+
+## Self-hosting
+
+Roxabi Live is designed to fork. See **[docs/DEPLOY.md](docs/DEPLOY.md)** for the complete step-by-step guide: creating a GitHub App, provisioning Cloudflare resources (Worker, D1, R2), setting repo CI secrets, and running migrations.
+
+Replace the following Roxabi-specific values with your own when forking:
+
+| Value | Where | How to obtain |
+|---|---|---|
+| `live.roxabi.dev` | `wrangler.toml` `routes` | Your own custom domain (or use `workers.dev`) |
+| `roxabi-live` / `roxabi-live-staging` | `wrangler.toml` `name` / `[env.staging]` | Your choice of Worker names |
+| D1 database IDs | `wrangler.toml` `[[d1_databases]]` | `wrangler d1 create <name>` |
+| R2 bucket names | `wrangler.toml` `[[r2_buckets]]` | `wrangler r2 bucket create <name>` |
+| GitHub App slug in install URL | `worker/src/` (redirect on no-install) | Your GitHub App's slug from App settings |
 
 ## Plugins
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,299 @@
+# Architecture — Roxabi Live
+
+Roxabi Live is a serverless operations cockpit that syncs GitHub issues and their dependency graph from a GitHub App installation into a Cloudflare D1 database, then serves the graph as a filterable web UI. The entire stack runs on Cloudflare: a single Worker handles HTTP via Hono, a Cron Trigger drives hourly sync, static frontend assets are served through the Worker's ASSETS binding, and R2 stores per-run audit logs. There is no persistent server, no Python runtime, and no local database in production.
+
+---
+
+## Serverless topology
+
+```
+                       Cloudflare edge
+ ┌─────────────────────────────────────────────────────────────┐
+ │                                                             │
+ │  CF Access (Email-OTP)          ┌─────────────────────┐    │
+ │  gates /admin/*                 │   Cloudflare Worker  │    │
+ │  Bypass on /webhook/*           │   (roxabi-live)      │    │
+ │                                 │                      │    │
+ │  Browser ──────────────────────►│  fetch handler       │    │
+ │  GitHub webhook ───────────────►│    Hono router       │    │
+ │  Cron (0 * * * *) ────────────►│  scheduled handler   │    │
+ │                                 └──────┬───────────────┘    │
+ │                                        │                    │
+ │              ┌─────────────────────────┼─────────────┐      │
+ │              │                         │             │      │
+ │              ▼                         ▼             ▼      │
+ │         D1 (DB)              R2 (LOGS)        ASSETS        │
+ │   roxabi-live-production    per-run audit    frontend/       │
+ │   [YOUR_D1_ID_PROD]         JSON files       HTML/JS/CSS     │
+ └─────────────────────────────────────────────────────────────┘
+```
+
+Worker entry: `worker/src/index.ts` — exports `fetch` (HTTP) and `scheduled` (Cron) handlers. Routing via Hono in `worker/src/router.ts`.
+
+---
+
+## Route table
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET` | `/api/version` | public | Build/version info |
+| `GET` | `/health` | public | DB reachability check + issue count |
+| `GET` | `/login` | public | Start GitHub App OAuth flow |
+| `GET` | `/oauth/callback` | public (validates D1 `oauth_state`) | Exchange code, create session, set cookie |
+| `POST` | `/logout` | public (null-safe) | Clear `__Host-session` cookie |
+| `GET` | `/api/me` | session | Current authenticated user |
+| `POST` | `/api/active-tenant` | session | Org-picker: set active tenant (>1 installation) |
+| `GET` | `/api/issues` | session | List issues (params: `repo`, `state`, `label`, `limit`, `offset`) |
+| `GET` | `/api/issues/*` | session | Single issue by key, e.g. `MyOrg/myrepo#42` |
+| `GET` | `/api/graph` | session | Full dep-graph JSON (nodes + edges), scoped to visible repos |
+| `POST` | `/webhook/github` | HMAC-SHA256 (`GITHUB_WEBHOOK_SECRET`); CF Access Bypass | GitHub org webhook receiver |
+| `POST` | `/admin/sync` | ADMIN_TOKEN Bearer + CF Access Email-OTP | Out-of-band sync trigger |
+| `*` | `/*` | public (ASSETS fallback) | Static frontend from `frontend/` |
+
+Session = `requireSession` middleware: reads `__Host-session` cookie → validates SHA-256 hash against D1 `sessions` table → attaches session context or returns 401.
+
+---
+
+## Request flow
+
+```
+Browser GET /api/graph
+  │
+  ├─ No __Host-session cookie ──► 401 (frontend redirects to /login)
+  │
+  ├─ Cookie present
+  │     │
+  │     ├─ Lookup token_hash in D1 sessions → expired/missing ──► 401
+  │     │
+  │     └─ Valid session (user_id, tenant_id)
+  │           │
+  │           ├─ resolveVisibleRepos(tenant_id, user_id)
+  │           │     └─ tenant_repo_access JOIN repos WHERE NOT is_private
+  │           │        UNION private repos WHERE user has cached permission
+  │           │
+  │           └─ SELECT issues + edges WHERE repo IN visible_repos
+  │                 └─ Return graph JSON
+  │
+GET /webhook/github (POST)
+  │
+  ├─ Verify X-Hub-Signature-256 (Web Crypto, GITHUB_WEBHOOK_SECRET)
+  ├─ Dispatch: issues / deps / sub_issues event handlers
+  └─ D1 upsert via worker/src/webhook/mutations.ts
+```
+
+---
+
+## Multi-tenant auth model
+
+### GitHub App OAuth
+
+1. `GET /login` — generates CSRF state, inserts into D1 `oauth_state` (10-minute TTL), redirects to GitHub authorize URL using `GITHUB_APP_CLIENT_ID`.
+2. `GET /oauth/callback` — consumes state (DELETE RETURNING, single-use), exchanges code for GitHub user token via `GITHUB_APP_CLIENT_SECRET`, upserts `users` + `tenants` + `user_installations` rows, creates session.
+3. On no installations found: redirects to `https://github.com/apps/<YOUR_APP_SLUG>/installations/new`.
+
+> **Fork:** Replace `<YOUR_APP_SLUG>` with your GitHub App's slug. The install URL is constructed from the App slug set during App creation.
+
+### Session cookie
+
+| Attribute | Value |
+|-----------|-------|
+| Name | `__Host-session` (constant `SESSION_COOKIE`) |
+| TTL | 28 800 s (8 h) |
+| Flags | `HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=28800` |
+| Storage | SHA-256 hash stored in D1 `sessions`; raw token never persisted |
+
+`__Host-` prefix mandates `Secure` + `Path=/` + no `Domain` attribute — prevents subdomain token theft.
+
+Revocation: delete row from `sessions` on logout or tenant suspension.
+
+### Suspended-tenant guard
+
+`tenants.suspended = 1` → `requireSession` returns 401 and clears cookie. Sync halts for that installation.
+
+### Authorization: tenant-scoped reads
+
+All `/api/*` reads are scoped through `resolveVisibleRepos`:
+
+- Public repos: `tenant_repo_access JOIN repos WHERE NOT is_private`
+- Private repos: per-user permission cache in D1 (populated from GitHub App install-token API calls)
+- `repos.is_private` defaults to `1` (fail-closed, migration 0007) — a repo is treated as private until a sync run confirms otherwise
+
+**Data tables (`issues`, `edges`, `repos`) carry no `tenant_id` column.** `issues.key` is globally unique (`MyOrg/myrepo#42`). Authorization is enforced at query time via the `tenant_repo_access` JOIN — not at rest on data rows (repo-canonical decision, #141).
+
+### Webhook HMAC
+
+`POST /webhook/github` verifies `X-Hub-Signature-256` using Web Crypto `crypto.subtle` (no `nodejs_compat` flag needed). Secret: `GITHUB_WEBHOOK_SECRET` (org-level webhook secret — **not** `GITHUB_APP_WEBHOOK_SECRET`, which exists in the `Env` interface but is not read on the request path). CF Access Bypass policy applies at the edge so GitHub can reach this endpoint.
+
+### Admin endpoint
+
+`POST /admin/sync` is protected by two independent layers:
+
+1. CF Access Email-OTP at the Cloudflare edge
+2. `Authorization: Bearer <ADMIN_TOKEN>` check in `worker/src/api/admin.ts`
+
+`ADMIN_TOKEN` unset = Worker-level gate disabled; CF Access alone guards.
+
+---
+
+## Sync architecture
+
+### Install-token fan-out (PAT-free)
+
+`GITHUB_TOKEN` (PAT) was retired in Phase 1 (#160, 2026-06-13). All GitHub API calls now use per-installation tokens:
+
+1. Worker signs an App-JWT using `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` (PKCS#8 DER, base64-encoded).
+2. Exchanges JWT for an installation access token via GitHub Apps REST API.
+3. Token cached encrypted (AES-GCM, `INSTALL_TOKEN_KEY` DEK) in D1 `install_tokens` — avoids per-request JWT generation.
+4. GraphQL queries run per installation using the cached token.
+
+Auth circuit breaker in `sync_control`: `auth_failures >= 2` sets `halted = 1`, sync stops, optional `NOTIFY_URL` alert fires.
+
+### GraphQL fields fetched
+
+`subIssues`, `parent`, `blockedBy`, `blocking` — used to derive both `parent` and `blocks` edges.
+
+### Edge algorithm
+
+| Relationship | GraphQL field | Edge direction | `kind` |
+|--------------|---------------|----------------|--------|
+| Parent → child | `subIssues` | `src=parent, dst=child` | `parent` |
+| Child → parent | `parent` | `src=parent, dst=child` | `parent` |
+| Blocks | `blockedBy`/`blocking` | `src=blocker, dst=blocked` | `blocks` |
+
+Edge semantics:
+
+- `parent`: `src` is the parent issue, `dst` is a sub-issue. Parent must complete before children can proceed.
+- `blocks`: `src` blocks `dst`. `src` open → `dst` is blocked; `src` closed → `dst` is ready.
+
+Per-issue upsert deletes only edges of the same `kind` before re-inserting — preserves the other kind.
+
+Frontend status computation (`frontend/state.js`):
+
+```js
+if (node.state === 'closed') return 'done';
+const openBlocker = blockers.some(e => nodesByKey.get(e.src)?.state === 'open');
+return openBlocker ? 'blocked' : 'ready';
+```
+
+### Slot rotation (subrequest cap)
+
+Cloudflare Workers have a subrequest limit per invocation. To stay within it with many repos:
+
+- `WINDOW=20` repos processed per Cron tick
+- `NUM_SLOTS=3` — repo list divided into 3 slots, each tick advances one slot
+- Watermark tracked in `sync_state.slot` per repo; `sync_control.sync_started_at` seeded by migration 0006
+- Known: with 34+ repos, slot 2 window `[40, 60)` may be empty → that tick is a no-op (expected, tracked #166)
+
+### R2 audit
+
+Each sync run writes a JSON audit record to R2 bucket `roxabi-live-logs` (staging: `roxabi-live-logs-staging`). Use D1 `sync_control` / `sync_state` for programmatic audit queries (R2 has no list API in wrangler v3+).
+
+---
+
+## Data model
+
+### D1 tables
+
+| Table | Purpose |
+|-------|---------|
+| `issues` | Issue corpus: `key`, `repo`, `number`, `payload` (JSON with title), `state`, `url`, timestamps, `milestone`, `labels` (lane/priority/size), `status`, `has_active_branch`, `is_stub` |
+| `edges` | Dependency edges: `src`, `dst`, `kind` (`parent` \| `blocks`) |
+| `repos` | Org repository list: `name`, `owner`, `is_archived`, `is_private`; used for tenant-filtered reads and sync fan-out |
+| `sync_state` | Per-repo sync watermark (`last_synced_at`, `cursor`, `slot`); windowed rotation |
+| `sync_control` | Advisory distributed lock (`sync_running`, stale after 900 s), auth circuit breaker (`auth_failures >= 2` → `halted=1`), `sync_started_at` |
+| `sessions` | App-level sessions: `token_hash` (SHA-256), `user_id`, `tenant_id`, `expires_at` |
+| `oauth_state` | CSRF state for OAuth flow: state token, expiry (10 min), single-use (`DELETE RETURNING`) |
+| `users` | GitHub user records: `github_id`, `login`, `name`, `avatar_url`, `email` |
+| `tenants` | GitHub App installations = tenants: `installation_id`, org `login`, `suspended` flag |
+| `user_installations` | Many-to-many join: `user_id` ↔ `tenant_id` |
+| `tenant_repo_access` | Per-tenant repo visibility: `tenant_id` + repo key; scopes `/api/*` reads |
+| `install_tokens` | Encrypted GitHub App installation tokens at rest (AES-GCM) |
+| `data_version` | Schema/data version marker (migration 0003) |
+
+**Repo-canonical invariant:** `issues.key` is globally unique (`org/repo#number`). No `tenant_id` on `issues`, `edges`, or `repos`. Authorization enforced at query time via `tenant_repo_access`. `issues.payload` is the ZK seam for title (Phase 1: populated; future phases may encrypt).
+
+### Migrations
+
+Applied in order at deploy time (`wrangler d1 migrations apply DB --remote`):
+
+```
+0001_initial.sql
+0002_repos.sql
+0003_data_version.sql
+0004_tenancy_auth.sql
+0005_sync_slot_seed.sql
+0006_sync_started_at_seed.sql
+0007_repo_access_is_private.sql
+0008_tenant_not_null.sql
+```
+
+---
+
+## Dep-graph versions
+
+| Version | Status | Entry |
+|---------|--------|-------|
+| v1 | frozen (legacy CLI, decommissioned) | `dep-graph` script |
+| v5 | frozen (static HTML build, decommissioned) | `dep-graph-v5` script |
+| v6 | **primary** — served via CF Worker ASSETS binding | `GET /api/graph` |
+
+---
+
+## Key files
+
+### Worker (active)
+
+| File | Role |
+|------|------|
+| `worker/src/index.ts` | Worker entry point (`fetch` + `scheduled` handlers) |
+| `worker/src/router.ts` | Request routing (Hono) |
+| `worker/src/types.ts` | `Env` interface + shared types |
+| `worker/src/api/issues.ts` | `GET /api/issues`, `GET /api/issues/:key` |
+| `worker/src/api/graph.ts` | `GET /api/graph` |
+| `worker/src/api/admin.ts` | `POST /admin/sync` (ADMIN_TOKEN-gated) |
+| `worker/src/api/version.ts` | `GET /api/version` |
+| `worker/src/sync/sync.ts` | Hourly sync orchestrator + R2 audit write |
+| `worker/src/sync/graphql.ts` | GitHub GraphQL client (`fetch()`) |
+| `worker/src/sync/queries.ts` | GraphQL query strings |
+| `worker/src/sync/parse.ts` | Issue/edge parsing |
+| `worker/src/webhook/handlers.ts` | Webhook dispatch (issues/deps/sub_issues) |
+| `worker/src/webhook/hmac.ts` | HMAC verification |
+| `worker/src/webhook/mutations.ts` | D1 write helpers |
+| `worker/migrations/` | D1 schema migrations |
+| `wrangler.toml` | Worker config (bindings, Cron, routes, environments) |
+| `frontend/` | Static HTML/JS/CSS served via ASSETS binding |
+
+### Package layout
+
+```
+worker/
+  src/
+    index.ts          # fetch + scheduled entry
+    router.ts
+    types.ts
+    api/              # issues, graph, admin, version
+    sync/             # sync, graphql, queries, parse
+    webhook/          # handlers, hmac, mutations
+  migrations/
+wrangler.toml         # repo root — binds both envs
+frontend/             # served via ASSETS binding
+```
+
+---
+
+## Fork / self-hosting replacements
+
+The following values are specific to the Roxabi deployment and must be replaced when forking:
+
+| Placeholder | Where to obtain |
+|-------------|-----------------|
+| `live.roxabi.dev` | Your custom domain; set in `wrangler.toml` top-level `routes` |
+| `roxabi-live` / `roxabi-live-staging` | Choose your Worker names; set in `wrangler.toml` `name` + `[env.staging]` |
+| `c3951107-146c-4a7d-a8a5-86d09e4570e9` (prod D1 ID) | Output of `wrangler d1 create <your-db-name>` |
+| `dd96d8cd-db6b-49ed-8218-53c88773aff4` (staging D1 ID) | Output of `wrangler d1 create <your-db-name>-staging` |
+| `roxabi-live-logs` / `roxabi-live-logs-staging` | Choose your R2 bucket names; create with `wrangler r2 bucket create` |
+| `<YOUR_APP_SLUG>` in install redirect URL | GitHub App slug from your App's settings page |
+| `GITHUB_ORG` secret | Your GitHub org slug (e.g. `MyOrg`) |
+| CF Access policy (Email-OTP, mickael@bouly.io) | Create your own Access application in the Cloudflare Zero Trust dashboard scoped to `/admin/*`; add Bypass for `/webhook/*` |
+
+> **Wrangler routes inheritance gotcha:** the top-level `routes` key in `wrangler.toml` IS inherited by named `[env.*]` blocks (unlike `d1_databases`/`r2_buckets` which are not). `[env.staging]` must explicitly set `routes = []` to prevent the staging Worker from binding your production custom domain.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,579 @@
+# Self-Hosting Guide
+
+End-to-end instructions to go from a fresh fork to a running deployment on Cloudflare Workers.
+
+---
+
+## 0. What you'll provision
+
+**Checklist — gather or create each before starting:**
+
+- [ ] Cloudflare account (free tier is sufficient for the Worker + D1 + R2)
+- [ ] Cloudflare account ID (Dashboard → top-right account switcher → copy ID)
+- [ ] A Cloudflare API token with Worker + D1 + R2 + Secret permissions (see step 2)
+- [ ] Two D1 databases: `<your-app>-production` and `<your-app>-staging`
+- [ ] Two R2 buckets: `<your-app>-logs` and `<your-app>-logs-staging`
+- [ ] A custom domain configured in Cloudflare DNS **OR** use the free `*.workers.dev` subdomain
+- [ ] A GitHub organization you administer (the App will be installed on it)
+- [ ] A GitHub App registered in that org or your personal account (step 4)
+- [ ] Node 20 and `npm` installed locally
+- [ ] Wrangler CLI available via `npx` (no global install required; `wrangler ^3.99.0` is in `worker/devDependencies`)
+
+**Prerequisites — local tools:**
+
+```bash
+node --version   # must be 20.x
+npm --version    # comes with Node
+npx wrangler --version   # pulls from worker/node_modules after npm ci
+```
+
+---
+
+## 1. Fork & clone
+
+```bash
+# Fork the repo on GitHub, then:
+git clone https://github.com/<YOUR_ORG>/<YOUR_FORK>.git
+cd <YOUR_FORK>
+cd worker && npm ci && cd ..
+```
+
+The wrangler config file (`wrangler.toml`) lives at the **repo root**, not inside `worker/`.
+All `wrangler` commands below pass `--config ../wrangler.toml` when run from `worker/`.
+
+---
+
+## 2. Cloudflare resources
+
+### 2a. Get your account ID
+
+```bash
+# After logging in to the Cloudflare dashboard:
+# Dashboard → top-right → "Account Home" → copy the Account ID shown in the URL or sidebar
+# Format: 32 hex characters, e.g. b5e90be971920ce406f7b679c4f1cd33
+export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
+```
+
+> **Why this matters:** the Cloudflare API token used for deployment may have access to
+> multiple accounts. Wrangler requires `CLOUDFLARE_ACCOUNT_ID` to be set or it returns
+> a 403 when running `d1 migrations apply --remote` or `d1 execute --remote`. Export it
+> in every shell session where you run wrangler commands.
+
+### 2b. Create a Cloudflare API token
+
+Dashboard → My Profile → API Tokens → Create Token → Custom Token:
+
+| Permission | Resource | Access |
+|---|---|---|
+| Account / Workers Scripts | All accounts | Edit |
+| Account / D1 | All accounts | Edit |
+| Account / R2 Storage | All accounts | Edit |
+| Zone / Workers Routes | All zones (or specific zone) | Edit |
+
+Save the token — you will add it as `CF_API_TOKEN` in GitHub repo secrets (step 6).
+
+### 2c. Create D1 databases
+
+```bash
+cd worker
+
+# Production database
+npx wrangler d1 create <YOUR_APP>-production --config ../wrangler.toml
+# Note the output: database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# Staging database
+npx wrangler d1 create <YOUR_APP>-staging --config ../wrangler.toml
+# Note the output: database_id = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+```
+
+### 2d. Create R2 buckets
+
+```bash
+cd worker
+
+# Production audit log bucket
+npx wrangler r2 bucket create <YOUR_APP>-logs --config ../wrangler.toml
+
+# Staging audit log bucket
+npx wrangler r2 bucket create <YOUR_APP>-logs-staging --config ../wrangler.toml
+```
+
+---
+
+## 3. Edit wrangler.toml
+
+Replace the Roxabi-specific values with your own. Fields to change:
+
+```toml
+# Top-level Worker name (prod)
+name = "<YOUR_APP>"                        # was: "roxabi-live"
+
+# Custom domain — remove this block if using workers.dev instead:
+routes = [
+  { pattern = "<YOUR_DOMAIN>", custom_domain = true },
+]
+# If using workers.dev (no custom domain), replace with:
+# workers_dev = true
+# routes = []
+
+# Prod D1 binding
+[[d1_databases]]
+binding        = "DB"
+database_name  = "<YOUR_APP>-production"  # was: "roxabi-live-production"
+database_id    = "<PROD_DB_ID>"           # captured in step 2c
+migrations_dir = "worker/migrations"
+
+# Prod R2 bucket
+[[r2_buckets]]
+binding     = "LOGS"
+bucket_name = "<YOUR_APP>-logs"           # was: "roxabi-live-logs"
+
+# Staging env — Worker name
+[env.staging]
+name = "<YOUR_APP>-staging"               # was: "roxabi-live-staging"
+workers_dev = true
+routes = []    # KEEP THIS — see note below
+
+# Staging D1 binding
+[[env.staging.d1_databases]]
+binding        = "DB"
+database_name  = "<YOUR_APP>-staging"     # was: "roxabi-live-staging"
+database_id    = "<STAGING_DB_ID>"        # captured in step 2c
+migrations_dir = "worker/migrations"
+
+# Staging R2 bucket
+[[env.staging.r2_buckets]]
+binding     = "LOGS"
+bucket_name = "<YOUR_APP>-logs-staging"   # was: "roxabi-live-logs-staging"
+```
+
+> **routes=[] gotcha (staging):** `routes` is an inheritable wrangler key. Without
+> `routes = []` in `[env.staging]`, a staging deploy would inherit the top-level custom
+> domain entry and bind your production domain to the staging Worker. Always keep
+> `routes = []` in the staging env block. This is distinct from `[[d1_databases]]` and
+> `[[r2_buckets]]`, which are NOT inherited and must be repeated per env.
+
+---
+
+## 4. Register the GitHub App
+
+### 4a. Create the App
+
+GitHub → Settings → Developer settings → GitHub Apps → New GitHub App (or use your org's settings page for an org-owned App).
+
+**Fill in:**
+
+| Field | Value |
+|---|---|
+| GitHub App name | `<YOUR_APP>` (must be unique on GitHub) |
+| Homepage URL | `https://<YOUR_DOMAIN>` |
+| Webhook URL | `https://<YOUR_DOMAIN>/webhook/github` |
+| Webhook secret | A strong random string — **save it** as `GITHUB_WEBHOOK_SECRET` |
+
+**Permissions (Repository):**
+
+| Permission | Level |
+|---|---|
+| Issues | Read |
+| Metadata | Read (mandatory) |
+| Pull requests | Read |
+
+**Permissions (Organization):**
+
+| Permission | Level |
+|---|---|
+| Members | Read |
+
+**Subscribe to events:**
+
+- `issues`
+- `sub_issues`
+- `issue_comment` (optional — for future use)
+- `pull_request`
+
+**OAuth settings:**
+
+| Field | Value |
+|---|---|
+| Callback URL | `https://<YOUR_DOMAIN>/oauth/callback` |
+| Expire user authorization tokens | Yes (recommended) |
+| Request user authorization (OAuth) during installation | Yes |
+
+**After creation — note:**
+
+- **App ID** (numeric, shown on the App settings page) → `GITHUB_APP_ID`
+- **Client ID** (shown on the App settings page) → `GITHUB_APP_CLIENT_ID`
+
+**Generate a Client Secret:**
+
+App settings → Generate a new client secret → save as `GITHUB_APP_CLIENT_SECRET`.
+
+**Generate a Private Key:**
+
+App settings → Private keys → Generate a private key → downloads a `.pem` file.
+
+Convert to base64-encoded PKCS#8 DER (the format the Worker expects):
+
+```bash
+# Convert PEM RSA key to PKCS#8 DER, then base64-encode it:
+openssl pkcs8 -topk8 -inform PEM -outform DER -nocrypt \
+  -in <downloaded-key>.pem \
+  | base64 -w 0
+# Copy the single-line base64 output → GITHUB_APP_PRIVATE_KEY
+```
+
+**Generate a Webhook Secret for the App-level webhook** (distinct from the org webhook):
+
+```bash
+openssl rand -hex 32
+# Save this as GITHUB_APP_WEBHOOK_SECRET
+```
+
+**Generate the AES-GCM DEK for install token encryption:**
+
+```bash
+openssl rand -base64 32
+# Save this as INSTALL_TOKEN_KEY (exactly 32 bytes decoded = 256-bit AES key)
+```
+
+### 4b. Install the App on your org
+
+GitHub App settings → Install App → select your organization → Install.
+
+After installation, the App is assigned an **installation ID** (visible in the URL:
+`/organizations/<org>/settings/installations/<installation_id>`).
+
+The Worker discovers and stores this automatically via the OAuth flow (first `/login` visit
+seeds the tenant). No manual seeding is required.
+
+> **Install URL pattern** (if you need to send users to install): 
+> `https://github.com/apps/<YOUR_APP_SLUG>/installations/new`
+> Replace `<YOUR_APP_SLUG>` with the slugified App name GitHub assigned.
+
+---
+
+## 5. Set Worker secrets
+
+Run these from the `worker/` directory. All commands pass `--config ../wrangler.toml`.
+Export `CLOUDFLARE_ACCOUNT_ID` before running.
+
+```bash
+cd worker
+export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
+```
+
+### Required secrets — set for BOTH prod and staging
+
+For each secret, run the command once without `--env staging` (prod) and once with
+`--env staging` (staging). Use the same value for both unless you have separate Apps.
+
+```bash
+# Org-level webhook HMAC secret (must match the Webhook secret set in step 4a)
+printf %s '<GITHUB_WEBHOOK_SECRET>' \
+  | npx wrangler secret put GITHUB_WEBHOOK_SECRET --config ../wrangler.toml
+printf %s '<GITHUB_WEBHOOK_SECRET>' \
+  | npx wrangler secret put GITHUB_WEBHOOK_SECRET --env staging --config ../wrangler.toml
+
+# GitHub App numeric ID
+printf %s '<GITHUB_APP_ID>' \
+  | npx wrangler secret put GITHUB_APP_ID --config ../wrangler.toml
+printf %s '<GITHUB_APP_ID>' \
+  | npx wrangler secret put GITHUB_APP_ID --env staging --config ../wrangler.toml
+
+# GitHub App OAuth client ID
+printf %s '<GITHUB_APP_CLIENT_ID>' \
+  | npx wrangler secret put GITHUB_APP_CLIENT_ID --config ../wrangler.toml
+printf %s '<GITHUB_APP_CLIENT_ID>' \
+  | npx wrangler secret put GITHUB_APP_CLIENT_ID --env staging --config ../wrangler.toml
+
+# GitHub App OAuth client secret
+printf %s '<GITHUB_APP_CLIENT_SECRET>' \
+  | npx wrangler secret put GITHUB_APP_CLIENT_SECRET --config ../wrangler.toml
+printf %s '<GITHUB_APP_CLIENT_SECRET>' \
+  | npx wrangler secret put GITHUB_APP_CLIENT_SECRET --env staging --config ../wrangler.toml
+
+# GitHub App RSA private key (base64 PKCS#8 DER from step 4a)
+printf %s '<GITHUB_APP_PRIVATE_KEY>' \
+  | npx wrangler secret put GITHUB_APP_PRIVATE_KEY --config ../wrangler.toml
+printf %s '<GITHUB_APP_PRIVATE_KEY>' \
+  | npx wrangler secret put GITHUB_APP_PRIVATE_KEY --env staging --config ../wrangler.toml
+
+# App-level webhook secret (from step 4a — distinct from org webhook secret).
+# Note: the live POST /webhook/github handler verifies HMAC against GITHUB_WEBHOOK_SECRET
+# (org-level, above), NOT this GITHUB_APP_WEBHOOK_SECRET. This one is present in the Env
+# interface for completeness but is not read on the request path; set it anyway for parity.
+printf %s '<GITHUB_APP_WEBHOOK_SECRET>' \
+  | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --config ../wrangler.toml
+printf %s '<GITHUB_APP_WEBHOOK_SECRET>' \
+  | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --env staging --config ../wrangler.toml
+
+# AES-GCM DEK for encrypting install tokens at rest (base64, 32 bytes, from step 4a)
+printf %s '<INSTALL_TOKEN_KEY>' \
+  | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
+printf %s '<INSTALL_TOKEN_KEY>' \
+  | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
+
+# GitHub org slug to sync (e.g. "MyOrg") — treated as a secret in practice
+printf %s '<YOUR_GITHUB_ORG>' \
+  | npx wrangler secret put GITHUB_ORG --config ../wrangler.toml
+printf %s '<YOUR_GITHUB_ORG>' \
+  | npx wrangler secret put GITHUB_ORG --env staging --config ../wrangler.toml
+```
+
+### Optional secrets
+
+```bash
+# Bearer token for POST /admin/sync defense-in-depth gate.
+# If unset, the Worker-level gate is disabled (CF Access alone guards /admin/*).
+printf %s '<YOUR_ADMIN_TOKEN>' \
+  | npx wrangler secret put ADMIN_TOKEN --config ../wrangler.toml
+printf %s '<YOUR_ADMIN_TOKEN>' \
+  | npx wrangler secret put ADMIN_TOKEN --env staging --config ../wrangler.toml
+
+# Webhook URL for sync circuit-breaker halt/auth-failure alerts.
+# If unset, no external notification is sent.
+printf %s '<YOUR_NOTIFY_URL>' \
+  | npx wrangler secret put NOTIFY_URL --config ../wrangler.toml
+printf %s '<YOUR_NOTIFY_URL>' \
+  | npx wrangler secret put NOTIFY_URL --env staging --config ../wrangler.toml
+```
+
+**Verify secrets are set:**
+
+```bash
+npx wrangler secret list --config ../wrangler.toml
+npx wrangler secret list --env staging --config ../wrangler.toml
+```
+
+---
+
+## 6. CI repo secrets
+
+Set these in GitHub: repo → Settings → Secrets and variables → Actions → New repository secret.
+
+| Secret name | Value | Purpose |
+|---|---|---|
+| `CF_API_TOKEN` | Cloudflare API token from step 2b | `wrangler deploy` + D1 migrations |
+| `CLOUDFLARE_ACCOUNT_ID` | Your 32-char account ID | Required — token may see multiple accounts |
+| `GH_APP_ID` | GitHub App numeric ID | Post-deploy injection as `GITHUB_APP_ID` Worker secret |
+| `GH_APP_PRIVATE_KEY` | base64 PKCS#8 DER private key | Post-deploy injection as `GITHUB_APP_PRIVATE_KEY` |
+| `GH_APP_WEBHOOK_SECRET` | App webhook secret | Post-deploy injection as `GITHUB_APP_WEBHOOK_SECRET` |
+| `GH_INSTALL_TOKEN_KEY` | base64 AES-GCM DEK | Post-deploy injection as `INSTALL_TOKEN_KEY` |
+
+> **Why `GH_APP_*` instead of `GITHUB_APP_*`?** GitHub Actions forbids repository secret
+> names that start with `GITHUB_` (returns 422 on create). The CI workflow maps
+> `GH_APP_*` → `GITHUB_APP_*` Worker secrets in a post-deploy injection step.
+> Only these four (`GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_WEBHOOK_SECRET`,
+> `INSTALL_TOKEN_KEY`) are injected by CI. The remaining Worker secrets —
+> `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_ORG`,
+> and the optional `ADMIN_TOKEN` / `NOTIFY_URL` — are **not** injected by CI; set them
+> manually via `wrangler secret put` (step 5) or add your own injection steps.
+
+Once `CF_API_TOKEN` is set, every push to `staging` or `main` automatically:
+1. Applies D1 migrations
+2. Deploys the Worker
+3. Injects the four App secrets listed above
+
+---
+
+## 7. Apply migrations
+
+### Via CI (recommended)
+
+Push to `staging` triggers the `deploy` job, which applies migrations automatically before
+deploying. Push to `main` for production.
+
+### Manually
+
+```bash
+cd worker
+export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
+
+# Staging
+npx wrangler d1 migrations apply DB --env staging --remote --config ../wrangler.toml
+
+# Production
+npx wrangler d1 migrations apply DB --remote --config ../wrangler.toml
+```
+
+Migrations are applied in order:
+
+```
+0001_initial.sql
+0002_repos.sql
+0003_data_version.sql
+0004_tenancy_auth.sql
+0005_sync_slot_seed.sql
+0006_sync_started_at_seed.sql
+0007_repo_access_is_private.sql
+0008_tenant_not_null.sql
+```
+
+Wrangler tracks applied migrations and skips already-applied ones — safe to re-run.
+
+---
+
+## 8. Deploy
+
+### Via CI (recommended)
+
+```bash
+git push origin staging   # deploys to staging Worker
+git push origin main      # deploys to production Worker
+```
+
+The `deploy` job is a no-op if `CF_API_TOKEN` is not set — it logs a notice and exits
+green, so CI is safe to enable before credentials are provisioned.
+
+### Manual deploy
+
+```bash
+cd worker
+export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
+export CLOUDFLARE_API_TOKEN=<YOUR_CF_API_TOKEN>
+
+# Staging
+npx wrangler deploy --env staging --config ../wrangler.toml
+
+# Production
+npx wrangler deploy --config ../wrangler.toml
+```
+
+---
+
+## 9. First run & verify
+
+### Health check
+
+```bash
+# Replace with your Worker URL (workers.dev or custom domain):
+curl https://<YOUR_DOMAIN>/health
+# Expected: 200 JSON with issue count (0 before first sync)
+
+curl https://<YOUR_DOMAIN>/api/version
+# Expected: 200 JSON with data_version timestamp
+```
+
+### Sign in
+
+1. Open `https://<YOUR_DOMAIN>` in a browser.
+2. The frontend auth gate redirects to `/login`.
+3. Authorize the GitHub App → OAuth callback sets the `__Host-session` cookie.
+4. If your App is not yet installed on any org, GitHub redirects you to the install page
+   (`https://github.com/apps/<YOUR_APP_SLUG>/installations/new`). Install it, then return.
+5. The dashboard loads — issues and graph are empty until after the first sync.
+
+### Trigger a sync
+
+The cron runs hourly at minute 0 (`0 * * * *`). To trigger immediately:
+
+```bash
+# Requires ADMIN_TOKEN to be set (step 5):
+curl -X POST https://<YOUR_DOMAIN>/admin/sync \
+  -H "Authorization: Bearer <YOUR_ADMIN_TOKEN>"
+# Expected: 200 (or 202) — sync queued/started
+```
+
+If `ADMIN_TOKEN` is not set and you have Cloudflare Access on `/admin/*`, authenticate
+via the Access OTP challenge first (browser flow or `cf-access-*` service token).
+
+After the sync completes, refresh the dashboard — issues and the dependency graph appear.
+
+---
+
+## 10. Auth model
+
+The app uses **GitHub App OAuth for all user-facing auth**. Visiting `/login` starts
+the OAuth flow; the callback at `/oauth/callback` exchanges the code for a GitHub token,
+resolves the user's org installations, creates a D1 session, and sets a `__Host-session`
+cookie (HttpOnly; Secure; SameSite=Strict; 8-hour TTL). All `/api/*` routes require a
+valid session (the `requireSession` middleware returns 401 if the cookie is absent or
+expired). No personal data leaves the Worker except what GitHub provides in the OAuth
+response.
+
+`/admin/*` has an **additional** layer: an `ADMIN_TOKEN` Bearer check in the Worker
+(defense-in-depth). You may also place Cloudflare Access Email-OTP in front of
+`/admin/*` at the edge for a second factor. The `/webhook/github` route has a CF Access
+Bypass (if Access is configured) so that GitHub can reach it; the Worker validates
+every webhook request via HMAC-SHA256 (`X-Hub-Signature-256`, `GITHUB_WEBHOOK_SECRET`).
+
+For CF Access setup on `/admin/*` see [docs/s7-access-cutover.md](s7-access-cutover.md).
+
+---
+
+## 11. Troubleshooting
+
+### 403 on `wrangler d1 migrations apply --remote`
+
+The API token sees more than one Cloudflare account. Export `CLOUDFLARE_ACCOUNT_ID`
+before running any remote wrangler command:
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
+```
+
+### Graph is empty after first login
+
+The graph is built from synced data. Either wait for the hourly cron (fires at `:00`) or
+trigger a manual sync via `POST /admin/sync`. After sync, reload the dashboard.
+
+`is_private` values for repos default to `1` (fail-closed, migration 0007). The hourly
+sync corrects these from the GitHub API. After the first successful sync, private/public
+status will be accurate.
+
+### Webhook returns 401 or signature failure
+
+The `GITHUB_WEBHOOK_SECRET` set in the Worker must exactly match the webhook secret
+configured on the GitHub org webhook (or App webhook). Trailing newlines in the secret
+break HMAC verification — use `printf %s '<secret>'` (not `echo`) when setting the
+secret:
+
+```bash
+printf %s '<GITHUB_WEBHOOK_SECRET>' \
+  | npx wrangler secret put GITHUB_WEBHOOK_SECRET --config ../wrangler.toml
+```
+
+Verify the secret is set:
+
+```bash
+npx wrangler secret list --config ../wrangler.toml
+# Should show GITHUB_WEBHOOK_SECRET in the list
+```
+
+### `routes` on staging accidentally binds prod domain
+
+If a staging deploy claims your production domain, the `routes = []` line is missing from
+`[env.staging]` in `wrangler.toml`. Add it and redeploy staging. See step 3.
+
+### Dashboard shows "No organizations found" after login
+
+The GitHub App is not installed on any org the authenticated user has access to. Go to
+`https://github.com/apps/<YOUR_APP_SLUG>/installations/new` and install it.
+
+### Session cookie not set (infinite redirect loop)
+
+The `__Host-session` cookie requires `Secure` + `Path=/` + no `Domain` attribute. These
+are set by the Worker automatically but only work over HTTPS. Ensure your custom domain
+has TLS configured, or use the `*.workers.dev` URL (always HTTPS).
+
+### Local dev
+
+```bash
+cd worker
+npm ci
+
+# Create worker/.dev.vars with your secrets (do not commit this file):
+# GITHUB_WEBHOOK_SECRET=...
+# GITHUB_APP_ID=...
+# GITHUB_APP_CLIENT_ID=...
+# GITHUB_APP_CLIENT_SECRET=...
+# GITHUB_APP_PRIVATE_KEY=...
+# GITHUB_APP_WEBHOOK_SECRET=...
+# INSTALL_TOKEN_KEY=...
+# GITHUB_ORG=...
+
+npx wrangler dev   # uses --config ../wrangler.toml (set in package.json dev script)
+# → http://localhost:8787
+```
+
+Wrangler dev automatically creates a local D1 preview database — no remote D1 is used.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,157 +1,104 @@
-# Getting Started
+# Getting Started — Local Development
 
-> [!NOTE]
-> **Production (2026-06-08+):** Roxabi Live runs as a **Cloudflare Worker** at
-> `https://live.roxabi.dev` (CF Access Email-OTP). Python/systemd/M₁ is decommissioned.
-> For Worker local dev: `cd worker && npm ci && npx wrangler dev`.
-> The Python setup below applies to the legacy app only.
+This guide covers running **roxabi-live** locally as a Cloudflare Worker. For production and self-hosted deployment, see [docs/DEPLOY.md](DEPLOY.md).
 
 ## Prerequisites
 
-**Worker dev (active):**
-- Node.js (for `wrangler`) — `npx wrangler dev` works without a global install
-- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) — `npm ci` in `worker/`
+- **Node.js 20** — verify with `node --version` (should print `v20.x`)
+- **npm** — bundled with Node; no global wrangler install required
 
-**Legacy Python app (decommissioned — reference only):**
-- Python 3.12 (managed via `.python-version` — `pyenv` or system install)
-- [uv](https://docs.astral.sh/uv/) — package manager
-- [GitHub CLI](https://cli.github.com/) (`gh`) — authenticated via `gh auth login` (needs `read:org`, `repo` scopes)
-- A GitHub org webhook secret (for real-time updates — optional for dev)
+No Python, no `uv`, no system-level dependencies beyond Node 20.
 
-## Installation
+## Clone and Install
 
 ```bash
-git clone https://github.com/Roxabi/roxabi-live.git
+git clone https://github.com/<YOUR_ORG>/<YOUR_FORK>.git
+# <!-- TODO: replace with your fork URL -->
 cd roxabi-live
-make install        # uv sync --group dev
+cd worker && npm ci
 ```
 
-## Configuration
+## Local Secrets
+
+Wrangler reads secrets from `worker/.dev.vars` automatically during `wrangler dev`. Create the file — it is gitignored and must never be committed:
+
+```ini
+# worker/.dev.vars
+GITHUB_WEBHOOK_SECRET=<your-org-level-webhook-secret>
+GITHUB_APP_ID=<your-app-numeric-id>
+GITHUB_APP_CLIENT_ID=<your-app-oauth-client-id>
+GITHUB_APP_CLIENT_SECRET=<your-app-oauth-client-secret>
+GITHUB_APP_PRIVATE_KEY=<base64-encoded-pkcs8-der-rsa-private-key>
+GITHUB_APP_WEBHOOK_SECRET=<your-app-level-webhook-secret>
+INSTALL_TOKEN_KEY=<base64-encoded-32-byte-aes-gcm-key>
+GITHUB_ORG=<your-github-org-slug>
+ADMIN_TOKEN=<optional-bearer-token-for-admin-sync>
+NOTIFY_URL=<optional-alert-webhook-url>
+```
+
+### Which secrets you actually need
+
+| Goal | Required secrets |
+|---|---|
+| Browse `/health`, `/api/version`, static frontend — no auth | None — wrangler dev works with an empty `.dev.vars` |
+| Exercise the OAuth login flow end-to-end | `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_ORG` |
+| Receive and verify org webhooks locally | `GITHUB_WEBHOOK_SECRET` (plus a tunnel to expose `localhost:8787`) |
+| Encrypt/decrypt install tokens | `INSTALL_TOKEN_KEY` |
+| Trigger manual sync via `POST /admin/sync` | `ADMIN_TOKEN` (omitting it disables the Worker-level Bearer check; CF Access guards prod) |
+
+> For most contributors, read-only local dev without any secrets is sufficient. The production deployment is the reference deployment for auth flows.
+
+### Where to obtain each value
+
+| Secret | How to obtain |
+|---|---|
+| `GITHUB_APP_ID` | GitHub App settings page → **App ID** (numeric) |
+| `GITHUB_APP_CLIENT_ID` | GitHub App settings page → **Client ID** |
+| `GITHUB_APP_CLIENT_SECRET` | GitHub App settings page → **Generate a new client secret** |
+| `GITHUB_APP_PRIVATE_KEY` | GitHub App settings → **Generate a private key** → convert to PKCS#8 DER → `base64 -w0` |
+| `GITHUB_APP_WEBHOOK_SECRET` | GitHub App settings → **Webhook secret** (App-level, distinct from org webhook) |
+| `GITHUB_WEBHOOK_SECRET` | GitHub org → Settings → Webhooks → your webhook entry → **Secret** |
+| `INSTALL_TOKEN_KEY` | Generate locally: `openssl rand -base64 32` |
+| `GITHUB_ORG` | Your GitHub org slug (e.g. `acme`) |
+| `ADMIN_TOKEN` | Any opaque string; generate with `openssl rand -hex 32` |
+| `NOTIFY_URL` | Optional — any webhook URL for circuit-breaker alerts (e.g. Discord incoming webhook) |
+
+## Run the Dev Server
 
 ```bash
-cp .env.example .env
+cd worker && npx wrangler dev
 ```
 
-Edit `.env`:
+The Worker starts at **http://localhost:8787**. Wrangler provisions a local D1 preview automatically — no external database setup is needed.
 
-```env
-CORPUS_DB_PATH=~/.roxabi/corpus.db
-GITHUB_WEBHOOK_SECRET=your-secret-here
-CORPUS_SYNC_INTERVAL_SECONDS=3600
-```
+Verify the setup:
 
-The corpus DB directory is created automatically on first sync.
+| Endpoint | Auth | What to expect |
+|---|---|---|
+| `GET /health` | public | `{"status":"ok","issues":<count>}` |
+| `GET /api/version` | public | build/version JSON |
+| `GET /login` | public | redirects to GitHub OAuth (requires App secrets) |
 
-## Initial Corpus Sync
+## Apply Migrations Locally
 
-Fetch all issues from the GitHub org into the local SQLite corpus:
+On first run the local D1 preview is empty. Apply all migrations once:
 
 ```bash
-make sync
-# or: uv run roxabi-corpus sync
+cd worker && npx wrangler d1 migrations apply DB --local --config ../wrangler.toml
 ```
 
-For a full re-sync (clears incremental sync state):
+Subsequent `wrangler dev` runs reuse the persisted local DB state.
 
-```bash
-make full-sync
-```
+## Production / Self-Hosting
 
-To scope to a single repo:
+See [docs/DEPLOY.md](DEPLOY.md) for:
 
-```bash
-uv run roxabi-corpus sync --repo Roxabi/lyra
-```
+- Cloudflare account and Worker setup
+- D1 database and R2 bucket provisioning
+- GitHub App creation, wrangler secret injection, and CI repo secrets
+- `wrangler deploy` flows for staging and production
+- Cloudflare Access configuration for `/admin/*`
 
-The sync uses `gh api graphql` — make sure `gh` is authenticated:
+## Legacy Note
 
-```bash
-gh auth login
-make sync
-```
-
-## Starting the Dev Server
-
-```bash
-uv run roxabi-live
-```
-
-Starts uvicorn on `http://localhost:8000`.
-
-Endpoints:
-- `http://localhost:8000/v6/` — dashboard
-- `http://localhost:8000/health` — health check + DB stats
-- `http://localhost:8000/api/graph` — raw graph JSON
-
-## Webhook Setup (optional for dev)
-
-For real-time updates, configure a GitHub org webhook:
-
-1. Go to **GitHub org → Settings → Webhooks → Add webhook**.
-2. Set the payload URL to your public endpoint, e.g. `https://your-host/webhook/github`.
-3. Content type: `application/json`.
-4. Set a secret and copy it to `GITHUB_WEBHOOK_SECRET` in `.env`.
-5. Subscribe to: **Issues**, **Sub-issues**.
-
-For local dev, use a tunnel (e.g. `ngrok http 8000`) to expose the local server.
-
-See [GitHub docs — Creating webhooks](https://docs.github.com/en/webhooks/using-webhooks/creating-webhooks) for details.
-
-## Production Deployment (Cloudflare Worker — CI-driven)
-
-> **Decommissioned (2026-06-08):** The Python/systemd/M₁ deployment described below has been retired. See the archived sections.
-
-Production is a Cloudflare Worker deployed via CI. Push to `main` → `wrangler deploy` (prod, `live.roxabi.dev`). Push to `staging` → `wrangler deploy --env staging`.
-
-### Local Worker dev
-
-```bash
-cd worker && npm ci && npx wrangler dev
-```
-
-Worker binds a local D1 preview. No Python/uvicorn needed.
-
-### Secrets (set once per environment)
-
-```bash
-printf %s '<value>' | wrangler secret put SECRET_NAME           # prod
-printf %s '<value>' | wrangler secret put SECRET_NAME --env staging
-```
-
-Required secrets: `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET`, `ADMIN_TOKEN`.
-
----
-
-## Legacy: Production Deployment via systemd (decommissioned 2026-06-08)
-
-> [!WARNING]
-> M₁ (`roxabituwer`) `live.service` was stopped and disabled on 2026-06-08. The
-> Python FastAPI app (`src/roxabi_live/`) is kept in the repo as a historical reference
-> but is no longer deployed. `~/.roxabi/corpus.db` was archived as `.bak` on M₁.
-> The sections below are preserved for reference only.
-
-Roxabi Live was deployed as a systemd user service on M1 (`roxabituwer`). The unit is at `deploy/systemd/live.service`.
-
-### Install (historical)
-
-```bash
-cp deploy/systemd/live.service ~/.config/systemd/user/live.service
-systemctl --user daemon-reload
-systemctl --user enable live.service
-systemctl --user start live.service
-```
-
-### Service control (historical)
-
-```bash
-systemctl --user status live.service
-journalctl --user -u live.service -f   # follow logs
-```
-
-Logs were written to `~/.local/state/roxabi-live/logs/` (archived on M₁).
-
-### Tailscale Funnel (retired)
-
-The Tailscale Funnel (`tailscale funnel --bg 8000`) that fronted M₁ has been retired
-(`tailscale funnel --https=443 off`). Ingress is now `https://live.roxabi.dev` via
-Cloudflare Access (Email-OTP).
+The pre-2026-06 Python/FastAPI app (`src/roxabi_live/`) is decommissioned; its `live.service` systemd unit is stopped and disabled. The code remains in git history for reference only — do not use `uv`, `make install`, `make sync`, or `uv run roxabi-live`.


### PR DESCRIPTION
## Summary

Make roxabi-live **fork/clone-and-install ready**. Adds a canonical self-hosting guide and refreshes every stale Python/M₁-era doc to the live Cloudflare Worker + D1 + multi-tenant GitHub App auth stack.

Generated by a 3-phase doc workflow (gather exact facts from `worker/src`, `wrangler.toml`, `ci.yml`, `router.ts`, auth/oauth/session, migrations → 5 parallel doc-writers → cross-doc consistency pass), then the consistency-pass findings were verified against source and applied.

## What changed

| File | Change |
|---|---|
| `docs/DEPLOY.md` | **new** — 11-section operator guide: CF resources, `wrangler.toml` fork edits, GitHub App registration + PKCS#8 key conversion, all 9 Worker secrets, CI repo secrets (`GH_APP_*` naming rationale), migrations, deploy, first-run OAuth, troubleshooting |
| `docs/ARCHITECTURE.md` | **new** — topology, route table, request flow, multi-tenant auth model, sync architecture, D1 tables, migrations, dep-graph versions, fork replacements (drops `(to be created)` in CLAUDE.md) |
| `README.md` | `GITHUB_TOKEN` row → full 10-secret table; OAuth + auth routes; Self-hosting section → DEPLOY.md; `.dev.vars` local-secret note |
| `docs/getting-started.md` | CF Worker-only local dev (`npm ci` + `wrangler dev`, `.dev.vars`); purged `uv`/`make`/`uvicorn`/`CORPUS_DB_PATH`/`ngrok`/`systemd` |
| `.env.example` | 9 Worker secrets with `wrangler put` commands; CI repo secrets; bindings/routes; inherited-routes gotcha; Python-era vars removed |

## Consistency-pass fixes (verified against `.github/workflows/ci.yml`)

- **`.env.example` (blocker):** corrected `GITHUB_APP_CLIENT_ID` / `GITHUB_APP_CLIENT_SECRET` — these are **NOT** injected by CI (only `GITHUB_APP_ID` / `PRIVATE_KEY` / `WEBHOOK_SECRET` / `INSTALL_TOKEN_KEY` are). Following the original (wrong) comment would skip provisioning them → broken OAuth `/login` + `/oauth/callback`. The gather agent had hallucinated CI injection for these two; CI source confirms otherwise.
- **`DEPLOY.md`:** completed the manual-vs-CI-injected secret list (added `CLIENT_ID` + `GITHUB_WEBHOOK_SECRET`).
- **`README.md`:** `wrangler secret put` snippet now uses `cd worker` + `npx` + `--config ../wrangler.toml` (matches DEPLOY.md; bare `wrangler` from repo root fails).
- **`DEPLOY.md` + `ARCHITECTURE.md`:** noted the live `POST /webhook/github` handler verifies HMAC against org-level `GITHUB_WEBHOOK_SECRET`, **not** `GITHUB_APP_WEBHOOK_SECRET`.

## Verification

- Docs-only changeset (no code/config touched).
- All internal cross-links resolve (`CONTRIBUTING.md`, `docs/DEPLOY.md`, `docs/s7-access-cutover.md`).
- No remaining active Python-era instructions (only intentional decommissioned-context notes).
- No remaining wrong CI-injection claims.
- pre-commit: lint + typecheck + trufflehog passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)