### PR TITLE
feat(security): ZK mode opt-in preference — API + UI (#142 S1)

### DIFF
--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -115,6 +115,28 @@
   color: var(--text);
 }
 
+.zk-opt-in-panel {
+  border-top: 1px solid var(--border);
+  margin-top: 6px;
+  padding-top: 6px;
+  text-align: left;
+}
+
+.zk-opt-in-label {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 8px;
+}
+
+.zk-opt-in-hint {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.5;
+  margin: 6px 0 0;
+  max-width: 720px;
+}
+
 /* ─── Body gate — hide dashboard chrome until auth resolved ──────────────── */
 
 body.gated .sticky-head,

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -202,14 +202,43 @@ function renderOrgPicker(me) {
 
 // ─── Internal: render operator notice ────────────────────────────────────────
 
-function renderOperatorNotice() {
+function renderOperatorNotice(me) {
   const el = $('operator-notice');
+  const zkOn = Boolean(me.user.zk_opt_in);
   el.innerHTML = `
-    <strong>Operator read access (this phase):</strong> the operator can read the issue data of the organisations you grant.
-    Don't paste secrets into issue bodies or titles.
-    <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">Manage</a>
+    <div class="operator-notice-main">
+      <strong>Operator read access (this phase):</strong> the operator can read the issue data of the organisations you grant.
+      Don't paste secrets into issue bodies or titles.
+      <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">Manage</a>
+    </div>
+    <div class="zk-opt-in-panel">
+      <label class="zk-opt-in-label">
+        <input type="checkbox" id="zk-opt-in-toggle" ${zkOn ? 'checked' : ''} />
+        Private mode (beta) — encrypt issue content client-side
+      </label>
+      <p class="zk-opt-in-hint" id="zk-opt-in-hint" ${zkOn ? '' : 'hidden'}>
+        <strong>Scope:</strong> content only, not structure. Issue state, blocker edges, and counts stay visible to the operator.
+        Full encryption pipeline ships in a follow-up; this toggle saves your preference.
+      </p>
+    </div>
   `;
   el.removeAttribute('hidden');
+
+  const toggle = $('zk-opt-in-toggle');
+  const hint = $('zk-opt-in-hint');
+  toggle.addEventListener('change', async () => {
+    const enabled = toggle.checked;
+    try {
+      await api('/api/zk-opt-in', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      });
+      hint.toggleAttribute('hidden', !enabled);
+    } catch {
+      toggle.checked = !enabled;
+    }
+  });
 }
 
 // ─── Internal: wire logout ────────────────────────────────────────────────────
@@ -273,7 +302,7 @@ export async function requireAuthGate() {
     // After ACK, remove gate class and wire persistent UI before returning 'dashboard'
     document.body.classList.remove('gated');
     renderOrgPicker(me);
-    renderOperatorNotice();
+    renderOperatorNotice(me);
     wireLogout();
     return 'dashboard';
   }
@@ -281,7 +310,7 @@ export async function requireAuthGate() {
   // view === 'dashboard': already consented, wire persistent UI immediately
   document.body.classList.remove('gated');
   renderOrgPicker(me);
-  renderOperatorNotice();
+  renderOperatorNotice(me);
   wireLogout();
   return 'dashboard';
 }

--- a/worker/migrations/0010_user_zk_opt_in.sql
+++ b/worker/migrations/0010_user_zk_opt_in.sql
@@ -1,0 +1,4 @@
+-- migration: 0010_user_zk_opt_in.sql
+-- Phase 2 (#142): per-user opt-in flag for client-side encryption mode.
+-- 0 = server-readable (Phase 1 default); 1 = user requested ZK mode (encryption pipeline).
+ALTER TABLE users ADD COLUMN zk_opt_in INTEGER NOT NULL DEFAULT 0;

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -56,6 +56,27 @@ function makeApp(db: D1Database): Hono<AuthEnv> {
 // ---------------------------------------------------------------------------
 
 describe("meRoute", () => {
+  it("includes zk_opt_in on user (defaults false when users row missing)", async () => {
+    const { db } = captureDb();
+    const app = makeApp(db);
+    const res = await app.request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as { user: { zk_opt_in: boolean } };
+    expect(body.user.zk_opt_in).toBe(false);
+  });
+
+  it("returns zk_opt_in true when users row has flag set", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.toLowerCase().includes("zk_opt_in")) {
+        return [{ zk_opt_in: 1 }];
+      }
+      return [];
+    });
+    const app = makeApp(db);
+    const res = await app.request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as { user: { zk_opt_in: boolean } };
+    expect(body.user.zk_opt_in).toBe(true);
+  });
+
   it("returns 200 with user fields from injected session", async () => {
     // Arrange
     const { db } = captureDb();

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -22,6 +22,11 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
     return c.json({ error: "unauthorized" }, 401);
   }
 
+  const userRow = await c.env.DB
+    .prepare(`SELECT zk_opt_in FROM users WHERE id = ?`)
+    .bind(s.userId)
+    .first<{ zk_opt_in: number }>();
+
   const rows = await c.env.DB
     .prepare(
       `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
@@ -34,6 +39,7 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
     user: {
       github_id: s.githubId,
       github_login: s.githubLogin,
+      zk_opt_in: userRow?.zk_opt_in === 1,
     },
     active_tenant_id: s.tenantId,
     installations: rows.results,

--- a/worker/src/api/zk-opt-in.test.ts
+++ b/worker/src/api/zk-opt-in.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { zkOptInRoute } from "./zk-opt-in";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { captureDb } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.post("/api/zk-opt-in", zkOptInRoute);
+  return app;
+}
+
+describe("zkOptInRoute", () => {
+  it("returns 400 when enabled is missing", async () => {
+    const { db } = captureDb();
+    const app = makeApp(db);
+    const res = await app.request(
+      "/api/zk-opt-in",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("updates users.zk_opt_in and returns the flag", async () => {
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+    const res = await app.request(
+      "/api/zk-opt-in",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { zk_opt_in: boolean };
+    expect(body.zk_opt_in).toBe(true);
+
+    const update = stmts().find((s) => s.sql.includes("UPDATE users SET zk_opt_in"));
+    expect(update).toBeDefined();
+    expect(update!.args).toEqual([1, 7]);
+  });
+
+  it("binds 0 when disabling", async () => {
+    const { db, stmts } = captureDb();
+    const app = makeApp(db);
+    await app.request(
+      "/api/zk-opt-in",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      },
+      makeEnv(db),
+    );
+    const update = stmts().find((s) => s.sql.includes("UPDATE users SET zk_opt_in"));
+    expect(update!.args[0]).toBe(0);
+  });
+});

--- a/worker/src/api/zk-opt-in.ts
+++ b/worker/src/api/zk-opt-in.ts
@@ -1,0 +1,45 @@
+/**
+ * POST /api/zk-opt-in — toggle per-user zero-knowledge mode preference (#142 S1).
+ *
+ * Body: { enabled: boolean }
+ *
+ * Stores intent only; ciphertext pipeline is a follow-up slice. When enabled,
+ * the UI must surface the residual trust gap (metadata leaks, XSS, etc.).
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/types";
+
+export async function zkOptInRoute(c: Context<AuthEnv>): Promise<Response> {
+  const s = c.get("session");
+  if (!s) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "enabled required" }, 400);
+  }
+
+  const enabled =
+    body !== null && typeof body === "object" && "enabled" in body
+      ? (body as Record<string, unknown>).enabled
+      : undefined;
+
+  if (typeof enabled !== "boolean") {
+    return c.json({ error: "enabled required" }, 400);
+  }
+
+  const flag = enabled ? 1 : 0;
+
+  await c.env.DB
+    .prepare(
+      `UPDATE users SET zk_opt_in = ?, updated_at = datetime('now') WHERE id = ?`,
+    )
+    .bind(flag, s.userId)
+    .run();
+
+  return c.json({ zk_opt_in: enabled });
+}

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -220,6 +220,19 @@ describe("tenant_repo_access table", () => {
 // Suite 7 — tenants table
 // ---------------------------------------------------------------------------
 
+describe("users table", () => {
+  it("has zk_opt_in column (Phase 2 opt-in, added in 0010)", () => {
+    expect(getColumnNames(db, "users")).toContain("zk_opt_in");
+  });
+
+  it("zk_opt_in defaults to 0 (server-readable mode)", () => {
+    const col = getColumns(db, "users").find((c) => c.name === "zk_opt_in");
+    expect(col).toBeDefined();
+    expect(col?.notnull).toBe(1);
+    expect(col?.dflt_value).toBe("0");
+  });
+});
+
 describe("tenants table", () => {
   it("has deleted_at column (soft-delete, added in 0009)", () => {
     expect(getColumnNames(db, "tenants")).toContain("deleted_at");

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -11,6 +11,7 @@ import { meRoute, logoutRoute } from "./api/me";
 import type { AuthEnv } from "./auth/types";
 import { requireSession } from "./auth/session";
 import { activeTenantRoute } from "./api/active-tenant";
+import { zkOptInRoute } from "./api/zk-opt-in";
 
 const app = new Hono<AuthEnv>();
 
@@ -71,6 +72,7 @@ app.get("/oauth/callback", callbackRoute);
 app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
 app.post("/api/active-tenant", requireSession, activeTenantRoute);
+app.post("/api/zk-opt-in", requireSession, zkOptInRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);


### PR DESCRIPTION
## Summary

Phase 2 slice 1 for #142 (epic stays open).

Stores per-user ZK mode **preference** — not full encryption yet.

## Changes

- Migration `0010_user_zk_opt_in.sql` — `users.zk_opt_in` flag (default 0)
- `GET /api/me` — exposes `user.zk_opt_in`
- `POST /api/zk-opt-in` — `{ enabled: boolean }` persists preference
- Frontend — dashboard toggle + honesty copy (content-only scope, metadata leaks)
- Tests — zk-opt-in route, me field, migration harness

## Follow-up slices (#142 remaining)

- Browser Web Crypto encrypt pipeline (ECIES → AES-GCM)
- Client-side GitHub fetch with user-to-server token
- `zk_payloads` ciphertext storage + decrypt-on-read in frontend
- CSP hardening, multi-device key bootstrap

## Test plan

- [x] worker `npm test` — 542/542
- [x] frontend `npm test` — 17/17