### PR TITLE
feat(webhook): real-time repo.created discovery + restore archived flag (#160 fallout)

### DIFF
--- a/worker/src/auth/installToken.test.ts
+++ b/worker/src/auth/installToken.test.ts
@@ -617,7 +617,29 @@ describe("listInstallationRepos — W2 pagination bound", () => {
     const repos = await listInstallationRepos("fake-token");
 
     expect(fetchMock).toHaveBeenCalledTimes(1); // short page → single fetch
-    expect(repos).toEqual([{ repo: "o/only", isPrivate: true }]);
+    expect(repos).toEqual([{ repo: "o/only", isPrivate: true, isArchived: undefined }]);
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps the GitHub archived flag to isArchived (#160 fallout)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          repositories: [
+            { full_name: "o/live", private: false, archived: false },
+            { full_name: "o/old", private: false, archived: true },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const repos = await listInstallationRepos("fake-token");
+
+    expect(repos).toEqual([
+      { repo: "o/live", isPrivate: false, isArchived: false },
+      { repo: "o/old", isPrivate: false, isArchived: true },
+    ]);
   });
 });

--- a/worker/src/auth/installToken.ts
+++ b/worker/src/auth/installToken.ts
@@ -222,6 +222,7 @@ export async function resolveInstallToken(
 interface GHRepository {
   full_name: string;
   private: boolean;
+  archived: boolean;
 }
 
 interface GHInstallationReposResponse {
@@ -235,13 +236,17 @@ interface GHInstallationReposResponse {
  * Paginates automatically (100 per page) until all repos are collected.
  *
  * @param token - GitHub installation access token (from getInstallationToken).
- * @returns Array of `{ repo: "owner/name", isPrivate: boolean }` entries.
+ * @returns Array of `{ repo: "owner/name", isPrivate, isArchived }` entries.
+ *          `isArchived` is optional in the type (so callers/mocks omitting it
+ *          still typecheck) but the real implementation always sets it from the
+ *          GitHub `archived` field — consumed by the repos-table archived flag.
  */
 export async function listInstallationRepos(
   token: string,
-): Promise<Array<{ repo: string; isPrivate: boolean }>> {
+): Promise<Array<{ repo: string; isPrivate: boolean; isArchived?: boolean }>> {
   const MAX_PAGES = 10;
-  const repos: Array<{ repo: string; isPrivate: boolean }> = [];
+  const repos: Array<{ repo: string; isPrivate: boolean; isArchived?: boolean }> =
+    [];
   let lastPageFull = false;
 
   for (let page = 1; page <= MAX_PAGES; page++) {
@@ -274,7 +279,7 @@ export async function listInstallationRepos(
     const pageRepos = body.repositories ?? [];
 
     for (const r of pageRepos) {
-      repos.push({ repo: r.full_name, isPrivate: r.private });
+      repos.push({ repo: r.full_name, isPrivate: r.private, isArchived: r.archived });
     }
 
     lastPageFull = pageRepos.length === 100;

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -1723,6 +1723,69 @@ describe("runSync — breaker + discovery (#160)", () => {
     expect(insertPub?.args[2]).toBe(0);
   });
 
+  it("B3c: repos table gets archived=1 for an installation-archived repo, 0 for a live one (#160 fallout)", async () => {
+    // Arrange — installation reports one live + one archived repo.
+    const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");
+    vi.mocked(getInstallationToken).mockResolvedValue("tok");
+    vi.mocked(listInstallationRepos).mockResolvedValue([
+      { repo: "o/live", isPrivate: false, isArchived: false },
+      { repo: "o/old", isPrivate: false, isArchived: true },
+    ]);
+
+    const { ghGraphql } = await import("./graphql");
+    vi.mocked(ghGraphql).mockResolvedValue({
+      data: {
+        repository: {
+          issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
+      },
+    });
+
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("sync_running") && sql.includes("UPDATE") && args[0] === 0) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("sync_running") && sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("key='halted'") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("key='auth_failures'") && sql.includes("SELECT") && !sql.includes("UPDATE")) {
+        return makeFakeStmt(sql, args, [{ value: "0" }], 0);
+      }
+      if (sql.includes("FROM tenants")) {
+        return makeFakeStmt(sql, args, [{ id: 1, installation_id: 10 }]);
+      }
+      if (sql.includes("SELECT repo FROM tenant_repo_access")) {
+        return makeFakeStmt(sql, args, [{ repo: "o/live" }, { repo: "o/old" }]);
+      }
+      return makeFakeStmt(sql, args, [], 1);
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const env = makeEnv({ DB: db });
+
+    // Act
+    await runSync(env);
+
+    // Assert — repos upsert binds archived per repo (args = [repo, archived]).
+    const recorded = db._recorded;
+    const insertOld = recorded.find(
+      (s) => s.sql.includes("INSERT INTO repos") && s.args[0] === "o/old",
+    );
+    const insertLive = recorded.find(
+      (s) => s.sql.includes("INSERT INTO repos") && s.args[0] === "o/live",
+    );
+    expect(insertOld?.args[1]).toBe(1);
+    expect(insertLive?.args[1]).toBe(0);
+  });
+
   it("B4: token-exhausted repo is skipped, runSync resolves without throwing", async () => {
     // Arrange — getInstallationToken always rejects for Phase 2 lookups
     const { getInstallationToken, listInstallationRepos } = await import("../auth/installToken");

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -1160,6 +1160,8 @@ export async function writeRunAudit(
 export interface TenantDiscovery {
   repoMap: Map<string, Array<{ tenantId: number; installationId: number }>>;
   staleTenantReposRemoved: number;
+  /** Repos the installation reports as archived — drives the repos.archived flag (#160 fallout). */
+  archivedRepos: Set<string>;
 }
 
 export async function discoverTenants(
@@ -1167,6 +1169,7 @@ export async function discoverTenants(
   env: Env,
 ): Promise<TenantDiscovery> {
   const repoMap = new Map<string, Array<{ tenantId: number; installationId: number }>>();
+  const archivedRepos = new Set<string>();
   let staleTenantReposRemoved = 0;
 
   const tenantRows = await db
@@ -1204,7 +1207,7 @@ export async function discoverTenants(
     }
 
     try {
-      let repos: Array<{ repo: string; isPrivate: boolean }>;
+      let repos: Array<{ repo: string; isPrivate: boolean; isArchived?: boolean }>;
       try {
         const token = await getInstallationToken(db, env, tenantId, installationId);
         repos = await listInstallationRepos(token);
@@ -1247,13 +1250,14 @@ export async function discoverTenants(
       }
 
       // Merge into global map (sorted ascending by tenantId — maintained by ORDER BY above).
-      for (const { repo } of repos) {
+      for (const { repo, isArchived } of repos) {
         const entry = repoMap.get(repo);
         if (entry) {
           entry.push({ tenantId, installationId });
         } else {
           repoMap.set(repo, [{ tenantId, installationId }]);
         }
+        if (isArchived) archivedRepos.add(repo);
       }
       console.log(`[sync] tenant ${tenantId} discovered ${repos.length} repo(s)`);
     } finally {
@@ -1261,7 +1265,7 @@ export async function discoverTenants(
     }
   }
 
-  return { repoMap, staleTenantReposRemoved };
+  return { repoMap, staleTenantReposRemoved, archivedRepos };
 }
 
 export async function runSync(env: Env): Promise<void> {
@@ -1307,8 +1311,11 @@ export async function runSync(env: Env): Promise<void> {
     before = { issues: bIssues?.c ?? 0, edges: bEdges?.c ?? 0, prs: bPrs?.c ?? 0 };
 
     // Phase 1 — per-tenant discovery: build Map<repo, [{tenantId,installationId}]>.
-    const { repoMap: repoTenantMap, staleTenantReposRemoved: tenantStale } =
-      await discoverTenants(db, env);
+    const {
+      repoMap: repoTenantMap,
+      staleTenantReposRemoved: tenantStale,
+      archivedRepos,
+    } = await discoverTenants(db, env);
     staleTenantReposRemoved = tenantStale;
 
     // Union of all repos accessible across all tenants.
@@ -1323,13 +1330,15 @@ export async function runSync(env: Env): Promise<void> {
     if (allRepos.length > WINDOW * NUM_SLOTS)
       console.warn(`[sync] ${allRepos.length} repos exceed window capacity ${WINDOW * NUM_SLOTS} — repos beyond index ${WINDOW * NUM_SLOTS} are not synced this cycle`);
 
-    // Upsert repos table from the union.
+    // Upsert repos table from the union. archived is sourced from the installation
+    // repo list (#160 fallout fix): listInstallationRepos now carries isArchived,
+    // so archived repos converge to archived=1 and the repo dropdown re-separates them.
     const repoUpsertStmts = allRepos.map((repo) =>
       db
         .prepare(
-          `INSERT INTO repos (repo, archived) VALUES (?, 0) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived`,
+          `INSERT INTO repos (repo, archived) VALUES (?, ?) ON CONFLICT(repo) DO UPDATE SET archived=excluded.archived`,
         )
-        .bind(repo),
+        .bind(repo, archivedRepos.has(repo) ? 1 : 0),
     );
     await batchChunked(db, repoUpsertStmts);
     console.log(`[sync] upserted ${allRepos.length} repo(s) from tenant discovery`);

--- a/worker/src/webhook/handlers-app.test.ts
+++ b/worker/src/webhook/handlers-app.test.ts
@@ -538,11 +538,86 @@ describe("handleRepository", () => {
     });
   });
 
+  describe("created", () => {
+    it("registers a new repo in tenant_repo_access + repos + bump (#160)", async () => {
+      // Arrange
+      const { db, batched, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "created",
+        installation: { id: 555 },
+        repository: {
+          full_name: "Roxabi/metalyde",
+          private: false,
+          archived: false,
+          node_id: "R_node",
+        },
+      };
+
+      // Act
+      await handleRepository(payload, db);
+
+      // Assert
+      expect(batchFn()).toHaveBeenCalledOnce();
+      const stmts = allBatchedStmts(batched());
+
+      const accessStmt = stmts.find((s) => /INSERT INTO tenant_repo_access/.test(s.sql));
+      expect(accessStmt).toBeDefined();
+      // upsertRepoAccess binds [tenantId, repo, is_private]
+      expect(accessStmt!.args).toEqual([1, "Roxabi/metalyde", 0]);
+
+      const repoStmt = stmts.find((s) => /INSERT INTO repos/.test(s.sql));
+      expect(repoStmt).toBeDefined();
+      // upsertRepo binds [repo, archived, node_id]
+      expect(repoStmt!.args).toEqual(["Roxabi/metalyde", 0, "R_node"]);
+
+      expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
+    });
+
+    it("marks archived=1 when the new repo is created archived", async () => {
+      const { db, batched } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "created",
+        installation: { id: 555 },
+        repository: { full_name: "Roxabi/old", private: false, archived: true, node_id: "N" },
+      };
+
+      await handleRepository(payload, db);
+
+      const repoStmt = allBatchedStmts(batched()).find((s) => /INSERT INTO repos/.test(s.sql));
+      expect(repoStmt!.args[1]).toBe(1);
+    });
+
+    it("no-ops (no batch) when no tenant matches the installation", async () => {
+      const { db, batchFn } = seededDb({ tenant: null });
+      const payload = {
+        action: "created",
+        installation: { id: 999 },
+        repository: { full_name: "Roxabi/orphan", private: false, archived: false },
+      };
+
+      await handleRepository(payload, db);
+
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+
+    it("no-ops (no batch) when installation.id is missing", async () => {
+      const { db, batchFn } = seededDb({ tenant: activeTenant });
+      const payload = {
+        action: "created",
+        repository: { full_name: "Roxabi/r", private: false },
+      };
+
+      await handleRepository(payload, db);
+
+      expect(batchFn()).not.toHaveBeenCalled();
+    });
+  });
+
   describe("unhandled action", () => {
     it("does NOT call db.batch for an unrecognized action", async () => {
-      // Arrange
+      // Arrange — "edited" is a real repository action this handler ignores.
       const { db, batchFn } = seededDb();
-      const payload = { action: "created", repository: { full_name: "Roxabi/r" } };
+      const payload = { action: "edited", repository: { full_name: "Roxabi/r" } };
 
       // Act
       await handleRepository(payload, db);

--- a/worker/src/webhook/handlers-app.ts
+++ b/worker/src/webhook/handlers-app.ts
@@ -32,6 +32,7 @@ import {
   deleteRepoAccess,
   deleteAllRepoAccessForTenant,
   setRepoPrivacy,
+  upsertRepo,
   cascadeRepoRename,
   invalidateCacheByRepo,
   invalidateCacheByUserRepo,
@@ -67,6 +68,19 @@ function isPrivateBit(repoObj: unknown): 0 | 1 {
   }
   const priv = (repoObj as Record<string, unknown>)["private"];
   return priv === false ? 0 : 1;
+}
+
+/**
+ * Derive 0|1 from a boolean-ish `archived` field found in GitHub repo objects.
+ * Defaults to 0 (live) on ambiguous input — archived only drives dropdown
+ * grouping, so the safe default is "show as live" rather than fail-closed.
+ */
+function archivedBit(repoObj: unknown): 0 | 1 {
+  if (!repoObj || typeof repoObj !== "object") {
+    return 0;
+  }
+  const arch = (repoObj as Record<string, unknown>)["archived"];
+  return arch === true ? 1 : 0;
 }
 
 /**
@@ -319,6 +333,11 @@ export async function handleInstallationRepositories(
  * Process a GitHub `repository` webhook event.
  *
  * Actions handled:
+ *   created     — register a brand-new repo in real time (#160 fallout): upsert
+ *                 tenant_repo_access (visibility) + repos (dropdown/graph). Under
+ *                 an "all repositories" installation GitHub does not fire
+ *                 installation_repositories.added, so this is the only signal that
+ *                 avoids the up-to-24h wait for the daily reconcile cron.
  *   renamed     — cascade rename across all repo-keyed tables (repos,
  *                 tenant_repo_access, issues, edges, user_repo_permission_cache).
  *   transferred — same cascade as renamed; the repo gets a new owner prefix while
@@ -326,8 +345,9 @@ export async function handleInstallationRepositories(
  *   privatized  — flip is_private=1 in tenant_repo_access; invalidate cache.
  *   publicized  — flip is_private=0 in tenant_repo_access; invalidate cache.
  *
- * These events are not tenant-scoped: privacy changes and renames apply across
- * every tenant that registered the repo. No tenant/org-login lookup is performed.
+ * Only `created` is tenant-scoped (it writes a tenant_repo_access row, so it
+ * resolves the tenant via installation.id). privacy changes and renames apply
+ * across every tenant that registered the repo — no tenant lookup is performed.
  *
  * oldFullName derivation for renamed / transferred (in priority order):
  *   1. node_id anchor — query repos.repo_node_id (stable across renames); if the
@@ -346,6 +366,7 @@ export async function handleRepository(
 ): Promise<void> {
   const action = payload["action"] as string | undefined;
   if (
+    action !== "created" &&
     action !== "renamed" &&
     action !== "transferred" &&
     action !== "privatized" &&
@@ -361,6 +382,34 @@ export async function handleRepository(
     return;
   }
   const nowIso = new Date().toISOString();
+
+  // ── created ───────────────────────────────────────────────────────────────
+  if (action === "created") {
+    const installation =
+      (payload["installation"] as Record<string, unknown> | undefined) ?? {};
+    const installationId = installation["id"] as number | undefined;
+    if (installationId == null) {
+      console.warn(
+        `[webhook/app] repository.created: missing installation.id for repo=${fullName}`,
+      );
+      return;
+    }
+    const tenant = await getTenantByInstallationId(db, installationId);
+    if (!tenant) {
+      console.warn(
+        `[webhook/app] repository.created: no tenant for installation_id=${installationId} — skipping repo=${fullName}`,
+      );
+      return;
+    }
+    const nodeId = (repoObj["node_id"] as string | undefined) ?? null;
+    await db.batch([
+      upsertRepoAccess(db, tenant.id, fullName, isPrivateBit(repoObj)),
+      upsertRepo(db, fullName, archivedBit(repoObj), nodeId),
+      bumpDataVersion(db, nowIso),
+    ]);
+    console.info(`[webhook/app] repository.created: registered repo=${fullName}`);
+    return;
+  }
 
   // ── renamed / transferred ─────────────────────────────────────────────────
   if (action === "renamed" || action === "transferred") {

--- a/worker/src/webhook/mutations.ts
+++ b/worker/src/webhook/mutations.ts
@@ -391,6 +391,31 @@ export function setRepoPrivacy(
   return db.prepare(SET_REPO_PRIVACY_SQL).bind(isPrivate, repo);
 }
 
+const UPSERT_REPO_SQL = `
+  INSERT INTO repos (repo, archived, repo_node_id)
+  VALUES (?, ?, ?)
+  ON CONFLICT(repo) DO UPDATE SET
+    archived = excluded.archived,
+    repo_node_id = COALESCE(excluded.repo_node_id, repos.repo_node_id)
+`;
+
+/**
+ * Prepare an upsert into the global `repos` table (the dropdown / graph source).
+ *
+ * Used by the `repository.created` webhook (#160 fallout) so a brand-new repo is
+ * registered in real time rather than waiting up to 24h for the daily cron.
+ * repo_node_id is preserved via COALESCE when the payload omits it (the daily
+ * sync fills it lazily otherwise; the rename cascade relies on it as anchor).
+ */
+export function upsertRepo(
+  db: D1Database,
+  repo: string,
+  archived: 0 | 1,
+  nodeId: string | null,
+): D1PreparedStatement {
+  return db.prepare(UPSERT_REPO_SQL).bind(repo, archived, nodeId);
+}
+
 /**
  * Prepare a cascade rename across all repo-keyed tables.
  *


### PR DESCRIPTION
## Why

Both issues surfaced while diagnosing *"why isn't the new repo `metalyde` on roxabi-live?"*. Both are collateral damage of #160 (per-installation `runSync` cutover + PAT retirement), which swapped org-PAT enumeration (`REPOS_QUERY` + `ARCHIVED_REPOS_QUERY`) for `listInstallationRepos`.

## Q1 — `feat`: handle `repository.created` (real-time new-repo discovery)

Under an **"all repositories"** installation GitHub does **not** fire `installation_repositories.added` for org-created repos, and `handleRepository` dropped the `created` action (early-return) — so a brand-new repo stayed invisible until the next daily reconcile cron (up to 24h).

- New tenant-scoped `created` branch: resolve tenant via `installation.id` → upsert `tenant_repo_access` (visibility) + `repos` (dropdown/graph) + `bumpDataVersion`.
- New `upsertRepo()` mutation helper (`repos` table; preserves `repo_node_id` via `COALESCE`).

⚠️ **Requires** the GitHub App to be subscribed to the **Repository** webhook event. The existing `renamed`/`transferred`/`privatized`/`publicized` handlers imply it already is — worth a one-time confirm in App settings.

## Q2 — `fix`: restore archived repo flag

`listInstallationRepos` dropped the `archived` field and the `repos` upsert hardcoded `archived=0`, so **every** repo was marked live → the dropdown's "Archived" group was always empty and the separator never rendered (frontend grouping intact since #129).

- `listInstallationRepos` now carries `isArchived` from the GitHub `archived` field.
- `discoverTenants` accumulates an `archivedRepos` set; `runSync` binds `archived` per repo.

ℹ️ Assumes `GET /installation/repositories` returns archived repos with `archived:true` (they remain accessible to the installation). Verifiable after the next cron / manual `POST /admin/sync`.

## Tests

- `installToken.test.ts`: `archived` → `isArchived` mapping
- `sync.test.ts` (B3c): archived repo → `repos.archived=1`, live → `0`
- `handlers-app.test.ts`: `repository.created` registers access+repos+bump; no-ops when tenant/installation missing; `unhandled action` test repointed to `edited` (was `created`)

All worker tests green (533 incl. migrations); typecheck clean; pre-commit (lint/typecheck/trufflehog) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)