### PR TITLE
feat(webhook): tenant routing gate + GitHub-App lifecycle handlers (#147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ Let:
 | `worker/src/sync/graphql.ts` | GitHub GraphQL client (`fetch()`) |
 | `worker/src/sync/queries.ts` | GraphQL query strings |
 | `worker/src/sync/parse.ts` | Issue/edge parsing |
-| `worker/src/webhook/handlers.ts` | Webhook dispatch (issues/deps/sub_issues) |
+| `worker/src/webhook/handlers.ts` | Webhook dispatch + tenant routing gate (issues/deps/sub_issues + installation/repository/member) |
+| `worker/src/webhook/handlers-app.ts` | App lifecycle handlers (installation/installation_repositories/repository/member/membership) |
+| `worker/src/webhook/tenant.ts` | Tenant lookup (`installation_id`/`account_login` → `tenants`) |
 | `worker/src/webhook/hmac.ts` | HMAC verification |
 | `worker/src/webhook/mutations.ts` | D1 write helpers |
 | `worker/migrations/` | D1 schema migrations |

--- a/artifacts/analyses/147-webhook-tenant-routing-analysis.mdx
+++ b/artifacts/analyses/147-webhook-tenant-routing-analysis.mdx
@@ -1,0 +1,118 @@
+---
+title: "S4 webhook tenant routing — implementation gap analysis"
+issue: 147
+parent_spec: "artifacts/specs/147-webhook-tenant-routing-spec.mdx"
+status: grounding
+tier: F-lite
+created: 2026-06-14
+method: "6-reader parallel gap-analysis workflow + manual schema verification against migrations 0001-0008"
+---
+
+> **Purpose:** ground `/plan` for #147. Maps the spec's 17 requirements (R1–R4, H1–H12, N1)
+> against current code (post S3a/S3b/S5/S6). Schema claims **verified directly** against
+> `worker/migrations/`. Two reconcile drifts corrected (see §0).
+
+## 0. Corrections applied to the raw analysis
+
+- **R3 is the suspended-tenant gate, NOT dual-secret.** The spec ([routing](../specs/147-webhook-tenant-routing-spec.mdx))
+  states *"Reuses the existing single-secret HMAC (`webhook/hmac.ts`)."* A reader hallucinated a
+  `GITHUB_APP_WEBHOOK_SECRET` / `GITHUB_WEBHOOK_SECRET` split. **Dual-secret verification is OUT OF SCOPE.**
+  R3 = *suspended tenant → log, 200, no write.*
+- **`repository` handler scope = spec's 4 actions only:** `renamed`, `transferred`, `privatized`,
+  `publicized`. The raw analysis expanded to `created/deleted/archived/unarchived` — not in spec, dropped.
+- Handler numbering below follows the **spec's exact 12-handler enumeration**.
+
+## 1. Summary
+
+Current webhook (`worker/src/webhook/handlers.ts`, 566 lines; `mutations.ts`, 257 lines) dispatches
+**7 events** — `issues`, `issue_dependencies`, `sub_issues`, `create`, `delete`, `pull_request`,
+`milestone` — with **zero tenant routing** and **zero installation/repository/member lifecycle handling**.
+
+Of 17 requirements: **EXISTS 2** (R4, N1) · **MISSING 15** (R1–R3, H1–H12). No partials.
+
+The schema substrate (S1 #144) is ready: `tenants`, `tenant_repo_access` (+`is_private`),
+`user_repo_permission_cache`, `users`, `user_installations`, `sessions`, `install_tokens` all exist.
+**One new column required** (`tenants.deleted_at` → migration 0009).
+
+## 2. Schema ground-truth (verified against migrations)
+
+| Table | Key columns (actual) | Notes for #147 |
+|---|---|---|
+| `tenants` | `id` PK · `installation_id` UNIQUE NOT NULL · `account_login` · `account_type` · `suspended_at` (nullable) · `created_at` · `updated_at` | **No `deleted_at`/`app_id`/`installed_at`.** Route key = `installation_id`. Membership fallback key = `account_login`. |
+| `tenant_repo_access` | PK `(tenant_id, repo)` · `is_private` NOT NULL DEFAULT 1 (0007) | `repo` = `owner/name`. Upsert: `ON CONFLICT(tenant_id,repo) DO UPDATE SET is_private`. |
+| `user_repo_permission_cache` | PK `(user_id, repo)` · `user_id`→`users.id` · `has_access` · `checked_at` | **Keyed `user_id`, not `github_id`.** H11/H12 must resolve `github_id → users.id` first. |
+| `users` | `id` PK · `github_id` UNIQUE · `github_login` | `github_id → users.id` resolution source. May return zero rows (user never logged in). |
+| `repos` | `repo` · `repo_node_id` TEXT + UNIQUE index `ux_repos_node_id` (0004, nullable, lazy-filled) | **`repo_node_id` exists** → valid rename/transfer anchor (H7/H8). Tolerate NULL on legacy rows. |
+| `sessions` | links to tenant (verify exact FK at impl) · `suspended_at` NOT-EXISTS guard in `validateSession` | H2 deletes sessions for tenant; H3/H4 rely on the guard, no immediate flush. |
+| `install_tokens` | per-tenant | H2 deletes for tenant. |
+| `issues` / `edges` | **no `tenant_id`** | R4 baseline (repo-canonical). `edges` embed repo in `key`. |
+| `sync_control` | PK `(tenant_id, key)` · sentinel `tenant_id=0` (Deviation D-2, no FK) | `bumpDataVersion` writes `tenant_id=0`. Cascades must NOT touch sentinel rows. |
+
+## 3. Gap matrix (spec-aligned)
+
+| Req | Spec requirement | Status | Tables / helpers | Notes |
+|---|---|---|---|---|
+| **R1** | `payload.installation.id → tenants` lookup before any write | MISSING | new `getTenantByInstallationId` | gate at top of dispatch |
+| **R2** | unknown installation → 200, no write | MISSING | — | `getTenant…` returns null → 200 `{ok,ignored}` |
+| **R3** | suspended tenant → log, 200, no write | MISSING | `tenants.suspended_at` | single-secret HMAC unchanged |
+| **R4** | issues/edges stay repo-canonical (no tenant_id filter) | EXISTS | — | preserved |
+| **H1** | `installation.created`: upsert tenant + tenant_repo_access per repo + enqueue sync | MISSING | `tenants`, `tenant_repo_access`, `sync_control` | reuse oauth.ts upsert + sync.ts access upsert |
+| **H2** | `installation.deleted`: delete access+install_tokens+sessions; retain issues/edges; set `deleted_at` | MISSING | + **migration 0009** `deleted_at` | soft-delete tenant row |
+| **H3** | `installation.suspend`: `suspended_at=now` | MISSING | `tenants` | |
+| **H4** | `installation.unsuspend`: `suspended_at=NULL` | MISSING | `tenants` | |
+| **H5** | `installation_repositories.added`: upsert access + trigger sync | MISSING | `tenant_repo_access`, `sync_control` | `payload.repositories_added[]` |
+| **H6** | `installation_repositories.removed`: delete access; retain issues/edges | MISSING | `tenant_repo_access` | `payload.repositories_removed[]` |
+| **H7** | `repository.renamed`: cascade rename anchored on `repo_node_id` | MISSING | `repos`,`tenant_repo_access`,`issues`,`edges` (key) | fallback `previous_repository.full_name`; transactional `db.batch` |
+| **H8** | `repository.transferred`: same cascade as H7 | MISSING | same | node_id stable across transfer |
+| **H9** | `repository.privatized`: `is_private=1` + invalidate cache `WHERE repo=?` | MISSING | `tenant_repo_access`, `user_repo_permission_cache` | reuse repoAccess.ts DELETE-by-repo |
+| **H10** | `repository.publicized`: `is_private=0` + invalidate cache `WHERE repo=?` | MISSING | same | |
+| **H11** | `member.removed`: invalidate cache for `(github_id→user_id, repo)` | MISSING | `user_repo_permission_cache` + `users` JOIN | `payload.member.id`, `payload.repository.full_name` |
+| **H12** | `membership.removed`: invalidate ALL cache rows for `github_id→user_id` | MISSING | same | **membership payload may lack `installation`** → route via `payload.organization.login → account_login` |
+| **N1** | no cross-tenant stub logic | EXISTS | — | superseded by repo-canonical |
+
+## 4. Reuse map (do NOT re-implement)
+
+| Existing | Location | For |
+|---|---|---|
+| `verifyHmac(body, header, secret)` | `webhook/hmac.ts` | unchanged single-secret gate |
+| `upsertIssueFromWebhook`/`deleteIssue`/`addEdge`/`removeEdge` | `webhook/mutations.ts` | H7/H8 cascade re-key/delete |
+| `bumpDataVersion(db, iso)` | `webhook/mutations.ts` | any mutating handler |
+| tenant upsert pattern `ON CONFLICT(installation_id) DO UPDATE` | `auth/oauth.ts` | H1 |
+| `tenant_repo_access` upsert `ON CONFLICT(tenant_id,repo) DO UPDATE SET is_private` | `sync/sync.ts` | H1/H5 |
+| `listInstallationRepos(token)` · `getInstallationToken(db,env,tenantId,installationId)` | `auth/installToken.ts` | H1 repo enumeration |
+| `deleteSession` + `suspended_at` NOT-EXISTS guard | `auth/session.ts` | H2/H3/H4 |
+| `user_repo_permission_cache` DELETE by `repo` / `(user_id,repo)` / `user_id` | `auth/repoAccess.ts` | H9/H10 / H11 / H12 |
+| `FakeD1`/`captureDb()`/`makeEnv()`/`makeContext()` harness | `webhook/handlers.test.ts` | all new tests |
+
+**New helper required:** `getTenantByInstallationId(db, installationId): Promise<TenantRow | null>`
+(+ `getTenantByOrgLogin(db, login)` for H12). Grep confirms neither exists.
+
+## 5. Risks / decisions for the plan
+
+1. **`handlers.ts` is 566 lines (>300 gate).** New lifecycle handlers → **new file**
+   `worker/src/webhook/handlers-app.ts`; `handlers.ts` dispatch delegates. Keep both <300 if possible.
+2. **Migration 0009** (`tenants.deleted_at TEXT`) required before H2. Small ALTER; follows 0007 pattern.
+3. **H12 routing:** `membership` payload may omit `installation` → must resolve tenant via
+   `payload.organization.login → tenants.account_login`. Single-path rule has this documented fallback.
+4. **H7/H8 cascade** touches `repos`+`tenant_repo_access`+`issues`+`edges`(key component); transactional
+   `db.batch`; must not disturb `sync_control` `tenant_id=0` sentinel. Edge-key rewrite is the trickiest unit.
+5. **`github_id → users.id` may be zero rows** (user never logged in) → H11/H12 handle gracefully (no-op).
+6. **H1 `listInstallationRepos` pagination** — large orgs vs 30s CPU. Bound it / lean on cron reconcile.
+7. **R3/dual-secret OUT OF SCOPE** — single-secret HMAC reused verbatim.
+
+## 6. Recommended decomposition (for /plan, F-lite)
+
+Group by GitHub event type (= dispatch branch), spec-action-complete inside each:
+
+| # | Unit | Covers | Files |
+|---|---|---|---|
+| T0 | migration 0009 `tenants.deleted_at` | H2 substrate | `worker/migrations/0009_tenant_deleted_at.sql` |
+| T1 | tenant-lookup helpers + types | R1/R2, all H | new `worker/src/webhook/tenant.ts` (or `auth/tenantLookup.ts`) + test |
+| T2 | routing gate (resolve installation→tenant; unknown/suspended → 200 no-write) | R1/R2/R3 | `handlers.ts` dispatch + test |
+| T3 | `installation` handler | H1/H2/H3/H4 | new `handlers-app.ts` + test |
+| T4 | `installation_repositories` handler | H5/H6 | `handlers-app.ts` + test |
+| T5 | `repository` handler (privatize/publicize cache + rename/transfer cascade) | H7/H8/H9/H10 | `handlers-app.ts` (+ cascade helper in `mutations.ts`) + test |
+| T6 | `member` + `membership` handlers (cache invalidation, github_id→user_id) | H11/H12 | `handlers-app.ts` + test |
+| T7 | dispatch wiring + allowlist extension + data_version bump integration | R1, all H | `handlers.ts` + test |
+
+**Critical path:** T0 → T1 → T2 → {T3, T4, T5, T6} (parallelizable) → T7.

--- a/artifacts/plans/147-webhook-tenant-routing-plan.mdx
+++ b/artifacts/plans/147-webhook-tenant-routing-plan.mdx
@@ -1,0 +1,273 @@
+---
+title: "Plan: feat(webhook): tenant routing + lifecycle handlers (Phase 1 S4)"
+issue: 147
+spec: artifacts/specs/147-webhook-tenant-routing-spec.mdx
+analysis: artifacts/analyses/147-webhook-tenant-routing-analysis.mdx
+complexity: 7/10
+tier: F-lite
+generated: 2026-06-14
+---
+
+## Summary
+
+Add GitHub-App tenant routing to the webhook (`payload.installation.id → tenants` before any write;
+unknown/suspended → 200 no-write) and 12 installation/repository/member lifecycle handlers, in a new
+`handlers-app.ts` (keeps `handlers.ts` under the 300-line gate). Substrate exists (S1 #144); one new
+column needed (`tenants.deleted_at`, migration 0009).
+
+## Architecture
+
+```mermaid
+flowchart TD
+  subgraph req[webhook request]
+    HMAC[verifyHmac single-secret] --> JP[JSON parse] --> EV[x-github-event + action]
+  end
+  subgraph handlers_ts[handlers.ts dispatch]
+    EV --> GATE{resolve installation.id → tenant}
+    GATE -->|null| IGN200[200 ignored, no write]
+    GATE -->|suspended_at set| IGN200
+    GATE -->|active tenant| ROUTE{event}
+    ROUTE -->|issues/deps/sub/create/delete/pr/milestone| EXIST[existing handlers]
+    ROUTE -->|installation*| HAPP
+    ROUTE -->|installation_repositories| HAPP
+    ROUTE -->|repository| HAPP
+    ROUTE -->|member/membership| HAPP
+    EXIST --> BUMP[bumpDataVersion]
+    HAPP --> BUMP
+  end
+  subgraph tenant_ts[tenant.ts]
+    GATE --> GTI[getTenantByInstallationId]
+    HAPP -. membership .-> GTO[getTenantByOrgLogin account_login]
+  end
+  subgraph handlers_app[handlers-app.ts]
+    HAPP[lifecycle handlers] --> MUT
+  end
+  subgraph mutations_ts[mutations.ts + reused auth helpers]
+    MUT[upsertTenant softDeleteTenant setSuspended\nupsertRepoAccess deleteRepoAccess setRepoPrivacy\ncascadeRepoRename invalidateCache* deleteSessions/Tokens]
+  end
+  MUT --> D1[(D1: tenants, tenant_repo_access,\nuser_repo_permission_cache, sessions,\ninstall_tokens, repos, issues, edges, sync_control)]
+```
+
+```mermaid
+flowchart LR
+  subgraph tenant.ts
+    f1[getTenantByInstallationId]
+    f2[getTenantByOrgLogin]
+    t1[TenantRow]
+  end
+  subgraph mutations.ts
+    m1[upsertTenant] --- m2[softDeleteTenant] --- m3[setTenantSuspended]
+    m4[upsertRepoAccess] --- m5[deleteRepoAccess] --- m6[setRepoPrivacy]
+    m7[cascadeRepoRename] --- m8[invalidateCacheByRepo/UserRepo/User]
+    m9[deleteSessionsForTenant] --- m10[deleteInstallTokensForTenant]
+  end
+  subgraph handlers-app.ts
+    h1[handleInstallation] --> m1 & m2 & m3 & m4 & m9 & m10
+    h2[handleInstallationRepositories] --> m4 & m5
+    h3[handleRepository] --> m6 & m7 & m8
+    h4[handleMember] --> m8
+    h5[handleMembership] --> f2 & m8
+  end
+  subgraph handlers.ts
+    d0[webhookHandler] --> f1 --> h1 & h2 & h3 & h4 & h5
+  end
+  subgraph tests
+    T_tenant[tenant.test.ts] --> f1 & f2
+    T_happ[handlers-app.test.ts] --> h1 & h2 & h3 & h4 & h5
+    T_mut[mutations.test.ts] --> m1
+    T_disp[handlers.test.ts] --> d0
+  end
+```
+
+## Bootstrap Context
+
+Grounding from `artifacts/analyses/147-webhook-tenant-routing-analysis.mdx` (schema verified vs migrations 0001-0008):
+
+- `tenants`: PK `id`, `installation_id` UNIQUE, `account_login`, `account_type`, `suspended_at`, `created_at`, `updated_at`. **No `deleted_at` → migration 0009.**
+- `tenant_repo_access`: PK `(tenant_id, repo)`, `is_private` (0007). Upsert `ON CONFLICT(tenant_id,repo) DO UPDATE SET is_private`.
+- `user_repo_permission_cache`: PK `(user_id, repo)`, `user_id`→`users.id`, `has_access`. **Cache keyed user_id, not github_id** → resolve `github_id→users.id` via `users` for H11/H12.
+- `repos.repo_node_id` exists (UNIQUE index) → valid rename/transfer anchor; tolerate NULL legacy rows.
+- `sync_control` sentinel `tenant_id=0` (Deviation D-2) — cascades must not touch it.
+- Reuse: `verifyHmac` (hmac.ts), `bumpDataVersion`/`upsertIssueFromWebhook`/`deleteIssue`/`addEdge`/`removeEdge` (mutations.ts), tenant upsert pattern (oauth.ts), repo-access upsert (sync.ts), `listInstallationRepos`/`getInstallationToken` (installToken.ts), `deleteSession`+suspended guard (session.ts), cache DELETE predicates (repoAccess.ts), `FakeD1`/`captureDb`/`makeEnv`/`makeContext` harness (handlers.test.ts).
+- **Single-secret HMAC unchanged (dual-secret OUT OF SCOPE).**
+
+## Agents
+
+| Agent instance | Tasks | Files | Subjects |
+|---|---|---|---|
+| backend-dev-A | T0, T1, T7 | 0009 migration · tenant.ts · handlers.ts | migrations, tenant-lookup, dispatch |
+| backend-dev-B | T2, T3, T4, T5, T6 | mutations.ts · handlers-app.ts | mutations, installation, repo, member |
+| tester-A | T8 | tenant.test.ts · handlers.test.ts | routing-tests |
+| tester-B | T9 | handlers-app.test.ts · mutations.test.ts | handler-tests |
+
+backend-dev-B carries 5 tasks (>4 cap) but all write the two shared files (`mutations.ts`, `handlers-app.ts`) — barrel-merge rule overrides the per-instance split to avoid parallel-write conflicts.
+
+## Wave Structure
+
+5 waves, max 2 parallel agents. Elapsed ~3 units vs ~6 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | backend-dev-A: T0, T1 |
+| 2 | Wave 1 done | 1 | backend-dev-B: T2 |
+| 3 | Wave 2 done | 1 | backend-dev-B: T3→T4→T5→T6 (chained, shared file) |
+| 4 | Wave 3 done | 2 ∥ | backend-dev-A: T7 · tester-B: T9 |
+| 5 | Wave 4 (T7) done | 1 | tester-A: T8 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T0 migration | 1 | trivial | 2 | — |
+| T1 tenant.ts | 2 fns | bounded | 6 | — |
+| T2 mutations helpers | ~10 fns | judgmental | 14 | — |
+| T3 installation handler | 4 actions | judgmental | 10 | — |
+| T4 installation_repositories | 2 actions | bounded | 6 | — |
+| T5 repository (cascade+privacy) | 4 actions | exploratory | 14 | — (kept; cascade is the hard unit) |
+| T6 member+membership | 2 handlers | judgmental | 10 | — |
+| T7 routing+dispatch | 1 file | judgmental | 12 | — |
+| T8 tenant+routing tests | 2 files | judgmental | 12 | — |
+| T9 handlers-app+mutations tests | 2 files | judgmental | 16 | — |
+
+**Total estimated ops: ~102**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T0, T1, T7 | 20 | migrations, tenant-lookup, dispatch | — (T0 trivial; under cap) |
+| backend-dev-B | T2-T6 | 54 | mutations, installation, repo, member | barrel-merge override (shared files) |
+| tester-A | T8 | 12 | routing-tests | — |
+| tester-B | T9 | 16 | handler-tests | — |
+
+## Consistency Report
+
+Covered: 17/17 requirements. R4 + N1 are EXISTS (no task — preserved by construction; verified in T7/T9 tests).
+Build tasks cover R1-R3 (T1/T7), H1-H4 (T3), H5-H6 (T4), H7-H10 (T5), H11-H12 (T6).
+Untraced tasks: none. Exemptions: none.
+
+## Micro-Tasks
+
+### T0 — Migration 0009: tenants.deleted_at  `[backend-dev-A · migrations · RED-free · diff 1]`
+- File: `worker/migrations/0009_tenant_deleted_at.sql`
+- Snippet: `ALTER TABLE tenants ADD COLUMN deleted_at TEXT;`
+- Verify: `cd worker && npx wrangler d1 migrations list roxabi-live-production --local 2>/dev/null | grep 0009` (or file exists + SQL parses in test apply)
+- Spec trace: H2 · Slice V1 · Difficulty 1
+
+### T1 — Tenant lookup helpers  `[backend-dev-A · tenant-lookup · diff 2]`
+- File: `worker/src/webhook/tenant.ts` (new)
+- Shape:
+  ```ts
+  export interface TenantRow { id: number; installation_id: number; account_login: string;
+    account_type: string; suspended_at: string | null; deleted_at: string | null; }
+  export async function getTenantByInstallationId(db: D1Database, installationId: number): Promise<TenantRow | null>
+  export async function getTenantByOrgLogin(db: D1Database, login: string): Promise<TenantRow | null>
+  ```
+- Verify: `cd worker && npx tsc --noEmit` + new unit test green
+- Spec trace: R1, R2, H12 · Slice V1 · Difficulty 2
+
+### T2 — Webhook mutation helpers  `[backend-dev-B · mutations · diff 3]`
+- File: `worker/src/webhook/mutations.ts` (extend); reuse `auth/repoAccess.ts`, `auth/session.ts` exports where present, else add local helpers.
+- Add: `upsertTenant`, `softDeleteTenant` (sets `deleted_at`), `setTenantSuspended(db,id,iso|null)`, `upsertRepoAccess(db,tenantId,repo,isPrivate)`, `deleteRepoAccess(db,tenantId,repo)`, `setRepoPrivacy(db,repo,isPrivate)`, `cascadeRepoRename(db,nodeId,oldFullName,newFullName)` (re-key `repos`,`tenant_repo_access`,`issues`,`edges` via `db.batch`, skip `sync_control` sentinel), `invalidateCacheByRepo`, `invalidateCacheByUserRepo`, `invalidateCacheByUser`, `deleteSessionsForTenant`, `deleteInstallTokensForTenant`.
+- Verify: `cd worker && npx tsc --noEmit` + `npm test -- mutations`
+- Spec trace: H1-H12 substrate · Slice V1 · Difficulty 3
+
+### T3 — installation handler (H1-H4)  `[backend-dev-B · installation · diff 3]`
+- File: `worker/src/webhook/handlers-app.ts` (new)
+- `handleInstallation(payload, db, env)` switch on `payload.action`:
+  - `created`: upsertTenant + per-repo upsertRepoAccess (from `payload.repositories[]`) + enqueue sync (sync_control hint)
+  - `deleted`: deleteRepoAccess(all) + deleteInstallTokensForTenant + deleteSessionsForTenant + softDeleteTenant; **retain issues/edges**
+  - `suspend`: setTenantSuspended(now) · `unsuspend`: setTenantSuspended(null)
+- Verify: `npm test -- handlers-app`
+- Spec trace: H1, H2, H3, H4 · Slice V1 · Difficulty 3
+
+### T4 — installation_repositories handler (H5-H6)  `[backend-dev-B · repo-access · diff 2]`
+- File: `worker/src/webhook/handlers-app.ts` (extend)
+- `handleInstallationRepositories(payload, db, env)`: `payload.repositories_added[]`→upsertRepoAccess + sync hint; `payload.repositories_removed[]`→deleteRepoAccess (retain issues/edges)
+- Verify: `npm test -- handlers-app`
+- Spec trace: H5, H6 · Slice V1 · Difficulty 2
+
+### T5 — repository handler (H7-H10)  `[backend-dev-B · repo-lifecycle · diff 4]`
+- File: `worker/src/webhook/handlers-app.ts` (extend)
+- `handleRepository(payload, db)` switch on `payload.action`:
+  - `renamed`: cascadeRepoRename anchored on `payload.repository.node_id` (fallback `payload.changes.repository.name.from` / `previous_repository.full_name`)
+  - `transferred`: same cascade
+  - `privatized`: setRepoPrivacy(1) + invalidateCacheByRepo · `publicized`: setRepoPrivacy(0) + invalidateCacheByRepo
+- Verify: `npm test -- handlers-app`
+- Spec trace: H7, H8, H9, H10 · Slice V1 · Difficulty 4
+
+### T6 — member + membership handlers (H11-H12)  `[backend-dev-B · member-cache · diff 3]`
+- File: `worker/src/webhook/handlers-app.ts` (extend)
+- `handleMember(payload, db)`: resolve `payload.member.id`(github_id)→users.id; invalidateCacheByUserRepo(user_id, `payload.repository.full_name`). Zero-rows → no-op.
+- `handleMembership(payload, db)`: resolve github_id→users.id; invalidateCacheByUser(user_id). Tenant routed via `getTenantByOrgLogin(payload.organization.login)` when `installation` absent.
+- Verify: `npm test -- handlers-app`
+- Spec trace: H11, H12 · Slice V1 · Difficulty 3
+
+### T7 — Routing gate + dispatch wiring  `[backend-dev-A · dispatch · diff 4]`
+- File: `worker/src/webhook/handlers.ts` (modify)
+- After JSON parse: for app/repo/member events resolve `payload.installation.id`→tenant (membership→org login); `null`→`{ok:true, ignored}` 200 no-write; `suspended_at`/`deleted_at` set→log+200 no-write. Extend allowlist (`installation`, `installation_repositories`, `repository`, `member`, `membership`) + dispatch to handlers-app fns; integrate `bumpDataVersion` on mutate.
+- Verify: `npx tsc --noEmit` + `npm test -- handlers`
+- Spec trace: R1, R2, R3, dispatch for H1-H12 · Slice V1 · Difficulty 4
+
+### RED-GATE V1 — all handler+routing tests green before ship
+- Verify: `cd worker && npm test && npx tsc --noEmit`
+
+### T8 — Tests: tenant lookup + routing reject paths  `[tester-A · routing-tests · diff 3]`
+- Files: `worker/src/webhook/tenant.test.ts` (new), `worker/src/webhook/handlers.test.ts` (extend)
+- Cover: getTenantBy* hit/miss; unknown installation→200 no-write (assert no D1 writes via captureDb); suspended→200 no-write; data_version not bumped on no-write.
+- Verify: `npm test -- tenant handlers`
+- Spec trace: R1, R2, R3 · Slice V1 · Difficulty 3
+
+### T9 — Tests: handlers-app + mutations  `[tester-B · handler-tests · diff 4]`
+- Files: `worker/src/webhook/handlers-app.test.ts` (new), `worker/src/webhook/mutations.test.ts` (extend)
+- Cover each handler/action: tenant upsert/soft-delete/suspend; repo-access add/remove; privacy+cache invalidation; rename/transfer cascade (issues/edges re-keyed, sentinel untouched); member/membership cache invalidation incl. github_id→user_id zero-rows no-op; issues/edges retention on uninstall.
+- Verify: `npm test -- handlers-app mutations`
+- Spec trace: H1-H12, N1 · Slice V1 · Difficulty 4
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 1 agent
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T0 | backend-dev-A | — | migrations |
+| T1 | backend-dev-A | — | tenant-lookup |
+
+### Wave 2 — after T0,T1, 1 agent
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-B | T0, T1 | mutations |
+
+### Wave 3 — after T2, 1 agent (chained, shared file)
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-B | T2 | installation |
+| T4 | backend-dev-B | T3 | repo-access |
+| T5 | backend-dev-B | T4 | repo-lifecycle |
+| T6 | backend-dev-B | T5 | member-cache |
+
+### Wave 4 — after T6, 2 agents ∥
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | backend-dev-A | T1, T6 | dispatch |
+| T9 | tester-B | T2, T6 | handler-tests |
+
+### Wave 5 — after T7, 1 agent
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T8 | tester-A | T7 | routing-tests |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T0: 10 — migrations (backend-dev-A)
+- T1: 11 — tenant-lookup (backend-dev-A)
+- T2: 12 — mutations (backend-dev-B)
+- T3: 13 — installation (backend-dev-B)
+- T4: 14 — repo-access (backend-dev-B)
+- T5: 15 — repo-lifecycle (backend-dev-B)
+- T6: 16 — member-cache (backend-dev-B)
+- T7: 17 — dispatch (backend-dev-A)
+- T8: 18 — routing-tests (tester-A)
+- T9: 19 — handler-tests (tester-B)

--- a/worker/migrations/0009_tenant_deleted_at.sql
+++ b/worker/migrations/0009_tenant_deleted_at.sql
@@ -1,0 +1,7 @@
+-- migration: 0009_tenant_deleted_at.sql
+-- Applied via: wrangler d1 migrations apply DB [--env staging] --remote
+--
+-- Soft-delete tombstone for installation.deleted webhook events (H2).
+-- Tenant row is retained (issues/edges intact); deleted_at = ISO timestamp
+-- when the installation was deleted, NULL = active.
+ALTER TABLE tenants ADD COLUMN deleted_at TEXT;

--- a/worker/src/webhook/handlers-app.test.ts
+++ b/worker/src/webhook/handlers-app.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  handleInstallation,
+  handleInstallationRepositories,
+  handleRepository,
+  handleMember,
+  handleMembership,
+} from "./handlers-app";
+import type { Env } from "../types";
+
+// ---------------------------------------------------------------------------
+// Fake-D1 harness
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = Row>() => Promise<T | null>;
+  all: <T = Row>() => Promise<{ results: T[] }>;
+}
+
+function makeStmt(sql: string, args: unknown[], rows: Row[]): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+/** Seeds .first() results by SQL match; records every bound stmt; captures db.batch arrays. */
+function seededDb(seed: { tenant?: Row | null; user?: Row | null; repo?: Row | null } = {}) {
+  const recorded: FakeStmt[] = [];
+  const batched: FakeStmt[][] = [];
+  const rowsFor = (sql: string): Row[] => {
+    if (/FROM tenants/.test(sql)) return seed.tenant ? [seed.tenant] : [];
+    if (/FROM users/.test(sql)) return seed.user ? [seed.user] : [];
+    if (/FROM repos/.test(sql)) return seed.repo ? [seed.repo] : [];
+    return [];
+  };
+  const db = {
+    prepare(sql: string) {
+      const direct = makeStmt(sql, [], rowsFor(sql));
+      recorded.push(direct);
+      return {
+        bind: (...args: unknown[]) => {
+          const s = makeStmt(sql, args, rowsFor(sql));
+          recorded.push(s);
+          return s;
+        },
+        first: <T = Row>() => direct.first<T>(),
+        run: () => direct.run(),
+        all: <T = Row>() => direct.all<T>(),
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      batched.push(stmts);
+      return stmts.map(() => ({ results: [], meta: { changes: 1 } }));
+    }),
+  } as unknown as D1Database;
+  return {
+    db,
+    recorded: () => recorded,
+    batched: () => batched,
+    batchFn: () => (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch,
+  };
+}
+
+function fakeEnv(): Env {
+  return { GITHUB_ORG: "Roxabi" } as unknown as Env;
+}
+
+const activeTenant: Row = {
+  id: 1,
+  installation_id: 555,
+  account_login: "Roxabi",
+  account_type: "Organization",
+  suspended_at: null,
+  deleted_at: null,
+};
+
+function batchedSql(batched: FakeStmt[][]): string[] {
+  return batched.flat().map((s) => s.sql);
+}
+
+function allBatchedStmts(batched: FakeStmt[][]): FakeStmt[] {
+  return batched.flat();
+}
+
+// ---------------------------------------------------------------------------
+// handleInstallation
+// ---------------------------------------------------------------------------
+
+describe("handleInstallation", () => {
+  describe("created", () => {
+    it("upserts tenant and batches repo-access rows + bump for each repository", async () => {
+      // Arrange
+      const { db, recorded, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "created",
+        installation: { id: 555, account: { login: "Roxabi", type: "Organization" } },
+        repositories: [
+          { full_name: "Roxabi/a", private: false },
+          { full_name: "Roxabi/b", private: true },
+        ],
+      };
+
+      // Act
+      await handleInstallation(payload, db, fakeEnv());
+
+      // Assert — upsertTenant ran as a standalone .run()
+      const allSql = recorded().map((s) => s.sql);
+      expect(allSql.some((sql) => /INSERT INTO tenants/.test(sql))).toBe(true);
+
+      // Assert — db.batch was called once with 3 statements:
+      //   2× INSERT INTO tenant_repo_access + 1× sync_control bump
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+      const accessStmts = stmts.filter((s) => /INSERT INTO tenant_repo_access/.test(s.sql));
+      expect(accessStmts).toHaveLength(2);
+
+      // First repo is public (is_private = 0)
+      const stmtA = accessStmts.find((s) => s.args.includes("Roxabi/a"));
+      expect(stmtA).toBeDefined();
+      expect(stmtA!.args).toContain(0);
+
+      // Second repo is private (is_private = 1)
+      const stmtB = accessStmts.find((s) => s.args.includes("Roxabi/b"));
+      expect(stmtB).toBeDefined();
+      expect(stmtB!.args).toContain(1);
+
+      // Bump included
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+  });
+
+  describe("deleted", () => {
+    it("batches soft-delete + repo-access purge + sessions + tokens + bump", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = { action: "deleted", installation: { id: 555 } };
+
+      // Act
+      await handleInstallation(payload, db, fakeEnv());
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const sqls = batchedSql(batched());
+
+      expect(sqls.some((sql) => /UPDATE tenants SET deleted_at/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /DELETE FROM tenant_repo_access WHERE tenant_id=\?/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /DELETE FROM sessions WHERE tenant_id=\?/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /DELETE FROM install_tokens WHERE tenant_id=\?/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+
+    it("does NOT touch issues or edges (retention invariant)", async () => {
+      // Arrange
+      const { db, batched } = seededDb({ tenant: activeTenant });
+      const payload = { action: "deleted", installation: { id: 555 } };
+
+      // Act
+      await handleInstallation(payload, db, fakeEnv());
+
+      // Assert — no statement references issues or edges tables
+      const sqls = batchedSql(batched());
+      expect(sqls.some((sql) => /FROM issues/.test(sql) || /INTO issues/.test(sql) || /DELETE FROM issues/.test(sql))).toBe(false);
+      expect(sqls.some((sql) => /FROM edges/.test(sql) || /INTO edges/.test(sql) || /DELETE FROM edges/.test(sql))).toBe(false);
+    });
+
+    it("is a no-op when tenant is unknown (idempotent)", async () => {
+      // Arrange
+      const { db, batchFn } = seededDb({ tenant: null });
+      const payload = { action: "deleted", installation: { id: 555 } };
+
+      // Act
+      await handleInstallation(payload, db, fakeEnv());
+
+      // Assert
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("suspend", () => {
+    it("batches suspended_at update with a non-null timestamp + bump", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = { action: "suspend", installation: { id: 555 } };
+
+      // Act
+      await handleInstallation(payload, db, fakeEnv());
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+      const suspendStmt = stmts.find((s) => /UPDATE tenants SET suspended_at/.test(s.sql));
+      expect(suspendStmt).toBeDefined();
+      // First arg is the suspended_at value — must be non-null (an ISO string)
+      expect(suspendStmt!.args[0]).not.toBeNull();
+      expect(typeof suspendStmt!.args[0]).toBe("string");
+
+      // Bump included
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+  });
+
+  describe("unsuspend", () => {
+    it("batches suspended_at update with null + bump", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = { action: "unsuspend", installation: { id: 555 } };
+
+      // Act
+      await handleInstallation(payload, db, fakeEnv());
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+      const suspendStmt = stmts.find((s) => /UPDATE tenants SET suspended_at/.test(s.sql));
+      expect(suspendStmt).toBeDefined();
+      // First arg is suspended_at — must be null (clearing the suspension)
+      expect(suspendStmt!.args[0]).toBeNull();
+
+      // Bump included
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleInstallationRepositories
+// ---------------------------------------------------------------------------
+
+describe("handleInstallationRepositories", () => {
+  describe("added", () => {
+    it("batches INSERT INTO tenant_repo_access + bump for each added repo", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "added",
+        installation: { id: 555 },
+        repositories_added: [{ full_name: "Roxabi/x", private: true }],
+      };
+
+      // Act
+      await handleInstallationRepositories(payload, db, fakeEnv());
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const sqls = batchedSql(batched());
+      expect(sqls.some((sql) => /INSERT INTO tenant_repo_access/.test(sql))).toBe(true);
+
+      const accessStmt = allBatchedStmts(batched()).find(
+        (s) => /INSERT INTO tenant_repo_access/.test(s.sql) && s.args.includes("Roxabi/x"),
+      );
+      expect(accessStmt).toBeDefined();
+      expect(accessStmt!.args).toContain(1); // is_private = 1
+
+      expect(sqls.some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+
+    it("does NOT call db.batch when repositories_added is empty", async () => {
+      // Arrange
+      const { db, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "added",
+        installation: { id: 555 },
+        repositories_added: [],
+      };
+
+      // Act
+      await handleInstallationRepositories(payload, db, fakeEnv());
+
+      // Assert
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removed", () => {
+    it("batches DELETE FROM tenant_repo_access for the removed repo + bump", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "removed",
+        installation: { id: 555 },
+        repositories_removed: [{ full_name: "Roxabi/x" }],
+      };
+
+      // Act
+      await handleInstallationRepositories(payload, db, fakeEnv());
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+      const deleteStmt = stmts.find(
+        (s) => /DELETE FROM tenant_repo_access WHERE tenant_id=\? AND repo=\?/.test(s.sql),
+      );
+      expect(deleteStmt).toBeDefined();
+      expect(deleteStmt!.args).toContain("Roxabi/x");
+      expect(deleteStmt!.args).toContain(1); // tenantId
+
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleRepository
+// ---------------------------------------------------------------------------
+
+describe("handleRepository", () => {
+  describe("renamed — fallback path (no node_id DB hit)", () => {
+    it("cascades rename across all repo-keyed tables + bump", async () => {
+      // Arrange — seed no repo row so node_id lookup returns null; handler falls back to
+      // changes.repository.name.from
+      const { db, batched, batchFn } = seededDb({ repo: null });
+      const payload = {
+        action: "renamed",
+        repository: { full_name: "Roxabi/new", node_id: "NID" },
+        changes: { repository: { name: { from: "old" } } },
+      };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const sqls = batchedSql(batched());
+
+      // All 5 cascade tables + bump
+      expect(sqls.some((sql) => /UPDATE repos SET repo=\?/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /UPDATE tenant_repo_access SET repo=\?/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /UPDATE issues SET repo=\?/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /UPDATE edges SET src_key = \? \|\| substr/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /UPDATE edges SET dst_key = \? \|\| substr/.test(sql))).toBe(true);
+      expect(sqls.some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+
+      // All cascade statements (all but the trailing bump) do not reference sync_control
+      const stmts = allBatchedStmts(batched());
+      const cascadeStmts = stmts.slice(0, stmts.length - 1);
+      expect(cascadeStmts.every((s) => !/sync_control/.test(s.sql))).toBe(true);
+    });
+  });
+
+  describe("transferred — node_id anchor path", () => {
+    it("resolves oldFullName via repo_node_id lookup and cascades rename + bump", async () => {
+      // Arrange — node_id lookup returns the stored old slug
+      const { db, batched, batchFn } = seededDb({ repo: { repo: "OldOwner/repo" } });
+      const payload = {
+        action: "transferred",
+        repository: { full_name: "NewOwner/repo", node_id: "NID" },
+      };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      // repos UPDATE carries old → new names
+      const reposStmt = stmts.find((s) => /UPDATE repos SET repo=\?/.test(s.sql));
+      expect(reposStmt).toBeDefined();
+      expect(reposStmt!.args).toContain("OldOwner/repo");
+      expect(reposStmt!.args).toContain("NewOwner/repo");
+
+      // All 5 cascade stmts + bump = 6
+      expect(stmts).toHaveLength(6);
+
+      // Bump is last
+      expect(/INSERT INTO sync_control/.test(stmts[stmts.length - 1].sql)).toBe(true);
+    });
+  });
+
+  describe("privatized", () => {
+    it("batches is_private=1 + cache invalidation by repo + bump", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb();
+      const payload = { action: "privatized", repository: { full_name: "Roxabi/r" } };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      const privacyStmt = stmts.find((s) => /UPDATE tenant_repo_access SET is_private=\?/.test(s.sql));
+      expect(privacyStmt).toBeDefined();
+      expect(privacyStmt!.args[0]).toBe(1);
+
+      const cacheStmt = stmts.find((s) => /DELETE FROM user_repo_permission_cache WHERE repo=\?/.test(s.sql));
+      expect(cacheStmt).toBeDefined();
+      expect(cacheStmt!.args).toContain("Roxabi/r");
+
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+  });
+
+  describe("publicized", () => {
+    it("batches is_private=0 + cache invalidation by repo + bump", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb();
+      const payload = { action: "publicized", repository: { full_name: "Roxabi/r" } };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      const privacyStmt = stmts.find((s) => /UPDATE tenant_repo_access SET is_private=\?/.test(s.sql));
+      expect(privacyStmt).toBeDefined();
+      expect(privacyStmt!.args[0]).toBe(0);
+
+      const cacheStmt = stmts.find((s) => /DELETE FROM user_repo_permission_cache WHERE repo=\?/.test(s.sql));
+      expect(cacheStmt).toBeDefined();
+
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+  });
+
+  describe("unhandled action", () => {
+    it("does NOT call db.batch for an unrecognized action", async () => {
+      // Arrange
+      const { db, batchFn } = seededDb();
+      const payload = { action: "created", repository: { full_name: "Roxabi/r" } };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleMember
+// ---------------------------------------------------------------------------
+
+describe("handleMember", () => {
+  describe("removed", () => {
+    it("batches DELETE FROM user_repo_permission_cache for (user_id, repo) + bump", async () => {
+      // Arrange — user seed: local user row for github_id=42
+      const { db, batched, batchFn } = seededDb({ user: { id: 7 } });
+      const payload = {
+        action: "removed",
+        member: { id: 42 },
+        repository: { full_name: "Roxabi/r" },
+      };
+
+      // Act
+      await handleMember(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      const cacheStmt = stmts.find(
+        (s) => /DELETE FROM user_repo_permission_cache WHERE user_id=\? AND repo=\?/.test(s.sql),
+      );
+      expect(cacheStmt).toBeDefined();
+      expect(cacheStmt!.args).toEqual([7, "Roxabi/r"]);
+
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+
+    it("does NOT call db.batch when user is unknown (never logged in)", async () => {
+      // Arrange
+      const { db, batchFn } = seededDb({ user: null });
+      const payload = {
+        action: "removed",
+        member: { id: 42 },
+        repository: { full_name: "Roxabi/r" },
+      };
+
+      // Act
+      await handleMember(payload, db);
+
+      // Assert
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("added", () => {
+    it("does NOT call db.batch (cache miss will re-verify on next request)", async () => {
+      // Arrange
+      const { db, batchFn } = seededDb({ user: { id: 7 } });
+      const payload = {
+        action: "added",
+        member: { id: 42 },
+        repository: { full_name: "Roxabi/r" },
+      };
+
+      // Act
+      await handleMember(payload, db);
+
+      // Assert
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleMembership
+// ---------------------------------------------------------------------------
+
+describe("handleMembership", () => {
+  describe("removed", () => {
+    it("batches full-user cache wipe (no repo filter) + bump", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb({ user: { id: 7 } });
+      const payload = { action: "removed", member: { id: 42 } };
+
+      // Act
+      await handleMembership(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      const cacheStmt = stmts.find(
+        (s) => /DELETE FROM user_repo_permission_cache WHERE user_id=\?/.test(s.sql),
+      );
+      expect(cacheStmt).toBeDefined();
+      // Must NOT have a repo filter
+      expect(/repo=\?/.test(cacheStmt!.sql)).toBe(false);
+      expect(cacheStmt!.args).toEqual([7]);
+
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+
+    it("does NOT call db.batch when user is unknown", async () => {
+      // Arrange
+      const { db, batchFn } = seededDb({ user: null });
+      const payload = { action: "removed", member: { id: 42 } };
+
+      // Act
+      await handleMembership(payload, db);
+
+      // Assert
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("added", () => {
+    it("does NOT call db.batch (cache miss will re-verify on next check)", async () => {
+      // Arrange
+      const { db, batchFn } = seededDb({ user: { id: 7 } });
+      const payload = { action: "added", member: { id: 42 } };
+
+      // Act
+      await handleMembership(payload, db);
+
+      // Assert
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/worker/src/webhook/handlers-app.test.ts
+++ b/worker/src/webhook/handlers-app.test.ts
@@ -136,6 +136,33 @@ describe("handleInstallation", () => {
       // Bump included
       expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
     });
+
+    it("created with no repositories still bumps data_version (tenant row created)", async () => {
+      // Arrange
+      const { db, recorded, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "created",
+        installation: { id: 555, account: { login: "Roxabi", type: "Organization" } },
+        repositories: [],
+      };
+
+      // Act
+      await handleInstallation(payload, db, fakeEnv());
+
+      // Assert — upsertTenant still runs as a standalone .run() (tenant row created/updated)
+      const allSql = recorded().map((s) => s.sql);
+      expect(allSql.some((sql) => /INSERT INTO tenants/.test(sql))).toBe(true);
+
+      // Assert — db.batch IS called exactly once; its sole statement is the data_version bump
+      // (installation.created is a lifecycle event — always bumps regardless of repo count)
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+      expect(stmts).toHaveLength(1);
+      expect(stmts[0].sql).toMatch(/INSERT INTO sync_control|data_version/);
+
+      // No repo-access rows — repositories list was empty
+      expect(stmts.every((s) => !/INSERT INTO tenant_repo_access/.test(s.sql))).toBe(true);
+    });
   });
 
   describe("deleted", () => {
@@ -304,6 +331,9 @@ describe("handleInstallationRepositories", () => {
       expect(deleteStmt!.args).toContain(1); // tenantId
 
       expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+
+      // Retention invariant: removing a repo from an installation must NOT purge issues or edges
+      expect(stmts.every((s) => !/FROM issues/.test(s.sql) && !/FROM edges/.test(s.sql))).toBe(true);
     });
   });
 });
@@ -339,10 +369,93 @@ describe("handleRepository", () => {
       expect(sqls.some((sql) => /UPDATE edges SET dst_key = \? \|\| substr/.test(sql))).toBe(true);
       expect(sqls.some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
 
-      // All cascade statements (all but the trailing bump) do not reference sync_control
+      // Mis-bind guard: UPDATE repos must bind BOTH new name (SET) and old name (WHERE)
+      // payload: full_name="Roxabi/new", changes.repository.name.from="old" → oldFullName="Roxabi/old"
       const stmts = allBatchedStmts(batched());
+      const reposUpdateStmt = stmts.find((s) => /UPDATE repos SET repo=\?/.test(s.sql));
+      expect(reposUpdateStmt).toBeDefined();
+      expect(reposUpdateStmt!.args).toContain("Roxabi/new"); // SET value
+      expect(reposUpdateStmt!.args).toContain("Roxabi/old"); // WHERE value
+
+      // All cascade statements (all but the trailing bump) do not reference sync_control
       const cascadeStmts = stmts.slice(0, stmts.length - 1);
       expect(cascadeStmts.every((s) => !/sync_control/.test(s.sql))).toBe(true);
+    });
+  });
+
+  describe("transferred — fallback path (no node_id DB hit)", () => {
+    it("resolves oldFullName via org login and cascades rename + bump", async () => {
+      // Arrange — no repo row so node_id lookup returns null; handler falls back to
+      // changes.owner.from.organization.login
+      const { db, batched, batchFn } = seededDb({ repo: null });
+      const payload = {
+        action: "transferred",
+        repository: { full_name: "NewOwner/repo", node_id: "NID" },
+        changes: { owner: { from: { organization: { login: "OldOwner" } } } },
+      };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      // WHERE arg in repos UPDATE must be the reconstructed old full name
+      const reposStmt = stmts.find((s) => /UPDATE repos SET repo=\?/.test(s.sql));
+      expect(reposStmt).toBeDefined();
+      expect(reposStmt!.args).toContain("NewOwner/repo"); // SET (new)
+      expect(reposStmt!.args).toContain("OldOwner/repo"); // WHERE (old)
+    });
+
+    it("handles combined transfer+rename: uses name.from to reconstruct old full name", async () => {
+      // Arrange — no node_id hit; payload has both owner change and name change
+      const { db, batched, batchFn } = seededDb({ repo: null });
+      const payload = {
+        action: "transferred",
+        repository: { full_name: "NewOwner/new-name", node_id: "NID" },
+        changes: {
+          owner: { from: { organization: { login: "OldOwner" } } },
+          repository: { name: { from: "old-name" } },
+        },
+      };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      // Regression guard: WHERE must use "old-name", not "new-name" (mis-bind bug)
+      const reposStmt = stmts.find((s) => /UPDATE repos SET repo=\?/.test(s.sql));
+      expect(reposStmt).toBeDefined();
+      expect(reposStmt!.args).toContain("NewOwner/new-name"); // SET (new)
+      expect(reposStmt!.args).toContain("OldOwner/old-name"); // WHERE (old — correct reconstruction)
+      // Sanity: the wrong value must NOT appear as WHERE
+      const whereArg = reposStmt!.args[reposStmt!.args.length - 1];
+      expect(whereArg).not.toBe("OldOwner/new-name");
+    });
+
+    it("resolves oldOwner via user.login when org block is absent", async () => {
+      // Arrange — changes.owner.from has user.login but no organization block
+      const { db, batched, batchFn } = seededDb({ repo: null });
+      const payload = {
+        action: "transferred",
+        repository: { full_name: "NewOwner/repo", node_id: "NID" },
+        changes: { owner: { from: { user: { login: "OldUser" } } } },
+      };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      const reposStmt = stmts.find((s) => /UPDATE repos SET repo=\?/.test(s.sql));
+      expect(reposStmt).toBeDefined();
+      expect(reposStmt!.args).toContain("OldUser/repo"); // WHERE (old — from user.login)
     });
   });
 

--- a/worker/src/webhook/handlers-app.ts
+++ b/worker/src/webhook/handlers-app.ts
@@ -140,6 +140,9 @@ export async function handleInstallation(
   // ── created ───────────────────────────────────────────────────────────────
   if (action === "created") {
     // Phase 1: upsert tenant row (standalone run — we need the PK before batching).
+    // Two-phase write: upsert the tenant standalone so we can read its PK below, then
+    // batch the repo-access rows + bump atomically. If phase 2 fails, GitHub re-delivers
+    // installation.created (ON CONFLICT re-runs idempotently) and the batch heals.
     await upsertTenant(db, {
       installation_id: installationId,
       account_login: accountLogin,
@@ -404,8 +407,12 @@ export async function handleRepository(
       if (oldOwner) {
         const slashIdx = fullName.lastIndexOf("/");
         if (slashIdx >= 0) {
-          const name = fullName.slice(slashIdx + 1);
-          oldFullName = `${oldOwner}/${name}`;
+          // A transfer may also rename: prefer changes.repository.name.from; fall back to the
+          // current name for a pure ownership transfer (name unchanged).
+          const repoChanges = (changes["repository"] as Record<string, unknown> | undefined) ?? {};
+          const nameChanges = (repoChanges["name"] as Record<string, unknown> | undefined) ?? {};
+          const oldName = (nameChanges["from"] as string | undefined) ?? fullName.slice(slashIdx + 1);
+          oldFullName = `${oldOwner}/${oldName}`;
         }
       }
     }

--- a/worker/src/webhook/handlers-app.ts
+++ b/worker/src/webhook/handlers-app.ts
@@ -1,0 +1,542 @@
+/**
+ * GitHub App lifecycle webhook handlers — installation, installation_repositories,
+ * repository, member, membership events.
+ *
+ * These handlers are dispatched by the existing webhookRoute in handlers.ts after
+ * single-secret HMAC verification (GITHUB_WEBHOOK_SECRET via verifyHmac). The
+ * dispatcher resolves payload.installation.id → tenants (tenant.ts) before
+ * forwarding; unknown, suspended, or deleted tenants receive a 200-no-write.
+ *
+ * Design contract (same as handlers.ts / mutations.ts):
+ *   - Handlers accept a typed-ish payload (Record<string,unknown>), db, and env.
+ *   - All D1 writes use db.batch([...stmts]) for atomicity; never call .run()
+ *     directly inside a handler unless it is a single isolated write before a
+ *     follow-up read is needed (see handleInstallation created→repo-upsert gap).
+ *   - Helpers in mutations.ts return D1PreparedStatement / D1PreparedStatement[].
+ *     Handlers fold them into a single db.batch call.
+ *   - Suspended / deleted tenants are NOT hard-deleted from `tenants`; the
+ *     soft-delete / suspended_at pattern is used so the row stays for audit.
+ *   - sync_control sentinel (tenant_id=0, Deviation D-2): ¬touched here.
+ */
+
+import type { Env } from "../types";
+import {
+  getTenantByInstallationId,
+} from "./tenant";
+import {
+  bumpDataVersion,
+  upsertTenant,
+  softDeleteTenant,
+  setTenantSuspended,
+  upsertRepoAccess,
+  deleteRepoAccess,
+  deleteAllRepoAccessForTenant,
+  setRepoPrivacy,
+  cascadeRepoRename,
+  invalidateCacheByRepo,
+  invalidateCacheByUserRepo,
+  invalidateCacheByUser,
+  deleteSessionsForTenant,
+  deleteInstallTokensForTenant,
+} from "./mutations";
+
+// ---------------------------------------------------------------------------
+// Module-local helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the full_name from a repository object in a webhook payload.
+ * Returns an empty string when the field is absent or malformed so callers
+ * can early-return on the empty-string check without additional type guards.
+ */
+function repoFullName(repoObj: unknown): string {
+  if (!repoObj || typeof repoObj !== "object") {
+    return "";
+  }
+  const fn = (repoObj as Record<string, unknown>)["full_name"];
+  return typeof fn === "string" ? fn : "";
+}
+
+/**
+ * Derive 0|1 from a boolean-ish `private` field found in GitHub repo objects.
+ * Defaults to 1 (private) on ambiguous input — fail-closed for access control.
+ */
+function isPrivateBit(repoObj: unknown): 0 | 1 {
+  if (!repoObj || typeof repoObj !== "object") {
+    return 1;
+  }
+  const priv = (repoObj as Record<string, unknown>)["private"];
+  return priv === false ? 0 : 1;
+}
+
+/**
+ * Resolve the local `users.id` for a given GitHub numeric user id.
+ * Returns null when the user has no local account (never logged in) — callers
+ * can skip cache invalidation safely in that case.
+ */
+async function resolveUserId(
+  db: D1Database,
+  githubId: number,
+): Promise<number | null> {
+  const row = await db
+    .prepare(`SELECT id FROM users WHERE github_id = ?`)
+    .bind(githubId)
+    .first<{ id: number }>();
+  return row?.id ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// H1 — handleInstallation
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a GitHub `installation` webhook event.
+ *
+ * Actions handled:
+ *   created        — upsert tenant, seed repo access from payload.repositories[].
+ *   deleted        — soft-delete tenant; purge sessions, install tokens, repo access.
+ *   suspend        — set suspended_at.
+ *   unsuspend      — clear suspended_at (pass null).
+ *   new_permissions_accepted — no-op (no data model change needed).
+ *
+ * Note on `created` two-phase write:
+ *   We need the tenant PK to upsert repo-access rows, but the PK is only
+ *   readable after the tenant row exists.  Solution:
+ *     1. Execute upsertTenant as a standalone .run() to create/update the row.
+ *     2. Read the tenant back via getTenantByInstallationId.
+ *     3. Batch repo-access upserts + bumpDataVersion atomically.
+ *   This is a deliberate deviation from pure batch-only writes — documented here
+ *   so a future reviewer does not "fix" it into a broken single-batch pattern.
+ *
+ * Note on `created` repos:
+ *   We use payload.repositories[] (the "selected repos" list GitHub provides on
+ *   install) rather than calling listInstallationRepos.  This avoids an extra
+ *   API round-trip during installation and is sufficient for phase 1 — the
+ *   installation_repositories event covers subsequent repo additions/removals.
+ */
+export async function handleInstallation(
+  payload: Record<string, unknown>,
+  db: D1Database,
+  env: Env,
+): Promise<void> {
+  const action = payload["action"] as string | undefined;
+  if (!action) {
+    console.warn("[webhook/app] installation event missing action");
+    return;
+  }
+
+  const installation = (payload["installation"] as Record<string, unknown> | undefined) ?? {};
+  const installationId = installation["id"] as number | undefined;
+  if (installationId == null) {
+    console.warn(`[webhook/app] installation.${action}: missing installation.id`);
+    return;
+  }
+
+  const account = (installation["account"] as Record<string, unknown> | undefined) ?? {};
+  const accountLogin = (account["login"] as string | undefined) ?? "";
+  const accountType = (account["type"] as string | undefined) ?? "Organization";
+  const nowIso = new Date().toISOString();
+
+  // ── created ───────────────────────────────────────────────────────────────
+  if (action === "created") {
+    // Phase 1: upsert tenant row (standalone run — we need the PK before batching).
+    await upsertTenant(db, {
+      installation_id: installationId,
+      account_login: accountLogin,
+      account_type: accountType,
+      nowIso,
+    }).run();
+
+    // Phase 2: read back the tenant PK.
+    const tenant = await getTenantByInstallationId(db, installationId);
+    if (!tenant) {
+      console.error(
+        `[webhook/app] installation.created: tenant not found after upsert for installation_id=${installationId}`,
+      );
+      return;
+    }
+    const tenantId = tenant.id;
+
+    // Build repo-access upserts from payload.repositories (the install-time selection).
+    const repositories = (payload["repositories"] as unknown[] | undefined) ?? [];
+    const repoStmts = repositories.flatMap((r) => {
+      const repo = repoFullName(r);
+      if (!repo) {
+        return [];
+      }
+      return [upsertRepoAccess(db, tenantId, repo, isPrivateBit(r))];
+    });
+
+    // Atomic: repo access + data-version bump.
+    await db.batch([...repoStmts, bumpDataVersion(db, nowIso)]);
+    return;
+  }
+
+  // ── deleted ───────────────────────────────────────────────────────────────
+  if (action === "deleted") {
+    const tenant = await getTenantByInstallationId(db, installationId);
+    if (!tenant) {
+      // Already gone — idempotent no-op.
+      console.warn(
+        `[webhook/app] installation.deleted: no tenant for installation_id=${installationId} — skipping`,
+      );
+      return;
+    }
+    const tenantId = tenant.id;
+
+    // Soft-delete + purge access/sessions/tokens in one batch.
+    await db.batch([
+      softDeleteTenant(db, tenantId, nowIso),
+      deleteAllRepoAccessForTenant(db, tenantId),
+      deleteSessionsForTenant(db, tenantId),
+      deleteInstallTokensForTenant(db, tenantId),
+      bumpDataVersion(db, nowIso),
+    ]);
+    return;
+  }
+
+  // ── suspend ───────────────────────────────────────────────────────────────
+  if (action === "suspend") {
+    const tenant = await getTenantByInstallationId(db, installationId);
+    if (!tenant) {
+      console.warn(
+        `[webhook/app] installation.suspend: no tenant for installation_id=${installationId} — skipping`,
+      );
+      return;
+    }
+    await db.batch([
+      setTenantSuspended(db, tenant.id, nowIso, nowIso),
+      bumpDataVersion(db, nowIso),
+    ]);
+    return;
+  }
+
+  // ── unsuspend ─────────────────────────────────────────────────────────────
+  if (action === "unsuspend") {
+    const tenant = await getTenantByInstallationId(db, installationId);
+    if (!tenant) {
+      console.warn(
+        `[webhook/app] installation.unsuspend: no tenant for installation_id=${installationId} — skipping`,
+      );
+      return;
+    }
+    await db.batch([
+      setTenantSuspended(db, tenant.id, null, nowIso),
+      bumpDataVersion(db, nowIso),
+    ]);
+    return;
+  }
+
+  // new_permissions_accepted and any future actions — acknowledged, no writes.
+  console.info(`[webhook/app] installation.${action}: no-op`);
+}
+
+// ---------------------------------------------------------------------------
+// H2 — handleInstallationRepositories
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a GitHub `installation_repositories` webhook event.
+ *
+ * Actions handled:
+ *   added   — upsert each repo in repositories_added[] into tenant_repo_access.
+ *   removed — delete each repo in repositories_removed[] from tenant_repo_access.
+ *
+ * Tenant lookup uses installation.id (always present on App webhook payloads).
+ * No-ops if the tenant is not found (deleted/unregistered installation).
+ */
+export async function handleInstallationRepositories(
+  payload: Record<string, unknown>,
+  db: D1Database,
+  env: Env,
+): Promise<void> {
+  const action = payload["action"] as string | undefined;
+  if (action !== "added" && action !== "removed") {
+    console.info(`[webhook/app] installation_repositories.${action}: no-op`);
+    return;
+  }
+
+  const installation = (payload["installation"] as Record<string, unknown> | undefined) ?? {};
+  const installationId = installation["id"] as number | undefined;
+  if (installationId == null) {
+    console.warn(
+      `[webhook/app] installation_repositories.${action}: missing installation.id`,
+    );
+    return;
+  }
+
+  const tenant = await getTenantByInstallationId(db, installationId);
+  if (!tenant) {
+    console.warn(
+      `[webhook/app] installation_repositories.${action}: no tenant for installation_id=${installationId} — skipping`,
+    );
+    return;
+  }
+  const tenantId = tenant.id;
+  const nowIso = new Date().toISOString();
+
+  if (action === "added") {
+    const repositories = (payload["repositories_added"] as unknown[] | undefined) ?? [];
+    const stmts = repositories.flatMap((r) => {
+      const repo = repoFullName(r);
+      if (!repo) {
+        return [];
+      }
+      return [upsertRepoAccess(db, tenantId, repo, isPrivateBit(r))];
+    });
+
+    if (stmts.length === 0) {
+      return;
+    }
+    await db.batch([...stmts, bumpDataVersion(db, nowIso)]);
+    return;
+  }
+
+  // removed
+  const repositories = (payload["repositories_removed"] as unknown[] | undefined) ?? [];
+  const stmts = repositories.flatMap((r) => {
+    const repo = repoFullName(r);
+    if (!repo) {
+      return [];
+    }
+    return [deleteRepoAccess(db, tenantId, repo)];
+  });
+
+  if (stmts.length === 0) {
+    return;
+  }
+  await db.batch([...stmts, bumpDataVersion(db, nowIso)]);
+}
+
+// ---------------------------------------------------------------------------
+// H3 — handleRepository
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a GitHub `repository` webhook event.
+ *
+ * Actions handled:
+ *   renamed     — cascade rename across all repo-keyed tables (repos,
+ *                 tenant_repo_access, issues, edges, user_repo_permission_cache).
+ *   transferred — same cascade as renamed; the repo gets a new owner prefix while
+ *                 the node_id remains stable (spec SC, H8).
+ *   privatized  — flip is_private=1 in tenant_repo_access; invalidate cache.
+ *   publicized  — flip is_private=0 in tenant_repo_access; invalidate cache.
+ *
+ * These events are not tenant-scoped: privacy changes and renames apply across
+ * every tenant that registered the repo. No tenant/org-login lookup is performed.
+ *
+ * oldFullName derivation for renamed / transferred (in priority order):
+ *   1. node_id anchor — query repos.repo_node_id (stable across renames); if the
+ *      stored slug differs from payload.repository.full_name, that stored slug IS
+ *      the old name. Most reliable path.
+ *   2. renamed fallback — changes.repository.name.from; owner is unchanged on a
+ *      pure rename so oldFullName = ${owner}/${changes.repository.name.from}.
+ *   3. transferred fallback — changes.owner.from.{user|organization}.login; repo
+ *      name is unchanged on a transfer so oldFullName = ${oldOwner}/${name}.
+ *   If none resolves to a non-empty string distinct from fullName the cascade is
+ *   skipped with a warning (cannot safely rewrite keys without the old prefix).
+ */
+export async function handleRepository(
+  payload: Record<string, unknown>,
+  db: D1Database,
+): Promise<void> {
+  const action = payload["action"] as string | undefined;
+  if (
+    action !== "renamed" &&
+    action !== "transferred" &&
+    action !== "privatized" &&
+    action !== "publicized"
+  ) {
+    return;
+  }
+
+  const repoObj = (payload["repository"] as Record<string, unknown> | undefined) ?? {};
+  const fullName = repoFullName(repoObj);
+  if (!fullName) {
+    console.warn(`[webhook/app] repository.${action}: missing repository.full_name`);
+    return;
+  }
+  const nowIso = new Date().toISOString();
+
+  // ── renamed / transferred ─────────────────────────────────────────────────
+  if (action === "renamed" || action === "transferred") {
+    const nodeId = (repoObj["node_id"] as string | undefined) ?? "";
+    const changes = (payload["changes"] as Record<string, unknown> | undefined) ?? {};
+
+    let oldFullName: string | null = null;
+
+    // Priority 1: node_id anchor — look up the currently stored slug by node_id.
+    if (nodeId) {
+      const row = await db
+        .prepare(`SELECT repo FROM repos WHERE repo_node_id = ?`)
+        .bind(nodeId)
+        .first<{ repo: string }>();
+      if (row && row.repo !== fullName) {
+        oldFullName = row.repo;
+      }
+    }
+
+    // Priority 2: renamed fallback — changes.repository.name.from (owner unchanged).
+    if (!oldFullName && action === "renamed") {
+      const repoChanges = (changes["repository"] as Record<string, unknown> | undefined) ?? {};
+      const nameChanges = (repoChanges["name"] as Record<string, unknown> | undefined) ?? {};
+      const oldName = (nameChanges["from"] as string | undefined) ?? "";
+      if (oldName) {
+        const slashIdx = fullName.lastIndexOf("/");
+        if (slashIdx >= 0) {
+          const owner = fullName.slice(0, slashIdx);
+          oldFullName = `${owner}/${oldName}`;
+        }
+      }
+    }
+
+    // Priority 3: transferred fallback — changes.owner.from.{user|organization}.login.
+    if (!oldFullName && action === "transferred") {
+      const ownerChanges = (changes["owner"] as Record<string, unknown> | undefined) ?? {};
+      const fromBlock = (ownerChanges["from"] as Record<string, unknown> | undefined) ?? {};
+      const userBlock = (fromBlock["user"] as Record<string, unknown> | undefined) ?? {};
+      const orgBlock = (fromBlock["organization"] as Record<string, unknown> | undefined) ?? {};
+      const oldOwner =
+        (userBlock["login"] as string | undefined) ??
+        (orgBlock["login"] as string | undefined) ??
+        "";
+      if (oldOwner) {
+        const slashIdx = fullName.lastIndexOf("/");
+        if (slashIdx >= 0) {
+          const name = fullName.slice(slashIdx + 1);
+          oldFullName = `${oldOwner}/${name}`;
+        }
+      }
+    }
+
+    if (!oldFullName || oldFullName === fullName) {
+      console.warn(
+        `[webhook/app] repository.${action}: could not derive oldFullName for repo=${fullName} — cascade skipped`,
+      );
+      return;
+    }
+
+    const renameStmts = cascadeRepoRename(db, oldFullName, fullName);
+    await db.batch([...renameStmts, bumpDataVersion(db, nowIso)]);
+    return;
+  }
+
+  // ── privatized / publicized ───────────────────────────────────────────────
+  const isPrivate: 0 | 1 = action === "privatized" ? 1 : 0;
+  await db.batch([
+    setRepoPrivacy(db, fullName, isPrivate),
+    invalidateCacheByRepo(db, fullName),
+    bumpDataVersion(db, nowIso),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// H4a — handleMember
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a GitHub `member` webhook event (repository-level collaborator changes).
+ *
+ * Actions handled:
+ *   added   — cache-miss will re-verify on next request; no proactive action needed.
+ *   removed — invalidate user_repo_permission_cache for (user_id, repo) if the
+ *             user has a local account; otherwise silently no-op.
+ *
+ * Note on user_id resolution:
+ *   GitHub member events carry `member.id` (the GitHub numeric user id).
+ *   The local `users` table stores `github_id` (integer). We resolve via
+ *   resolveUserId; if the user has never logged in, no local row exists and
+ *   there is nothing to invalidate.
+ */
+export async function handleMember(
+  payload: Record<string, unknown>,
+  db: D1Database,
+): Promise<void> {
+  const action = payload["action"] as string | undefined;
+  if (action !== "added" && action !== "removed") {
+    return;
+  }
+
+  // `added`: the next permission check will miss cache and re-verify live.
+  // No write needed — the live check will warm the cache correctly.
+  if (action === "added") {
+    return;
+  }
+
+  // `removed`: invalidate the specific (user, repo) pair.
+  const memberObj = (payload["member"] as Record<string, unknown> | undefined) ?? {};
+  const githubId = memberObj["id"] as number | undefined;
+  if (githubId == null) {
+    console.warn("[webhook/app] member.removed: missing member.id");
+    return;
+  }
+
+  const repoObj = (payload["repository"] as Record<string, unknown> | undefined) ?? {};
+  const repo = repoFullName(repoObj);
+  if (!repo) {
+    console.warn("[webhook/app] member.removed: missing repository.full_name");
+    return;
+  }
+
+  const userId = await resolveUserId(db, githubId);
+  if (userId === null) {
+    // User has never logged in — no cache entry to invalidate.
+    return;
+  }
+
+  const nowIso = new Date().toISOString();
+  await db.batch([
+    invalidateCacheByUserRepo(db, userId, repo),
+    bumpDataVersion(db, nowIso),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// H4b — handleMembership
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a GitHub `membership` webhook event (org team membership changes).
+ *
+ * Actions handled:
+ *   added   — no-op (cache miss will re-verify on next check).
+ *   removed — invalidate ALL user_repo_permission_cache rows for this user.
+ *             Removing someone from an org team can affect access to any
+ *             number of repos — we cannot cheaply enumerate which ones, so
+ *             a full-user cache wipe is the correct safe choice.
+ */
+export async function handleMembership(
+  payload: Record<string, unknown>,
+  db: D1Database,
+): Promise<void> {
+  const action = payload["action"] as string | undefined;
+  if (action !== "added" && action !== "removed") {
+    return;
+  }
+
+  // `added`: next check will re-verify live and warm the cache.
+  if (action === "added") {
+    return;
+  }
+
+  // `removed`: full-user cache wipe.
+  const memberObj = (payload["member"] as Record<string, unknown> | undefined) ?? {};
+  const githubId = memberObj["id"] as number | undefined;
+  if (githubId == null) {
+    console.warn("[webhook/app] membership.removed: missing member.id");
+    return;
+  }
+
+  const userId = await resolveUserId(db, githubId);
+  if (userId === null) {
+    // User has never logged in — nothing to invalidate.
+    return;
+  }
+
+  const nowIso = new Date().toISOString();
+  await db.batch([
+    invalidateCacheByUser(db, userId),
+    bumpDataVersion(db, nowIso),
+  ]);
+}

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -1200,3 +1200,229 @@ describe("webhookRoute", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tenant routing gate (S4 #147) — webhookRoute integration tests
+// ---------------------------------------------------------------------------
+//
+// These tests extend the webhookRoute suite (above) with a focus on the
+// tenant-routing gate introduced in #147.  They exercise the gate path in
+// isolation by supplying a seeded (or empty) fake DB so that
+// getTenantByInstallationId / getTenantByOrgLogin return controlled values.
+//
+// Architecture note — makeContextWith:
+//   makeContext() calls captureDb() internally and overwrites env.DB, so it is
+//   not possible to inject a pre-seeded DB through it.  makeContextWith() is a
+//   local variant that accepts the DB as a parameter, mirroring makeContext()
+//   exactly but skipping the internal captureDb() call.
+// ---------------------------------------------------------------------------
+
+/** Mirror of makeContext that accepts a pre-built db instead of creating one. */
+function makeContextWith(
+  req: Request,
+  env: Env,
+  db: D1Database & { _recorded: FakeStmt[] },
+): { c: Parameters<typeof webhookRoute>[0]; db: D1Database & { _recorded: FakeStmt[] } } {
+  const envWithDb: Env = { ...env, DB: db };
+
+  const headers: Record<string, string> = {};
+  req.headers.forEach((v, k) => {
+    headers[k.toLowerCase()] = v;
+  });
+
+  const c = {
+    env: envWithDb,
+    req: {
+      header: (name: string) => headers[name.toLowerCase()] ?? undefined,
+      arrayBuffer: () => req.arrayBuffer(),
+    },
+    json: (data: unknown, status?: number) =>
+      new Response(JSON.stringify(data), {
+        status: status ?? 200,
+        headers: { "content-type": "application/json" },
+      }),
+  } as unknown as Parameters<typeof webhookRoute>[0];
+
+  return { c, db };
+}
+
+/** Build a seeded fake DB that returns tenantRow for any FROM tenants query. */
+function seededTenantDb(
+  tenantRow: Record<string, unknown> | null,
+): D1Database & { _recorded: FakeStmt[] } {
+  return makeFakeDb((sql, args) => {
+    const rows = /FROM tenants/.test(sql) && tenantRow ? [tenantRow as FakeResult] : [];
+    return makeFakeStmt(sql, args, rows, 1);
+  });
+}
+
+const ACTIVE_TENANT = {
+  id: 1,
+  installation_id: 55_000,
+  account_login: "Roxabi",
+  account_type: "Organization",
+  suspended_at: null,
+  deleted_at: null,
+};
+
+describe("webhookRoute — tenant routing gate (S4 #147)", () => {
+  const SECRET = "test-secret";
+
+  /** Build a signed request carrying a payload with the given installation id. */
+  async function makeIssuesRequestWithInstallation(
+    installationId: number | null,
+  ): Promise<Request> {
+    const payload = {
+      action: "opened",
+      installation: installationId !== null ? { id: installationId } : undefined,
+      issue: {
+        number: 1,
+        title: "T",
+        state: "open",
+        html_url: "https://github.com/Roxabi/lyra/issues/1",
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+        closed_at: null,
+        milestone: null,
+        labels: [],
+      },
+      repository: { full_name: "Roxabi/lyra" },
+    };
+    const body = JSON.stringify(payload);
+    const enc = new TextEncoder().encode(body);
+    const sig = await computeHmac(enc.buffer as ArrayBuffer, SECRET);
+    return makeRequest(body, sig, "issues");
+  }
+
+  it("rejects an issues event for an unknown installation_id (tenant not in DB)", async () => {
+    // Arrange — no tenant row seeded; getTenantByInstallationId returns null
+    const db = seededTenantDb(null);
+    const env = makeEnv();
+    const req = await makeIssuesRequestWithInstallation(55_000);
+    const { c } = makeContextWith(req, env, db);
+
+    // Act
+    const res = await webhookRoute(c);
+    const body = await res.json<{ ok: boolean; ignored?: string }>();
+
+    // Assert — gate returns ignored, no DB writes
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, ignored: "issues" });
+    expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+  });
+
+  it("rejects an issues event when tenant is suspended (suspended_at non-null)", async () => {
+    // Arrange
+    const db = seededTenantDb({
+      ...ACTIVE_TENANT,
+      suspended_at: "2024-06-01T00:00:00Z",
+    });
+    const env = makeEnv();
+    const req = await makeIssuesRequestWithInstallation(55_000);
+    const { c } = makeContextWith(req, env, db);
+
+    // Act
+    const res = await webhookRoute(c);
+    const body = await res.json<{ ok: boolean; ignored?: string }>();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, ignored: "issues" });
+    expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+  });
+
+  it("rejects an issues event when tenant is soft-deleted (deleted_at non-null)", async () => {
+    // Arrange
+    const db = seededTenantDb({
+      ...ACTIVE_TENANT,
+      deleted_at: "2024-06-10T00:00:00Z",
+    });
+    const env = makeEnv();
+    const req = await makeIssuesRequestWithInstallation(55_000);
+    const { c } = makeContextWith(req, env, db);
+
+    // Act
+    const res = await webhookRoute(c);
+    const body = await res.json<{ ok: boolean; ignored?: string }>();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, ignored: "issues" });
+    expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+  });
+
+  it("passes through an issues event when tenant is active", async () => {
+    // Arrange — active tenant; gate must NOT return ignored
+    const db = seededTenantDb(ACTIVE_TENANT);
+    const env = makeEnv();
+    const req = await makeIssuesRequestWithInstallation(55_000);
+    const { c } = makeContextWith(req, env, db);
+
+    // Act
+    const res = await webhookRoute(c);
+    const body = await res.json<{ ok: boolean; ignored?: string }>();
+
+    // Assert — handler ran and bumped data_version (db.batch called at least once)
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.ignored).toBeUndefined();
+    expect(vi.mocked(db.batch)).toHaveBeenCalled();
+  });
+
+  it("rejects a membership event when org login resolves to no known tenant", async () => {
+    // Arrange — membership payload without installation block; org unknown
+    const db = seededTenantDb(null);
+    const env = makeEnv();
+    const payload = {
+      action: "added",
+      // No `installation` key — membership fallback via organization.login
+      organization: { login: "ghost-org" },
+      member: { login: "some-user" },
+      scope: "team",
+      team: { name: "devs" },
+    };
+    const body = JSON.stringify(payload);
+    const enc = new TextEncoder().encode(body);
+    const sig = await computeHmac(enc.buffer as ArrayBuffer, SECRET);
+    const req = makeRequest(body, sig, "membership");
+    const { c } = makeContextWith(req, env, db);
+
+    // Act
+    const res = await webhookRoute(c);
+    const resBody = await res.json<{ ok: boolean; ignored?: string }>();
+
+    // Assert — gate ignores because org login has no tenant row
+    expect(res.status).toBe(200);
+    expect(resBody).toEqual({ ok: true, ignored: "membership" });
+    expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
+  });
+
+  it("installation.created event is exempt from the tenant routing gate even when no tenant exists", async () => {
+    // Arrange — no tenant in DB; gate MUST NOT return ignored for installation events
+    const db = seededTenantDb(null);
+    const env = makeEnv();
+    const payload = {
+      action: "created",
+      installation: {
+        id: 55_000,
+        account: { login: "Roxabi", type: "Organization" },
+      },
+      repositories: [],
+      sender: { login: "mickael" },
+    };
+    const body = JSON.stringify(payload);
+    const enc = new TextEncoder().encode(body);
+    const sig = await computeHmac(enc.buffer as ArrayBuffer, SECRET);
+    const req = makeRequest(body, sig, "installation");
+    const { c } = makeContextWith(req, env, db);
+
+    // Act
+    const res = await webhookRoute(c);
+    const resBody = await res.json<{ ok: boolean; ignored?: string }>();
+
+    // Assert — gate is bypassed; response must NOT carry `ignored: "installation"`
+    expect(res.status).toBe(200);
+    expect(resBody.ok).toBe(true);
+    expect(resBody.ignored).toBeUndefined();
+  });
+});

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -29,6 +29,8 @@ import {
 import { BRANCH_ISSUE_RE, canonicalKey, extractFromLabels, syncBranches } from "../sync/sync";
 import { fetchIssueDeps, GraphQLError } from "../sync/graphql";
 import { resolveInstallToken } from "../auth/installToken";
+import { getTenantByInstallationId, getTenantByOrgLogin, type TenantRow } from "./tenant";
+import { handleInstallation, handleInstallationRepositories, handleRepository, handleMember, handleMembership } from "./handlers-app";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -515,16 +517,61 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
   const db = c.env.DB;
 
   // Unknown events short-circuit here — no data_version bump.
-  if (
-    event !== "issues" &&
-    event !== "issue_dependencies" &&
-    event !== "sub_issues" &&
-    event !== "create" &&
-    event !== "delete" &&
-    event !== "pull_request" &&
-    event !== "milestone"
-  ) {
+  const DATA_EVENTS = new Set([
+    "issues",
+    "issue_dependencies",
+    "sub_issues",
+    "create",
+    "delete",
+    "pull_request",
+    "milestone",
+  ]);
+  const APP_EVENTS = new Set([
+    "installation",
+    "installation_repositories",
+    "repository",
+    "member",
+    "membership",
+  ]);
+  if (event !== null && !DATA_EVENTS.has(event) && !APP_EVENTS.has(event)) {
     return c.json({ ok: true, ignored: event });
+  }
+  if (event === null) {
+    return c.json({ ok: true, ignored: event });
+  }
+
+  // ── Tenant routing gate (S4 #147) ──
+  // Resolve installation → tenant for events carrying installation context.
+  // membership payloads may omit `installation` → route via organization.login.
+  const installation = payload["installation"] as Record<string, unknown> | undefined;
+  const installationId =
+    typeof installation?.["id"] === "number" ? (installation["id"] as number) : undefined;
+
+  let tenant: TenantRow | null = null;
+  let hasRoutingContext = false;
+  if (installationId != null) {
+    tenant = await getTenantByInstallationId(db, installationId);
+    hasRoutingContext = true;
+  } else if (event === "membership") {
+    const org = payload["organization"] as Record<string, unknown> | undefined;
+    const login = org?.["login"];
+    if (typeof login === "string") {
+      tenant = await getTenantByOrgLogin(db, login);
+      hasRoutingContext = true;
+    }
+  }
+
+  // Control-plane `installation` events are EXEMPT from the unknown/suspended reject:
+  //   - installation.created bootstraps the tenant (it won't exist yet)
+  //   - suspend / unsuspend / deleted manage tenant lifecycle and must always run.
+  // All other events: when routing context is present, an unknown / suspended /
+  // (soft-)deleted tenant → 200 OK, NO write (GitHub does not retry; no orphan rows).
+  // When no routing context (legacy delivery without installation), fall through to
+  // preserve existing behavior.
+  if (event !== "installation" && hasRoutingContext) {
+    if (tenant === null || tenant.suspended_at !== null || tenant.deleted_at !== null) {
+      return c.json({ ok: true, ignored: event });
+    }
   }
 
   let mutated = false;
@@ -551,6 +598,17 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
     } else if (event === "milestone") {
       await handleMilestone(payload, db);
       mutated = true;
+    // App lifecycle events self-bump data_version inside their atomic batch — do not set `mutated`.
+    } else if (event === "installation") {
+      await handleInstallation(payload, db, c.env);
+    } else if (event === "installation_repositories") {
+      await handleInstallationRepositories(payload, db, c.env);
+    } else if (event === "repository") {
+      await handleRepository(payload, db);
+    } else if (event === "member") {
+      await handleMember(payload, db);
+    } else if (event === "membership") {
+      await handleMembership(payload, db);
     }
   } catch (err) {
     console.error("[webhook] unhandled handler error", err);

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -38,6 +38,24 @@ import { handleInstallation, handleInstallationRepositories, handleRepository, h
 
 const MAX_WEBHOOK_BODY_BYTES = 25 * 1024 * 1024; // 25 MB
 
+// Stable event allowlists — hoisted to module level to avoid re-allocation per request.
+const DATA_EVENTS = new Set([
+  "issues",
+  "issue_dependencies",
+  "sub_issues",
+  "create",
+  "delete",
+  "pull_request",
+  "milestone",
+]);
+const APP_EVENTS = new Set([
+  "installation",
+  "installation_repositories",
+  "repository",
+  "member",
+  "membership",
+]);
+
 // ---------------------------------------------------------------------------
 // Local helpers
 // ---------------------------------------------------------------------------
@@ -517,22 +535,6 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
   const db = c.env.DB;
 
   // Unknown events short-circuit here — no data_version bump.
-  const DATA_EVENTS = new Set([
-    "issues",
-    "issue_dependencies",
-    "sub_issues",
-    "create",
-    "delete",
-    "pull_request",
-    "milestone",
-  ]);
-  const APP_EVENTS = new Set([
-    "installation",
-    "installation_repositories",
-    "repository",
-    "member",
-    "membership",
-  ]);
   if (event !== null && !DATA_EVENTS.has(event) && !APP_EVENTS.has(event)) {
     return c.json({ ok: true, ignored: event });
   }

--- a/worker/src/webhook/mutations.test.ts
+++ b/worker/src/webhook/mutations.test.ts
@@ -555,3 +555,384 @@ describe("bumpDataVersion", () => {
     expect(stmts()[0].args).toEqual([iso, iso]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// webhook mutations — tenant/repo/cache helpers (S4 #147)
+// ---------------------------------------------------------------------------
+
+import {
+  upsertTenant,
+  softDeleteTenant,
+  setTenantSuspended,
+  upsertRepoAccess,
+  deleteRepoAccess,
+  deleteAllRepoAccessForTenant,
+  setRepoPrivacy,
+  cascadeRepoRename,
+  invalidateCacheByRepo,
+  invalidateCacheByUserRepo,
+  invalidateCacheByUser,
+  deleteSessionsForTenant,
+  deleteInstallTokensForTenant,
+} from "./mutations";
+
+describe("webhook mutations — tenant/repo/cache helpers (S4 #147)", () => {
+  const now = "2026-06-14T12:00:00.000Z";
+
+  // ── Tenant lifecycle ─────────────────────────────────────────────────────
+
+  describe("upsertTenant", () => {
+    it("binds installation_id, account_login, account_type, nowIso, nowIso", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      upsertTenant(db, {
+        installation_id: 111,
+        account_login: "Roxabi",
+        account_type: "Organization",
+        nowIso: now,
+      });
+      // Assert
+      expect(stmts()[0].args).toEqual([111, "Roxabi", "Organization", now, now]);
+    });
+
+    it("targets the tenants table via INSERT INTO tenants", () => {
+      const { db, stmts } = captureDb();
+      upsertTenant(db, {
+        installation_id: 111,
+        account_login: "Roxabi",
+        account_type: "Organization",
+        nowIso: now,
+      });
+      expect(stmts()[0].sql).toContain("INSERT INTO tenants");
+    });
+
+    it("uses ON CONFLICT(installation_id) and clears suspended_at and deleted_at", () => {
+      const { db, stmts } = captureDb();
+      upsertTenant(db, {
+        installation_id: 111,
+        account_login: "Roxabi",
+        account_type: "Organization",
+        nowIso: now,
+      });
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("ON CONFLICT(installation_id)");
+      expect(sql).toContain("suspended_at  = NULL");
+      expect(sql).toContain("deleted_at    = NULL");
+    });
+  });
+
+  describe("softDeleteTenant", () => {
+    it("binds nowIso, nowIso, tenantId — sets deleted_at and updated_at", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      softDeleteTenant(db, 7, now);
+      // Assert
+      expect(stmts()[0].args).toEqual([now, now, 7]);
+    });
+
+    it("targets the tenants table with UPDATE SET deleted_at", () => {
+      const { db, stmts } = captureDb();
+      softDeleteTenant(db, 7, now);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("UPDATE tenants");
+      expect(sql).toContain("deleted_at");
+    });
+  });
+
+  describe("setTenantSuspended", () => {
+    it("binds suspendedAtOrNull, nowIso, tenantId when suspending", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      setTenantSuspended(db, 7, now, now);
+      // Assert
+      expect(stmts()[0].args).toEqual([now, now, 7]);
+    });
+
+    it("binds null, nowIso, tenantId when unsuspending", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      setTenantSuspended(db, 7, null, now);
+      // Assert
+      expect(stmts()[0].args).toEqual([null, now, 7]);
+    });
+
+    it("targets tenants table with SET suspended_at", () => {
+      const { db, stmts } = captureDb();
+      setTenantSuspended(db, 7, now, now);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("UPDATE tenants");
+      expect(sql).toContain("suspended_at");
+    });
+  });
+
+  // ── Repository access ────────────────────────────────────────────────────
+
+  describe("upsertRepoAccess", () => {
+    it("binds tenantId, repo, isPrivate", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      upsertRepoAccess(db, 3, "Roxabi/roxabi-live", 1);
+      // Assert
+      expect(stmts()[0].args).toEqual([3, "Roxabi/roxabi-live", 1]);
+    });
+
+    it("binds isPrivate=0 for public repos", () => {
+      const { db, stmts } = captureDb();
+      upsertRepoAccess(db, 3, "Roxabi/public-repo", 0);
+      expect(stmts()[0].args).toEqual([3, "Roxabi/public-repo", 0]);
+    });
+
+    it("targets tenant_repo_access with INSERT ON CONFLICT DO UPDATE", () => {
+      const { db, stmts } = captureDb();
+      upsertRepoAccess(db, 3, "Roxabi/roxabi-live", 1);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("INSERT INTO tenant_repo_access");
+      expect(sql).toContain("ON CONFLICT");
+      expect(sql).toContain("is_private");
+    });
+  });
+
+  describe("deleteRepoAccess", () => {
+    it("binds tenantId, repo", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      deleteRepoAccess(db, 3, "Roxabi/roxabi-live");
+      // Assert
+      expect(stmts()[0].args).toEqual([3, "Roxabi/roxabi-live"]);
+    });
+
+    it("targets tenant_repo_access with WHERE tenant_id=? AND repo=?", () => {
+      const { db, stmts } = captureDb();
+      deleteRepoAccess(db, 3, "Roxabi/roxabi-live");
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("DELETE FROM tenant_repo_access");
+      expect(sql).toContain("tenant_id=?");
+      expect(sql).toContain("repo=?");
+    });
+  });
+
+  describe("deleteAllRepoAccessForTenant", () => {
+    it("binds tenantId only", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      deleteAllRepoAccessForTenant(db, 5);
+      // Assert
+      expect(stmts()[0].args).toEqual([5]);
+    });
+
+    it("deletes by tenant_id without narrowing by repo", () => {
+      const { db, stmts } = captureDb();
+      deleteAllRepoAccessForTenant(db, 5);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("DELETE FROM tenant_repo_access");
+      expect(sql).toContain("tenant_id=?");
+      // no per-repo narrowing (the table name contains "repo", so match the column filter)
+      expect(sql).not.toContain("repo=?");
+    });
+  });
+
+  describe("setRepoPrivacy", () => {
+    it("binds isPrivate, repo (UPDATE SET pattern)", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      setRepoPrivacy(db, "Roxabi/roxabi-live", 1);
+      // Assert — isPrivate first, then repo (WHERE clause)
+      expect(stmts()[0].args).toEqual([1, "Roxabi/roxabi-live"]);
+    });
+
+    it("binds isPrivate=0 for publicize", () => {
+      const { db, stmts } = captureDb();
+      setRepoPrivacy(db, "Roxabi/roxabi-live", 0);
+      expect(stmts()[0].args).toEqual([0, "Roxabi/roxabi-live"]);
+    });
+
+    it("targets tenant_repo_access with UPDATE SET is_private", () => {
+      const { db, stmts } = captureDb();
+      setRepoPrivacy(db, "Roxabi/roxabi-live", 1);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("UPDATE tenant_repo_access");
+      expect(sql).toContain("is_private=?");
+      expect(sql).toContain("WHERE repo=?");
+    });
+  });
+
+  // ── cascadeRepoRename (5 stmts) ──────────────────────────────────────────
+
+  describe("cascadeRepoRename", () => {
+    const oldName = "OldOrg/old-repo";
+    const newName = "NewOrg/new-repo";
+    const oldPrefix = oldName + "#";
+    const newPrefix = newName + "#";
+    const oldPrefixLen = oldPrefix.length;
+
+    it("returns exactly 5 prepared statements", () => {
+      // Arrange
+      const { db } = captureDb();
+      // Act
+      const stmts = cascadeRepoRename(db, oldName, newName) as unknown as FakeStmt[];
+      // Assert
+      expect(stmts).toHaveLength(5);
+    });
+
+    it("stmt[0] renames repo in repos table — binds (newName, oldName)", () => {
+      const { db } = captureDb();
+      const stmts = cascadeRepoRename(db, oldName, newName) as unknown as FakeStmt[];
+      expect(stmts[0].sql).toContain("UPDATE repos");
+      expect(stmts[0].sql).toContain("repo=?");
+      expect(stmts[0].args).toEqual([newName, oldName]);
+    });
+
+    it("stmt[1] renames repo in tenant_repo_access — binds (newName, oldName)", () => {
+      const { db } = captureDb();
+      const stmts = cascadeRepoRename(db, oldName, newName) as unknown as FakeStmt[];
+      expect(stmts[1].sql).toContain("UPDATE tenant_repo_access");
+      expect(stmts[1].args).toEqual([newName, oldName]);
+    });
+
+    it("stmt[2] renames repo and recomputes key in issues — binds (newName, newName, oldName)", () => {
+      const { db } = captureDb();
+      const stmts = cascadeRepoRename(db, oldName, newName) as unknown as FakeStmt[];
+      expect(stmts[2].sql).toContain("UPDATE issues");
+      expect(stmts[2].sql).toContain("repo=?");
+      expect(stmts[2].sql).toContain("key=");
+      expect(stmts[2].args).toEqual([newName, newName, oldName]);
+    });
+
+    it("stmt[3] rewrites edges src_key prefix — binds (newPrefix, oldPrefixLen+1, oldPrefixLen, oldPrefix)", () => {
+      const { db } = captureDb();
+      const stmts = cascadeRepoRename(db, oldName, newName) as unknown as FakeStmt[];
+      expect(stmts[3].sql).toContain("UPDATE edges");
+      expect(stmts[3].sql).toContain("src_key");
+      expect(stmts[3].args).toEqual([newPrefix, oldPrefixLen + 1, oldPrefixLen, oldPrefix]);
+    });
+
+    it("stmt[4] rewrites edges dst_key prefix — binds (newPrefix, oldPrefixLen+1, oldPrefixLen, oldPrefix)", () => {
+      const { db } = captureDb();
+      const stmts = cascadeRepoRename(db, oldName, newName) as unknown as FakeStmt[];
+      expect(stmts[4].sql).toContain("UPDATE edges");
+      expect(stmts[4].sql).toContain("dst_key");
+      expect(stmts[4].args).toEqual([newPrefix, oldPrefixLen + 1, oldPrefixLen, oldPrefix]);
+    });
+
+    it("retention invariant (D-2): no stmt touches sync_control", () => {
+      // Arrange
+      const { db } = captureDb();
+      // Act
+      const stmts = cascadeRepoRename(db, oldName, newName) as unknown as FakeStmt[];
+      // Assert — cascade must NOT touch sync_control sentinel rows
+      for (const stmt of stmts) {
+        expect(stmt.sql).not.toContain("sync_control");
+      }
+    });
+  });
+
+  // ── Permission cache invalidation ────────────────────────────────────────
+
+  describe("invalidateCacheByRepo", () => {
+    it("binds repo only", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      invalidateCacheByRepo(db, "Roxabi/roxabi-live");
+      // Assert
+      expect(stmts()[0].args).toEqual(["Roxabi/roxabi-live"]);
+    });
+
+    it("deletes from user_repo_permission_cache WHERE repo=?", () => {
+      const { db, stmts } = captureDb();
+      invalidateCacheByRepo(db, "Roxabi/roxabi-live");
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("DELETE FROM user_repo_permission_cache");
+      expect(sql).toContain("repo=?");
+    });
+  });
+
+  describe("invalidateCacheByUserRepo", () => {
+    it("binds userId, repo", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      invalidateCacheByUserRepo(db, 42, "Roxabi/roxabi-live");
+      // Assert
+      expect(stmts()[0].args).toEqual([42, "Roxabi/roxabi-live"]);
+    });
+
+    it("deletes from user_repo_permission_cache WHERE user_id=? AND repo=?", () => {
+      const { db, stmts } = captureDb();
+      invalidateCacheByUserRepo(db, 42, "Roxabi/roxabi-live");
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("DELETE FROM user_repo_permission_cache");
+      expect(sql).toContain("user_id=?");
+      expect(sql).toContain("repo=?");
+    });
+  });
+
+  describe("invalidateCacheByUser", () => {
+    it("binds userId only", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      invalidateCacheByUser(db, 42);
+      // Assert
+      expect(stmts()[0].args).toEqual([42]);
+    });
+
+    it("deletes from user_repo_permission_cache WHERE user_id=? only (no repo filter)", () => {
+      const { db, stmts } = captureDb();
+      invalidateCacheByUser(db, 42);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("DELETE FROM user_repo_permission_cache");
+      expect(sql).toContain("user_id=?");
+      // no per-repo narrowing (the table name contains "repo", so match the column filter)
+      expect(sql).not.toContain("repo=?");
+    });
+  });
+
+  // ── Session / install-token cleanup ──────────────────────────────────────
+
+  describe("deleteSessionsForTenant", () => {
+    it("binds tenantId only", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      deleteSessionsForTenant(db, 9);
+      // Assert
+      expect(stmts()[0].args).toEqual([9]);
+    });
+
+    it("deletes from sessions WHERE tenant_id=?", () => {
+      const { db, stmts } = captureDb();
+      deleteSessionsForTenant(db, 9);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("DELETE FROM sessions");
+      expect(sql).toContain("tenant_id=?");
+    });
+  });
+
+  describe("deleteInstallTokensForTenant", () => {
+    it("binds tenantId only", () => {
+      // Arrange
+      const { db, stmts } = captureDb();
+      // Act
+      deleteInstallTokensForTenant(db, 9);
+      // Assert
+      expect(stmts()[0].args).toEqual([9]);
+    });
+
+    it("deletes from install_tokens WHERE tenant_id=?", () => {
+      const { db, stmts } = captureDb();
+      deleteInstallTokensForTenant(db, 9);
+      const sql = stmts()[0].sql;
+      expect(sql).toContain("DELETE FROM install_tokens");
+      expect(sql).toContain("tenant_id=?");
+    });
+  });
+});

--- a/worker/src/webhook/mutations.ts
+++ b/worker/src/webhook/mutations.ts
@@ -255,3 +255,267 @@ export function renameMilestone(
 ): D1PreparedStatement {
   return db.prepare(RENAME_MILESTONE_SQL).bind(newTitle, repo, oldTitle);
 }
+
+// ---------------------------------------------------------------------------
+// Tenant lifecycle helpers
+// ---------------------------------------------------------------------------
+
+const UPSERT_TENANT_SQL = `
+  INSERT INTO tenants (installation_id, account_login, account_type, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?)
+  ON CONFLICT(installation_id) DO UPDATE SET
+    account_login = excluded.account_login,
+    account_type  = excluded.account_type,
+    updated_at    = excluded.updated_at,
+    suspended_at  = NULL,
+    deleted_at    = NULL
+`;
+
+const SOFT_DELETE_TENANT_SQL =
+  "UPDATE tenants SET deleted_at=?, updated_at=? WHERE id=?";
+
+const SET_TENANT_SUSPENDED_SQL =
+  "UPDATE tenants SET suspended_at=?, updated_at=? WHERE id=?";
+
+/**
+ * Prepare an upsert for a tenant row.
+ *
+ * On conflict (re-install after soft-delete or suspend), clears both
+ * deleted_at and suspended_at; created_at is preserved via the INSERT
+ * value being excluded from the UPDATE SET.
+ */
+export function upsertTenant(
+  db: D1Database,
+  t: {
+    installation_id: number;
+    account_login: string;
+    account_type: string;
+    nowIso: string;
+  },
+): D1PreparedStatement {
+  return db
+    .prepare(UPSERT_TENANT_SQL)
+    .bind(t.installation_id, t.account_login, t.account_type, t.nowIso, t.nowIso);
+}
+
+/**
+ * Prepare a soft-delete for a tenant (sets deleted_at; row is retained).
+ */
+export function softDeleteTenant(
+  db: D1Database,
+  tenantId: number,
+  nowIso: string,
+): D1PreparedStatement {
+  return db.prepare(SOFT_DELETE_TENANT_SQL).bind(nowIso, nowIso, tenantId);
+}
+
+/**
+ * Prepare a statement to set or clear the suspended_at timestamp for a tenant.
+ * Pass null for suspendedAtOrNull to unsuspend.
+ */
+export function setTenantSuspended(
+  db: D1Database,
+  tenantId: number,
+  suspendedAtOrNull: string | null,
+  nowIso: string,
+): D1PreparedStatement {
+  return db
+    .prepare(SET_TENANT_SUSPENDED_SQL)
+    .bind(suspendedAtOrNull, nowIso, tenantId);
+}
+
+// ---------------------------------------------------------------------------
+// Repository access helpers
+// ---------------------------------------------------------------------------
+
+const UPSERT_REPO_ACCESS_SQL = `
+  INSERT INTO tenant_repo_access (tenant_id, repo, is_private)
+  VALUES (?, ?, ?)
+  ON CONFLICT(tenant_id, repo) DO UPDATE SET
+    is_private = excluded.is_private
+`;
+
+const DELETE_REPO_ACCESS_SQL =
+  "DELETE FROM tenant_repo_access WHERE tenant_id=? AND repo=?";
+
+const DELETE_ALL_REPO_ACCESS_FOR_TENANT_SQL =
+  "DELETE FROM tenant_repo_access WHERE tenant_id=?";
+
+const SET_REPO_PRIVACY_SQL =
+  "UPDATE tenant_repo_access SET is_private=? WHERE repo=?";
+
+/**
+ * Prepare an upsert for a single repo in tenant_repo_access.
+ */
+export function upsertRepoAccess(
+  db: D1Database,
+  tenantId: number,
+  repo: string,
+  isPrivate: 0 | 1,
+): D1PreparedStatement {
+  return db.prepare(UPSERT_REPO_ACCESS_SQL).bind(tenantId, repo, isPrivate);
+}
+
+/**
+ * Prepare a delete for a single repo from tenant_repo_access.
+ * Issues/edges for that repo are retained (globally shared).
+ */
+export function deleteRepoAccess(
+  db: D1Database,
+  tenantId: number,
+  repo: string,
+): D1PreparedStatement {
+  return db.prepare(DELETE_REPO_ACCESS_SQL).bind(tenantId, repo);
+}
+
+/**
+ * Prepare a delete of all repo-access rows for a tenant.
+ * Used on app uninstall (H2). Issues/edges are retained.
+ */
+export function deleteAllRepoAccessForTenant(
+  db: D1Database,
+  tenantId: number,
+): D1PreparedStatement {
+  return db.prepare(DELETE_ALL_REPO_ACCESS_FOR_TENANT_SQL).bind(tenantId);
+}
+
+/**
+ * Prepare a repo-wide privacy flip in tenant_repo_access.
+ * Affects all tenants that have this repo registered (repo is the key).
+ */
+export function setRepoPrivacy(
+  db: D1Database,
+  repo: string,
+  isPrivate: 0 | 1,
+): D1PreparedStatement {
+  return db.prepare(SET_REPO_PRIVACY_SQL).bind(isPrivate, repo);
+}
+
+/**
+ * Prepare a cascade rename across all repo-keyed tables.
+ *
+ * Prefix-safe edge rewrite strategy:
+ *   Issue keys have the format `{repo}#{number}`. A naive REPLACE or LIKE
+ *   would match `_` / `%` metacharacters in repo names (unlikely but valid
+ *   in forks). Instead we bind the computed prefix strings as parameters and
+ *   use substr() + length comparisons — zero metachar risk, no escaping needed.
+ *
+ *   The substr() offset is 1-based in SQLite:
+ *     src_key[0 .. oldPrefixLen-1] == oldPrefix  →  replace with newPrefix
+ *     new key = newPrefix || src_key[oldPrefixLen+1 ..]
+ *
+ * sync_control sentinel rows (tenant_id = 0, Deviation D-2) are intentionally
+ * NOT touched: sync_control keys are not repo-scoped, so no cascade is needed.
+ *
+ * Returns D1PreparedStatement[] — the caller folds into db.batch([...stmts]).
+ */
+export function cascadeRepoRename(
+  db: D1Database,
+  oldFullName: string,
+  newFullName: string,
+): D1PreparedStatement[] {
+  const oldPrefix = oldFullName + "#";
+  const newPrefix = newFullName + "#";
+  const oldPrefixLen = oldPrefix.length;
+  return [
+    db.prepare(`UPDATE repos SET repo=? WHERE repo=?`).bind(newFullName, oldFullName),
+    db
+      .prepare(`UPDATE tenant_repo_access SET repo=? WHERE repo=?`)
+      .bind(newFullName, oldFullName),
+    // issues: key = repo#number — recompute key from the intact number column
+    db
+      .prepare(`UPDATE issues SET repo=?, key=? || '#' || number WHERE repo=?`)
+      .bind(newFullName, newFullName, oldFullName),
+    // edges src_key: match rows whose src_key starts with oldPrefix, rewrite prefix
+    db
+      .prepare(
+        `UPDATE edges SET src_key = ? || substr(src_key, ?) WHERE substr(src_key, 1, ?) = ?`,
+      )
+      .bind(newPrefix, oldPrefixLen + 1, oldPrefixLen, oldPrefix),
+    // edges dst_key: same logic for dst_key
+    db
+      .prepare(
+        `UPDATE edges SET dst_key = ? || substr(dst_key, ?) WHERE substr(dst_key, 1, ?) = ?`,
+      )
+      .bind(newPrefix, oldPrefixLen + 1, oldPrefixLen, oldPrefix),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Permission cache invalidation helpers
+// ---------------------------------------------------------------------------
+
+const INVALIDATE_CACHE_BY_REPO_SQL =
+  "DELETE FROM user_repo_permission_cache WHERE repo=?";
+
+const INVALIDATE_CACHE_BY_USER_REPO_SQL =
+  "DELETE FROM user_repo_permission_cache WHERE user_id=? AND repo=?";
+
+const INVALIDATE_CACHE_BY_USER_SQL =
+  "DELETE FROM user_repo_permission_cache WHERE user_id=?";
+
+/**
+ * Prepare a delete of all permission-cache entries for a given repo.
+ * Use when a repo's privacy status changes (privatize/publicize).
+ */
+export function invalidateCacheByRepo(
+  db: D1Database,
+  repo: string,
+): D1PreparedStatement {
+  return db.prepare(INVALIDATE_CACHE_BY_REPO_SQL).bind(repo);
+}
+
+/**
+ * Prepare a delete of the permission-cache entry for a specific (user, repo) pair.
+ * Use when a user loses access to a specific repo (member removed).
+ */
+export function invalidateCacheByUserRepo(
+  db: D1Database,
+  userId: number,
+  repo: string,
+): D1PreparedStatement {
+  return db.prepare(INVALIDATE_CACHE_BY_USER_REPO_SQL).bind(userId, repo);
+}
+
+/**
+ * Prepare a delete of all permission-cache entries for a given user.
+ * Use when a user loses org membership (all repo access revoked).
+ */
+export function invalidateCacheByUser(
+  db: D1Database,
+  userId: number,
+): D1PreparedStatement {
+  return db.prepare(INVALIDATE_CACHE_BY_USER_SQL).bind(userId);
+}
+
+// ---------------------------------------------------------------------------
+// Session / install-token cleanup helpers
+// ---------------------------------------------------------------------------
+
+const DELETE_SESSIONS_FOR_TENANT_SQL =
+  "DELETE FROM sessions WHERE tenant_id=?";
+
+const DELETE_INSTALL_TOKENS_FOR_TENANT_SQL =
+  "DELETE FROM install_tokens WHERE tenant_id=?";
+
+/**
+ * Prepare a delete of all active sessions for a tenant.
+ * Used on uninstall to force re-auth on next login.
+ */
+export function deleteSessionsForTenant(
+  db: D1Database,
+  tenantId: number,
+): D1PreparedStatement {
+  return db.prepare(DELETE_SESSIONS_FOR_TENANT_SQL).bind(tenantId);
+}
+
+/**
+ * Prepare a delete of the cached install token for a tenant.
+ * Used on uninstall to remove the encrypted token from the D1 cache.
+ */
+export function deleteInstallTokensForTenant(
+  db: D1Database,
+  tenantId: number,
+): D1PreparedStatement {
+  return db.prepare(DELETE_INSTALL_TOKENS_FOR_TENANT_SQL).bind(tenantId);
+}

--- a/worker/src/webhook/tenant.test.ts
+++ b/worker/src/webhook/tenant.test.ts
@@ -127,6 +127,8 @@ describe("getTenantByInstallationId", () => {
       const stmt = recorded.find((s) => /FROM tenants/.test(s.sql));
       expect(stmt).toBeDefined();
       expect(stmt!.args).toContain(99_000);
+      // Column-swap guard: WHERE clause must reference installation_id, not account_login
+      expect(stmt!.sql).toMatch(/WHERE\s+installation_id\s*=\s*\?/);
     });
   });
 
@@ -173,6 +175,8 @@ describe("getTenantByOrgLogin", () => {
       const stmt = recorded.find((s) => /FROM tenants/.test(s.sql));
       expect(stmt).toBeDefined();
       expect(stmt!.args).toContain("Roxabi");
+      // Column-swap guard: WHERE clause must reference account_login, not installation_id
+      expect(stmt!.sql).toMatch(/WHERE\s+account_login\s*=\s*\?/);
     });
   });
 

--- a/worker/src/webhook/tenant.test.ts
+++ b/worker/src/webhook/tenant.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+import { getTenantByInstallationId, getTenantByOrgLogin, type TenantRow } from "./tenant";
+
+// ---------------------------------------------------------------------------
+// FakeD1 — minimal subset sufficient for single-row .prepare().bind().first()
+// ---------------------------------------------------------------------------
+
+type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
+
+interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database & { _recorded: FakeStmt[] } {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 1 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Seeded fake-DB — seeds a single tenant row for FROM tenants queries
+// ---------------------------------------------------------------------------
+
+function seededDb(tenantRow: TenantRow | null): D1Database & { _recorded: FakeStmt[] } {
+  return makeFakeDb((sql, args) => {
+    const rows =
+      /FROM tenants/.test(sql) && tenantRow ? [tenantRow as unknown as FakeResult] : [];
+    return makeFakeStmt(sql, args, rows, 1);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const TENANT_ROW: TenantRow = {
+  id: 1,
+  installation_id: 99_000,
+  account_login: "Roxabi",
+  account_type: "Organization",
+  suspended_at: null,
+  deleted_at: null,
+};
+
+// ---------------------------------------------------------------------------
+// getTenantByInstallationId
+// ---------------------------------------------------------------------------
+
+describe("getTenantByInstallationId", () => {
+  describe("when a matching row exists", () => {
+    it("returns the TenantRow with correct fields", async () => {
+      // Arrange
+      const db = seededDb(TENANT_ROW);
+
+      // Act
+      const result = await getTenantByInstallationId(db, 99_000);
+
+      // Assert
+      expect(result).toEqual(TENANT_ROW);
+    });
+
+    it("binds the installation_id arg to the prepared statement", async () => {
+      // Arrange
+      const db = seededDb(TENANT_ROW);
+
+      // Act
+      await getTenantByInstallationId(db, 99_000);
+
+      // Assert — exactly one statement was bound, carrying the installation_id
+      const recorded = db._recorded;
+      const stmt = recorded.find((s) => /FROM tenants/.test(s.sql));
+      expect(stmt).toBeDefined();
+      expect(stmt!.args).toContain(99_000);
+    });
+  });
+
+  describe("when no matching row exists", () => {
+    it("returns null", async () => {
+      // Arrange — unseeded DB, .first() resolves null
+      const db = seededDb(null);
+
+      // Act
+      const result = await getTenantByInstallationId(db, 42);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTenantByOrgLogin
+// ---------------------------------------------------------------------------
+
+describe("getTenantByOrgLogin", () => {
+  describe("when a matching row exists", () => {
+    it("returns the TenantRow with correct fields", async () => {
+      // Arrange
+      const db = seededDb(TENANT_ROW);
+
+      // Act
+      const result = await getTenantByOrgLogin(db, "Roxabi");
+
+      // Assert
+      expect(result).toEqual(TENANT_ROW);
+    });
+
+    it("binds the account_login arg to the prepared statement", async () => {
+      // Arrange
+      const db = seededDb(TENANT_ROW);
+
+      // Act
+      await getTenantByOrgLogin(db, "Roxabi");
+
+      // Assert — statement bound with the login string
+      const recorded = db._recorded;
+      const stmt = recorded.find((s) => /FROM tenants/.test(s.sql));
+      expect(stmt).toBeDefined();
+      expect(stmt!.args).toContain("Roxabi");
+    });
+  });
+
+  describe("when no matching row exists", () => {
+    it("returns null", async () => {
+      // Arrange
+      const db = seededDb(null);
+
+      // Act
+      const result = await getTenantByOrgLogin(db, "ghost-org");
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/worker/src/webhook/tenant.ts
+++ b/worker/src/webhook/tenant.ts
@@ -1,0 +1,69 @@
+/**
+ * Tenant lookup helpers for webhook routing.
+ *
+ * getTenantByInstallationId — primary path: every webhook with `installation`
+ *   in the payload carries the installation id; route via that.
+ * getTenantByOrgLogin       — fallback path: membership webhooks may omit
+ *   `installation`; route via payload.organization.login instead.
+ *
+ * Both return null (never undefined) when no matching row exists.
+ * D1Database is an ambient global from @cloudflare/workers-types.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TenantRow {
+  id: number;
+  installation_id: number;
+  account_login: string;
+  account_type: string;
+  suspended_at: string | null;
+  deleted_at: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a tenant by GitHub App installation id.
+ * Returns null if no matching row exists.
+ */
+export async function getTenantByInstallationId(
+  db: D1Database,
+  installationId: number,
+): Promise<TenantRow | null> {
+  return (
+    (await db
+      .prepare(
+        `SELECT id, installation_id, account_login, account_type, suspended_at, deleted_at
+         FROM tenants
+         WHERE installation_id = ?`,
+      )
+      .bind(installationId)
+      .first<TenantRow>()) ?? null
+  );
+}
+
+/**
+ * Look up a tenant by the GitHub account login (org or user name).
+ * Used when a webhook payload lacks an `installation` block.
+ * Returns null if no matching row exists.
+ */
+export async function getTenantByOrgLogin(
+  db: D1Database,
+  login: string,
+): Promise<TenantRow | null> {
+  return (
+    (await db
+      .prepare(
+        `SELECT id, installation_id, account_login, account_type, suspended_at, deleted_at
+         FROM tenants
+         WHERE account_login = ?`,
+      )
+      .bind(login)
+      .first<TenantRow>()) ?? null
+  );
+}


### PR DESCRIPTION
## Summary
- Route every webhook by `payload.installation.id → tenants` **before any write**; unknown / suspended / soft-deleted tenant → **200 OK, no DB write** (no orphan rows; GitHub does not retry). Deliveries without installation context fall through to existing repo-canonical behavior, preserving org-webhook ingestion during the org→App cutover.
- Add 12 GitHub-App lifecycle handlers in a new `worker/src/webhook/handlers-app.ts` (keeps `handlers.ts` focused): installation `{created,deleted,suspend,unsuspend}`, installation_repositories `{added,removed}`, repository `{renamed,transferred,privatized,publicized}`, `member.removed`, `membership.removed`.
- Migration `0009` adds `tenants.deleted_at` (soft-delete tombstone — uninstall retains `issues`/`edges`).

**Design notes:** single-secret HMAC unchanged (dual-secret out of scope). Repo rename/transfer cascades re-key `repos`/`tenant_repo_access`/`issues`/`edges` with a prefix-safe `substr` rewrite (node_id anchor + changes-payload fallback); the `sync_control` `tenant_id=0` sentinel is never touched. App handlers self-bump `data_version` inside their atomic `db.batch`; the dispatcher does not double-bump. Permission-cache invalidation resolves `github_id → users.id` (zero-rows → no-op).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #147: tenant routing + lifecycle handlers (Phase 1 S4 of #141) | OPEN |
| Analysis | [147-webhook-tenant-routing-analysis.mdx](artifacts/analyses/147-webhook-tenant-routing-analysis.mdx) | Present |
| Spec | [147-webhook-tenant-routing-spec.mdx](artifacts/specs/147-webhook-tenant-routing-spec.mdx) | Present |
| Implementation | 1 commit on `feat/147-webhook-tenant-routing` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (78 new) | Passed |

## Test Plan
- [ ] Webhook with unknown `installation.id` → 200 `{ok, ignored}`, zero D1 writes, `data_version` unchanged.
- [ ] Suspended / soft-deleted tenant → 200 no-write; `installation.unsuspend` still processes (control-plane exempt).
- [ ] `installation.created` seeds `tenants` + `tenant_repo_access`; `installation.deleted` purges access/tokens/sessions but **retains** `issues`/`edges`.
- [ ] `repository.renamed`/`transferred` re-keys issues+edges; `sync_control` sentinel untouched.
- [ ] `repository.privatized`/`publicized` flips `is_private` + invalidates permission cache.
- [ ] `member.removed`/`membership.removed` invalidates cache (no-op when user never logged in).

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC1: installation.id→tenants before write; unknown/suspended→200 no-write | `handlers.test.ts :: webhookRoute — tenant routing gate (S4 #147)`, `tenant.test.ts :: getTenantBy*` | ✓ proven |
| SC2: installation.created upserts tenant + tenant_repo_access | `handlers-app.test.ts :: handleInstallation > created` | ✓ proven |
| SC3: installation.deleted purges access/tokens/sessions; issues/edges retained; deleted_at set | `handlers-app.test.ts :: handleInstallation > deleted (+ retention invariant)` | ✓ proven |
| SC4: suspend/unsuspend toggle suspended_at | `handlers-app.test.ts :: handleInstallation > suspend/unsuspend` | ✓ proven |
| SC5: installation_repositories added/removed | `handlers-app.test.ts :: handleInstallationRepositories` | ✓ proven |
| SC6: repository renamed+transferred cascade (node_id anchor; sentinel untouched) | `handlers-app.test.ts :: handleRepository > renamed/transferred`, `mutations.test.ts :: cascadeRepoRename` | ✓ proven |
| SC7: privatized/publicized + cache invalidation | `handlers-app.test.ts :: handleRepository > privatized/publicized` | ✓ proven |
| SC8: member.removed/membership.removed cache deletion | `handlers-app.test.ts :: handleMember / handleMembership` | ✓ proven |
| SC9: no cross-tenant stub logic | — | ⚠ NO TEST — out-of-scope (superseded by repo-canonical; no stub code) |

Falsification gate: stashing the 4 source files turns 39 new tests RED; restored → full suite 493/493 GREEN.

Fixes #147

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`