### PR TITLE
test(migrations): migration harness — apply 0001–0009 vs real SQLite + schema asserts (#154)

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -12,6 +12,8 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250109.0",
+        "@types/better-sqlite3": "^7.6.13",
+        "better-sqlite3": "^12.10.1",
         "typescript": "^5.7.2",
         "vitest": "^2.1.8",
         "wrangler": "^3.99.0"
@@ -1420,12 +1422,32 @@
         "win32"
       ]
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -1583,12 +1605,95 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.1.tgz",
+      "integrity": "sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1626,6 +1731,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -1711,6 +1823,22 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1719,6 +1847,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defu": {
@@ -1734,9 +1872,18 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1821,6 +1968,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1835,6 +1992,20 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
     },
@@ -1864,6 +2035,13 @@
         "source-map": "^0.6.1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -1879,6 +2057,41 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
@@ -1918,6 +2131,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniflare": {
       "version": "3.20250718.3",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
@@ -1943,6 +2169,23 @@
       "engines": {
         "node": ">=16.13"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1980,12 +2223,42 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -2047,12 +2320,82 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/printable-characters": {
       "version": "1.0.42",
       "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/rollup": {
       "version": "4.61.1",
@@ -2156,13 +2499,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
       "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2217,6 +2580,53 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
@@ -2293,6 +2703,56 @@
         "npm": ">=6"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2345,6 +2805,19 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2379,6 +2852,13 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unenv": {
       "version": "2.0.0-rc.14",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
@@ -2397,6 +2877,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3036,6 +3523,13 @@
         "@esbuild/win32-ia32": "0.17.19",
         "@esbuild/win32-x64": "0.17.19"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250109.0",
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.10.1",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8",
     "wrangler": "^3.99.0"

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -1,0 +1,243 @@
+/**
+ * migrations.test.ts — apply worker/migrations/*.sql against a real in-memory SQLite
+ * and assert the resulting schema matches what the app assumes.
+ *
+ * Uses better-sqlite3 (installed as a devDependency) so this runs inside the
+ * existing `npm test` (vitest) job in CI — no CF credentials required.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeAll } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// worker/src/migrations.test.ts → worker/migrations/ (one level up)
+const MIGRATIONS_DIR = join(__dirname, "..", "migrations");
+
+type ColumnInfo = {
+  cid: number;
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+type IndexInfo = { seqno: number; cid: number; name: string };
+
+function getColumns(db: Database.Database, table: string): ColumnInfo[] {
+  return db.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[];
+}
+
+function getColumnNames(db: Database.Database, table: string): string[] {
+  return getColumns(db, table).map((c) => c.name);
+}
+
+function getPkColumns(db: Database.Database, table: string): string[] {
+  return getColumns(db, table)
+    .filter((c) => c.pk > 0)
+    .sort((a, b) => a.pk - b.pk)
+    .map((c) => c.name);
+}
+
+function getIndexColumns(
+  db: Database.Database,
+  table: string,
+  indexName: string,
+): string[] {
+  const info = db
+    .prepare(`PRAGMA index_info(${indexName})`)
+    .all() as IndexInfo[];
+  return info.sort((a, b) => a.seqno - b.seqno).map((r) => r.name);
+}
+
+// ---------------------------------------------------------------------------
+// Apply migrations once for the whole suite
+// ---------------------------------------------------------------------------
+
+let db: Database.Database;
+
+beforeAll(() => {
+  db = new Database(":memory:");
+
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
+    db.exec(sql);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Suite 1 — migration chain
+// ---------------------------------------------------------------------------
+
+describe("migration chain", () => {
+  it("applies all migrations without throwing", () => {
+    // If beforeAll did not throw, the chain succeeded. Verify the db is usable.
+    const result = db
+      .prepare("SELECT COUNT(*) AS cnt FROM sync_control")
+      .get() as { cnt: number };
+    expect(result.cnt).toBeGreaterThanOrEqual(0);
+  });
+
+  it("loads all migration files in lexical order", () => {
+    const files = readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+    // Expect exactly 0001–0009 (9 files)
+    expect(files).toHaveLength(9);
+    expect(files[0]).toMatch(/^0001_/);
+    expect(files[8]).toMatch(/^0009_/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2 — issues table schema
+// ---------------------------------------------------------------------------
+
+describe("issues table", () => {
+  it("has a payload column", () => {
+    expect(getColumnNames(db, "issues")).toContain("payload");
+  });
+
+  it("does NOT have a title column (moved into payload JSON in 0004)", () => {
+    expect(getColumnNames(db, "issues")).not.toContain("title");
+  });
+
+  it("does NOT have a tenant_id column (repo-canonical pivot — no tenant_id on data tables)", () => {
+    expect(getColumnNames(db, "issues")).not.toContain("tenant_id");
+  });
+
+  it("has key as the primary key", () => {
+    expect(getPkColumns(db, "issues")).toEqual(["key"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3 — repos table schema
+// ---------------------------------------------------------------------------
+
+describe("repos table", () => {
+  it("does NOT have a tenant_id column (repo-canonical pivot)", () => {
+    expect(getColumnNames(db, "repos")).not.toContain("tenant_id");
+  });
+
+  it("has repo as the primary key", () => {
+    expect(getPkColumns(db, "repos")).toEqual(["repo"]);
+  });
+
+  it("has a repo_node_id column (added in 0004)", () => {
+    expect(getColumnNames(db, "repos")).toContain("repo_node_id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 4 — sync_control composite PK
+// ---------------------------------------------------------------------------
+
+describe("sync_control table", () => {
+  it("has composite primary key (tenant_id, key)", () => {
+    // PRAGMA table_info pk column: non-zero = part of PK; pk value = position (1-based)
+    expect(getPkColumns(db, "sync_control")).toEqual(["tenant_id", "key"]);
+  });
+
+  it("has value column that is NOT NULL (restored in 0008)", () => {
+    const col = getColumns(db, "sync_control").find((c) => c.name === "value");
+    expect(col).toBeDefined();
+    expect(col!.notnull).toBe(1);
+  });
+
+  it("contains the global sentinel rows with tenant_id=0", () => {
+    const rows = db
+      .prepare("SELECT key FROM sync_control WHERE tenant_id = 0 ORDER BY key")
+      .all() as { key: string }[];
+    const keys = rows.map((r) => r.key);
+    // Seeds from 0001, 0003, 0005, 0006 (all migrated into new table by 0004 + 0008)
+    expect(keys).toContain("auth_failures");
+    expect(keys).toContain("halted");
+    expect(keys).toContain("sync_running");
+    expect(keys).toContain("sync_slot");
+    expect(keys).toContain("data_version");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 5 — zk_payloads composite PK
+// ---------------------------------------------------------------------------
+
+describe("zk_payloads table", () => {
+  it("has composite primary key (user_id, issue_key)", () => {
+    expect(getPkColumns(db, "zk_payloads")).toEqual(["user_id", "issue_key"]);
+  });
+
+  it("has expected columns", () => {
+    const cols = getColumnNames(db, "zk_payloads");
+    expect(cols).toContain("user_id");
+    expect(cols).toContain("issue_key");
+    expect(cols).toContain("pubkey_fp");
+    expect(cols).toContain("encrypted_payload");
+    expect(cols).toContain("updated_at");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 6 — tenant_repo_access schema
+// ---------------------------------------------------------------------------
+
+describe("tenant_repo_access table", () => {
+  it("has composite primary key (tenant_id, repo)", () => {
+    expect(getPkColumns(db, "tenant_repo_access")).toEqual([
+      "tenant_id",
+      "repo",
+    ]);
+  });
+
+  it("has is_private column (added in 0007) defaulting to 1", () => {
+    const col = getColumns(db, "tenant_repo_access").find(
+      (c) => c.name === "is_private",
+    );
+    expect(col).toBeDefined();
+    expect(col!.notnull).toBe(1);
+    expect(col!.dflt_value).toBe("1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 7 — tenants table
+// ---------------------------------------------------------------------------
+
+describe("tenants table", () => {
+  it("has deleted_at column (soft-delete, added in 0009)", () => {
+    expect(getColumnNames(db, "tenants")).toContain("deleted_at");
+  });
+
+  it("deleted_at is nullable (NULL = active)", () => {
+    const col = getColumns(db, "tenants").find((c) => c.name === "deleted_at");
+    expect(col).toBeDefined();
+    expect(col!.notnull).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 8 — edges and indexes
+// ---------------------------------------------------------------------------
+
+describe("edges table and indexes", () => {
+  it("has composite primary key (src_key, dst_key, kind)", () => {
+    expect(getPkColumns(db, "edges")).toEqual(["src_key", "dst_key", "kind"]);
+  });
+
+  it("ix_edges_dst index exists on edges(dst_key)", () => {
+    const cols = getIndexColumns(db, "edges", "ix_edges_dst");
+    expect(cols).toEqual(["dst_key"]);
+  });
+});

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -62,15 +62,20 @@ function getIndexColumns(
 // ---------------------------------------------------------------------------
 
 let db: Database.Database;
+let appliedFiles: string[];
 
 beforeAll(() => {
   db = new Database(":memory:");
 
-  const files = readdirSync(MIGRATIONS_DIR)
+  appliedFiles = readdirSync(MIGRATIONS_DIR)
     .filter((f) => f.endsWith(".sql"))
     .sort();
 
-  for (const file of files) {
+  if (appliedFiles.length === 0) {
+    throw new Error(`No migration files found in ${MIGRATIONS_DIR}`);
+  }
+
+  for (const file of appliedFiles) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
     db.exec(sql);
   }
@@ -86,17 +91,17 @@ describe("migration chain", () => {
     const result = db
       .prepare("SELECT COUNT(*) AS cnt FROM sync_control")
       .get() as { cnt: number };
-    expect(result.cnt).toBeGreaterThanOrEqual(0);
+    expect(result.cnt).toBeGreaterThan(0);
   });
 
   it("loads all migration files in lexical order", () => {
-    const files = readdirSync(MIGRATIONS_DIR)
-      .filter((f) => f.endsWith(".sql"))
-      .sort();
-    // Expect exactly 0001–0009 (9 files)
-    expect(files).toHaveLength(9);
-    expect(files[0]).toMatch(/^0001_/);
-    expect(files[8]).toMatch(/^0009_/);
+    // Uses appliedFiles captured by beforeAll — verifies the actual apply order, not just FS state.
+    expect(appliedFiles.length).toBeGreaterThanOrEqual(9);
+    expect(appliedFiles[0]).toMatch(/^0001_/);
+    // Contiguity check: each file's 4-digit prefix must equal its 1-based position
+    for (let i = 0; i < appliedFiles.length; i++) {
+      expect(parseInt(appliedFiles[i].slice(0, 4), 10)).toBe(i + 1);
+    }
   });
 });
 
@@ -153,7 +158,7 @@ describe("sync_control table", () => {
   it("has value column that is NOT NULL (restored in 0008)", () => {
     const col = getColumns(db, "sync_control").find((c) => c.name === "value");
     expect(col).toBeDefined();
-    expect(col!.notnull).toBe(1);
+    expect(col?.notnull).toBe(1);
   });
 
   it("contains the global sentinel rows with tenant_id=0", () => {
@@ -206,8 +211,8 @@ describe("tenant_repo_access table", () => {
       (c) => c.name === "is_private",
     );
     expect(col).toBeDefined();
-    expect(col!.notnull).toBe(1);
-    expect(col!.dflt_value).toBe("1");
+    expect(col?.notnull).toBe(1);
+    expect(col?.dflt_value).toBe("1");
   });
 });
 
@@ -223,7 +228,7 @@ describe("tenants table", () => {
   it("deleted_at is nullable (NULL = active)", () => {
     const col = getColumns(db, "tenants").find((c) => c.name === "deleted_at");
     expect(col).toBeDefined();
-    expect(col!.notnull).toBe(0);
+    expect(col?.notnull).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `worker/src/migrations.test.ts`: vitest test that applies all 9 `worker/migrations/*.sql` files (0001–0009) against a `better-sqlite3` in-memory database and asserts 20 schema invariants the app relies on.
- Installs `better-sqlite3` + `@types/better-sqlite3` as devDependencies (39 packages, native addon — builds from source; CI `node` job has a compiler available).
- Runs inside the **existing `npm test` vitest job** — no Cloudflare credentials required, no CI changes needed.

## Approach

`better-sqlite3` in-memory (not `wrangler d1 migrations apply --local`, which requires CF creds the CI worker job doesn't have). Migration files are read lexically (0001→0009) via `readdirSync` + `db.exec()`.

## Assertions (20 tests)

| Suite | What is asserted |
|---|---|
| migration chain | All 9 files apply without throwing; lexical order |
| issues | `payload` column exists; no `title` (moved to JSON in 0004); no `tenant_id` (repo-canonical pivot); PK = `key` |
| repos | No `tenant_id`; PK = `repo`; `repo_node_id` column (added 0004) |
| sync_control | Composite PK `(tenant_id, key)`; `value` NOT NULL (rebuilt in 0008); sentinel rows `tenant_id=0` seeded |
| zk_payloads | Composite PK `(user_id, issue_key)`; all 5 columns present |
| tenant_repo_access | Composite PK `(tenant_id, repo)`; `is_private` NOT NULL default 1 (added 0007) |
| tenants | `deleted_at` column exists (added 0009); nullable (NULL = active) |
| edges | Composite PK `(src_key, dst_key, kind)`; `ix_edges_dst` index on `dst_key` |

## Falsification gate (evidence)

- Removed `worker/migrations/` → `ENOENT: no such file or directory, scandir '.../worker/migrations'` — all 20 tests skipped/failed
- Restored → 20/20 pass

Closes #154