### PR TITLE
chore: promote staging → main (ZK S2 #142)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6,7 +6,8 @@ import { initGraph, clearSearchHighlight }   from './graph.js';
 import { MultiSelect } from './multi_select.js';
 import { clearPinned } from './hover.js';
 import { repoTone } from './tone.js';
-import { api, AuthError, requireAuthGate } from './auth.js';
+import { api, AuthError, requireAuthGate, getSessionProfile } from './auth.js';
+import { applyZkDecryption } from './zk-sync.js';
 
 const $ = id => document.getElementById(id);
 
@@ -250,10 +251,16 @@ async function loadGraphData() {
 
 // Re-fetch graph data and re-render, preserving view/filters (held in state).
 // Uses data.repos (Array<{repo,archived}>) from /api/graph; falls back to nodes-derived if absent.
-async function loadAndRender() {
+let sessionZkOptIn = false;
+let sessionGithubLogin = '';
+
+async function loadAndRender(zkOptIn, githubLogin) {
   const data  = await loadGraphData();
   const nodes = data.nodes || [];
   const edges = data.edges || [];
+  if (zkOptIn) {
+    await applyZkDecryption(nodes, githubLogin);
+  }
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
   state.nodesByKey = new Map(nodes.map(n => [n.key, n]));
@@ -283,7 +290,9 @@ function startPolling() {
     if (document.hidden) return;  // skip while tab is backgrounded
     try {
       const v = await fetchVersion();
-      if (lastVersion !== null && v !== lastVersion) await loadAndRender();
+      if (lastVersion !== null && v !== lastVersion) {
+        await loadAndRender(sessionZkOptIn, sessionGithubLogin);
+      }
       lastVersion = v;
     } catch { /* transient — retry next tick */ }
   }, POLL_MS);
@@ -303,7 +312,10 @@ async function init() {
   }
   restoreControls();
   try {
-    await loadAndRender();
+    const me = await getSessionProfile();
+    sessionZkOptIn = Boolean(me.user?.zk_opt_in);
+    sessionGithubLogin = me.user?.github_login ?? '';
+    await loadAndRender(sessionZkOptIn, sessionGithubLogin);
     try { lastVersion = await fetchVersion(); } catch { /* poller will retry */ }
     startPolling();
   } catch (e) {

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,5 +1,5 @@
 // auth.js — Auth gate state machine, consent persistence, API wrapper
-// Exports: AuthError, api, hasConsent, setConsent, resolveView, requireAuthGate
+// Exports: AuthError, api, hasConsent, setConsent, resolveView, requireAuthGate, getSessionProfile
 
 const $ = id => document.getElementById(id);
 
@@ -58,6 +58,11 @@ export function resolveView(me, consented) {
 async function fetchMe() {
   const resp = await api('/api/me');
   return resp.json();
+}
+
+/** Session profile from /api/me — for dashboard bootstrap after auth gate. */
+export async function getSessionProfile() {
+  return fetchMe();
 }
 
 // ─── Internal: render landing ─────────────────────────────────────────────────
@@ -202,6 +207,19 @@ function renderOrgPicker(me) {
 
 // ─── Internal: render operator notice ────────────────────────────────────────
 
+async function enableZkMode(me) {
+  const graphResp = await api('/api/graph');
+  const { nodes } = await graphResp.json();
+  const { sealGraphTitles } = await import('./zk-sync.js');
+  await sealGraphTitles(nodes ?? [], me.user.github_login);
+  await api('/api/zk-opt-in', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled: true }),
+  });
+  location.reload();
+}
+
 function renderOperatorNotice(me) {
   const el = $('operator-notice');
   const zkOn = Boolean(me.user.zk_opt_in);
@@ -218,7 +236,7 @@ function renderOperatorNotice(me) {
       </label>
       <p class="zk-opt-in-hint" id="zk-opt-in-hint" ${zkOn ? '' : 'hidden'}>
         <strong>Scope:</strong> content only, not structure. Issue state, blocker edges, and counts stay visible to the operator.
-        Full encryption pipeline ships in a follow-up; this toggle saves your preference.
+        Titles are encrypted client-side; your private key stays in this browser.
       </p>
     </div>
   `;
@@ -228,15 +246,21 @@ function renderOperatorNotice(me) {
   const hint = $('zk-opt-in-hint');
   toggle.addEventListener('change', async () => {
     const enabled = toggle.checked;
+    toggle.disabled = true;
     try {
+      if (enabled) {
+        await enableZkMode(me);
+        return;
+      }
       await api('/api/zk-opt-in', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ enabled }),
+        body: JSON.stringify({ enabled: false }),
       });
-      hint.toggleAttribute('hidden', !enabled);
+      location.reload();
     } catch {
       toggle.checked = !enabled;
+      toggle.disabled = false;
     }
   });
 }

--- a/frontend/zk-crypto.js
+++ b/frontend/zk-crypto.js
@@ -1,0 +1,185 @@
+// zk-crypto.js — ECIES P-256 + IndexedDB key storage (#142 S2)
+// Ephemeral ECDH-P256 → HKDF-SHA256 → AES-GCM-256
+
+const DB_NAME = 'roxabi-zk-v1';
+const STORE_NAME = 'keypairs';
+const HKDF_INFO = new TextEncoder().encode('roxabi-zk-ecies-v1');
+const HKDF_SALT = new Uint8Array(32);
+
+function toBytes(buf) {
+  if (buf instanceof Uint8Array) return buf;
+  if (buf instanceof ArrayBuffer) return new Uint8Array(buf);
+  if (ArrayBuffer.isView(buf)) {
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+  return new Uint8Array(buf);
+}
+
+function b64Encode(buf) {
+  const bytes = toBytes(buf);
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+function b64Decode(str) {
+  const bin = atob(str);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbGet(login) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(login);
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbPut(login, record) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(record, login);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function generateKeyPair() {
+  return crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    ['deriveKey', 'deriveBits'],
+  );
+}
+
+/** SHA-256(SPKI) first 16 bytes as hex — stored alongside ciphertext rows. */
+export async function fingerprintPublicKey(publicKey) {
+  const spki = await crypto.subtle.exportKey('spki', publicKey);
+  const hash = await crypto.subtle.digest('SHA-256', spki);
+  return [...new Uint8Array(hash)]
+    .slice(0, 16)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function deriveAesKey(sharedBits) {
+  const base = await crypto.subtle.importKey(
+    'raw',
+    toBytes(sharedBits),
+    'HKDF',
+    false,
+    ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: HKDF_SALT, info: HKDF_INFO },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/**
+ * Ensure a per-login ECDH key pair exists in IndexedDB.
+ * @returns {{ publicKey: CryptoKey, privateKey: CryptoKey, pubkeyFp: string }}
+ */
+export async function ensureZkKeyPair(githubLogin) {
+  const existing = await idbGet(githubLogin);
+  if (existing?.publicKey && existing?.privateKey) {
+    const pubkeyFp =
+      existing.pubkeyFp ?? (await fingerprintPublicKey(existing.publicKey));
+    return { publicKey: existing.publicKey, privateKey: existing.privateKey, pubkeyFp };
+  }
+
+  const pair = await generateKeyPair();
+  const pubkeyFp = await fingerprintPublicKey(pair.publicKey);
+  await idbPut(githubLogin, {
+    publicKey: pair.publicKey,
+    privateKey: pair.privateKey,
+    pubkeyFp,
+  });
+  return { publicKey: pair.publicKey, privateKey: pair.privateKey, pubkeyFp };
+}
+
+/** ECIES encrypt plaintext string to envelope JSON. */
+export async function eciesEncrypt(publicKey, plaintext) {
+  const ephemeral = await crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    true,
+    ['deriveBits'],
+  );
+  const shared = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: publicKey },
+    ephemeral.privateKey,
+    256,
+  );
+  const aesKey = await deriveAesKey(shared);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    aesKey,
+    new TextEncoder().encode(plaintext),
+  );
+  const epk = await crypto.subtle.exportKey('raw', ephemeral.publicKey);
+  return JSON.stringify({
+    v: 1,
+    epk: b64Encode(epk),
+    iv: b64Encode(iv),
+    ct: b64Encode(ct),
+  });
+}
+
+/** ECIES decrypt envelope JSON to plaintext string. */
+export async function eciesDecrypt(privateKey, envelopeJson) {
+  const env = JSON.parse(envelopeJson);
+  if (env.v !== 1) throw new Error('unsupported envelope version');
+
+  const epkRaw = b64Decode(env.epk);
+  const ephemeralPub = await crypto.subtle.importKey(
+    'raw',
+    epkRaw,
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    [],
+  );
+  const shared = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: ephemeralPub },
+    privateKey,
+    256,
+  );
+  const aesKey = await deriveAesKey(shared);
+  const plain = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: b64Decode(env.iv) },
+    aesKey,
+    b64Decode(env.ct),
+  );
+  return new TextDecoder().decode(plain);
+}
+
+/** Encrypt issue title payload `{ title }`. */
+export async function sealTitle(publicKey, title) {
+  return eciesEncrypt(publicKey, JSON.stringify({ title }));
+}
+
+/** Decrypt issue title from envelope. */
+export async function openTitle(privateKey, envelopeJson) {
+  const plain = await eciesDecrypt(privateKey, envelopeJson);
+  const obj = JSON.parse(plain);
+  return obj.title ?? null;
+}

--- a/frontend/zk-crypto.test.js
+++ b/frontend/zk-crypto.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  eciesEncrypt,
+  eciesDecrypt,
+  sealTitle,
+  openTitle,
+  fingerprintPublicKey,
+} from './zk-crypto.js';
+
+describe('zk-crypto ECIES', () => {
+  /** @type {CryptoKey} */
+  let publicKey;
+  /** @type {CryptoKey} */
+  let privateKey;
+
+  beforeAll(async () => {
+    const pair = await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' },
+      false,
+      ['deriveBits'],
+    );
+    publicKey = pair.publicKey;
+    privateKey = pair.privateKey;
+  });
+
+  it('roundtrips arbitrary plaintext', async () => {
+    const envelope = await eciesEncrypt(publicKey, '{"title":"Secret issue"}');
+    const plain = await eciesDecrypt(privateKey, envelope);
+    expect(plain).toBe('{"title":"Secret issue"}');
+  });
+
+  it('sealTitle/openTitle extracts title', async () => {
+    const envelope = await sealTitle(publicKey, 'Fix the bug');
+    expect(await openTitle(privateKey, envelope)).toBe('Fix the bug');
+  });
+
+  it('fingerprintPublicKey returns 32 hex chars', async () => {
+    const fp = await fingerprintPublicKey(publicKey);
+    expect(fp).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -1,0 +1,63 @@
+// zk-sync.js — seal-on-enable + decrypt-on-load (#142 S2)
+
+import { api } from './auth.js';
+import { ensureZkKeyPair, sealTitle, openTitle } from './zk-crypto.js';
+
+const BULK = 200;
+
+async function putPayloadBatches(payloads) {
+  for (let i = 0; i < payloads.length; i += BULK) {
+    await api('/api/zk/payloads', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payloads: payloads.slice(i, i + BULK) }),
+    });
+  }
+}
+
+/**
+ * Seal visible graph titles into zk_payloads (call before enabling zk_opt_in).
+ * @param {Array<{ key: string, title: string|null }>} nodes
+ */
+export async function sealGraphTitles(nodes, githubLogin) {
+  const { publicKey, pubkeyFp } = await ensureZkKeyPair(githubLogin);
+  const payloads = [];
+
+  for (const node of nodes) {
+    if (!node.title) continue;
+    const encrypted_payload = await sealTitle(publicKey, node.title);
+    payloads.push({
+      issue_key: node.key,
+      pubkey_fp: pubkeyFp,
+      encrypted_payload,
+    });
+  }
+
+  if (payloads.length > 0) {
+    await putPayloadBatches(payloads);
+  }
+}
+
+/**
+ * Decrypt server-redacted titles for zk_opt_in users.
+ * @param {Array<{ key: string, title: string|null }>} nodes
+ */
+export async function applyZkDecryption(nodes, githubLogin) {
+  const resp = await api('/api/zk/payloads');
+  const { payloads } = await resp.json();
+  const byKey = new Map((payloads ?? []).map((p) => [p.issue_key, p]));
+  const { privateKey } = await ensureZkKeyPair(githubLogin);
+
+  for (const node of nodes) {
+    const row = byKey.get(node.key);
+    if (!row) {
+      if (node.title == null) node.title = '(sealed)';
+      continue;
+    }
+    try {
+      node.title = await openTitle(privateKey, row.encrypted_payload);
+    } catch {
+      node.title = '(decrypt error)';
+    }
+  }
+}

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,7 +14,7 @@ worker/src/sync/sync.test.ts  # 1570 lines — #180 integration harness for runS
 worker/src/webhook/handlers.test.ts  # 920 lines — #180 webhook handler contract tests
 worker/src/auth/oauth.test.ts  # 864 lines — #180 OAuth callback + batch tests
 worker/src/api/issues.test.ts  # 632 lines — #180 tenant-scoped issues API tests
-worker/src/api/graph.test.ts  # 626 lines — #180 tenant-scoped graph API tests
+worker/src/api/graph.test.ts  # 652 lines — #180 tenant-scoped graph + #142 S2 zk title redaction
 worker/src/webhook/mutations.test.ts  # 587 lines — #180 webhook mutation tests
 worker/src/webhook/handlers-app.test.ts  # 498 lines — #180 app lifecycle handler tests
 worker/src/auth/installToken.test.ts  # 470 lines — #180 install token + pagination tests

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -56,6 +56,7 @@ function makeGraphEnv(
   edges: unknown[],
   repos: unknown[] = [],
   overrideVisible?: string[],
+  zkOptIn = false,
 ): Env {
   const visibleRepos =
     overrideVisible ??
@@ -66,6 +67,7 @@ function makeGraphEnv(
       sql,
       args,
       dispatchByTable(sql, {
+        "zk_opt_in": [{ zk_opt_in: zkOptIn ? 1 : 0 }],
         "tenant_repo_access": visibleRepos.map((repo) => ({
           repo,
           is_private: 0,
@@ -157,6 +159,31 @@ describe("GET /api/graph", () => {
       expect(Array.isArray(body.nodes)).toBe(true);
       expect(Array.isArray(body.edges)).toBe(true);
       expect(Array.isArray(body.repos)).toBe(true);
+    });
+
+    it("redacts titles when zk_opt_in is enabled", async () => {
+      const issue = {
+        key: "Roxabi/roxabi-live#7",
+        repo: "Roxabi/roxabi-live",
+        number: 7,
+        title: "Secret title",
+        state: "open",
+        url: null,
+        milestone: null,
+        lane: null,
+        priority: null,
+        size: null,
+        status: null,
+        is_stub: 0,
+        has_active_branch: 0,
+      };
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv([], [], [issue], [], [], undefined, true),
+      );
+      const body = await res.json<{ nodes: Record<string, unknown>[] }>();
+      expect(body.nodes[0].title).toBeNull();
     });
 
     it("maps IssueRow fields to Node shape", async () => {

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -16,6 +16,7 @@
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { resolveVisibleRepos } from "../auth/repoAccess";
+import { userZkOptIn } from "../auth/zk";
 import { parseMilestone } from "../sync/parse";
 
 const LANE_LABEL_PREFIX = "graph:lane/";
@@ -116,6 +117,10 @@ interface EdgeRow {
 }
 
 export const graphRoute = async (c: Context<AuthEnv>) => {
+  const s = c.get("session");
+  const redactTitles =
+    s !== undefined && (await userZkOptIn(c.env.DB, s.userId));
+
   const visible = await resolveVisibleRepos(c);
 
   if (visible.length === 0) {
@@ -184,7 +189,7 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
       key: row.key,
       repo: row.repo,
       number: row.number,
-      title: row.title,
+      title: redactTitles ? null : row.title,
       state: row.state,
       dev_state: devState,
       url: row.url,

--- a/worker/src/api/zk-opt-in.ts
+++ b/worker/src/api/zk-opt-in.ts
@@ -3,7 +3,8 @@
  *
  * Body: { enabled: boolean }
  *
- * Stores intent only; ciphertext pipeline is a follow-up slice. When enabled,
+ * When enabled, graph titles are redacted server-side; client decrypts via
+ * zk_payloads. When enabling, the UI seals titles first (see frontend/zk-sync.js).
  * the UI must surface the residual trust gap (metadata leaks, XSS, etc.).
  */
 

--- a/worker/src/api/zk-payloads.test.ts
+++ b/worker/src/api/zk-payloads.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { listZkPayloadsRoute, putZkPayloadsRoute } from "./zk-payloads";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { captureDb } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.get("/api/zk/payloads", listZkPayloadsRoute);
+  app.put("/api/zk/payloads", putZkPayloadsRoute);
+  return app;
+}
+
+describe("listZkPayloadsRoute", () => {
+  it("returns 403 when zk_opt_in is off", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_opt_in")) return [{ zk_opt_in: 0 }];
+      return [];
+    });
+    const res = await makeApp(db).request("/api/zk/payloads", {}, makeEnv(db));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns payloads when zk_opt_in is on", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_opt_in")) return [{ zk_opt_in: 1 }];
+      if (sql.includes("zk_payloads")) {
+        return [{
+          issue_key: "Roxabi/live#1",
+          pubkey_fp: "abc123",
+          encrypted_payload: "cipher",
+          updated_at: "2026-01-01",
+        }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request("/api/zk/payloads", {}, makeEnv(db));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { payloads: unknown[] };
+    expect(body.payloads).toHaveLength(1);
+  });
+});
+
+describe("putZkPayloadsRoute", () => {
+  it("upserts ciphertext rows without requiring zk_opt_in", async () => {
+    const { db, stmts } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/payloads",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          payloads: [{
+            issue_key: "Roxabi/live#42",
+            pubkey_fp: "deadbeef",
+            encrypted_payload: "envelope-json",
+          }],
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const upsert = stmts().find((s) => s.sql.includes("INSERT INTO zk_payloads"));
+    expect(upsert).toBeDefined();
+    expect(upsert!.args[0]).toBe(7);
+    expect(upsert!.args[1]).toBe("Roxabi/live#42");
+  });
+});

--- a/worker/src/api/zk-payloads.ts
+++ b/worker/src/api/zk-payloads.ts
@@ -1,0 +1,117 @@
+/**
+ * ZK ciphertext blob store (#142 S2).
+ *
+ * GET  /api/zk/payloads — list user's sealed issue payloads
+ * PUT  /api/zk/payloads — bulk upsert ciphertext (session-gated; seal-before-opt-in OK)
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/types";
+import { userZkOptIn } from "../auth/zk";
+
+const ISSUE_KEY_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+#[0-9]+$/;
+const MAX_BULK = 200;
+const MAX_CIPHERTEXT_BYTES = 64 * 1024;
+
+interface PayloadRow {
+  issue_key: string;
+  pubkey_fp: string;
+  encrypted_payload: string;
+  updated_at: string;
+}
+
+interface PutEntry {
+  issue_key: string;
+  pubkey_fp: string;
+  encrypted_payload: string;
+}
+
+export async function listZkPayloadsRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+
+  if (!(await userZkOptIn(c.env.DB, s.userId))) {
+    return c.json({ error: "zk_not_enabled" }, 403);
+  }
+
+  const rows = await c.env.DB
+    .prepare(
+      `SELECT issue_key, pubkey_fp, encrypted_payload, updated_at
+       FROM zk_payloads WHERE user_id = ?`,
+    )
+    .bind(s.userId)
+    .all<PayloadRow>();
+
+  return c.json({ payloads: rows.results });
+}
+
+export async function putZkPayloadsRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "payloads required" }, 400);
+  }
+
+  const payloads =
+    body !== null &&
+    typeof body === "object" &&
+    "payloads" in body &&
+    Array.isArray((body as { payloads: unknown }).payloads)
+      ? (body as { payloads: unknown[] }).payloads
+      : null;
+
+  if (!payloads || payloads.length === 0) {
+    return c.json({ error: "payloads required" }, 400);
+  }
+  if (payloads.length > MAX_BULK) {
+    return c.json({ error: `payloads max ${MAX_BULK}` }, 400);
+  }
+
+  const entries: PutEntry[] = [];
+  for (const raw of payloads) {
+    if (raw === null || typeof raw !== "object") {
+      return c.json({ error: "invalid payload entry" }, 400);
+    }
+    const e = raw as Record<string, unknown>;
+    const issue_key = e.issue_key;
+    const pubkey_fp = e.pubkey_fp;
+    const encrypted_payload = e.encrypted_payload;
+    if (typeof issue_key !== "string" || !ISSUE_KEY_RE.test(issue_key)) {
+      return c.json({ error: "invalid issue_key" }, 400);
+    }
+    if (typeof pubkey_fp !== "string" || pubkey_fp.length < 8 || pubkey_fp.length > 128) {
+      return c.json({ error: "invalid pubkey_fp" }, 400);
+    }
+    if (
+      typeof encrypted_payload !== "string" ||
+      encrypted_payload.length === 0 ||
+      encrypted_payload.length > MAX_CIPHERTEXT_BYTES
+    ) {
+      return c.json({ error: "invalid encrypted_payload" }, 400);
+    }
+    entries.push({ issue_key, pubkey_fp, encrypted_payload });
+  }
+
+  await c.env.DB.batch(
+    entries.map((e) =>
+      c.env.DB.prepare(
+        `INSERT INTO zk_payloads (user_id, issue_key, pubkey_fp, encrypted_payload, updated_at)
+         VALUES (?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(user_id, issue_key) DO UPDATE SET
+           pubkey_fp = excluded.pubkey_fp,
+           encrypted_payload = excluded.encrypted_payload,
+           updated_at = datetime('now')`,
+      ).bind(s.userId, e.issue_key, e.pubkey_fp, e.encrypted_payload),
+    ),
+  );
+
+  return c.json({ upserted: entries.length });
+}

--- a/worker/src/auth/zk.ts
+++ b/worker/src/auth/zk.ts
@@ -1,0 +1,12 @@
+/** ZK mode helpers (#142). */
+
+export async function userZkOptIn(
+  db: D1Database,
+  userId: number,
+): Promise<boolean> {
+  const row = await db
+    .prepare(`SELECT zk_opt_in FROM users WHERE id = ?`)
+    .bind(userId)
+    .first<{ zk_opt_in: number }>();
+  return row?.zk_opt_in === 1;
+}

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -12,6 +12,7 @@ import type { AuthEnv } from "./auth/types";
 import { requireSession } from "./auth/session";
 import { activeTenantRoute } from "./api/active-tenant";
 import { zkOptInRoute } from "./api/zk-opt-in";
+import { listZkPayloadsRoute, putZkPayloadsRoute } from "./api/zk-payloads";
 
 const app = new Hono<AuthEnv>();
 
@@ -73,6 +74,9 @@ app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
 app.post("/api/active-tenant", requireSession, activeTenantRoute);
 app.post("/api/zk-opt-in", requireSession, zkOptInRoute);
+app.use("/api/zk/payloads", requireSession);
+app.get("/api/zk/payloads", listZkPayloadsRoute);
+app.put("/api/zk/payloads", putZkPayloadsRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);


### PR DESCRIPTION
## Summary

Promote staging to production after #142 S2 merge (#207).

## Included

- **#142 S2** — ZK ciphertext pipeline: `GET/PUT /api/zk/payloads`, graph title redaction, browser ECIES seal/decrypt

## Tests

CI green on #207 (worker 546, frontend 20).

## Post-merge

- release-please #204 will version/changelog
- Deploy job applies to `live.roxabi.dev` (no new migration — `zk_payloads` already in 0004)