### PR TITLE
fix(auth): re-verify user_installations in validateSession (#185)

### DIFF
--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -143,6 +143,17 @@ describe("validateSession — SQL guard clauses", () => {
     expect(stmts()[0].sql).toContain("suspended_at IS NOT NULL");
   });
 
+  it("SQL contains EXISTS guard on user_installations membership (#185)", async () => {
+    // Arrange
+    const { db, stmts } = captureDb();
+    // Act
+    await validateSession(db, "g".repeat(64));
+    // Assert
+    expect(stmts()[0].sql).toContain("user_installations");
+    expect(stmts()[0].sql).toContain("ui.user_id = s.user_id");
+    expect(stmts()[0].sql).toContain("ui.tenant_id = s.tenant_id");
+  });
+
   it("passes the hash of rawToken as the bound arg (¬raw token itself)", async () => {
     // Arrange
     const { db, stmts } = captureDb();
@@ -229,6 +240,33 @@ describe("validateSession — suspended-tenant behavioral guard", () => {
     const result = await validateSession(db, "a".repeat(64));
 
     // Assert — suspended tenant session must be filtered out → null
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSession — revoked membership behavioral guard (#185)
+// ---------------------------------------------------------------------------
+
+describe("validateSession — user_installations membership guard", () => {
+  it("returns null when user_installations link is absent (guard is mutation-catching)", async () => {
+    const validRow: FakeResult = {
+      userId: 7,
+      tenantId: 9,
+      githubId: 42,
+      githubLogin: "alice",
+    };
+
+    const db = makeFakeDb((sql, args) => {
+      const membershipGuardPresent =
+        sql.includes("user_installations") &&
+        sql.includes("ui.user_id = s.user_id") &&
+        sql.includes("ui.tenant_id = s.tenant_id");
+      return makeFakeStmt(sql, args, membershipGuardPresent ? [] : [validRow], 0);
+    });
+
+    const result = await validateSession(db, "a".repeat(64));
+
     expect(result).toBeNull();
   });
 });

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -60,7 +60,7 @@ export async function mintSession(
 /**
  * Validate a raw session token.
  * Returns the SessionContext if the session is valid (not expired, not revoked,
- * tenant not suspended), or null otherwise.
+ * tenant not suspended, user still linked to the installation), or null otherwise.
  */
 export async function validateSession(
   db: D1Database,
@@ -75,7 +75,11 @@ export async function validateSession(
        WHERE s.token_hash = ?
          AND s.expires_at > datetime('now')
          AND s.revoked_at IS NULL
-         AND NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL)`,
+         AND NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL)
+         AND EXISTS (
+           SELECT 1 FROM user_installations ui
+           WHERE ui.user_id = s.user_id AND ui.tenant_id = s.tenant_id
+         )`,
     )
     .bind(hash)
     .first<SessionContext>();


### PR DESCRIPTION
## Summary

Closes #185.

`validateSession` now requires an active `user_installations` row for the session's `(user_id, tenant_id)`. If the link is removed after mint, the session is rejected immediately on the next request instead of remaining valid for the full 8-hour TTL.

Aligns per-request auth with the membership gate already used by `active-tenant.ts`.

## Changes

- `worker/src/auth/session.ts` — add `EXISTS (SELECT 1 FROM user_installations …)` to the validation query
- `worker/src/auth/session.test.ts` — SQL contract test + mutation-catching behavioral guard

## Test plan

- [x] `npm test` — 535/535 green
- [x] pre-commit lint + typecheck passed