### PR TITLE
refactor(test): extract FakeD1 harness to worker/test/fake-d1.ts (#159)

### DIFF
--- a/worker/src/test-utils.ts
+++ b/worker/src/test-utils.ts
@@ -1,159 +1,28 @@
 /**
- * test-utils.ts — shared FakeD1 harness for Worker vitest suites.
+ * test-utils.ts — shared test helpers for Worker vitest suites.
  *
- * NOT a test file — no `describe`/`it`/`expect`. Imported by *.test.ts files.
- * Sources consolidated from: me.test.ts, session.test.ts, installToken.test.ts
+ * FakeD1 primitives live in worker/test/fake-d1.ts (#159) and are re-exported here
+ * so existing tests keep importing from "../test-utils".
  */
 
-import { vi } from "vitest";
 import type { Env } from "./types";
 import type { SessionContext } from "./auth/types";
 
-// ---------------------------------------------------------------------------
-// Core FakeD1 types
-// ---------------------------------------------------------------------------
+export type { FakeResult, FakeStmt } from "../test/fake-d1";
+export {
+  makeFakeStmt,
+  makeFakeDb,
+  captureDb,
+  captureDbWithRows,
+  fixedFirstDb,
+} from "../test/fake-d1";
 
-export type FakeResult = { [k: string]: unknown };
-
-export interface FakeStmt {
-  sql: string;
-  args: unknown[];
-  run: () => Promise<{ meta: { changes: number } }>;
-  first: <T = FakeResult>() => Promise<T | null>;
-  all: <T = FakeResult>() => Promise<{ results: T[] }>;
-}
-
-// ---------------------------------------------------------------------------
-// Low-level primitives
-// ---------------------------------------------------------------------------
-
-export function makeFakeStmt(
-  sql: string,
-  args: unknown[],
-  rows: FakeResult[],
-  changes = 0,
-): FakeStmt {
-  return {
-    sql,
-    args,
-    run: vi.fn().mockResolvedValue({ meta: { changes } }),
-    first: vi.fn().mockResolvedValue(rows[0] ?? null),
-    all: vi.fn().mockResolvedValue({ results: rows }),
-  };
-}
-
-export function makeFakeDb(
-  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
-): D1Database & { _recorded: FakeStmt[] } {
-  const recorded: FakeStmt[] = [];
-
-  const db = {
-    prepare(sql: string) {
-      let directStmt: FakeStmt | null = null;
-      const getDirectStmt = (): FakeStmt => {
-        if (!directStmt) {
-          directStmt = stmtFactory(sql, []);
-          recorded.push(directStmt);
-        }
-        return directStmt;
-      };
-
-      return {
-        first<T = FakeResult>(): Promise<T | null> {
-          return getDirectStmt().first<T>();
-        },
-        run(): Promise<{ meta: { changes: number } }> {
-          return getDirectStmt().run();
-        },
-        all<T = FakeResult>(): Promise<{ results: T[] }> {
-          return getDirectStmt().all<T>();
-        },
-        bind(...args: unknown[]) {
-          const stmt = stmtFactory(sql, args);
-          recorded.push(stmt);
-          return stmt;
-        },
-      };
-    },
-    batch: vi.fn(async (stmts: FakeStmt[]) => {
-      await Promise.all(stmts.map((s) => s.run()));
-      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
-    }),
-    _recorded: recorded,
-  } as unknown as D1Database & { _recorded: FakeStmt[] };
-
-  return db;
-}
-
-// ---------------------------------------------------------------------------
-// Higher-level capture helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Returns a FakeD1 that records every prepared statement.
- *
- * Optional `handler` receives (sql, args) and returns rows for that query.
- * When omitted, every query returns empty rows (same as original captureDb()).
- */
-export function captureDb(
-  handler?: (sql: string, args: unknown[]) => FakeResult[],
-): { db: D1Database & { _recorded: FakeStmt[] }; stmts: () => FakeStmt[] } {
-  const captured: FakeStmt[] = [];
-  const db = makeFakeDb((sql, args) => {
-    const rows = handler ? handler(sql, args) : [];
-    const stmt = makeFakeStmt(sql, args, rows, 0);
-    captured.push(stmt);
-    return stmt;
-  });
-  return { db, stmts: () => captured };
-}
-
-/** Every query returns the same fixed rows. */
-export function captureDbWithRows(
-  rows: FakeResult[],
-): { db: D1Database & { _recorded: FakeStmt[] }; stmts: () => FakeStmt[] } {
-  const captured: FakeStmt[] = [];
-  const db = makeFakeDb((sql, args) => {
-    const stmt = makeFakeStmt(sql, args, rows, 0);
-    captured.push(stmt);
-    return stmt;
-  });
-  return { db, stmts: () => captured };
-}
-
-/**
- * Every query returns the single provided row (or null).
- * Sourced from session.test.ts — useful for single-row lookups (SELECT … LIMIT 1).
- */
-export function fixedFirstDb(row: FakeResult | null): D1Database {
-  return makeFakeDb((sql, args) =>
-    makeFakeStmt(sql, args, row !== null ? [row] : [], 0),
-  );
-}
+import type { FakeResult } from "../test/fake-d1";
 
 // ---------------------------------------------------------------------------
 // SQL-dispatch helper
 // ---------------------------------------------------------------------------
 
-/**
- * Route a SQL string to a row set by matching table-name keywords.
- *
- * Keys in `map` are matched against `sql.toLowerCase()` via `includes()`.
- * First match wins. Returns `[]` when no key matches.
- *
- * Typical use inside a `captureDb` handler:
- *
- *   const { db } = captureDb((sql) =>
- *     dispatchByTable(sql, {
- *       "tenant_repo_access":          [{ repo_id: 1, tenant_id: 1 }],
- *       "user_repo_permission_cache":  [{ permission: "read" }],
- *       "tenants":                     [{ id: 1, github_org: "Roxabi" }],
- *     }),
- *   );
- *
- * Keys for the two new #148 tables (`tenant_repo_access`, `user_repo_permission_cache`)
- * are deliberately called out in the example above.
- */
 export function dispatchByTable(
   sql: string,
   map: Record<string, FakeResult[]>,
@@ -171,11 +40,6 @@ export function dispatchByTable(
 // Fixtures
 // ---------------------------------------------------------------------------
 
-/**
- * Canonical stub session for #148 tests.
- * Values differ from per-file stubs in older tests (alice/7/9/42) — use these
- * for all new Wave-1 / Wave-2 tests unless a specific scenario requires custom values.
- */
 export const STUB_SESSION: SessionContext = {
   userId: 1,
   tenantId: 1,
@@ -183,10 +47,6 @@ export const STUB_SESSION: SessionContext = {
   githubLogin: "octocat",
 };
 
-/**
- * Minimal Env builder — only fields required by most route handlers.
- * Cast via `unknown as Env` so callers do not need to satisfy optional fields.
- */
 export function makeEnv(db: D1Database): Env {
   return {
     DB: db,

--- a/worker/test/fake-d1.ts
+++ b/worker/test/fake-d1.ts
@@ -1,0 +1,106 @@
+/**
+ * fake-d1.ts — shared FakeD1 harness for Worker vitest suites (#159).
+ *
+ * Lives outside src/ (not shipped). Import via test-utils.ts or directly in tests.
+ */
+
+import { vi } from "vitest";
+
+export type FakeResult = { [k: string]: unknown };
+
+export interface FakeStmt {
+  sql: string;
+  args: unknown[];
+  run: () => Promise<{ meta: { changes: number } }>;
+  first: <T = FakeResult>() => Promise<T | null>;
+  all: <T = FakeResult>() => Promise<{ results: T[] }>;
+}
+
+export function makeFakeStmt(
+  sql: string,
+  args: unknown[],
+  rows: FakeResult[],
+  changes = 0,
+): FakeStmt {
+  return {
+    sql,
+    args,
+    run: vi.fn().mockResolvedValue({ meta: { changes } }),
+    first: vi.fn().mockResolvedValue(rows[0] ?? null),
+    all: vi.fn().mockResolvedValue({ results: rows }),
+  };
+}
+
+export function makeFakeDb(
+  stmtFactory: (sql: string, args: unknown[]) => FakeStmt,
+): D1Database & { _recorded: FakeStmt[] } {
+  const recorded: FakeStmt[] = [];
+
+  const db = {
+    prepare(sql: string) {
+      let directStmt: FakeStmt | null = null;
+      const getDirectStmt = (): FakeStmt => {
+        if (!directStmt) {
+          directStmt = stmtFactory(sql, []);
+          recorded.push(directStmt);
+        }
+        return directStmt;
+      };
+
+      return {
+        first<T = FakeResult>(): Promise<T | null> {
+          return getDirectStmt().first<T>();
+        },
+        run(): Promise<{ meta: { changes: number } }> {
+          return getDirectStmt().run();
+        },
+        all<T = FakeResult>(): Promise<{ results: T[] }> {
+          return getDirectStmt().all<T>();
+        },
+        bind(...args: unknown[]) {
+          const stmt = stmtFactory(sql, args);
+          recorded.push(stmt);
+          return stmt;
+        },
+      };
+    },
+    batch: vi.fn(async (stmts: FakeStmt[]) => {
+      await Promise.all(stmts.map((s) => s.run()));
+      return stmts.map(() => ({ results: [], meta: { changes: 0 } }));
+    }),
+    _recorded: recorded,
+  } as unknown as D1Database & { _recorded: FakeStmt[] };
+
+  return db;
+}
+
+export function captureDb(
+  handler?: (sql: string, args: unknown[]) => FakeResult[],
+): { db: D1Database & { _recorded: FakeStmt[] }; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const rows = handler ? handler(sql, args) : [];
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+export function captureDbWithRows(
+  rows: FakeResult[],
+): { db: D1Database & { _recorded: FakeStmt[] }; stmts: () => FakeStmt[] } {
+  const captured: FakeStmt[] = [];
+  const db = makeFakeDb((sql, args) => {
+    const stmt = makeFakeStmt(sql, args, rows, 0);
+    captured.push(stmt);
+    return stmt;
+  });
+  return { db, stmts: () => captured };
+}
+
+export function fixedFirstDb(row: FakeResult | null): D1Database {
+  return makeFakeDb((sql, args) =>
+    makeFakeStmt(sql, args, row !== null ? [row] : [], 0),
+  );
+}

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -12,5 +12,5 @@
     "forceConsistentCasingInFileNames": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Closes #159.

Extracts the shared FakeD1 stub from `worker/src/test-utils.ts` into `worker/test/fake-d1.ts` (not shipped). `test-utils.ts` re-exports primitives so existing `*.test.ts` imports stay unchanged.

## Test plan

- [x] `npm test` — 535/535 green
- [x] `npm run typecheck` — clean