### PR TITLE
chore: promote staging → main (D1 redaction #142)

### DIFF
--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -4,16 +4,16 @@
 # The declared count is a local cap — exceeding it fails the gate.
 
 # Production sources above QG_FILE_MAX=300 (split deferred; cap prevents growth)
-worker/src/sync/sync.ts  # 1171 lines — #180 sync orchestrator; split tracked separately
-worker/src/webhook/handlers.ts  # 445 lines — #180 issue webhook dispatch surface
+worker/src/sync/sync.ts  # 1188 lines — #180 sync orchestrator; split tracked separately
+worker/src/webhook/handlers.ts  # 448 lines — #180 issue webhook dispatch surface
 worker/src/webhook/handlers-app.ts  # 369 lines — #180 GitHub App lifecycle handlers
 worker/src/webhook/mutations.ts  # 339 lines — #180 D1 write helpers for webhooks
 
 # Test files (colocated *.test.ts — exempt with local caps, not production code)
 worker/src/sync/sync.test.ts  # 1570 lines — #180 integration harness for runSync
-worker/src/webhook/handlers.test.ts  # 920 lines — #180 webhook handler contract tests
+worker/src/webhook/handlers.test.ts  # 930 lines — #180 webhook handler contract tests
 worker/src/auth/oauth.test.ts  # 864 lines — #180 OAuth callback + batch tests
-worker/src/api/issues.test.ts  # 632 lines — #180 tenant-scoped issues API tests
+worker/src/api/issues.test.ts  # 659 lines — #180 tenant-scoped issues API tests
 worker/src/api/graph.test.ts  # 652 lines — #180 tenant-scoped graph + #142 S2 zk title redaction
 worker/src/webhook/mutations.test.ts  # 587 lines — #180 webhook mutation tests
 worker/src/webhook/handlers-app.test.ts  # 498 lines — #180 app lifecycle handler tests

--- a/worker/migrations/0012_scrub_zk_sealed_payloads.sql
+++ b/worker/migrations/0012_scrub_zk_sealed_payloads.sql
@@ -1,0 +1,5 @@
+-- migration: 0012_scrub_zk_sealed_payloads.sql
+-- One-time scrub: issues with zk_payloads rows must not retain plaintext titles in D1.
+
+UPDATE issues SET payload = json_object()
+WHERE key IN (SELECT DISTINCT issue_key FROM zk_payloads);

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -60,6 +60,7 @@ interface ListEnvOptions {
   countN: number;
   rows: unknown[];
   labels?: unknown[];
+  zkOptIn?: boolean;
 }
 
 interface CapturedCall {
@@ -114,13 +115,16 @@ function makeListEnvWithCapture(
 }
 
 function makeListEnv(opts: ListEnvOptions): Env {
-  const { countN, rows, labels = [] } = opts;
+  const { countN, rows, labels = [], zkOptIn = false } = opts;
 
   return {
     DB: {
       prepare: (sql: string) => ({
         bind: (..._args: unknown[]) => ({
-          first: async () => null,
+          first: async () => {
+            if (sql.includes("zk_opt_in")) return { zk_opt_in: zkOptIn ? 1 : 0 };
+            return null;
+          },
           all: async () => {
             if (sql.includes("FROM labels")) return { results: labels };
             return { results: [] };
@@ -142,6 +146,7 @@ interface GetEnvOptions {
   labels?: unknown[];
   blocking?: unknown[];
   blockedBy?: unknown[];
+  zkOptIn?: boolean;
 }
 
 function makeGetEnv(opts: GetEnvOptions): Env {
@@ -150,6 +155,7 @@ function makeGetEnv(opts: GetEnvOptions): Env {
     labels = [],
     blocking = [],
     blockedBy = [],
+    zkOptIn = false,
   } = opts;
 
   // Dispatch by SQL content — robust to query reordering:
@@ -163,6 +169,7 @@ function makeGetEnv(opts: GetEnvOptions): Env {
       prepare: (sql: string) => ({
         bind: (..._args: unknown[]) => ({
           first: async () => {
+            if (sql.includes("zk_opt_in")) return { zk_opt_in: zkOptIn ? 1 : 0 };
             if (sql.includes("FROM issues WHERE key")) return issueRow;
             return null;
           },
@@ -371,6 +378,17 @@ describe("GET /api/issues", () => {
       const body = await res.json<{ issues: Record<string, unknown>[] }>();
       expect(body.issues[0].is_stub).toBe(false);
     });
+
+    it("redacts titles when zk_opt_in is enabled", async () => {
+      const row = makeIssueRow({ title: "Secret title" });
+      const res = await app.request(
+        "/api/issues",
+        {},
+        makeListEnv({ countN: 1, rows: [row], zkOptIn: true }),
+      );
+      const body = await res.json<{ issues: Record<string, unknown>[] }>();
+      expect(body.issues[0].title).toBeNull();
+    });
   });
 
   describe("labels per issue", () => {
@@ -494,6 +512,17 @@ describe("GET /api/issues/:key", () => {
       expect(Array.isArray(body.labels)).toBe(true);
       expect(Array.isArray(body.blocking)).toBe(true);
       expect(Array.isArray(body.blocked_by)).toBe(true);
+    });
+
+    it("redacts title when zk_opt_in is enabled", async () => {
+      const row = makeIssueRow({ title: "Secret title" });
+      const res = await app.request(
+        "/api/issues/Roxabi/roxabi-live%231",
+        {},
+        makeGetEnv({ issueRow: row, zkOptIn: true }),
+      );
+      const body = await res.json<Record<string, unknown>>();
+      expect(body.title).toBeNull();
     });
 
     it("issues SELECT uses JSON_EXTRACT(payload,'$.title') AS title", async () => {

--- a/worker/src/api/issues.ts
+++ b/worker/src/api/issues.ts
@@ -11,6 +11,7 @@
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { resolveVisibleRepos } from "../auth/repoAccess";
+import { userZkOptIn } from "../auth/zk";
 
 const ISSUE_KEY_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+#[0-9]+$/;
 
@@ -44,6 +45,10 @@ interface EdgeJoinRow {
 }
 
 export const listIssuesRoute = async (c: Context<AuthEnv>) => {
+  const s = c.get("session");
+  const redactTitles =
+    s !== undefined && (await userZkOptIn(c.env.DB, s.userId));
+
   const visible = await resolveVisibleRepos(c);
 
   const url = new URL(c.req.url);
@@ -125,7 +130,7 @@ export const listIssuesRoute = async (c: Context<AuthEnv>) => {
     key: row.key,
     repo: row.repo,
     number: row.number,
-    title: row.title,
+    title: redactTitles ? null : row.title,
     state: row.state,
     url: row.url,
     labels: labelsByKey.get(row.key) ?? [],
@@ -140,6 +145,10 @@ export const listIssuesRoute = async (c: Context<AuthEnv>) => {
 };
 
 export const getIssueRoute = async (c: Context<AuthEnv>) => {
+  const s = c.get("session");
+  const redactTitles =
+    s !== undefined && (await userZkOptIn(c.env.DB, s.userId));
+
   const visible = await resolveVisibleRepos(c);
 
   // Extract key from path: /api/issues/<owner>/<repo>#<number>
@@ -212,7 +221,7 @@ export const getIssueRoute = async (c: Context<AuthEnv>) => {
     key: row.key,
     repo: row.repo,
     number: row.number,
-    title: row.title,
+    title: redactTitles ? null : row.title,
     state: row.state,
     url: row.url,
     labels,

--- a/worker/src/api/zk-payloads.test.ts
+++ b/worker/src/api/zk-payloads.test.ts
@@ -89,4 +89,28 @@ describe("putZkPayloadsRoute", () => {
     expect(upsert!.args[0]).toBe(7);
     expect(upsert!.args[1]).toBe("Roxabi/live#42");
   });
+
+  it("scrubs plaintext titles from issues.payload after upsert", async () => {
+    const { db, stmts } = captureDb(() => []);
+    await makeApp(db).request(
+      "/api/zk/payloads",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          payloads: [{
+            issue_key: "Roxabi/live#99",
+            pubkey_fp: "deadbeef",
+            encrypted_payload: "envelope-json",
+          }],
+        }),
+      },
+      makeEnv(db),
+    );
+    const scrub = stmts().find(
+      (s) => s.sql.includes("UPDATE issues SET payload = json_object()"),
+    );
+    expect(scrub).toBeDefined();
+    expect(scrub!.args).toContain("Roxabi/live#99");
+  });
 });

--- a/worker/src/api/zk-payloads.ts
+++ b/worker/src/api/zk-payloads.ts
@@ -7,7 +7,7 @@
 
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
-import { userZkOptIn } from "../auth/zk";
+import { scrubIssuePayloads, userZkOptIn } from "../auth/zk";
 
 const ISSUE_KEY_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+#[0-9]+$/;
 const MAX_BULK = 200;
@@ -111,6 +111,11 @@ export async function putZkPayloadsRoute(
            updated_at = datetime('now')`,
       ).bind(s.userId, e.issue_key, e.pubkey_fp, e.encrypted_payload),
     ),
+  );
+
+  await scrubIssuePayloads(
+    c.env.DB,
+    entries.map((e) => e.issue_key),
   );
 
   return c.json({ upserted: entries.length });

--- a/worker/src/auth/zk.test.ts
+++ b/worker/src/auth/zk.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  d1PayloadTitle,
+  loadZkSealedIssueKeys,
+  isIssueZkSealed,
+  scrubIssuePayloads,
+} from "./zk";
+import { captureDb } from "../test-utils";
+
+describe("zk D1 redaction helpers", () => {
+  it("d1PayloadTitle returns null for sealed keys", () => {
+    const sealed = new Set(["Roxabi/live#1"]);
+    expect(d1PayloadTitle("Secret", "Roxabi/live#1", sealed)).toBeNull();
+    expect(d1PayloadTitle("Visible", "Roxabi/live#2", sealed)).toBe("Visible");
+  });
+
+  it("loadZkSealedIssueKeys returns distinct issue_key set", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_payloads")) {
+        return [{ issue_key: "A/r#1" }, { issue_key: "B/r#2" }];
+      }
+      return [];
+    });
+    const keys = await loadZkSealedIssueKeys(db);
+    expect(keys).toEqual(new Set(["A/r#1", "B/r#2"]));
+  });
+
+  it("isIssueZkSealed is true when a row exists", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_payloads")) return [{ one: 1 }];
+      return [];
+    });
+    expect(await isIssueZkSealed(db, "X/r#9")).toBe(true);
+  });
+
+  it("scrubIssuePayloads issues UPDATE per chunk", async () => {
+    const { db, stmts } = captureDb(() => []);
+    await scrubIssuePayloads(db, ["A/r#1", "B/r#2"]);
+    const scrub = stmts().find(
+      (s) => s.sql.includes("UPDATE issues SET payload = json_object()"),
+    );
+    expect(scrub).toBeDefined();
+    expect(scrub!.args).toEqual(["A/r#1", "B/r#2"]);
+  });
+});

--- a/worker/src/auth/zk.ts
+++ b/worker/src/auth/zk.ts
@@ -10,3 +10,50 @@ export async function userZkOptIn(
     .first<{ zk_opt_in: number }>();
   return row?.zk_opt_in === 1;
 }
+
+/** Issue keys that have at least one zk_payloads ciphertext row. */
+export async function loadZkSealedIssueKeys(
+  db: D1Database,
+): Promise<Set<string>> {
+  const rows = await db
+    .prepare(`SELECT DISTINCT issue_key FROM zk_payloads`)
+    .all<{ issue_key: string }>();
+  return new Set((rows.results ?? []).map((r) => r.issue_key));
+}
+
+export async function isIssueZkSealed(
+  db: D1Database,
+  issueKey: string,
+): Promise<boolean> {
+  const row = await db
+    .prepare(`SELECT 1 AS one FROM zk_payloads WHERE issue_key = ? LIMIT 1`)
+    .bind(issueKey)
+    .first<{ one: number }>();
+  return row != null;
+}
+
+/** Title written into issues.payload — null when issue content is sealed. */
+export function d1PayloadTitle(
+  title: string | null | undefined,
+  issueKey: string,
+  sealedKeys: ReadonlySet<string>,
+): string | null {
+  if (sealedKeys.has(issueKey)) return null;
+  return title ?? null;
+}
+
+/** Wipe plaintext content from issues.payload after sealing. */
+export async function scrubIssuePayloads(
+  db: D1Database,
+  issueKeys: string[],
+): Promise<void> {
+  const unique = [...new Set(issueKeys)];
+  for (let i = 0; i < unique.length; i += 90) {
+    const chunk = unique.slice(i, i + 90);
+    const ph = chunk.map(() => "?").join(",");
+    await db
+      .prepare(`UPDATE issues SET payload = json_object() WHERE key IN (${ph})`)
+      .bind(...chunk)
+      .run();
+  }
+}

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -269,6 +269,35 @@ describe("tenants table", () => {
 // Suite 8 — edges and indexes
 // ---------------------------------------------------------------------------
 
+describe("0012_scrub_zk_sealed_payloads", () => {
+  it("clears issues.payload for keys present in zk_payloads", () => {
+    const scrubDb = new Database(":memory:");
+    const preScrub = appliedFiles.filter((f) => !f.startsWith("0012_"));
+    for (const file of preScrub) {
+      scrubDb.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+    }
+    scrubDb.exec(`
+      INSERT INTO users (id, github_id, github_login)
+      VALUES (1, 1, 'tester');
+      INSERT INTO issues (key, repo, number, payload, state)
+      VALUES ('Roxabi/live#1', 'Roxabi/live', 1, json_object('title', 'secret'), 'open'),
+             ('Roxabi/live#2', 'Roxabi/live', 2, json_object('title', 'visible'), 'open');
+      INSERT INTO zk_payloads (user_id, issue_key, pubkey_fp, encrypted_payload, updated_at)
+      VALUES (1, 'Roxabi/live#1', 'fp1', 'cipher', datetime('now'));
+    `);
+    scrubDb.exec(readFileSync(join(MIGRATIONS_DIR, "0012_scrub_zk_sealed_payloads.sql"), "utf8"));
+    const row1 = scrubDb
+      .prepare(`SELECT json_extract(payload, '$.title') AS title FROM issues WHERE key = ?`)
+      .get("Roxabi/live#1") as { title: string | null };
+    const row2 = scrubDb
+      .prepare(`SELECT json_extract(payload, '$.title') AS title FROM issues WHERE key = ?`)
+      .get("Roxabi/live#2") as { title: string | null };
+    expect(row1.title).toBeNull();
+    expect(row2.title).toBe("visible");
+    scrubDb.close();
+  });
+});
+
 describe("edges table and indexes", () => {
   it("has composite primary key (src_key, dst_key, kind)", () => {
     expect(getPkColumns(db, "edges")).toEqual(["src_key", "dst_key", "kind"]);

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -19,6 +19,7 @@ import {
 } from "./queries";
 import type { Env } from "../types";
 import { getInstallationToken, listInstallationRepos } from "../auth/installToken";
+import { d1PayloadTitle, loadZkSealedIssueKeys } from "../auth/zk";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -327,6 +328,7 @@ export async function syncRepoIssues(
   name: string,
   collectedEdges: Map<string, EdgeData>,
   fullSync = false,
+  sealedKeys: ReadonlySet<string> = new Set(),
 ): Promise<void> {
   const repo = `${owner}/${name}`;
   let cursor: string | null = null;
@@ -371,7 +373,7 @@ export async function syncRepoIssues(
           key,
           repo,
           node.number,
-          node.title,
+          d1PayloadTitle(node.title, key, sealedKeys),
           node.state.toLowerCase(),
           node.url,
           node.createdAt,
@@ -736,6 +738,7 @@ export async function syncRepoBundle(
   name: string,
   collectedEdges: Map<string, EdgeData>,
   fullSync = false,
+  sealedKeys: ReadonlySet<string> = new Set(),
 ): Promise<number> {
   const repo = `${owner}/${name}`;
 
@@ -806,7 +809,7 @@ export async function syncRepoBundle(
             key,
             repo,
             node.number,
-            node.title,
+            d1PayloadTitle(node.title, key, sealedKeys),
             node.state.toLowerCase(),
             node.url,
             node.createdAt,
@@ -924,6 +927,7 @@ interface StubIssueData {
 export async function closedHopPass(
   db: D1Database,
   resolveToken: (owner: string, name: string) => Promise<string>,
+  sealedKeys: ReadonlySet<string> = new Set(),
 ): Promise<number> {
   const missingRows = await db
     .prepare(
@@ -988,7 +992,7 @@ export async function closedHopPass(
         key,
         ownerRepo,
         node.number,
-        node.title,
+        d1PayloadTitle(node.title, key, sealedKeys),
         node.state.toLowerCase(),
         node.url,
         node.createdAt,
@@ -1435,6 +1439,7 @@ export async function runSync(env: Env): Promise<void> {
       };
 
     // Pass 1: bundled issues + refs + PRs per repo in window.
+    const sealedKeys = await loadZkSealedIssueKeys(db);
     const collectedEdges = new Map<string, EdgeData>();
     let skippedCount = 0;
     for (const repo of windowedRepos) {
@@ -1447,7 +1452,15 @@ export async function runSync(env: Env): Promise<void> {
         const token = await resolveToken();
         // Daily cron = full reconcile (#80): fullSync forces a complete re-fetch
         // (since=null) so deps-only edge changes are healed regardless of updatedAt.
-        stalePrsClosed += await syncRepoBundle(db, token, owner, name, collectedEdges, true);
+        stalePrsClosed += await syncRepoBundle(
+          db,
+          token,
+          owner,
+          name,
+          collectedEdges,
+          true,
+          sealedKeys,
+        );
       } catch (err) {
         console.error(`[sync] skipping ${repo}:`, err);
         skippedCount++;
@@ -1460,14 +1473,18 @@ export async function runSync(env: Env): Promise<void> {
     await flushEdges(db, collectedEdges);
 
     // Closed-hop pass with per-(owner,name) resolver.
-    stubsCount = await closedHopPass(db, async (owner: string, name: string) => {
-      const repo = `${owner}/${name}`;
-      const repoTenants = repoTenantMap.get(repo);
-      if (!repoTenants || repoTenants.length === 0) {
-        throw new Error(`no tenant for ${repo}`);
-      }
-      return makeRepoResolver(repoTenants)();
-    });
+    stubsCount = await closedHopPass(
+      db,
+      async (owner: string, name: string) => {
+        const repo = `${owner}/${name}`;
+        const repoTenants = repoTenantMap.get(repo);
+        if (!repoTenants || repoTenants.length === 0) {
+          throw new Error(`no tenant for ${repo}`);
+        }
+        return makeRepoResolver(repoTenants)();
+      },
+      sealedKeys,
+    );
     console.log(`[sync] completed — stubs=${stubsCount}`);
 
     // Advance slot.

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -43,7 +43,7 @@ vi.mock("../auth/installToken", () => ({
 import { fetchIssueDeps } from "../sync/graphql";
 import { syncBranches } from "../sync/sync";
 import { resolveInstallToken } from "../auth/installToken";
-import { makeFakeDb, makeFakeStmt, type FakeStmt } from "../test-utils";
+import { makeFakeDb, makeFakeStmt, captureDb as dispatchCaptureDb, type FakeStmt } from "../test-utils";
 
 // FakeResult kept local: richer variant ({ value?, changes? }) used in captureDb casts
 type FakeResult = { value?: string; changes?: number; [k: string]: unknown };
@@ -193,6 +193,19 @@ describe("handleIssues", () => {
       expect(batchArgs.length).toBeGreaterThan(1);
       const labelSqls = batchArgs.slice(1).map((s) => s.sql);
       expect(labelSqls.some((s) => s.includes("DELETE FROM labels"))).toBe(true);
+    });
+
+    it("binds null title when issue is zk-sealed", async () => {
+      const { db } = dispatchCaptureDb((sql) => {
+        if (sql.includes("zk_payloads")) return [{ one: 1 }];
+        return [];
+      });
+      const payload = makeIssuePayload("edited", { title: "Plaintext from GitHub" });
+
+      await handleIssues(payload, db);
+
+      const batchArgs = vi.mocked(db.batch).mock.calls[0][0] as unknown as FakeStmt[];
+      expect(batchArgs[0].args[3]).toBeNull();
     });
 
     it("batch contains label INSERT stmts for each label name", async () => {

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -26,6 +26,7 @@ import {
   bumpDataVersion,
   type WebhookIssue,
 } from "./mutations";
+import { isIssueZkSealed } from "../auth/zk";
 import { BRANCH_ISSUE_RE, canonicalKey, extractFromLabels, syncBranches } from "../sync/sync";
 import { fetchIssueDeps, GraphQLError } from "../sync/graphql";
 import { resolveInstallToken } from "../auth/installToken";
@@ -112,11 +113,14 @@ export async function handleIssues(payload: Record<string, unknown>, db: D1Datab
 
   const derived = extractFromLabels(names);
 
+  const sealed = await isIssueZkSealed(db, key);
+  const title = sealed ? null : ((issue["title"] as string | undefined) ?? null);
+
   const issuePartial: WebhookIssue = {
     key,
     repo,
     number: issue["number"] as number,
-    title: issue["title"] as string,
+    title,
     state: issue["state"] as string,
     url: (issue["html_url"] as string | undefined) ?? null,
     created_at: (issue["created_at"] as string | null | undefined) ?? null,

--- a/worker/src/webhook/mutations.ts
+++ b/worker/src/webhook/mutations.ts
@@ -85,7 +85,7 @@ export interface WebhookIssue {
   key: string;
   repo: string;
   number: number;
-  title: string;
+  title: string | null;
   state: string;
   url: string | null;
   created_at?: string | null;


### PR DESCRIPTION
## Promote staging → main

Ships **#142 Option A** — D1 plaintext title scrub for zk-sealed issues.

### Included
- `feat(worker): scrub D1 plaintext titles for zk-sealed issues (#142)`
- Migration `0012_scrub_zk_sealed_payloads` (one-time prod scrub on deploy)
- Sync/webhook/PUT scrub + `/api/issues` title redaction for `zk_opt_in`

### Post-merge verification
- [ ] CI deploy applies migration 0012 to prod D1
- [ ] Smoke: sealed issues have `issues.payload = {}` (no `$.title`)
- [ ] Close #142

Closes #142