### PR TITLE
chore: promote staging to main — Node 22 CI hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install worker deps
         run: cd worker && npm ci
       - name: Typecheck (tsc)
@@ -112,7 +112,7 @@ jobs:
         name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - if: steps.guard.outputs.enabled == 'true'
         name: Install worker deps
         run: cd worker && npm ci


### PR DESCRIPTION
Redeploy after #156 wrangler 4 deploy failure (Node 20 → 22 in worker/deploy jobs).