### PR TITLE
feat(security): ZK user token handoff + GitHub body sync (#142 S3)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,7 +7,8 @@ import { MultiSelect } from './multi_select.js';
 import { clearPinned } from './hover.js';
 import { repoTone } from './tone.js';
 import { api, AuthError, requireAuthGate, getSessionProfile } from './auth.js';
-import { applyZkDecryption } from './zk-sync.js';
+import { applyZkDecryption, syncZkContentFromGitHub } from './zk-sync.js';
+import { consumeZkHandoffFromUrl, getGithubUserToken } from './zk-github.js';
 
 const $ = id => document.getElementById(id);
 
@@ -312,10 +313,24 @@ async function init() {
   }
   restoreControls();
   try {
+    await consumeZkHandoffFromUrl();
     const me = await getSessionProfile();
     sessionZkOptIn = Boolean(me.user?.zk_opt_in);
     sessionGithubLogin = me.user?.github_login ?? '';
     await loadAndRender(sessionZkOptIn, sessionGithubLogin);
+    if (sessionZkOptIn && getGithubUserToken()) {
+      try {
+        const { synced } = await syncZkContentFromGitHub(
+          state.nodes,
+          sessionGithubLogin,
+        );
+        if (synced > 0) {
+          await applyZkDecryption(state.nodes, sessionGithubLogin);
+          state.nodesByKey = new Map(state.nodes.map(n => [n.key, n]));
+          render();
+        }
+      } catch { /* GitHub sync is best-effort */ }
+    }
     try { lastVersion = await fetchVersion(); } catch { /* poller will retry */ }
     startPolling();
   } catch (e) {

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -236,7 +236,8 @@ function renderOperatorNotice(me) {
       </label>
       <p class="zk-opt-in-hint" id="zk-opt-in-hint" ${zkOn ? '' : 'hidden'}>
         <strong>Scope:</strong> content only, not structure. Issue state, blocker edges, and counts stay visible to the operator.
-        Titles are encrypted client-side; your private key stays in this browser.
+        Titles and bodies are encrypted client-side; keys stay in this browser.
+        <a href="/login?zk=1" id="zk-github-link">Link GitHub</a> to sync issue bodies.
       </p>
     </div>
   `;

--- a/frontend/zk-crypto.js
+++ b/frontend/zk-crypto.js
@@ -172,14 +172,24 @@ export async function eciesDecrypt(privateKey, envelopeJson) {
   return new TextDecoder().decode(plain);
 }
 
-/** Encrypt issue title payload `{ title }`. */
-export async function sealTitle(publicKey, title) {
-  return eciesEncrypt(publicKey, JSON.stringify({ title }));
+/** Encrypt issue content `{ title, body? }`. */
+export async function sealContent(publicKey, content) {
+  return eciesEncrypt(publicKey, JSON.stringify(content));
 }
 
-/** Decrypt issue title from envelope. */
-export async function openTitle(privateKey, envelopeJson) {
+/** Decrypt issue content envelope. */
+export async function openContent(privateKey, envelopeJson) {
   const plain = await eciesDecrypt(privateKey, envelopeJson);
-  const obj = JSON.parse(plain);
+  return JSON.parse(plain);
+}
+
+/** Encrypt issue title payload `{ title }`. */
+export async function sealTitle(publicKey, title) {
+  return sealContent(publicKey, { title });
+}
+
+/** Decrypt issue title from envelope (legacy + content payloads). */
+export async function openTitle(privateKey, envelopeJson) {
+  const obj = await openContent(privateKey, envelopeJson);
   return obj.title ?? null;
 }

--- a/frontend/zk-crypto.test.js
+++ b/frontend/zk-crypto.test.js
@@ -4,6 +4,8 @@ import {
   eciesDecrypt,
   sealTitle,
   openTitle,
+  sealContent,
+  openContent,
   fingerprintPublicKey,
 } from './zk-crypto.js';
 
@@ -32,6 +34,16 @@ describe('zk-crypto ECIES', () => {
   it('sealTitle/openTitle extracts title', async () => {
     const envelope = await sealTitle(publicKey, 'Fix the bug');
     expect(await openTitle(privateKey, envelope)).toBe('Fix the bug');
+  });
+
+  it('sealContent/openContent roundtrips title and body', async () => {
+    const envelope = await sealContent(publicKey, {
+      title: 'Secret',
+      body: 'Private body text',
+    });
+    const content = await openContent(privateKey, envelope);
+    expect(content.title).toBe('Secret');
+    expect(content.body).toBe('Private body text');
   });
 
   it('fingerprintPublicKey returns 32 hex chars', async () => {

--- a/frontend/zk-github.js
+++ b/frontend/zk-github.js
@@ -1,0 +1,119 @@
+// zk-github.js — browser-side GitHub user token + GraphQL relay (#142 S3)
+
+import { api } from './auth.js';
+
+const TOKEN_KEY = 'roxabi:gh-user-token';
+
+export function getGithubUserToken() {
+  return sessionStorage.getItem(TOKEN_KEY);
+}
+
+export function setGithubUserToken(token) {
+  if (token) sessionStorage.setItem(TOKEN_KEY, token);
+  else sessionStorage.removeItem(TOKEN_KEY);
+}
+
+/** Consume ?zk_handoff= from URL after OAuth redirect. */
+export async function consumeZkHandoffFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('zk_handoff');
+  if (!code) return false;
+
+  params.delete('zk_handoff');
+  const qs = params.toString();
+  const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
+  window.history.replaceState({}, '', next);
+
+  const resp = await api('/api/zk/consume-handoff', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  });
+  const { github_token } = await resp.json();
+  setGithubUserToken(github_token);
+  return true;
+}
+
+export function zkLoginUrl(redirect = '/') {
+  const dest = encodeURIComponent(redirect);
+  return `/login?zk=1&redirect=${dest}`;
+}
+
+/** Relay GraphQL to GitHub via Worker (CORS-safe). */
+export async function githubGraphql(query, variables, githubToken) {
+  const token = githubToken ?? getGithubUserToken();
+  if (!token) throw new Error('github_user_token missing');
+
+  const resp = await api('/api/zk/github/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-GitHub-User-Token': token,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const body = await resp.json();
+  if (body.errors) {
+    throw new Error(body.errors[0]?.message ?? 'graphql error');
+  }
+  return body.data;
+}
+
+const ISSUE_CONTENT_QUERY = `
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $number) { title body }
+    }
+  }
+`;
+
+function parseIssueKey(key) {
+  const hash = key.lastIndexOf('#');
+  if (hash < 0) return null;
+  const repo = key.slice(0, hash);
+  const number = Number(key.slice(hash + 1));
+  const slash = repo.indexOf('/');
+  if (slash < 0 || !Number.isFinite(number)) return null;
+  return {
+    owner: repo.slice(0, slash),
+    name: repo.slice(slash + 1),
+    number,
+  };
+}
+
+/**
+ * Fetch title+body for issue keys (batched aliases, 25 per request).
+ * @returns {Map<string, { title: string|null, body: string|null }>}
+ */
+export async function fetchIssueContentMap(issueKeys, githubToken) {
+  const parsed = issueKeys
+    .map((key) => ({ key, ...parseIssueKey(key) }))
+    .filter((p) => p.owner && p.name && p.number);
+
+  const out = new Map();
+  const BATCH = 25;
+
+  for (let i = 0; i < parsed.length; i += BATCH) {
+    const chunk = parsed.slice(i, i + BATCH);
+    const fields = chunk
+      .map((p, idx) =>
+        `i${idx}: repository(owner: ${JSON.stringify(p.owner)}, name: ${JSON.stringify(p.name)}) {
+          issue(number: ${p.number}) { title body }
+        }`,
+      )
+      .join('\n');
+    const query = `query { ${fields} }`;
+    const data = await githubGraphql(query, undefined, githubToken);
+    chunk.forEach((p, idx) => {
+      const issue = data?.[`i${idx}`]?.issue;
+      if (issue) {
+        out.set(p.key, {
+          title: issue.title ?? null,
+          body: issue.body ?? null,
+        });
+      }
+    });
+  }
+
+  return out;
+}

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -1,7 +1,8 @@
-// zk-sync.js — seal-on-enable + decrypt-on-load (#142 S2)
+// zk-sync.js — seal-on-enable + decrypt-on-load + GitHub content sync (#142 S2/S3)
 
 import { api } from './auth.js';
-import { ensureZkKeyPair, sealTitle, openTitle } from './zk-crypto.js';
+import { ensureZkKeyPair, sealContent, openContent } from './zk-crypto.js';
+import { fetchIssueContentMap, getGithubUserToken } from './zk-github.js';
 
 const BULK = 200;
 
@@ -15,17 +16,19 @@ async function putPayloadBatches(payloads) {
   }
 }
 
-/**
- * Seal visible graph titles into zk_payloads (call before enabling zk_opt_in).
- * @param {Array<{ key: string, title: string|null }>} nodes
- */
-export async function sealGraphTitles(nodes, githubLogin) {
+async function sealNodes(nodes, githubLogin, contentByKey) {
   const { publicKey, pubkeyFp } = await ensureZkKeyPair(githubLogin);
   const payloads = [];
 
   for (const node of nodes) {
-    if (!node.title) continue;
-    const encrypted_payload = await sealTitle(publicKey, node.title);
+    const fromGh = contentByKey?.get(node.key);
+    const title = fromGh?.title ?? node.title;
+    if (!title && !fromGh?.body) continue;
+
+    const encrypted_payload = await sealContent(publicKey, {
+      title: title ?? null,
+      body: fromGh?.body ?? null,
+    });
     payloads.push({
       issue_key: node.key,
       pubkey_fp: pubkeyFp,
@@ -36,6 +39,27 @@ export async function sealGraphTitles(nodes, githubLogin) {
   if (payloads.length > 0) {
     await putPayloadBatches(payloads);
   }
+}
+
+/**
+ * Seal visible graph titles into zk_payloads (call before enabling zk_opt_in).
+ * @param {Array<{ key: string, title: string|null }>} nodes
+ */
+export async function sealGraphTitles(nodes, githubLogin) {
+  await sealNodes(nodes, githubLogin, null);
+}
+
+/**
+ * Fetch title+body from GitHub and re-seal zk_payloads (ZK users with user token).
+ */
+export async function syncZkContentFromGitHub(nodes, githubLogin, githubToken) {
+  const token = githubToken ?? getGithubUserToken();
+  if (!token) return { synced: 0, skipped: 'no_token' };
+
+  const keys = nodes.map((n) => n.key);
+  const contentByKey = await fetchIssueContentMap(keys, token);
+  await sealNodes(nodes, githubLogin, contentByKey);
+  return { synced: contentByKey.size, skipped: null };
 }
 
 /**
@@ -55,7 +79,9 @@ export async function applyZkDecryption(nodes, githubLogin) {
       continue;
     }
     try {
-      node.title = await openTitle(privateKey, row.encrypted_payload);
+      const content = await openContent(privateKey, row.encrypted_payload);
+      node.title = content.title ?? '(sealed)';
+      if (content.body != null) node.body = content.body;
     } catch {
       node.title = '(decrypt error)';
     }

--- a/worker/migrations/0011_zk_user_token_handoffs.sql
+++ b/worker/migrations/0011_zk_user_token_handoffs.sql
@@ -1,0 +1,17 @@
+-- migration: 0011_zk_user_token_handoffs.sql
+-- Ephemeral OAuth user-token handoff for ZK client fetch (#142 S3).
+-- Tokens are AES-GCM encrypted at rest for ≤5 minutes, single-use consume.
+
+ALTER TABLE oauth_state ADD COLUMN zk_token_handoff INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS user_token_handoffs (
+  code       TEXT PRIMARY KEY,
+  user_id    INTEGER NOT NULL REFERENCES users(id),
+  token_enc  TEXT NOT NULL,
+  token_iv   TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_user_token_handoffs_user_id ON user_token_handoffs(user_id);
+CREATE INDEX IF NOT EXISTS ix_user_token_handoffs_expires_at ON user_token_handoffs(expires_at);

--- a/worker/src/api/zk-github-proxy.test.ts
+++ b/worker/src/api/zk-github-proxy.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { zkGithubGraphqlRoute } from "./zk-github-proxy";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { captureDb } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.post("/api/zk/github/graphql", zkGithubGraphqlRoute);
+  return app;
+}
+
+describe("zkGithubGraphqlRoute", () => {
+  it("returns 403 when zk_opt_in is off", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_opt_in")) return [{ zk_opt_in: 0 }];
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/github/graphql",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-GitHub-User-Token": "gho_test",
+        },
+        body: JSON.stringify({ query: "{ viewer { login } }" }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("forwards GraphQL to GitHub when zk_opt_in is on", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { viewer: { login: "alice" } } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_opt_in")) return [{ zk_opt_in: 1 }];
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/github/graphql",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-GitHub-User-Token": "gho_test_token",
+        },
+        body: JSON.stringify({ query: "{ viewer { login } }" }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalled();
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.github.com/graphql");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer gho_test_token");
+  });
+});

--- a/worker/src/api/zk-github-proxy.ts
+++ b/worker/src/api/zk-github-proxy.ts
@@ -1,0 +1,70 @@
+/**
+ * POST /api/zk/github/graphql — session-gated GitHub GraphQL relay (#142 S3).
+ *
+ * Browser holds the user token; Worker forwards the request without persisting
+ * token or response body (plaintext in memory during the request only).
+ *
+ * Header: X-GitHub-User-Token: <user-to-server token>
+ * Body: standard GitHub GraphQL JSON { query, variables? }
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/types";
+import { userZkOptIn } from "../auth/zk";
+
+const MAX_BODY_BYTES = 32 * 1024;
+
+export async function zkGithubGraphqlRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+
+  if (!(await userZkOptIn(c.env.DB, s.userId))) {
+    return c.json({ error: "zk_not_enabled" }, 403);
+  }
+
+  const ghToken = c.req.header("X-GitHub-User-Token");
+  if (!ghToken || ghToken.length < 10 || ghToken.length > 512) {
+    return c.json({ error: "github_user_token required" }, 400);
+  }
+
+  const raw = await c.req.text();
+  if (!raw || raw.length > MAX_BODY_BYTES) {
+    return c.json({ error: "invalid body" }, 400);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return c.json({ error: "invalid json" }, 400);
+  }
+
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    !("query" in parsed) ||
+    typeof (parsed as { query: unknown }).query !== "string"
+  ) {
+    return c.json({ error: "query required" }, 400);
+  }
+
+  const upstream = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${ghToken}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+      "User-Agent": "roxabi-live-zk",
+    },
+    body: raw,
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}

--- a/worker/src/api/zk-handoff.test.ts
+++ b/worker/src/api/zk-handoff.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { consumeZkHandoffRoute } from "./zk-handoff";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { captureDb } from "../test-utils";
+
+vi.mock("../auth/userTokenHandoff", () => ({
+  consumeUserTokenHandoff: vi.fn(),
+}));
+
+import { consumeUserTokenHandoff } from "../auth/userTokenHandoff";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("asset", { status: 200 }) } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.post("/api/zk/consume-handoff", consumeZkHandoffRoute);
+  return app;
+}
+
+describe("consumeZkHandoffRoute", () => {
+  it("returns github_token on successful consume", async () => {
+    vi.mocked(consumeUserTokenHandoff).mockResolvedValue("gho_secret");
+    const { db } = captureDb(() => []);
+    const code = "a".repeat(32);
+    const res = await makeApp(db).request(
+      "/api/zk/consume-handoff",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { github_token: string };
+    expect(body.github_token).toBe("gho_secret");
+    expect(consumeUserTokenHandoff).toHaveBeenCalledWith(expect.anything(), 7, code);
+  });
+
+  it("returns 410 when handoff expired", async () => {
+    vi.mocked(consumeUserTokenHandoff).mockResolvedValue(null);
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/consume-handoff",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "b".repeat(32) }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(410);
+  });
+});

--- a/worker/src/api/zk-handoff.ts
+++ b/worker/src/api/zk-handoff.ts
@@ -1,0 +1,48 @@
+/**
+ * POST /api/zk/consume-handoff — one-time GitHub user-token delivery (#142 S3).
+ *
+ * Body: { code: string }
+ * Returns: { github_token: string }
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/types";
+import { consumeUserTokenHandoff } from "../auth/userTokenHandoff";
+
+const CODE_RE = /^[0-9a-f]{32}$/;
+
+export async function consumeZkHandoffRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "code required" }, 400);
+  }
+
+  const code =
+    body !== null &&
+    typeof body === "object" &&
+    "code" in body &&
+    typeof (body as { code: unknown }).code === "string"
+      ? (body as { code: string }).code
+      : null;
+
+  if (!code || !CODE_RE.test(code)) {
+    return c.json({ error: "invalid code" }, 400);
+  }
+
+  try {
+    const github_token = await consumeUserTokenHandoff(c.env, s.userId, code);
+    if (!github_token) {
+      return c.json({ error: "handoff_expired" }, 410);
+    }
+    return c.json({ github_token });
+  } catch {
+    return c.json({ error: "handoff_unavailable" }, 503);
+  }
+}

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -12,6 +12,7 @@ import type { Context } from "hono";
 import type { Env } from "../types";
 import { mintSession } from "./session";
 import { sessionCookie } from "./cookies";
+import { createUserTokenHandoff } from "./userTokenHandoff";
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -53,6 +54,7 @@ export async function loginRoute(
   c: Context<{ Bindings: Env }>,
 ): Promise<Response> {
   const redirectAfter = sanitizeRedirect(c.req.query("redirect") ?? undefined);
+  const zkTokenHandoff = c.req.query("zk") === "1" ? 1 : 0;
 
   // 16 random bytes → 32 hex chars
   const stateBytes = new Uint8Array(16);
@@ -61,10 +63,10 @@ export async function loginRoute(
 
   // Store state in D1 — single-use, expires in 10 minutes
   await c.env.DB.prepare(
-    `INSERT INTO oauth_state (state, redirect_after, expires_at)
-     VALUES (?, ?, datetime('now', '+10 minutes'))`,
+    `INSERT INTO oauth_state (state, redirect_after, expires_at, zk_token_handoff)
+     VALUES (?, ?, datetime('now', '+10 minutes'), ?)`,
   )
-    .bind(state, redirectAfter)
+    .bind(state, redirectAfter, zkTokenHandoff)
     .run();
 
   // Build GitHub authorize URL — redirect_uri derived from origin only (D-6)
@@ -111,16 +113,18 @@ export async function callbackRoute(
 
   // Consume state — single-use + expiry guard in one atomic statement (closes TOCTOU)
   const stateRow = await c.env.DB.prepare(
-    `DELETE FROM oauth_state WHERE state = ? AND expires_at > datetime('now') RETURNING redirect_after`,
+    `DELETE FROM oauth_state WHERE state = ? AND expires_at > datetime('now')
+     RETURNING redirect_after, zk_token_handoff`,
   )
     .bind(state)
-    .first<{ redirect_after: string | null }>();
+    .first<{ redirect_after: string | null; zk_token_handoff: number }>();
 
   if (!stateRow) {
     return c.json({ error: "bad_request" }, 400);
   }
 
-  const redirectAfter = stateRow.redirect_after ?? "/";
+  let redirectAfter = stateRow.redirect_after ?? "/";
+  const wantsZkHandoff = stateRow.zk_token_handoff === 1;
 
   // Build redirect_uri from origin (D-6)
   const origin = new URL(c.req.url).origin;
@@ -246,6 +250,21 @@ export async function callbackRoute(
 
   // Mint session tied to the first installation's tenant
   const rawToken = await mintSession(c.env.DB, userId, firstTenantId);
+
+  if (wantsZkHandoff) {
+    try {
+      const handoffCode = await createUserTokenHandoff(
+        c.env,
+        userId,
+        access_token,
+      );
+      const dest = new URL(redirectAfter, origin);
+      dest.searchParams.set("zk_handoff", handoffCode);
+      redirectAfter = `${dest.pathname}${dest.search}`;
+    } catch {
+      // INSTALL_TOKEN_KEY unset — skip handoff, user can retry /login?zk=1
+    }
+  }
 
   return new Response(null, {
     status: 302,

--- a/worker/src/auth/userTokenHandoff.ts
+++ b/worker/src/auth/userTokenHandoff.ts
@@ -1,0 +1,66 @@
+/**
+ * Ephemeral GitHub user-token handoff (#142 S3).
+ *
+ * OAuth callback encrypts the user access_token into user_token_handoffs;
+ * the browser consumes it once via POST /api/zk/consume-handoff.
+ * Never logs plaintext tokens.
+ */
+
+import type { Env } from "../types";
+import { encryptToken, importDek, decryptToken } from "./tokenCrypto";
+
+const HANDOFF_TTL_MINUTES = 5;
+
+function handoffCode(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function getDek(env: Env): Promise<CryptoKey> {
+  const b64 = env.INSTALL_TOKEN_KEY;
+  if (!b64) {
+    throw new Error("INSTALL_TOKEN_KEY not configured");
+  }
+  return importDek(b64);
+}
+
+export async function createUserTokenHandoff(
+  env: Env,
+  userId: number,
+  plaintextToken: string,
+): Promise<string> {
+  const dek = await getDek(env);
+  const { enc, iv } = await encryptToken(dek, plaintextToken);
+  const code = handoffCode();
+
+  await env.DB.prepare(
+    `INSERT INTO user_token_handoffs (code, user_id, token_enc, token_iv, expires_at)
+     VALUES (?, ?, ?, ?, datetime('now', '+${HANDOFF_TTL_MINUTES} minutes'))`,
+  )
+    .bind(code, userId, enc, iv)
+    .run();
+
+  return code;
+}
+
+export async function consumeUserTokenHandoff(
+  env: Env,
+  userId: number,
+  code: string,
+): Promise<string | null> {
+  const row = await env.DB.prepare(
+    `DELETE FROM user_token_handoffs
+     WHERE code = ? AND user_id = ? AND expires_at > datetime('now')
+     RETURNING token_enc, token_iv`,
+  )
+    .bind(code, userId)
+    .first<{ token_enc: string; token_iv: string }>();
+
+  if (!row) return null;
+
+  const dek = await getDek(env);
+  return decryptToken(dek, row.token_enc, row.token_iv);
+}

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -220,6 +220,26 @@ describe("tenant_repo_access table", () => {
 // Suite 7 — tenants table
 // ---------------------------------------------------------------------------
 
+describe("user_token_handoffs table", () => {
+  it("has code primary key (0011)", () => {
+    expect(getPkColumns(db, "user_token_handoffs")).toEqual(["code"]);
+  });
+
+  it("has expected columns", () => {
+    const cols = getColumnNames(db, "user_token_handoffs");
+    expect(cols).toContain("user_id");
+    expect(cols).toContain("token_enc");
+    expect(cols).toContain("token_iv");
+    expect(cols).toContain("expires_at");
+  });
+});
+
+describe("oauth_state zk_token_handoff", () => {
+  it("has zk_token_handoff column (0011)", () => {
+    expect(getColumnNames(db, "oauth_state")).toContain("zk_token_handoff");
+  });
+});
+
 describe("users table", () => {
   it("has zk_opt_in column (Phase 2 opt-in, added in 0010)", () => {
     expect(getColumnNames(db, "users")).toContain("zk_opt_in");

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -13,6 +13,8 @@ import { requireSession } from "./auth/session";
 import { activeTenantRoute } from "./api/active-tenant";
 import { zkOptInRoute } from "./api/zk-opt-in";
 import { listZkPayloadsRoute, putZkPayloadsRoute } from "./api/zk-payloads";
+import { consumeZkHandoffRoute } from "./api/zk-handoff";
+import { zkGithubGraphqlRoute } from "./api/zk-github-proxy";
 
 const app = new Hono<AuthEnv>();
 
@@ -77,6 +79,8 @@ app.post("/api/zk-opt-in", requireSession, zkOptInRoute);
 app.use("/api/zk/payloads", requireSession);
 app.get("/api/zk/payloads", listZkPayloadsRoute);
 app.put("/api/zk/payloads", putZkPayloadsRoute);
+app.post("/api/zk/consume-handoff", requireSession, consumeZkHandoffRoute);
+app.post("/api/zk/github/graphql", requireSession, zkGithubGraphqlRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);


### PR DESCRIPTION
## Summary

Phase 2 slice 3 for #142 — browser-held GitHub user token + client-side body sync.

## Changes

**Worker**
- Migration `0011` — `user_token_handoffs` + `oauth_state.zk_token_handoff`
- `/login?zk=1` — OAuth callback creates ephemeral encrypted handoff → `?zk_handoff=<code>`
- `POST /api/zk/consume-handoff` — one-time token delivery to browser
- `POST /api/zk/github/graphql` — session+zk relay (CORS-safe; no persistence)

**Frontend**
- `zk-github.js` — sessionStorage token, handoff consume, GraphQL relay client
- `zk-sync.js` — seal `{title, body}`; sync from GitHub when token present
- ZK panel link: **Link GitHub** → `/login?zk=1`

## Tests

- Worker: 553 (+7)
- Frontend: 21 (+1 content roundtrip)

## Residual / follow-up

- `issues.payload` still plaintext in D1 (server sync) — operator D1 read
- Multi-device key bootstrap, periodic client refresh UX
- Epic #142 can close after smoke + doc update, or S4 for D1 redaction

Closes slice 3 of #142.