### PR TITLE
refactor(auth): batch tenant upserts + user_installation links in oauth callback (#158)

### DIFF
--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -6,6 +6,22 @@ import { loginRoute, callbackRoute } from "./oauth";
 import type { FakeResult, FakeStmt } from "../test-utils";
 import { makeFakeStmt, makeFakeDb, captureDb } from "../test-utils";
 
+/**
+ * #158: the default makeFakeDb batch() mock returns empty results. This override
+ * surfaces each batched statement's own RETURNING rows (via stmt.all()) so tenant
+ * ids flow through batch results. Shared test-utils.ts is intentionally untouched.
+ */
+function applyBatchOverride(db: D1Database): void {
+  (db as unknown as { batch: unknown }).batch = vi.fn(async (stmts: FakeStmt[]) =>
+    Promise.all(
+      stmts.map(async (s) => {
+        const { results } = await s.all<FakeResult>();
+        return { results, meta: { changes: results.length } };
+      }),
+    ),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -451,17 +467,8 @@ describe("callbackRoute", () => {
         captured.push(stmt);
         return stmt;
       });
-      // #158: the default makeFakeDb batch() mock returns empty results; the new
-      // callback reads tenant ids from RETURNING via batch(). Surface each
-      // statement's own rows (from makeFakeStmt) so the tenant id flows through.
-      (db as unknown as { batch: unknown }).batch = vi.fn(async (stmts: FakeStmt[]) =>
-        Promise.all(
-          stmts.map(async (s) => {
-            const { results } = await s.all<FakeResult>();
-            return { results, meta: { changes: results.length } };
-          }),
-        ),
-      );
+      // #158: surface each statement's RETURNING rows through batch results.
+      applyBatchOverride(db);
       return db;
     }
 
@@ -657,18 +664,36 @@ describe("callbackRoute", () => {
         [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
       );
       const { app, env } = makeApp(db);
-      await app.request(
+      const res = await app.request(
         `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
         { method: "GET" },
         env,
       );
+      // Behavioral outcome, not just call shape: the two batches must yield 302 + cookie.
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Set-Cookie")).toContain("__Host-session");
       expect((db as unknown as { batch: ReturnType<typeof vi.fn> }).batch).toHaveBeenCalledTimes(2);
     });
 
-    it("handles multiple installations: upserts all tenants + links, returns 302 with session cookie", async () => {
+    it("handles multiple installations: distinct tenant ids route to the correct links + 302", async () => {
       const stateValue = "g".repeat(32);
       const captured: FakeStmt[] = [];
       const db = makeHappyPathDb(captured);
+      const idByInstall: Record<number, number> = { 9: 100, 11: 101 };
+      (db as unknown as { batch: unknown }).batch = vi.fn(async (stmts: FakeStmt[]) =>
+        stmts.map((s) => {
+          const isTenantUpsert =
+            s.sql.toLowerCase().includes("tenants") &&
+            s.sql.toLowerCase().includes("returning");
+          if (isTenantUpsert) {
+            return {
+              results: [{ id: idByInstall[s.args[0] as number] }],
+              meta: { changes: 1 },
+            };
+          }
+          return { results: [], meta: { changes: 0 } };
+        }),
+      );
       stubFetchSequence(
         "t",
         { id: 42, login: "alice" },
@@ -695,6 +720,32 @@ describe("callbackRoute", () => {
         s.sql.toLowerCase().includes("user_installations"),
       );
       expect(links).toHaveLength(2);
+      expect(links.map((s) => s.args[1])).toEqual([100, 101]);
+    });
+
+    it("returns 500 db_error when a tenant upsert batch returns no RETURNING row", async () => {
+      const stateValue = "j".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
+      // Simulate D1 returning empty .results for the tenant upsert (no RETURNING row)
+      // → tenantIds contains undefined → the some(id == null) guard must 500.
+      (db as unknown as { batch: unknown }).batch = vi.fn(async (stmts: FakeStmt[]) =>
+        stmts.map(() => ({ results: [], meta: { changes: 0 } })),
+      );
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+      const { app, env } = makeApp(db);
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: "db_error" });
+      expect(res.headers.get("Set-Cookie")).toBeNull();
     });
   });
 
@@ -741,15 +792,8 @@ describe("callbackRoute", () => {
         captured.push(stmt);
         return stmt;
       });
-      // #158: override batch() so tenant RETURNING ids surface through batch results
-      (db as unknown as { batch: unknown }).batch = vi.fn(async (stmts: FakeStmt[]) =>
-        Promise.all(
-          stmts.map(async (s) => {
-            const { results } = await s.all<FakeResult>();
-            return { results, meta: { changes: results.length } };
-          }),
-        ),
-      );
+      // #158: surface tenant RETURNING ids through batch results.
+      applyBatchOverride(db);
 
       // Stub fetch so both calls hit GitHub APIs successfully
       let fetchCallCount = 0;

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -404,7 +404,7 @@ describe("callbackRoute", () => {
      */
     function makeHappyPathDb(captured: FakeStmt[], redirectAfter = "/"): D1Database {
       let oauthDeleteCallCount = 0;
-      return makeFakeDb((sql, args) => {
+      const db = makeFakeDb((sql, args) => {
         const isOauthDelete =
           sql.toLowerCase().includes("oauth_state") &&
           sql.toLowerCase().includes("delete");
@@ -451,6 +451,18 @@ describe("callbackRoute", () => {
         captured.push(stmt);
         return stmt;
       });
+      // #158: the default makeFakeDb batch() mock returns empty results; the new
+      // callback reads tenant ids from RETURNING via batch(). Surface each
+      // statement's own rows (from makeFakeStmt) so the tenant id flows through.
+      (db as unknown as { batch: unknown }).batch = vi.fn(async (stmts: FakeStmt[]) =>
+        Promise.all(
+          stmts.map(async (s) => {
+            const { results } = await s.all<FakeResult>();
+            return { results, meta: { changes: results.length } };
+          }),
+        ),
+      );
+      return db;
     }
 
     it("uses atomic DELETE...RETURNING to consume state (closes TOCTOU)", async () => {
@@ -634,6 +646,56 @@ describe("callbackRoute", () => {
       const cookie = res.headers.get("Set-Cookie") ?? "";
       expect(cookie).toContain("__Host-session=");
     });
+
+    it("uses two DB.batch round-trips (tenants + links) instead of a per-install loop", async () => {
+      const stateValue = "h".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+      );
+      const { app, env } = makeApp(db);
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+      expect((db as unknown as { batch: ReturnType<typeof vi.fn> }).batch).toHaveBeenCalledTimes(2);
+    });
+
+    it("handles multiple installations: upserts all tenants + links, returns 302 with session cookie", async () => {
+      const stateValue = "g".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [
+          { id: 9, account: { login: "Roxabi", type: "Organization" } },
+          { id: 11, account: { login: "OtherOrg", type: "Organization" } },
+        ],
+      );
+      const { app, env } = makeApp(db);
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Set-Cookie")).toContain("__Host-session");
+      const tenantUpserts = captured.filter(
+        (s) =>
+          s.sql.toLowerCase().includes("tenants") &&
+          s.sql.toLowerCase().includes("returning"),
+      );
+      expect(tenantUpserts).toHaveLength(2);
+      const links = captured.filter((s) =>
+        s.sql.toLowerCase().includes("user_installations"),
+      );
+      expect(links).toHaveLength(2);
+    });
   });
 
   describe("replay attack — behavioral single-use enforcement", () => {
@@ -679,6 +741,15 @@ describe("callbackRoute", () => {
         captured.push(stmt);
         return stmt;
       });
+      // #158: override batch() so tenant RETURNING ids surface through batch results
+      (db as unknown as { batch: unknown }).batch = vi.fn(async (stmts: FakeStmt[]) =>
+        Promise.all(
+          stmts.map(async (s) => {
+            const { results } = await s.all<FakeResult>();
+            return { results, meta: { changes: results.length } };
+          }),
+        ),
+      );
 
       // Stub fetch so both calls hit GitHub APIs successfully
       let fetchCallCount = 0;

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -208,38 +208,36 @@ export async function callbackRoute(
   }
   const userId = userRow.id;
 
-  // Upsert each installation as a tenant and link to user
-  let firstTenantId: number | null = null;
+  // Upsert all installations as tenants in one batched round-trip (RETURNING id),
+  // then link them to the user in a second batch. Replaces the per-installation
+  // sequential loop (2N round-trips → 2). #158
+  // installations is guaranteed non-empty here (the length===0 case returned above),
+  // so neither batch() is ever called with an empty array.
+  const tenantResults = await c.env.DB.batch<{ id: number }>(
+    installations.map((inst) =>
+      c.env.DB.prepare(
+        `INSERT INTO tenants (installation_id, account_login, account_type) VALUES (?, ?, ?)
+         ON CONFLICT(installation_id) DO UPDATE SET account_login=excluded.account_login,
+           account_type=excluded.account_type, updated_at=datetime('now')
+         RETURNING id`,
+      ).bind(inst.id, inst.account.login, inst.account.type),
+    ),
+  );
 
-  for (const inst of installations) {
-    const tenantRow = await c.env.DB.prepare(
-      `INSERT INTO tenants (installation_id, account_login, account_type) VALUES (?, ?, ?)
-       ON CONFLICT(installation_id) DO UPDATE SET account_login=excluded.account_login,
-         account_type=excluded.account_type, updated_at=datetime('now')
-       RETURNING id`,
-    )
-      .bind(inst.id, inst.account.login, inst.account.type)
-      .first<{ id: number }>();
-
-    if (!tenantRow) {
-      return c.json({ error: "db_error" }, 500);
-    }
-    const tenantId = tenantRow.id;
-
-    await c.env.DB.prepare(
-      `INSERT OR IGNORE INTO user_installations (user_id, tenant_id) VALUES (?, ?)`,
-    )
-      .bind(userId, tenantId)
-      .run();
-
-    if (firstTenantId === null) {
-      firstTenantId = tenantId;
-    }
-  }
-
-  if (firstTenantId === null) {
+  const tenantIds = tenantResults.map((r) => r.results[0]?.id);
+  if (tenantIds.some((id) => id == null)) {
     return c.json({ error: "db_error" }, 500);
   }
+  const firstTenantId = tenantIds[0] as number;
+
+  // Link each tenant to the user (idempotent) in one batch.
+  await c.env.DB.batch(
+    tenantIds.map((tid) =>
+      c.env.DB.prepare(
+        `INSERT OR IGNORE INTO user_installations (user_id, tenant_id) VALUES (?, ?)`,
+      ).bind(userId, tid as number),
+    ),
+  );
 
   // Mint session tied to the first installation's tenant
   const rawToken = await mintSession(c.env.DB, userId, firstTenantId);

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -211,6 +211,8 @@ export async function callbackRoute(
   // Upsert all installations as tenants in one batched round-trip (RETURNING id),
   // then link them to the user in a second batch. Replaces the per-installation
   // sequential loop (2N round-trips → 2). #158
+  // Each DB.batch() runs as a single implicit D1 transaction (all-or-nothing), which
+  // also closes the partial-write race the old sequential loop had.
   // installations is guaranteed non-empty here (the length===0 case returned above),
   // so neither batch() is ever called with an empty array.
   const tenantResults = await c.env.DB.batch<{ id: number }>(
@@ -224,18 +226,21 @@ export async function callbackRoute(
     ),
   );
 
-  const tenantIds = tenantResults.map((r) => r.results[0]?.id);
-  if (tenantIds.some((id) => id == null)) {
+  const maybeTenantIds = tenantResults.map((r) => r.results[0]?.id);
+  if (maybeTenantIds.some((id) => id == null)) {
     return c.json({ error: "db_error" }, 500);
   }
-  const firstTenantId = tenantIds[0] as number;
+  // Guard above guarantees every entry is defined; narrow the whole array once
+  // rather than casting each element (.some() does not narrow in TS).
+  const tenantIds = maybeTenantIds as number[];
+  const firstTenantId = tenantIds[0];
 
   // Link each tenant to the user (idempotent) in one batch.
   await c.env.DB.batch(
     tenantIds.map((tid) =>
       c.env.DB.prepare(
         `INSERT OR IGNORE INTO user_installations (user_id, tenant_id) VALUES (?, ?)`,
-      ).bind(userId, tid as number),
+      ).bind(userId, tid),
     ),
   );
 


### PR DESCRIPTION
## Summary

Closes the last epic-#141 auth sidecar. Converts the oauth callback's per-installation **sequential** D1 loop into two batched round-trips.

### Before → after
Per installation the callback did 2 sequential awaits (tenant upsert `RETURNING id`, then `user_installations` insert) → **2N round-trips** for N installations.

Now:
1. One `DB.batch()` of all tenant upserts (`RETURNING id`) → read ids from `results`.
2. One `DB.batch()` of all `user_installations` links.

→ **2 round-trips** regardless of N. Batch A commits before batch B, so the links reference committed tenant rows (no FK race). The `installations.length === 0` early-return upstream guarantees neither `batch()` is ever called with an empty array.

### Test harness note
The shared `makeFakeDb.batch` mock (`test-utils.ts`) returns empty `.results` and is **deliberately left untouched** — webhook/issues tests read `r.meta.changes` from it and `issues.test.ts` overrides `batch` per-test. Instead the `batch` override is **isolated to oauth's `makeHappyPathDb`**, surfacing each statement's RETURNING rows so the tenant id flows through.

### Tests
- +2 new: (a) asserts exactly **2** `DB.batch` calls (locks in the round-trip reduction), (b) multi-installation path → both tenants upserted + both linked + 302 w/ `__Host-session`.
- Existing happy-path assertions (tenants upsert / user_installations INSERT / 302 Set-Cookie / redirect_after) still pass through the new batch path.
- `npm run typecheck` clean · `npm test` **523/523**.

### Noted alternative (not done)
A single batch interleaving tenant-upsert + `INSERT … SELECT id FROM tenants WHERE installation_id=?` would cut to **1** round-trip but couples the link to a SQL subquery. Two-batch is clearer/safer and already eliminates the N-scaling; single-batch is a deferrable micro-opt.

Closes #158