### PR TITLE
feat(sync): daily full reconcile + richer run audit, disable staging cron (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Let:
 **Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
 - Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150) — pending cutover, see docs/s7-access-cutover.md**
 - Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
-- Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 * * * *` + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
+- Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 0 * * *` (daily full reconcile, #80) + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
 - Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)
 - `/admin/*` gated by `ADMIN_TOKEN` secret (defense-in-depth, #123) in addition to edge Access
 - M₁ (roxabituwer) **decommissioned 2026-06-08**: `live.service` stopped+disabled, Tailscale Funnel retired, `~/.roxabi/corpus.db` archived
@@ -41,7 +41,7 @@ Let:
 | `worker/src/api/graph.ts` | `GET /api/graph` |
 | `worker/src/api/admin.ts` | `POST /admin/sync` (ADMIN_TOKEN-gated) |
 | `worker/src/api/version.ts` | `GET /api/version` |
-| `worker/src/sync/sync.ts` | Hourly sync orchestrator + R2 audit write |
+| `worker/src/sync/sync.ts` | Daily reconcile orchestrator + R2 audit write |
 | `worker/src/sync/graphql.ts` | GitHub GraphQL client (`fetch()`) |
 | `worker/src/sync/queries.ts` | GraphQL query strings |
 | `worker/src/sync/parse.ts` | Issue/edge parsing |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 |:---:|:---:|:---:|
 | ![Table](docs/images/table-view.png) | ![List](docs/images/list-view.png) | ![Graph](docs/images/graph-view.png) |
 
-Roxabi Live pulls GitHub issues from the entire org into a [Cloudflare D1](https://developers.cloudflare.com/d1/) database and serves a multi-view dashboard at **[live.roxabi.dev](https://live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via a GitHub org webhook, and re-syncs hourly via a Cron Trigger — all on a single Cloudflare Worker.
+Roxabi Live pulls GitHub issues from the entire org into a [Cloudflare D1](https://developers.cloudflare.com/d1/) database and serves a multi-view dashboard at **[live.roxabi.dev](https://live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via a GitHub org webhook, and re-syncs daily via a Cron Trigger — all on a single Cloudflare Worker.
 
 **Multi-user:** any GitHub user with access to the installed GitHub App can sign in via OAuth (`GET /login`). The app is session-gated — `/api/*` requires an active session cookie. `/admin/*` additionally sits behind Cloudflare Access (Email-OTP) as a defense-in-depth layer.
 
@@ -39,7 +39,7 @@ Deploys are CI-driven: push to `staging` → staging Worker; push to `main` → 
 
 ```mermaid
 flowchart LR
-    CRON[Cron Trigger\n0 * * * *]
+    CRON[Cron Trigger\n0 0 * * *]
     GH[GitHub Org\nGraphQL API]
     W[CF Worker\nHono]
     DB[(D1\nroxabi-live-production)]
@@ -47,7 +47,7 @@ flowchart LR
     FE[Dashboard\nlive.roxabi.dev]
     WH[GitHub Webhook\nPOST /webhook/github]
 
-    CRON -->|hourly scheduled| W
+    CRON -->|daily scheduled| W
     GH -->|GraphQL| W
     W -->|upsert| DB
     DB -->|read| W
@@ -57,7 +57,7 @@ flowchart LR
 ```
 
 **Sync flow:**
-1. A Cron Trigger (`0 * * * *`) invokes the Worker's `scheduled` handler hourly; `POST /admin/sync` triggers it out-of-band.
+1. A Cron Trigger (`0 0 * * *`) invokes the Worker's `scheduled` handler daily (full reconcile, #80); `POST /admin/sync` triggers it out-of-band.
 2. The Worker fetches issues via GitHub GraphQL — `subIssues`, `parent`, `blockedBy`, `blocking` fields — and upserts into D1 (tables: `issues`, `edges`, `repos`, `sync_state`).
 3. The Worker serves the corpus over a JSON API; the static frontend (ASSETS binding) builds the views client-side.
 4. The GitHub org webhook (`POST /webhook/github`, HMAC-verified) applies incremental updates in real time; each sync run writes a JSON audit to R2.
@@ -69,7 +69,7 @@ flowchart LR
 | **Views** | Pivot matrix (milestones x lanes), flat list, SVG dependency graph |
 | **Filters** | Multi-select: repo, milestone, priority, status; full-text search |
 | **Dependencies** | Parent/child edges + blocker edges; status propagation (blocked/ready/done) |
-| **Sync** | GitHub GraphQL sync; hourly Cron Trigger; real-time webhook updates |
+| **Sync** | GitHub GraphQL sync; daily Cron Trigger; real-time webhook updates |
 | **Theme** | Light/dark toggle |
 | **Storage** | Cloudflare D1 (serverless SQLite) + R2 per-run audit log |
 
@@ -104,7 +104,7 @@ Bindings live in [`wrangler.toml`](wrangler.toml); secrets are set per-environme
 | `DB` | D1 | Issue corpus + sessions (`roxabi-live-production` / `roxabi-live-staging`) |
 | `ASSETS` | Static | Serves `frontend/` via ASSETS binding |
 | `LOGS` | R2 | Per-run sync audit (`roxabi-live-logs` / `roxabi-live-logs-staging`) |
-| Cron | trigger | `0 * * * *` — hourly sync |
+| Cron | trigger | `0 0 * * *` — daily full reconcile |
 
 ### Secrets
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — Roxabi Live
 
-Roxabi Live is a serverless operations cockpit that syncs GitHub issues and their dependency graph from a GitHub App installation into a Cloudflare D1 database, then serves the graph as a filterable web UI. The entire stack runs on Cloudflare: a single Worker handles HTTP via Hono, a Cron Trigger drives hourly sync, static frontend assets are served through the Worker's ASSETS binding, and R2 stores per-run audit logs. There is no persistent server, no Python runtime, and no local database in production.
+Roxabi Live is a serverless operations cockpit that syncs GitHub issues and their dependency graph from a GitHub App installation into a Cloudflare D1 database, then serves the graph as a filterable web UI. The entire stack runs on Cloudflare: a single Worker handles HTTP via Hono, a Cron Trigger drives a daily full reconcile, static frontend assets are served through the Worker's ASSETS binding, and R2 stores per-run audit logs. There is no persistent server, no Python runtime, and no local database in production.
 
 ---
 
@@ -16,7 +16,7 @@ Roxabi Live is a serverless operations cockpit that syncs GitHub issues and thei
  │                                 │                      │    │
  │  Browser ──────────────────────►│  fetch handler       │    │
  │  GitHub webhook ───────────────►│    Hono router       │    │
- │  Cron (0 * * * *) ────────────►│  scheduled handler   │    │
+ │  Cron (0 0 * * *) ────────────►│  scheduled handler   │    │
  │                                 └──────┬───────────────┘    │
  │                                        │                    │
  │              ┌─────────────────────────┼─────────────┐      │
@@ -184,6 +184,8 @@ Cloudflare Workers have a subrequest limit per invocation. To stay within it wit
 - Watermark tracked in `sync_state.slot` per repo; `sync_control.sync_started_at` seeded by migration 0006
 - Known: with 34+ repos, slot 2 window `[40, 60)` may be empty → that tick is a no-op (expected, tracked #166)
 
+> **Daily full reconcile (#80):** The Cron trigger (`0 0 * * *`) runs `since=null` — all repos, no watermark filter. This heals deps-only edge drift (e.g. `blockedBy`/`blocking` changes that arrive only via the sync path, not webhook events). The webhook still handles real-time intra-day updates.
+
 ### R2 audit
 
 Each sync run writes a JSON audit record to R2 bucket `roxabi-live-logs` (staging: `roxabi-live-logs-staging`). Use D1 `sync_control` / `sync_state` for programmatic audit queries (R2 has no list API in wrangler v3+).
@@ -252,7 +254,7 @@ Applied in order at deploy time (`wrangler d1 migrations apply DB --remote`):
 | `worker/src/api/graph.ts` | `GET /api/graph` |
 | `worker/src/api/admin.ts` | `POST /admin/sync` (ADMIN_TOKEN-gated) |
 | `worker/src/api/version.ts` | `GET /api/version` |
-| `worker/src/sync/sync.ts` | Hourly sync orchestrator + R2 audit write |
+| `worker/src/sync/sync.ts` | Daily reconcile orchestrator + R2 audit write |
 | `worker/src/sync/graphql.ts` | GitHub GraphQL client (`fetch()`) |
 | `worker/src/sync/queries.ts` | GraphQL query strings |
 | `worker/src/sync/parse.ts` | Issue/edge parsing |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -465,7 +465,7 @@ curl https://<YOUR_DOMAIN>/api/version
 
 ### Trigger a sync
 
-The cron runs hourly at minute 0 (`0 * * * *`). To trigger immediately:
+The cron runs daily at 00:00 UTC (`0 0 * * *`). To trigger immediately:
 
 ```bash
 # Requires ADMIN_TOKEN to be set (step 5):
@@ -514,10 +514,10 @@ export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
 
 ### Graph is empty after first login
 
-The graph is built from synced data. Either wait for the hourly cron (fires at `:00`) or
+The graph is built from synced data. Either wait for the daily cron (fires at 00:00 UTC) or
 trigger a manual sync via `POST /admin/sync`. After sync, reload the dashboard.
 
-`is_private` values for repos default to `1` (fail-closed, migration 0007). The hourly
+`is_private` values for repos default to `1` (fail-closed, migration 0007). The daily
 sync corrects these from the GitHub API. After the first successful sync, private/public
 status will be accurate.
 

--- a/docs/cloudflared-setup.md
+++ b/docs/cloudflared-setup.md
@@ -276,4 +276,4 @@ Webhook delivery:
 - Rotate the identity-provider allowlist: edit the `Allow owner` policy (Step A.5).
 - After a `_halted` reconciler event (CRITICAL log emitted due to repeated auth failures): rotate the GitHub token, then restart the live service to clear the sticky halt state: `systemctl --user restart live.service`. The reconciler will resume on the next hourly tick.
 
-> **Note (2026-06-08 — decommissioned):** `live.service` no longer runs on M₁. The CF Worker handles sync via `ADMIN_TOKEN`-gated `/admin/sync` (manual) or hourly Cron Trigger. To clear a halted sync on the Worker: rotate `GITHUB_TOKEN` via `wrangler secret put`, then trigger `POST /admin/sync` with `Authorization: Bearer <ADMIN_TOKEN>`.
+> **Note (2026-06-08 — decommissioned):** `live.service` no longer runs on M₁. The CF Worker handles sync via `ADMIN_TOKEN`-gated `/admin/sync` (manual) or daily Cron Trigger. To clear a halted sync on the Worker: rotate `GITHUB_TOKEN` via `wrangler secret put`, then trigger `POST /admin/sync` with `Authorization: Bearer <ADMIN_TOKEN>`.

--- a/docs/s8-cron-observability.md
+++ b/docs/s8-cron-observability.md
@@ -2,7 +2,7 @@
 
 Issue [#100](https://github.com/Roxabi/roxabi-live/issues/100) · epic [#92](https://github.com/Roxabi/roxabi-live/issues/92).
 
-The **code** for S8 shipped in S4 (#96): the hourly Cron trigger, the `scheduled()`
+The **code** for S8 shipped in S4 (#96): the daily Cron trigger, the `scheduled()`
 handler, and the auth-halt → `NOTIFY_URL` alert all exist. This slice adds the
 **observability config** and the **operational steps** that can't live in the repo, plus
 two code hardening changes (typed `Env.NOTIFY_URL`, halt-alert test).
@@ -98,11 +98,11 @@ Unset = alerts disabled (the code no-ops; the breaker still halts the sync).
 
 ## Acceptance verification (Accept criteria, #100)
 
-1. **≥1 successful Cron execution in prod.** After deploy, wait for the top of an hour, then:
+1. **≥1 successful Cron execution in prod.** After deploy, wait for 00:00 UTC, then:
 
    ```bash
    # CF dashboard → Workers & Pages → roxabi-live → Cron → invocation log shows success
-   # OR via D1 (watermark advanced within the last ~65 min):
+   # OR via D1 (watermark advanced within the last ~25 hours):
    wrangler d1 execute roxabi-live-production --remote \
      --command "SELECT key, value, datetime(updated_at) FROM sync_control WHERE key IN ('halted','auth_failures'); SELECT MAX(last_synced_at) AS watermark FROM sync_state;"
    ```
@@ -115,7 +115,7 @@ Unset = alerts disabled (the code no-ops; the breaker still halts the sync).
      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq '.result[] | select(.name=="roxabi-live-logs") | {last_complete,last_error}'
    ```
 
-3. **`/api/version` timestamp ≤ 65 min old** after one prod hour:
+3. **`/api/version` timestamp ≤ 25 hours old** after one prod day:
 
    ```bash
    curl -sS https://<prod-host>/api/version | jq '.'

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5,7 +5,8 @@ import type { Env } from "./types";
 export default {
   fetch: app.fetch,
 
-  // Hourly Cron Trigger (wrangler.toml [triggers].crons = "0 * * * *").
+  // Daily Cron Trigger (wrangler.toml [triggers].crons = "0 0 * * *") — runs a
+  // FULL reconcile (since=null) so deps-only edge changes are healed daily (#80).
   scheduled: async (
     _controller: ScheduledController,
     env: Env,

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1459,7 +1459,9 @@ describe("runSync — multi-tenant installation sync (#160)", () => {
   });
 
   it("window-past-end: sync_slot beyond repo count → no REPO_BUNDLE_QUERY fetches and runSync resolves", async () => {
-    // WINDOW=20 (sync.ts const), NUM_SLOTS=3.
+    // WINDOW=20 (sync.ts const), NUM_SLOTS=2 → code only persists slots {0,1}.
+    // slot=2 here is a FORCED out-of-range value to exercise the slice-past-end
+    // guard defensively (a stale/garbage persisted slot must not crash Phase 2).
     // 21 repos → windowing engages (allRepos.length > WINDOW).
     // slot=2 → windowStart = 2 * 20 = 40 ≥ 21 → windowedRepos=[] → no bundle fetches.
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -849,6 +849,57 @@ describe("syncRepoBundle", () => {
     const batchMock = (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch;
     expect(batchMock).toHaveBeenCalled();
   });
+
+  it("fullSync=true forces since=null without reading the watermark, and returns stale PRs closed (#80)", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        rateLimit: { cost: 1, remaining: 4999 },
+        repository: {
+          issues: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+          refs: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+          pullRequests: {
+            nodes: [
+              {
+                number: 5,
+                state: "OPEN",
+                closingIssuesReferences: { nodes: [] },
+                labels: { nodes: [] },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      // Watermark present — must be ignored when fullSync=true.
+      if (sql.includes("SELECT last_synced_at")) {
+        return makeFakeStmt(sql, args, [{ last_synced_at: "2026-01-01T00:00:00Z" }]);
+      }
+      // pr_state: #5 and #6 open in D1; GitHub reports only #5 → #6 is stale.
+      if (sql.includes("SELECT number FROM pr_state") && sql.includes("state='open'")) {
+        return makeFakeStmt(sql, args, [{ number: 5 }, { number: 6 }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    const closed = await syncRepoBundle(db, "fake-token", "Roxabi", "lyra", new Map(), true);
+
+    // since passed as null (full reconcile) despite the watermark being present
+    expect(mockGhGraphql).toHaveBeenCalledWith(
+      "REPO_BUNDLE_QUERY",
+      expect.objectContaining({ owner: "Roxabi", name: "lyra", since: null }),
+      "fake-token",
+    );
+    // watermark SELECT never issued when fullSync=true
+    expect(db._recorded.find((s) => s.sql.includes("SELECT last_synced_at"))).toBeUndefined();
+    // PR #6 (open in D1, absent from GitHub) closed → count returned
+    expect(closed).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1140,6 +1191,53 @@ describe("writeRunAudit", () => {
       watermark: "2026-06-08T09:00:00Z",
       halted: false,
       authFailures: 0,
+    });
+  });
+
+  it("records net deltas + corrections when before-snapshot + corrections supplied (#80)", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const put = vi.fn().mockResolvedValue(undefined);
+    const db = auditDb();
+    const env = { DB: db, LOGS: { put } } as unknown as Env;
+
+    await writeRunAudit(env, db, {
+      outcome: "success",
+      stubs: 2,
+      durationMs: 500,
+      before: { issues: 2600, edges: 2400, prs: 370 },
+      reposSynced: 8,
+      reposSkipped: 1,
+      corrections: { stalePrsClosed: 3, staleReposPruned: 1, staleTenantReposRemoved: 2 },
+    });
+
+    const snap = JSON.parse(put.mock.calls[0][1] as string);
+    // after (auditDb) = {2650, 2432, 373}; before = {2600, 2400, 370}
+    expect(snap.deltas).toEqual({ issues: 50, edges: 32, prs: 3 });
+    expect(snap.reposSynced).toBe(8);
+    expect(snap.reposSkipped).toBe(1);
+    expect(snap.corrections).toEqual({
+      stubsCreated: 2,
+      stalePrsClosed: 3,
+      staleReposPruned: 1,
+      staleTenantReposRemoved: 2,
+    });
+  });
+
+  it("emits zero deltas when no before-snapshot is supplied", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const put = vi.fn().mockResolvedValue(undefined);
+    const db = auditDb();
+    const env = { DB: db, LOGS: { put } } as unknown as Env;
+
+    await writeRunAudit(env, db, { outcome: "success", stubs: 0, durationMs: 1 });
+
+    const snap = JSON.parse(put.mock.calls[0][1] as string);
+    expect(snap.deltas).toEqual({ issues: 0, edges: 0, prs: 0 });
+    expect(snap.corrections).toEqual({
+      stubsCreated: 0,
+      stalePrsClosed: 0,
+      staleReposPruned: 0,
+      staleTenantReposRemoved: 0,
     });
   });
 

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -25,10 +25,20 @@ import { getInstallationToken, listInstallationRepos } from "../auth/installToke
 // ---------------------------------------------------------------------------
 
 export const MAX_PAGES = 500;
-/** Repos synced per slot per tick. Coverage ceiling: WINDOW * NUM_SLOTS = 60 repos. */
+/**
+ * Repos synced per cron tick. Capped at 20 to stay under the Workers Free
+ * 50-subrequest/invocation budget: a FULL reconcile (#80, since=null) costs
+ * ~1 subrequest per issue page, and the largest repo (roxabi-factory, ~1k
+ * issues) alone is ~11 pages — so a single run cannot reconcile all repos.
+ */
 export const WINDOW = 20;
-/** Number of rotation slots. Coverage ceiling: WINDOW * NUM_SLOTS = 60 repos. */
-export const NUM_SLOTS = 3;
+/**
+ * Rotation slots. Coverage ceiling = WINDOW * NUM_SLOTS = 40 repos; with the
+ * daily cron each repo is full-reconciled every NUM_SLOTS days (= 2). 36 repos
+ * today → fits in 2 slots, no wasted tick. Beyond 40 repos, raise this / WINDOW
+ * (watch the subreq budget) or migrate to the dormant Queues fan-out (wrangler.toml).
+ */
+export const NUM_SLOTS = 2;
 
 /** Verbatim port of sync.py UPSERT_ISSUE_SQL — full sync path (sets status=null). */
 export const UPSERT_ISSUE_SQL = `

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -316,17 +316,22 @@ export async function syncRepoIssues(
   owner: string,
   name: string,
   collectedEdges: Map<string, EdgeData>,
+  fullSync = false,
 ): Promise<void> {
   const repo = `${owner}/${name}`;
   let cursor: string | null = null;
   let pages = 0;
 
-  // Read watermark from previous sync (null on first run → full fetch)
-  const syncStateRow = await db
-    .prepare("SELECT last_synced_at FROM sync_state WHERE repo=?")
-    .bind(repo)
-    .first<{ last_synced_at: string | null }>();
-  const since: string | null = syncStateRow?.last_synced_at ?? null;
+  // Read watermark from previous sync (null on first run → full fetch).
+  // fullSync (#80) forces since=null to reconcile deps-only changes.
+  let since: string | null = null;
+  if (!fullSync) {
+    const syncStateRow = await db
+      .prepare("SELECT last_synced_at FROM sync_state WHERE repo=?")
+      .bind(repo)
+      .first<{ last_synced_at: string | null }>();
+    since = syncStateRow?.last_synced_at ?? null;
+  }
 
   while (true) {
     const response: { data: IssuesData } & Record<string, unknown> = await ghGraphql<IssuesData>(
@@ -590,7 +595,7 @@ export async function applyPrState(
   repo: string,
   upsertStmts: D1PreparedStatement[],
   seenPrNumbers: number[],
-): Promise<void> {
+): Promise<number> {
   await batchChunked(db, upsertStmts);
 
   if (seenPrNumbers.length > 0) {
@@ -611,11 +616,13 @@ export async function applyPrState(
         .bind(repo, ...chunk)
         .run();
     }
+    return stale.length;
   } else {
-    await db
+    const res = await db
       .prepare(`UPDATE pr_state SET state='closed' WHERE repo=? AND state='open'`)
       .bind(repo)
       .run();
+    return res.meta.changes ?? 0;
   }
 }
 
@@ -718,15 +725,22 @@ export async function syncRepoBundle(
   owner: string,
   name: string,
   collectedEdges: Map<string, EdgeData>,
-): Promise<void> {
+  fullSync = false,
+): Promise<number> {
   const repo = `${owner}/${name}`;
 
-  // Read watermark (null on first run → full fetch)
-  const syncStateRow = await db
-    .prepare("SELECT last_synced_at FROM sync_state WHERE repo=?")
-    .bind(repo)
-    .first<{ last_synced_at: string | null }>();
-  const since: string | null = syncStateRow?.last_synced_at ?? null;
+  // Watermark gates the incremental fetch. fullSync (#80) forces since=null so a
+  // complete re-fetch reconciles edges even for deps-only changes — which never
+  // bump issue.updatedAt and are therefore invisible to an incremental `since`
+  // query (only the webhook path catches them otherwise).
+  let since: string | null = null;
+  if (!fullSync) {
+    const syncStateRow = await db
+      .prepare("SELECT last_synced_at FROM sync_state WHERE repo=?")
+      .bind(repo)
+      .first<{ last_synced_at: string | null }>();
+    since = syncStateRow?.last_synced_at ?? null;
+  }
 
   // Per-connection cursor state
   let issuesCursor: string | null = null;
@@ -868,9 +882,10 @@ export async function syncRepoBundle(
     .bind(repo, nowIso)
     .run();
 
-  // Apply branch + PR state (deferred so all pages are fetched first)
+  // Apply branch + PR state (deferred so all pages are fetched first).
+  // Returns the count of stale open PRs closed, surfaced into the run audit.
   await applyActiveBranches(db, repo, matchedBranchNumbers);
-  await applyPrState(db, repo, prUpsertStmts, seenPrNumbers);
+  return applyPrState(db, repo, prUpsertStmts, seenPrNumbers);
 }
 
 // ---------------------------------------------------------------------------
@@ -1001,13 +1016,33 @@ export type RunOutcome = "success" | "empty" | "halted" | "auth_error" | "error"
  * Best-effort: no-op when LOGS is unbound, and never throws into runSync — a
  * failed audit must not fail the sync. Free-plan alternative to Logpush→R2.
  */
+/** Correction counters surfaced by a single reconcile run (#80). */
+export interface RunCorrections {
+  /** Open PRs in D1 closed because GitHub no longer reports them open. */
+  stalePrsClosed: number;
+  /** Repos whose rows were pruned (no longer accessible via any installation). */
+  staleReposPruned: number;
+  /** tenant_repo_access rows deleted (repo dropped from an installation). */
+  staleTenantReposRemoved: number;
+}
+
+/** Input to writeRunAudit. New fields are optional → callers may omit them. */
+export interface RunAuditInfo {
+  outcome: RunOutcome;
+  stubs: number;
+  durationMs: number;
+  /** Table COUNT(*) snapshot taken at the start of the run (enables net deltas). */
+  before?: { issues: number; edges: number; prs: number };
+  reposSynced?: number;
+  reposSkipped?: number;
+  corrections?: RunCorrections;
+}
+
 export async function writeRunAudit(
   env: Env,
   db: D1Database,
-  info: { outcome: RunOutcome; stubs: number; durationMs: number },
+  info: RunAuditInfo,
 ): Promise<void> {
-  const bucket = env.LOGS;
-  if (!bucket) return;
   try {
     const [issues, edges, prs, wm, ctrl] = await Promise.all([
       db.prepare("SELECT COUNT(*) AS c FROM issues").first<{ c: number }>(),
@@ -1026,18 +1061,66 @@ export async function writeRunAudit(
       (ctrl.results ?? []).map((r) => [r.key, r.value] as const),
     );
     const ts = new Date().toISOString();
+
+    const after = {
+      issues: issues?.c ?? 0,
+      edges: edges?.c ?? 0,
+      prs: prs?.c ?? 0,
+    };
+    // No before-snapshot → report zero deltas (don't fabricate churn).
+    const before = info.before ?? after;
+    const corrections: RunCorrections = info.corrections ?? {
+      stalePrsClosed: 0,
+      staleReposPruned: 0,
+      staleTenantReposRemoved: 0,
+    };
+    const reposSynced = info.reposSynced ?? 0;
+    const reposSkipped = info.reposSkipped ?? 0;
+    // Net delta per table — the meaningful "what changed this run" signal.
+    // (flushEdges always wipes+rewrites, so raw insert/delete row counts are
+    // churn noise; the after-before net is the real correction.)
+    const deltas = {
+      issues: after.issues - before.issues,
+      edges: after.edges - before.edges,
+      prs: after.prs - before.prs,
+    };
+
     const summary = {
       ts,
       outcome: info.outcome,
       durationMs: info.durationMs,
       stubs: info.stubs,
-      issues: issues?.c ?? 0,
-      edges: edges?.c ?? 0,
-      prs: prs?.c ?? 0,
+      // after-run snapshot (kept top-level for backward compatibility)
+      issues: after.issues,
+      edges: after.edges,
+      prs: after.prs,
       watermark: wm?.w ?? null,
       halted: ctrlMap.get("halted") === "1",
       authFailures: Number(ctrlMap.get("auth_failures") ?? 0),
+      // #80 — durable trace of what this reconcile run corrected
+      reposSynced,
+      reposSkipped,
+      deltas,
+      corrections: {
+        stubsCreated: info.stubs,
+        stalePrsClosed: corrections.stalePrsClosed,
+        staleReposPruned: corrections.staleReposPruned,
+        staleTenantReposRemoved: corrections.staleTenantReposRemoved,
+      },
     };
+
+    // Human-readable one-liner for Workers Logs (~3-day retention on Free) —
+    // logged even when R2 is unbound so the cadence is always observable.
+    const d = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
+    console.log(
+      `[sync] reconcile: repos=${reposSynced}/${reposSynced + reposSkipped} ` +
+        `issuesΔ${d(deltas.issues)} edgesΔ${d(deltas.edges)} prsΔ${d(deltas.prs)} ` +
+        `stubs=${info.stubs} prs-closed=${corrections.stalePrsClosed} ` +
+        `pruned=${corrections.staleReposPruned} tenant-repos-removed=${corrections.staleTenantReposRemoved}`,
+    );
+
+    const bucket = env.LOGS;
+    if (!bucket) return;
     const key = `runs/${ts.slice(0, 10)}/${ts}.json`;
     await bucket.put(key, JSON.stringify(summary), {
       httpMetadata: { contentType: "application/json" },
@@ -1064,11 +1147,17 @@ export async function writeRunAudit(
  *   5. Accumulate Map<repo, Array<{tenantId, installationId}>> sorted by tenantId
  *      (lowest = owning; used for token fallback in Phase 2).
  */
+export interface TenantDiscovery {
+  repoMap: Map<string, Array<{ tenantId: number; installationId: number }>>;
+  staleTenantReposRemoved: number;
+}
+
 export async function discoverTenants(
   db: D1Database,
   env: Env,
-): Promise<Map<string, Array<{ tenantId: number; installationId: number }>>> {
+): Promise<TenantDiscovery> {
   const repoMap = new Map<string, Array<{ tenantId: number; installationId: number }>>();
+  let staleTenantReposRemoved = 0;
 
   const tenantRows = await db
     .prepare(`SELECT id, installation_id FROM tenants WHERE installation_id IS NOT NULL ORDER BY id ASC`)
@@ -1143,6 +1232,7 @@ export async function discoverTenants(
             .bind(tenantId, repo),
         );
         await batchChunked(db, deleteStmts);
+        staleTenantReposRemoved += stale.length;
         console.log(`[sync] tenant ${tenantId} removed ${stale.length} stale repo(s)`);
       }
 
@@ -1161,7 +1251,7 @@ export async function discoverTenants(
     }
   }
 
-  return repoMap;
+  return { repoMap, staleTenantReposRemoved };
 }
 
 export async function runSync(env: Env): Promise<void> {
@@ -1181,6 +1271,13 @@ export async function runSync(env: Env): Promise<void> {
   const t0 = Date.now();
   let outcome: RunOutcome = "error";
   let stubsCount = 0;
+  // #80 — reconcile observability: before-snapshot (for net deltas) + correction counters.
+  let before = { issues: 0, edges: 0, prs: 0 };
+  let staleReposPruned = 0;
+  let stalePrsClosed = 0;
+  let staleTenantReposRemoved = 0;
+  let reposSynced = 0;
+  let reposSkipped = 0;
 
   try {
     const startedAt = new Date().toISOString();
@@ -1191,8 +1288,18 @@ export async function runSync(env: Env): Promise<void> {
       .bind(startedAt, startedAt)
       .run();
 
+    // Capture table sizes before the run so the audit records true net deltas (#80).
+    const [bIssues, bEdges, bPrs] = await Promise.all([
+      db.prepare("SELECT COUNT(*) AS c FROM issues").first<{ c: number }>(),
+      db.prepare("SELECT COUNT(*) AS c FROM edges").first<{ c: number }>(),
+      db.prepare("SELECT COUNT(*) AS c FROM pr_state").first<{ c: number }>(),
+    ]);
+    before = { issues: bIssues?.c ?? 0, edges: bEdges?.c ?? 0, prs: bPrs?.c ?? 0 };
+
     // Phase 1 — per-tenant discovery: build Map<repo, [{tenantId,installationId}]>.
-    const repoTenantMap = await discoverTenants(db, env);
+    const { repoMap: repoTenantMap, staleTenantReposRemoved: tenantStale } =
+      await discoverTenants(db, env);
+    staleTenantReposRemoved = tenantStale;
 
     // Union of all repos accessible across all tenants.
     const allRepos = [...repoTenantMap.keys()].sort();
@@ -1270,13 +1377,13 @@ export async function runSync(env: Env): Promise<void> {
 
     if (pruneStmts.length > 0) {
       await batchChunked(db, pruneStmts);
-      const totalStale = new Set([
+      staleReposPruned = new Set([
         ...staleIssueRepos,
         ...staleEdgeReposUniq,
         ...stalePrStateRepos,
         ...staleSyncStateRepos,
       ]).size;
-      console.log(`[sync] pruned data for ${totalStale} stale repo(s)`);
+      console.log(`[sync] pruned data for ${staleReposPruned} stale repo(s)`);
     }
 
     // Phase 2 — deduped windowed fan-out.
@@ -1319,12 +1426,16 @@ export async function runSync(env: Env): Promise<void> {
       const resolveToken = makeRepoResolver(repoTenants);
       try {
         const token = await resolveToken();
-        await syncRepoBundle(db, token, owner, name, collectedEdges);
+        // Daily cron = full reconcile (#80): fullSync forces a complete re-fetch
+        // (since=null) so deps-only edge changes are healed regardless of updatedAt.
+        stalePrsClosed += await syncRepoBundle(db, token, owner, name, collectedEdges, true);
       } catch (err) {
         console.error(`[sync] skipping ${repo}:`, err);
         skippedCount++;
       }
     }
+    reposSynced = windowedRepos.length - skippedCount;
+    reposSkipped = skippedCount;
 
     // Pass 2: flush all edges (deferred to avoid cross-repo FK hazard).
     await flushEdges(db, collectedEdges);
@@ -1384,6 +1495,14 @@ export async function runSync(env: Env): Promise<void> {
       outcome,
       stubs: stubsCount,
       durationMs: Date.now() - t0,
+      before,
+      reposSynced,
+      reposSkipped,
+      corrections: {
+        stalePrsClosed,
+        staleReposPruned,
+        staleTenantReposRemoved,
+      },
     });
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,12 +27,15 @@ directory = "./frontend"
 binding   = "ASSETS"
 
 [triggers]
-crons = ["0 * * * *"]
+# Daily reconcile (was hourly "0 * * * *", #80). The webhook path handles real-time
+# intra-day changes; this cron is the heal net and runs a FULL reconcile (since=null)
+# so deps-only edge changes — which never bump issue.updatedAt — are healed each day.
+crons = ["0 0 * * *"]
 
 # Workers Logs (S8, #100) — in-dashboard invocation logs (~3-day retention on the
 # Free plan). NOTE: persistent export via Logpush→R2 needs Workers Paid; on Free the
 # persistent audit trail is instead written by the Worker itself (#120, see [[r2_buckets]]
-# below). head_sampling_rate=1 keeps every cron invocation (1/hour — volume is trivial).
+# below). head_sampling_rate=1 keeps every cron invocation (1/day — volume is trivial).
 [observability]
 enabled = true
 head_sampling_rate = 1
@@ -66,7 +69,11 @@ database_id    = "dd96d8cd-db6b-49ed-8218-53c88773aff4"
 migrations_dir = "worker/migrations"
 
 [env.staging.triggers]
-crons = ["0 * * * *"]
+# Staging sync DISABLED (manual/test-only env). An autonomous staging cron would
+# fire a redundant 2nd full GitHub sync + D1 writes every tick against the shared
+# Free-plan quota for no prod benefit. Deploy `--env staging` to test sync manually,
+# or hit POST /admin/sync. Re-enable by restoring a cron expr here if needed.
+crons = []
 
 # Named environments do not inherit top-level [observability] — repeat per env.
 [env.staging.observability]


### PR DESCRIPTION
## What

Closes #80 and bundles the sync-cadence + observability changes requested alongside it.

### 1. Cron cadence (`wrangler.toml`)
- **Prod**: hourly `0 * * * *` → **daily `0 0 * * *`**.
- **Staging**: cron **disabled** (`crons = []`). Staging is manual/test-only; an autonomous staging cron fired a redundant 2nd full GitHub sync + D1 writes against the shared Free-plan quota. Test via `--env staging` deploy or `POST /admin/sync`.

### 2. #80 fix — cron = FULL reconcile (windowed)
GitHub doesn't bump `issue.updatedAt` on dependency-edge changes, so the incremental `since` query never re-fetched deps-only changes → drift unless a webhook caught it. The cron now calls `syncRepoBundle(..., fullSync=true)` → `since=null` → re-fetches **all** issues (open + closed) and reconciles every edge.

**Cadence reality (Free 50-subreq/invocation cap):** a full reconcile costs ~1 subrequest per issue page. `roxabi-factory` alone (~1046 issues) = **11 pages**; all 36 repos in one run ≈ **51 subreqs → over the cap**. So windowing (20 repos/run) is mandatory. **`NUM_SLOTS` 3 → 2** (Option B): 36 repos fit 2 slots with no wasted tick → the daily cron **full-reconciles each repo every 2 days**. Webhooks still carry real-time intra-day changes; the cron is the backstop. Coverage ceiling = `WINDOW*NUM_SLOTS` = **40 repos** (beyond that: raise WINDOW/NUM_SLOTS within the subreq budget, or use the dormant Queues fan-out).

### 3. Durable audit of corrections (R2 + Workers Logs)
`writeRunAudit` now records **what each run corrected**, not just snapshot totals:
- `deltas` `{issues, edges, prs}` — net (after − before).
- `corrections` `{stubsCreated, stalePrsClosed, staleReposPruned, staleTenantReposRemoved}`.
- `reposSynced` / `reposSkipped`.
- One-line Workers Logs summary: `[sync] reconcile: repos=8/9 issuesΔ+5 edgesΔ+3 prsΔ-1 stubs=2 prs-closed=1 pruned=0 tenant-repos-removed=0`.

`applyPrState`, `discoverTenants`, `syncRepoBundle` surface their correction counts.

> **Design note:** net delta, *not* raw insert/delete row counts. `flushEdges` always wipes+rewrites edges, so row-level counts are churn noise every run — the after−before net is the real correction. True per-edge `+X/-Y` would need batch `meta.changes` instrumentation that conflicts with the shared FakeD1 mock; deferred.

## Live drift check (D1 API, prod + staging)
**No drift today.** Both DBs synced independently and agree: issues **1848 = 1848**, edges **1617 ≈ 1616** (Δ1 = one sync-cycle skew), open PRs 53 = 53. `halted=0`, `auth_failures=0`, watermarks fresh (≤1h). The #80 risk is theoretical (missed webhook).

## Tests
`npm run typecheck` ✓ · `npm test` ✓ **527 passed** (sync suite 84).
New: `fullSync=true` forces `since=null` without reading the watermark + returns stale-PR-closed count; audit `deltas`/`corrections` shape (with/without before-snapshot). Existing slot tests hold (`(0+1)%2=1`; slice-past-end guard is NUM_SLOTS-independent).

## Docs
hourly→daily cadence across `CLAUDE.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/DEPLOY.md`, `docs/s8-cron-observability.md`, `docs/cloudflared-setup.md`. Legacy M₁/Python reconciler refs left as historical.

## Follow-ups / risks
- Coverage ceiling is now **40 repos** (36 today → 4 headroom). Approaching it → bump WINDOW/NUM_SLOTS within the 50-subreq budget, or activate Queues fan-out.
- Per-repo reconcile cadence = 2 days on the daily cron. For true daily per-repo heal under the cap, a 12h cron (`0 */12 * * *`) would be needed — deferred (user chose strict 24h).
- True per-edge `+inserted/-deleted` (vs net delta) deferred — needs batch `meta.changes` plumbing around the shared FakeD1 mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)