### PR TITLE
docs(s7): mark CF Access cutover EXECUTED (verified live, not pending)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Let:
 ## Project
 
 **Roxabi Live** — operations cockpit (Cloudflare Worker + D1, TypeScript)
-- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150) — pending cutover, see docs/s7-access-cutover.md**
+- Prod: Cloudflare Worker `roxabi-live` at **https://live.roxabi.dev**; **/admin/* behind Cloudflare Access (Email-OTP, mickael@bouly.io); public app gated by app-level sessions (#141, S7 #150) — cutover DONE (verified 2026-06-16): Access gates /admin (OTP) + /webhook (bypass) only, no catch-all; public app on Worker `requireSession`. See docs/s7-access-cutover.md**
 - Data: D1 `roxabi-live-production` (replaces `~/.roxabi/corpus.db` / aiosqlite)
 - Sync: GitHub GraphQL via `fetch()` in `worker/src/sync/`, driven by Cron Trigger `0 0 * * *` (daily full reconcile, #80) + real-time GitHub org webhook → `POST /webhook/github` (HMAC-gated; Access Bypass on `/webhook/*`)
 - Frontend: static dep-graph assets served via Worker ASSETS binding (`frontend/`)

--- a/docs/s7-access-cutover.md
+++ b/docs/s7-access-cutover.md
@@ -2,9 +2,22 @@
 
 Issue [#150](https://github.com/Roxabi/roxabi-live/issues/150) · epic [#141](https://github.com/Roxabi/roxabi-live/issues/141).
 
-## Status: NOT YET EXECUTED
+## Status: EXECUTED — verified live 2026-06-16
 
-This is the operator procedure for the S7 go. The repo PR + a green staging deploy are what ships now; the cutover below is operator-gated.
+CF Access for `live.roxabi.dev` is already in the post-S7 end-state. Inventory shows only
+two apps for the host — `/admin` (OTP) and `/webhook` (Bypass) — and **no catch-all app**
+(the "App 1" the procedure below removes does not exist). Verified against prod:
+
+| Endpoint | Observed | Meaning |
+|---|---|---|
+| `/api/graph`, `/api/issues` | `401`, **no** `*.cloudflareaccess.com` redirect | Worker `requireSession` gates (not edge) |
+| `/admin/sync` | `302` → `*.cloudflareaccess.com` | OTP app active |
+| `/api/version` | `200` | public, no session |
+| `/` | `200` | frontend auth-gate served (not raw 401) |
+| `/webhook/github` | `404` (Worker), no redirect | Bypass active |
+
+The operator procedure below is retained for **reference and rollback** only — do not
+re-run it (there is no App 1 to remove; re-adding/removing apps would risk the working state).
 
 ---
 


### PR DESCRIPTION
## What
Corrects stale docs: the S7 CF Access cutover is **already in effect** in prod, but `docs/s7-access-cutover.md` said "NOT YET EXECUTED" and `CLAUDE.md` said "pending cutover".

## Evidence (verified live 2026-06-16)
CF Access inventory for `live.roxabi.dev`: only `/admin` (OTP) + `/webhook` (Bypass) apps — **no catch-all "App 1"**. Prod behaviour:

| Endpoint | Observed | Meaning |
|---|---|---|
| `/api/graph`, `/api/issues` | `401`, no `*.cloudflareaccess.com` redirect | Worker `requireSession` gates (not edge) |
| `/admin/sync` | `302` → OTP | admin app active |
| `/api/version`, `/` | `200` | public / frontend gate |
| `/webhook/github` | `404` (Worker), no redirect | bypass active |

## Changes
- `docs/s7-access-cutover.md`: status `NOT YET EXECUTED` → `EXECUTED — verified live`; runbook retained for reference/rollback only (do not re-run — no App 1 to remove).
- `CLAUDE.md`: "pending cutover" → "cutover DONE (verified 2026-06-16)".

Doc-only; no code/behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)