### PR TITLE
feat(zk): account-key multi-device encryption (#216)

### DIFF
--- a/artifacts/frames/216-zk-account-key-frame.mdx
+++ b/artifacts/frames/216-zk-account-key-frame.mdx
@@ -1,0 +1,43 @@
+---
+title: "ZK account-key: passphrase backup + structure-only sync (#216)"
+issue: 216
+status: approved
+tier: F-full
+date: 2026-06-18
+design: docs/zk-account-key-design.md
+---
+
+## Problem
+
+Private mode is always on (#142 / `0013`), but ECDH keys are per-device IndexedDB only — no cross-device recovery. Server sync still fetches `title` from GitHub (operator sees plaintext at sync time). Legacy plaintext remains in `issues.payload` for unsealed issues.
+
+## Who
+
+- **Primary:** Roxabi Live users who seal issue titles client-side and need multi-device unlock.
+- **Secondary:** teammates on the same org installation (hybrid model: shared graph, per-user ciphertext).
+
+## Constraints
+
+- **Client-side encryption** framing — not strict zero-knowledge (metadata + JS supply chain residual trust).
+- **No team/org shared key** — per-user `accountKey` + `zk_key_backups`.
+- **Passphrase never on server** — D1 stores wrapped blob only.
+- **Structure-only server sync** — App token path never persists title/body.
+- **Incremental PRs** behind `ZK_ACCOUNT_KEY` / `ZK_STRUCTURE_ONLY` flags.
+- **Migration 0015** (global title scrub) gated separately from PR 6 (CI auto-applies on `main` merge).
+
+## Out of Scope
+
+- WebAuthn PRF, QR pairing, `.roxabi-recovery` export (Phase 2 / PR 10).
+- Org/team shared encryption key, Gist backup.
+
+## Premise Validity
+
+**Success:** User enrolls passphrase on Device 1, unlocks on Device 2, sees decrypted titles; cron/webhook never writes titles to D1 when structure-only flag on; User B can independently seal after Link GitHub.
+
+**Failure:** Enrollment breaks existing seals; structure-only ships before client sealing path; backup overwrite via stolen session without re-auth.
+
+## References
+
+- Approved design: `docs/zk-account-key-design.md`
+- Parent epic: #142 (closed)
+- Branch: `feat/zk-always-on` (always-on baseline landed)

--- a/artifacts/plans/216-zk-account-key-plan.mdx
+++ b/artifacts/plans/216-zk-account-key-plan.mdx
@@ -1,0 +1,43 @@
+---
+title: "Plan: ZK account-key implementation (#216)"
+issue: 216
+spec: artifacts/specs/216-zk-account-key-spec.mdx
+complexity: 9/10
+tier: F-full
+generated: 2026-06-18T00:00:00Z
+design: docs/zk-account-key-design.md
+---
+
+## Summary
+
+11-PR stack from approved design. Current branch `feat/zk-always-on` already ships always-on private mode + sealed-key redaction. This plan continues on the same branch for #216 implementation.
+
+## Micro-tasks (active slice: PR 1)
+
+### T1 — Migration `0014_zk_key_backups.sql`
+- Create `zk_key_backups` (user_id PK, backup_version, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp, timestamps)
+- `ALTER TABLE zk_payloads ADD COLUMN key_fp TEXT`
+- `UPDATE zk_payloads SET key_fp = pubkey_fp WHERE key_fp IS NULL AND pubkey_fp IS NOT NULL`
+
+### T2 — `migrations.test.ts`
+- Assert `zk_key_backups` schema
+- Assert `zk_payloads.key_fp` column + backfill behaviour
+- Update migration count contiguity (14 files)
+
+## Task IDs
+
+| Task | Description | Status |
+|------|-------------|--------|
+| T1 | Migration 0014 | pending |
+| T2 | Migration tests | pending |
+
+## Dependencies
+
+- PR 1 → PR 1b, PR 2, PR 7 (parallel 1b/3 after 1)
+- Full order per design doc PR Plan section
+
+## Quality gates
+
+```bash
+cd worker && npm run typecheck && npm test
+```

--- a/artifacts/plans/216-zk-account-key-plan.mdx
+++ b/artifacts/plans/216-zk-account-key-plan.mdx
@@ -28,8 +28,9 @@ design: docs/zk-account-key-design.md
 
 | Task | Description | Status |
 |------|-------------|--------|
-| T1 | Migration 0014 | pending |
-| T2 | Migration tests | pending |
+| T1 | Migration 0014 | completed |
+| T2 | Migration tests | completed |
+| PR 1b–9 | Full stack (excl. PR 11 scrub) | completed |
 
 ## Dependencies
 

--- a/artifacts/specs/216-zk-account-key-spec.mdx
+++ b/artifacts/specs/216-zk-account-key-spec.mdx
@@ -1,0 +1,45 @@
+---
+title: "Spec: ZK account-key + structure-only sync (#216)"
+issue: 216
+frame: artifacts/frames/216-zk-account-key-frame.mdx
+status: approved
+tier: F-full
+date: 2026-06-18
+design: docs/zk-account-key-design.md
+---
+
+## Summary
+
+Implement passphrase-backed multi-device encryption (`accountKey` + D1 `zk_key_backups`), migrate ECDH v1 payloads to v2, and structure-only server sync. Full design in `docs/zk-account-key-design.md`.
+
+## Acceptance Criteria
+
+### PR 1 — Schema
+- [ ] `zk_key_backups` table per user (`user_id` PK)
+- [ ] `zk_payloads.key_fp` nullable column; backfill from `pubkey_fp`
+
+### PR 1b — Flags
+- [ ] `ZK_ACCOUNT_KEY` env var; exposed on `/api/me`
+
+### PR 2 — Backup API
+- [ ] `GET/PUT /api/zk/key-backup`; enroll 409; UPDATE requires OAuth re-auth proof
+- [ ] `zk_enrolled` on `/api/me`
+
+### PR 3–5 — Frontend crypto + enrollment + v1 migration
+- [ ] hash-wasm Argon2id; v2 AES-GCM envelopes; enrollment + unlock UI
+
+### PR 6 — Structure-only sync (code only)
+- [ ] Remove `title` from GraphQL when `ZK_STRUCTURE_ONLY` on
+
+### PR 11 — Title scrub (gated merge)
+- [ ] `0015_scrub_all_issue_titles.sql` after enrollment ≥ 95%
+
+## Slices
+
+See **PR Plan** in `docs/zk-account-key-design.md` — order: 1 → 1b → 2 → 3 → 7 → 4 → 5 → 6 → 8 → 9 → 11.
+
+## Non-Functional
+
+- OAuth re-auth for backup UPDATE (session hijack mitigation)
+- 15 min idle lock; `m=65536` Argon2id fixed
+- Observability via R2 LOGS + Workers Logs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,6 +214,19 @@ Each sync run writes a JSON audit record to R2 bucket `roxabi-live-logs` (stagin
 
 **Repo-canonical invariant:** `issues.key` is globally unique (`org/repo#number`). No `tenant_id` on `issues`, `edges`, or `repos`. Authorization enforced at query time via `tenant_repo_access`. `issues.payload` is the ZK seam for title (Phase 1: populated; future phases may encrypt).
 
+### Client-side encryption (account key, #216)
+
+Per-user **account keys** replace per-device ECDH for content encryption. Passphrase-wrapped backups live in D1 (`zk_key_backups`); ciphertext in `zk_payloads` is keyed by `(user_id, issue_key)`. Graph structure stays shared; titles are redacted API-side once any user seals an issue.
+
+| Piece | Role |
+|-------|------|
+| `zk_key_backups` | Passphrase-wrapped `accountKey` per user (enrollment / multi-device unlock) |
+| `zk_payloads` | Per-user AES-GCM ciphertext for issue content |
+| `ZK_ACCOUNT_KEY` | Feature flag — enrollment + unlock gate when on |
+| `ZK_STRUCTURE_ONLY` | Sync/webhook omit title/body from GitHub on server path |
+
+User-facing behavior, multi-device recovery, and hybrid multi-user flows: **`docs/ZK_ENCRYPTION.md`**. Full design: `docs/zk-account-key-design.md`.
+
 ### Migrations
 
 Applied in order at deploy time (`wrangler d1 migrations apply DB --remote`):

--- a/docs/ZK_ENCRYPTION.md
+++ b/docs/ZK_ENCRYPTION.md
@@ -1,0 +1,61 @@
+# Client-side encryption (ZK account key)
+
+Roxabi Live encrypts issue **titles and bodies** in your browser before anything is stored in D1. The server keeps **graph structure** (state, blockers, labels, milestones) visible to operators; content is per-user ciphertext.
+
+This is **client-side encryption**, not strict zero-knowledge. The operator cannot read stored ciphertext or your passphrase, but structural metadata is visible, sync uses a GitHub App token for structure, and served JavaScript is a residual trust surface. See `docs/zk-account-key-design.md` for the full threat model.
+
+---
+
+## How it works
+
+1. **Enrollment** — You choose a passphrase. Argon2id derives a wrapping key; your random `accountKey` is wrapped and stored in D1 (`zk_key_backups`). The passphrase never leaves the browser.
+2. **Unlock** — On each device/session you enter the passphrase to unwrap `accountKey` into memory (15-minute idle lock).
+3. **Seal** — Titles/bodies are encrypted with `accountKey` and uploaded to `zk_payloads`. D1 plaintext titles for those issues are scrubbed.
+4. **Decrypt** — The dashboard fetches your ciphertext rows and decrypts locally after unlock.
+
+Issue content can also be fetched from GitHub with your **user OAuth token** (tab-scoped) to re-seal or sync bodies — see **Link GitHub** in the operator notice.
+
+---
+
+## Multi-device
+
+| Scenario | What to do |
+|----------|------------|
+| **New laptop / browser** | Sign in → unlock with the same passphrase → titles decrypt via D1 backup. |
+| **Lost passphrase** | Ciphertext cannot be recovered. Re-link GitHub and re-seal from GitHub if you still have repo access. |
+| **Sealed on Device 1 before backup** | Complete enrollment on the original device first, or use Link GitHub on the new device to re-seal from GitHub. |
+
+---
+
+## Hybrid multi-user (same org installation)
+
+Graph rows (`issues`, `edges`) are **shared** across teammates on one GitHub App installation. Ciphertext in `zk_payloads` is **per user** — there is no team passphrase.
+
+| What you see | Why |
+|--------------|-----|
+| Structure (state, edges, labels) | Shared canonical graph in D1. |
+| `(sealed)` on a title | Another teammate sealed that issue, or you have not sealed/decrypted it yet. |
+| Your decrypted titles | You enrolled, unlocked, and have a `zk_payloads` row for that issue. |
+
+**Product copy:** Each teammate encrypts their own view of issue titles. You will see `(sealed)` until you link GitHub and sync.
+
+**FAQ**
+
+- *Why does my teammate see titles but I see (sealed)?* — They sealed with their key; you have not linked GitHub and sealed yet.
+- *Can we share one team passphrase?* — No. Shared org keys are intentionally not supported.
+
+When **any** user seals an issue, API responses redact that issue’s title for **everyone** (`title: null` from `/api/graph`). Each user independently fetches from GitHub and seals with their own `accountKey`.
+
+---
+
+## Server sync (structure-only)
+
+When `ZK_STRUCTURE_ONLY` is enabled, cron and webhooks persist structure and metadata only — no title/body from GitHub on the server path. Combined with client sealing, operators do not receive issue content via sync.
+
+---
+
+## Further reading
+
+- Design: `docs/zk-account-key-design.md`
+- Architecture pointer: `docs/ARCHITECTURE.md` (ZK section)
+- Implementation: `frontend/zk-crypto.js`, `frontend/zk-enroll.js`, `worker/src/api/zk-key-backup.ts`, `worker/src/api/zk-payloads.ts`

--- a/docs/zk-account-key-design.md
+++ b/docs/zk-account-key-design.md
@@ -1,0 +1,891 @@
+# Passphrase + D1 Key Backup + Structure-Only Sync (ZK Multi-Device, Hybrid Multi-User)
+
+| Field | Value |
+|-------|-------|
+| **Author** | Roxabi Engineering |
+| **Date** | 2026-06-18 |
+| **Status** | Approved (design review consensus 2026-06-18) |
+| **GitHub** | [#216](https://github.com/Roxabi/roxabi-live/issues/216) (parent [#142](https://github.com/Roxabi/roxabi-live/issues/142)) |
+| **Repo** | Roxabi/roxabi-live — Cloudflare Worker + D1 + static frontend (`live.roxabi.dev`) |
+
+---
+
+## Overview
+
+Roxabi Live’s private mode (#142 S2/S3) encrypts issue **content** (title, body) client-side and stores per-user ciphertext in D1 (`zk_payloads`). Today the encryption key is a **per-device ECDH P-256 key pair** in IndexedDB (`frontend/zk-crypto.js` → `ensureZkKeyPair`), which cannot be recovered on a new browser or after clearing site data. Meanwhile, the **server sync path** still fetches `title` from GitHub via the App installation token (`worker/src/sync/queries.ts` → `ISSUES_QUERY`), meaning the operator can read content at sync time despite D1 redaction.
+
+This design closes both gaps:
+
+1. **Multi-device recovery** — Bitwarden-style **passphrase → Argon2id (WASM) → AES-GCM wrapped `accountKey`** stored in a new D1 table `zk_key_backups`. The passphrase never leaves the browser; the server stores only the wrapped blob.
+2. **Structure-only server sync** — Cron, webhook, and stub-resolution paths persist **graph structure and metadata only** (state, edges, labels, milestone, repo flags). No `title`/`body` from GitHub on the server path for any issue once this ships.
+3. **Hybrid multi-user** — Graph structure remains **shared/canonical** (one row per `issue_key` in `issues` + `edges`). Content remains **per-user encrypted** (`zk_payloads(user_id, issue_key)`). No team/org shared encryption key.
+
+Marketing must describe this as **“client-side encryption”**, not strict zero-knowledge. The operator cannot read stored ciphertext or passphrase, but structural metadata leaks, GitHub App sync sees structure, OAuth token relay exists, and served-JS integrity is a residual trust surface (see spike ADR in `artifacts/analyses/zk-encryption-spike-analysis.mdx`).
+
+---
+
+## Background & Motivation
+
+### Current state (verified in codebase)
+
+| Area | Implementation | Limitation |
+|------|----------------|------------|
+| **Key material** | ECDH P-256 key pair per `github_login` in IndexedDB `roxabi-zk-v1` / `keypairs` | No cross-device recovery; new device = new key = cannot decrypt old ciphertext |
+| **Content crypto** | ECIES: ephemeral ECDH → HKDF → AES-GCM (`eciesEncrypt` / `sealContent`) | Self-encrypt-to-own-pubkey works on one device only |
+| **Ciphertext store** | `zk_payloads PRIMARY KEY (user_id, issue_key)` + `pubkey_fp NOT NULL` | Per-user rows; User B cannot read User A’s blobs |
+| **D1 redaction** | `loadZkSealedIssueKeys` → `redactIssueTitle` / `d1PayloadTitle`; `scrubIssuePayloads` wipes `issues.payload` | Redaction is reactive; sync still **fetches** titles from GitHub first |
+| **Private mode** | Always on (`0013_zk_always_on.sql`); `ensurePrivateMode` in `app.js` on every load | Assumes single-device key; `zk_opt_in` forced to 1 client-side |
+| **GitHub content fetch** | User OAuth token in `sessionStorage` (`zk-github.js`); relay via `POST /api/zk/github/graphql` | Required for bodies and re-seal; token in tab memory |
+| **Graph structure** | Repo-canonical `issues` + `edges`; no `tenant_id` on data rows (#141) | Correct foundation for hybrid model |
+
+### Pain points
+
+1. **Device loss** — Clearing IndexedDB or switching laptops breaks decryption with no recovery path.
+2. **Operator plaintext exposure at sync** — `ISSUES_QUERY` requests `title`; Worker memory sees plaintext during cron even when D1 stores `null` for sealed keys.
+3. **Legacy plaintext in D1** — `0012_scrub_zk_sealed_payloads.sql` scrubs only issues **with** `zk_payloads` rows; unsealed issues still expose `JSON_EXTRACT(payload,'$.title')` via `/api/graph` (`graph.ts` line 178).
+4. **Multi-user confusion** — User B sees `(sealed)` for issues User A sealed; must independently Link GitHub + fetch + seal (works today but undocumented; no shared team key by design).
+5. **Weak passphrase story** — No KDF-backed backup exists yet; future export needs Argon2id, not PBKDF2-only.
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+
+- Introduce **`accountKey`** (AES-256-GCM) as the sole content-encryption key per user, recoverable via passphrase + D1 backup.
+- Support **Device 1 enroll**, **Device 2 unlock**, and document **lost passphrase** + **transitional multi-device** behavior.
+- **Migrate** existing ECDH-encrypted `zk_payloads` to `accountKey` envelopes without data loss on the enrolling device.
+- **Structure-only server sync**: server GraphQL and webhooks never persist title/body; **purge legacy plaintext** in D1.
+- Preserve **hybrid multi-user**: shared graph, per-user ciphertext, global redaction on any seal.
+- Ship **threat model table** suitable for security review and marketing copy.
+- Incremental PR plan mergeable behind **`ZK_ACCOUNT_KEY` feature flag from PR 1b**.
+
+### Non-Goals
+
+- **Team/org shared encryption key** — rejected (operational + key-escrow complexity).
+- **Gist backup** — rejected (URL-leakable, revision history; spike ADR §Decision 4).
+- **GitHub org-repo key backup** — rejected (operator/GitHub-visible storage).
+- **Server-side decryption** — never.
+- **Full zero-knowledge claim** — out of scope; honesty requirement.
+- **Phase 2 items** in this epic: WebAuthn PRF, QR pairing, `.roxabi-recovery` export (spec’d, not implemented here).
+
+---
+
+## Proposed Design
+
+### Architecture (target state)
+
+```mermaid
+flowchart TB
+  subgraph browser [Browser]
+    UI[Dashboard UI]
+    ZK[zk-crypto.js accountKey]
+    SYNC[zk-sync.js seal/decrypt]
+    GH[zk-github.js user token]
+    UI --> SYNC
+    SYNC --> ZK
+    SYNC --> GH
+  end
+
+  subgraph worker [Cloudflare Worker]
+    API["/api/zk/*"]
+    SYNCW[sync.ts structure-only]
+    WH[webhook handlers]
+    API --> D1
+    SYNCW --> D1
+    WH --> D1
+  end
+
+  subgraph d1 [D1]
+    ISSUES["issues + edges<br/>SHARED structure"]
+    ZKP["zk_payloads<br/>PER-USER ciphertext"]
+    ZKB["zk_key_backups<br/>PER-USER wrapped accountKey"]
+  end
+
+  subgraph github [GitHub]
+    GQL_APP[App install token<br/>structure fields only]
+    GQL_USER[User OAuth token<br/>title + body client-only]
+  end
+
+  SYNC -->|PUT ciphertext| API
+  SYNC -->|GET backup / payloads| API
+  GH -->|GraphQL relay| API
+  API --> GQL_USER
+  SYNCW --> GQL_APP
+  GH -.->|direct relay| GQL_USER
+```
+
+### User lifecycle: `zk_opt_in` vs `zk_enrolled` vs unlock
+
+Migration `0013_zk_always_on.sql` sets `zk_opt_in = 1` for all users. The client (`app.js` → `ensurePrivateMode`) still POSTs `zk_opt_in: true` on every load. **`zk_opt_in` is legacy/internal** — kept for API compatibility (`GET /api/zk/payloads` 403 gate) but **not** the enrollment gate.
+
+| Concept | Storage | Meaning | Gate |
+|---------|---------|---------|------|
+| **`zk_opt_in`** | `users.zk_opt_in` | Private mode preference (always `1` since #142 always-on) | Legacy 403 on `/api/zk/payloads` GET; deprecated for UX |
+| **`zk_enrolled`** | `zk_key_backups` row exists | User has a passphrase-wrapped backup on server | Blocks dashboard until enrolled (when flag on) |
+| **`unlocked`** | In-memory `accountKey` only | Passphrase entered this session | Blocks decrypt/seal until unlock |
+
+```mermaid
+stateDiagram-v2
+  [*] --> LoggedIn: OAuth session
+  LoggedIn --> NotEnrolled: zk_enrolled=false
+  NotEnrolled --> Enrolled: PUT /api/zk/key-backup (first device)
+  LoggedIn --> Locked: zk_enrolled=true, no accountKey in memory
+  Locked --> Unlocked: passphrase OK
+  Enrolled --> Locked: page load / idle lock
+  Unlocked --> Locked: explicit Lock / idle timeout / pagehide
+  NotEnrolled --> BlockedDevice2: v1 payloads exist, no backup
+  BlockedDevice2 --> NotEnrolled: complete setup on original device OR GitHub re-seal
+```
+
+**PR 4 change:** Remove client calls to `POST /api/zk-opt-in` from the critical path (or make idempotent no-op). Gate on `zk_enrolled` + unlock, not `zk_opt_in`.
+
+---
+
+### Key hierarchy: `accountKey`
+
+```
+passphrase (user memory only, never transmitted)
+    │
+    ▼ Argon2id WASM (random 16-byte salt per backup)
+wrappingKey (256-bit AES-GCM CryptoKey, derived — see KDF contract below)
+    │
+    ▼ AES-GCM wrap
+wrappedAccountKey blob ──► D1 zk_key_backups.wrapped_key (+ wrap_iv, kdf_params)
+    │
+    ▼ unwrap after passphrase
+accountKey (AES-256-GCM, 32 bytes random)
+    │
+    ▼ AES-GCM encrypt JSON { title, body? }
+encrypted_payload ──► D1 zk_payloads.encrypted_payload (per user_id, issue_key)
+```
+
+#### KDF output contract
+
+**Fixed Argon2id parameters (all platforms):** `{ m: 65536, t: 3, p: 1 }` — **no adaptive downgrade** on mobile or low-RAM devices (user decision 2026-06-18). Every enrollment, unlock, and passphrase rotation uses the same params; `kdf_params` stored in D1 must match. Rationale: single golden test vector, cross-device determinism, and consistent offline brute-force cost; low-RAM phones may see longer unlock (~1–3 s) but remain within PR 3 acceptance targets.
+
+```javascript
+// frontend/zk-kdf.js — exported constant; never branch on deviceMemory
+export const ARGON2_PARAMS = { m: 65536, t: 3, p: 1 };
+```
+
+Argon2id (via `hash-wasm`) must produce **exactly 32 bytes** of key material. Import as AES-256-GCM wrapping key:
+
+```javascript
+// frontend/zk-kdf.js — deterministic contract
+async function deriveWrappingKey(passphrase, salt, params) {
+  const raw = await argon2id({
+    password: passphrase,
+    salt,
+    parallelism: params.p,
+    iterations: params.t,
+    memorySize: params.m, // KiB
+    hashLength: 32,       // MUST be 32 — AES-256
+    outputType: 'binary',
+  });
+  if (raw.byteLength !== 32) throw new Error('KDF output length mismatch');
+  return crypto.subtle.importKey(
+    'raw',
+    raw,
+    { name: 'AES-GCM', length: 256 },
+    false, // non-extractable wrapping key
+    ['encrypt', 'decrypt'],
+  );
+}
+```
+
+**PBKDF2 fallback** (WASM load failure only — enrollment blocked in production):
+
+```javascript
+const wrappingKey = await crypto.subtle.importKey(
+  'raw',
+  await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: 600_000,
+      hash: 'SHA-256',
+    },
+    await crypto.subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveBits']),
+    256,
+  ),
+  { name: 'AES-GCM', length: 256 },
+  false,
+  ['encrypt', 'decrypt'],
+);
+```
+
+**Test vector (cross-browser determinism — PR 3 acceptance):**
+
+| Field | Value |
+|-------|-------|
+| Passphrase | `test-passphrase-roxabi` |
+| Salt (hex) | `0123456789abcdef0123456789abcdef` |
+| Argon2id params | `{ m: 65536, t: 3, p: 1 }` |
+| Raw output (hex, 32 B) | `393129b988be5445dc701ce6901813357b507550eff59d7dae0c023dc1a47a3c` |
+| Fixture file | `frontend/test/fixtures/zk-kdf-vectors.json` (same values; PR 3 imports) |
+| Wrapped-key round-trip | Fixed `accountKey` (hex) + `wrap_iv` → known `wrapped_key` ciphertext (computed in PR 3 tests) |
+
+_Computed with `hash-wasm@4.x` `argon2id()`, 2026-06-18._
+
+**Generation (enrollment):**
+
+```javascript
+const accountKey = await crypto.subtle.generateKey(
+  { name: 'AES-GCM', length: 256 },
+  true, // extractable only long enough to wrap
+  ['encrypt', 'decrypt'],
+);
+const salt = crypto.getRandomValues(new Uint8Array(16));
+const wrappingKey = await deriveWrappingKey(passphrase, salt, ARGON2_PARAMS);
+const wrapIv = crypto.getRandomValues(new Uint8Array(12));
+const rawAccountKey = await crypto.subtle.exportKey('raw', accountKey);
+const wrapped = await crypto.subtle.encrypt({ name: 'AES-GCM', iv: wrapIv }, wrappingKey, rawAccountKey);
+// Re-import accountKey as non-extractable session key after wrap
+```
+
+**Content envelope (v2 — replaces ECIES v1):**
+
+```json
+{
+  "v": 2,
+  "alg": "AES-GCM-256",
+  "iv": "<b64 12 bytes>",
+  "ct": "<b64 ciphertext of UTF-8 JSON {title, body?}>"
+}
+```
+
+**Fingerprint:** `key_fp = SHA-256(rawAccountKey)[0:16]` hex — stored in `zk_payloads.key_fp` and `zk_key_backups.key_fp`.
+
+#### Session handling and idle lock
+
+| Event | Behavior |
+|-------|----------|
+| **Unlock** | Passphrase → unwrap → non-extractable `accountKey` in module memory |
+| **Explicit Lock** | Clear `accountKey`; UI returns to unlock prompt |
+| **Idle timeout** | **15 minutes** without user input (`pointerdown`, `keydown`, `touchstart`) → auto-lock |
+| **`visibilitychange` → hidden** | Start idle timer; do **not** clear key immediately (background tab may return) |
+| **`pagehide` / `beforeunload`** | Clear `accountKey` immediately |
+| **Session cookie** | `SESSION_TTL_SECONDS = 28800` (8 h, `worker/src/auth/types.ts`) — user may re-unlock without re-login while session valid |
+
+IndexedDB (`roxabi-zk-v2` / `account_meta`) stores only `{ key_fp, enrolled_at }` — never raw key or passphrase.
+
+#### Argon2id WASM bundling (committed approach)
+
+The `frontend/` tree is **static ES modules** served via Wrangler `[assets]` — no bundler (`frontend/package.json` is vitest-only).
+
+| Decision | Choice |
+|----------|--------|
+| Library | **`hash-wasm`** vendored as ESM |
+| Layout | `frontend/vendor/hash-wasm/esm/` (committed, pinned version in `package-lock` at repo root or vendor README) |
+| Wrapper | `frontend/zk-kdf.js` — single `deriveWrappingKey` export |
+| WASM load | `argon2id()` from hash-wasm uses `WebAssembly.instantiate` internally; **no COOP/COEP** headers required |
+| CSP | No change needed today (no `unsafe-eval`); WASM compiles from same-origin static asset |
+| Size | ~25 KB gzip WASM + ~3 KB JS — well within Workers asset limits |
+
+**PR 3 acceptance criteria:**
+- Enrollment + unlock round-trip in vitest with mocked `crypto.subtle` + real hash-wasm.
+- Staging manual: cold load enrollment completes in **< 3 s** on mid-tier mobile (Pixel 6 class), **< 1 s** desktop.
+- `zk.kdf_fallback` counter stays 0 in staging for 1 week before prod flag flip.
+
+---
+
+### D1 schema changes
+
+**New table `zk_key_backups`:**
+
+```sql
+CREATE TABLE IF NOT EXISTS zk_key_backups (
+  user_id        INTEGER NOT NULL REFERENCES users(id) PRIMARY KEY,
+  backup_version INTEGER NOT NULL DEFAULT 1,
+  kdf_alg        TEXT NOT NULL DEFAULT 'argon2id',
+  kdf_params     TEXT NOT NULL,
+  wrap_iv        TEXT NOT NULL,
+  wrapped_key    TEXT NOT NULL,
+  key_fp         TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+**`zk_payloads` — migration 0014 (add column):**
+
+```sql
+ALTER TABLE zk_payloads ADD COLUMN key_fp TEXT;
+UPDATE zk_payloads SET key_fp = pubkey_fp WHERE key_fp IS NULL AND pubkey_fp IS NOT NULL;
+```
+
+#### `pubkey_fp` → `key_fp` transition period
+
+| Phase | Duration | Server PUT behavior | Server read |
+|-------|----------|---------------------|-------------|
+| **Dual-accept** | Weeks 1–4 after PR 7 | Accept `key_fp` **or** `pubkey_fp`; **dual-write** both columns with same fingerprint value | Return both fields |
+| **key_fp primary** | Weeks 5–8 | Require `key_fp`; accept `pubkey_fp` alias, map to `key_fp` | `key_fp` only in JSON |
+| **Drop legacy** | Migration 0017+ | `pubkey_fp` column dropped | `key_fp NOT NULL` |
+
+Dual-write SQL in `putZkPayloadsRoute`:
+
+```sql
+INSERT INTO zk_payloads (user_id, issue_key, pubkey_fp, key_fp, encrypted_payload, updated_at)
+VALUES (?, ?, ?, ?, ?, datetime('now'))
+ON CONFLICT(user_id, issue_key) DO UPDATE SET
+  pubkey_fp = excluded.key_fp,
+  key_fp = excluded.key_fp,
+  ...
+```
+
+This satisfies `pubkey_fp NOT NULL` (`0004_tenancy_auth.sql`) until column drop.
+
+**Legacy plaintext scrub — migration 0015 (separate PR, manually gated):**
+
+```sql
+-- One-shot: remove all issue titles from D1 (not only sealed issues).
+-- NOT bundled with PR 6 — see PR 11 and Rollout Plan.
+UPDATE issues SET payload = json_object();
+```
+
+Extends `0012_scrub_zk_sealed_payloads.sql` which only targeted issues with `zk_payloads` rows.
+
+> **CI auto-apply warning:** `.github/workflows/ci.yml` runs `wrangler d1 migrations apply DB --remote` on every merge to `main`. **Migration file presence ≠ apply time.** The `0015` SQL file must not land on `main` until enrollment threshold is met (PR 11 held as draft or merged only in Phase D). Until 0015 applies, structure-only sync (PR 6) stops **new** title writes; legacy plaintext in `issues.payload` remains readable via `/api/graph` for unsealed issues.
+
+---
+
+### API / Interface Changes
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET` | `/api/zk/key-backup` | session | Return wrapped backup for unlock (ungated — enrollment check is client-side; 404 if no row) |
+| `PUT` | `/api/zk/key-backup` | session | Create backup (enroll) or rotate passphrase (see semantics below) |
+| `GET` | `/api/zk/payloads` | session + `zk_opt_in` | List user’s ciphertext rows (legacy gate; always passes since 0013) |
+| `PUT` | `/api/zk/payloads` | session | Bulk upsert; triggers `scrubIssuePayloads` |
+| `GET` | `/api/me` | session | Add `zk_enrolled`, `zk_account_key_enabled` (flag) |
+
+> **Auth asymmetry (intentional):** `PUT /api/zk/key-backup` is session-only so first enrollment works before any backup row exists. `GET` is also session-only (404 when not enrolled). The `zk_opt_in` check on `GET /api/zk/payloads` is a legacy 403 path retained for API compatibility, not an enrollment gate.
+
+#### `PUT /api/zk/key-backup` semantics
+
+| Case | Request | Server behavior |
+|------|---------|-----------------|
+| **First enroll** | No existing row; body includes `key_fp`, `backup_version: 1` | `INSERT` — **no `reauth_proof` required** |
+| **Passphrase change** | Row exists; same `key_fp`; new `wrapped_key`; `expected_backup_version` matches; **`reauth_proof` valid** | `UPDATE`, increment `backup_version` |
+| **Compromise recovery** | Row exists; `rotation: true` + new `key_fp`; **`expected_backup_version` matches**; **`reauth_proof` valid** | `UPDATE` (client must re-seal all payloads separately) |
+| **Duplicate enroll** | Row exists; different `key_fp`; no `rotation: true` | **`409 { error: "enrolled" }`** — second device must unlock, not enroll |
+| **Stale overwrite** | Row exists; `expected_backup_version` mismatch | **`409 { error: "backup_version_conflict" }`** |
+| **Missing re-auth** | Row exists; any UPDATE without valid `reauth_proof` | **`403 { error: "reauth_required" }`** |
+
+**Passphrase rotation (decided):** **Re-wrap same `accountKey`** (Bitwarden-style). Client unwraps locally with old passphrase, re-wraps with new passphrase, sends new `wrapped_key` with same `key_fp`, matching `expected_backup_version`, and fresh `reauth_proof`. **No payload re-encryption.** Reserve new `key_fp` + GitHub re-seal for compromise recovery only (`rotation: true`).
+
+#### Step-up re-auth for backup UPDATE (v1 blocking mitigation)
+
+Any `PUT` that **updates** an existing `zk_key_backups` row (passphrase change or `rotation: true`) requires a server-validated **`reauth_proof`** — a single-use token proving the user completed GitHub OAuth within the last **5 minutes**. This is the primary server-enforceable control against passive session hijack; CAS alone is insufficient because the attacker can `GET /api/zk/key-backup` to read `backup_version`.
+
+**Flow** (mirrors `user_token_handoffs` in `worker/src/auth/userTokenHandoff.ts`):
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant B as Browser
+  participant GH as GitHub OAuth
+  participant API as Worker
+
+  U->>B: Click "Change passphrase" / "Rotate key"
+  B->>API: GET /login?reauth=1&redirect=/settings
+  API->>GH: OAuth authorize
+  GH->>API: /oauth/callback (reauth flag on oauth_state)
+  API->>API: INSERT zk_reauth_proofs (code, user_id, 5min TTL)
+  API->>B: Redirect /settings?zk_reauth={code}
+  B->>API: POST /api/zk/consume-reauth { code }
+  API-->>B: { reauth_proof: "…" } (opaque, single-use, 5min)
+  B->>B: User enters old + new passphrase locally
+  B->>API: PUT /api/zk/key-backup { reauth_proof, expected_backup_version, … }
+  API->>API: DELETE zk_reauth_proofs WHERE code=… RETURNING
+```
+
+**New table `zk_reauth_proofs`** (migration 0014 or 0014b):
+
+```sql
+CREATE TABLE IF NOT EXISTS zk_reauth_proofs (
+  code       TEXT PRIMARY KEY,
+  user_id    INTEGER NOT NULL REFERENCES users(id),
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+**New routes:** `POST /api/zk/consume-reauth` (session + code → single-use `reauth_proof` token); OAuth callback branch when `oauth_state.reauth = 1`.
+
+**`rotation: true` requirements (all mandatory):**
+- `expected_backup_version` must match current row (CAS — rejects stale/confused writes)
+- Valid `reauth_proof` (fresh OAuth)
+- Explicit `rotation: true` in body
+- New `key_fp` + new `wrapped_key`
+
+**Rate limiting (defense in depth):** Max **5 `PUT` attempts per `user_id` per hour**. Returns `429`.
+
+**Audit trail:** On every successful PUT, log `{ event: "zk.backup.updated", user_id, key_fp, backup_version, rotation: bool }` — never log `wrapped_key` or `reauth_proof`.
+
+#### Residual risk (honest)
+
+| Scenario | Blocked by re-auth? | Notes |
+|----------|---------------------|-------|
+| Passive stolen session cookie | **Yes** | Attacker cannot UPDATE backup without fresh GitHub OAuth |
+| XSS driving re-auth while user is active | **Partially** | If XSS triggers `/login?reauth=1` and user completes GitHub prompt unaware, overwrite possible — same class as OAuth phishing |
+| XSS exfiltrating `accountKey` from memory | **No** | Re-auth does not help; mitigated by idle lock + CSP |
+| Physical access, unlocked tab, user enters passphrase | **No** | Out of scope for server controls |
+| First enroll (INSERT) with hijacked session | **No** | Attacker enrolls victim before victim does — victim sees 409 on real enroll; **monitor `zk.enroll.success` anomalies** |
+
+HMAC proof from `accountKey` was considered but rejected for v1: the server cannot verify without storing challenges per session and the proof still originates from a compromised browser. OAuth re-auth is stronger because it requires GitHub-side user interaction.
+
+---
+
+### Structure-only server sync
+
+**Principle:** The GitHub **App installation token** may fetch only fields required for dep-graph operations. **Title and body are never requested or written.**
+
+#### GraphQL fields — before / after
+
+| Query constant | File | Remove | Keep |
+|----------------|------|--------|------|
+| `ISSUES_QUERY` | `worker/src/sync/queries.ts` | `title` | `number`, `state`, `url`, timestamps, `milestone { title }`, `labels`, deps fields |
+| `REPO_BUNDLE_QUERY` | same | `title` | same + `refs`, `pullRequests` |
+| `STUB_ISSUE_QUERY` | same | `title` | `number`, `state`, `url`, timestamps |
+| `SINGLE_ISSUE_DEPS_QUERY` | same | _(none)_ | `blockedBy`, `blocking` |
+| `PRS_QUERY` | same | _(unchanged)_ | PR metadata |
+
+#### Write path changes (all title-bearing paths)
+
+| Path | File | Change |
+|------|------|--------|
+| Cron / admin sync | `worker/src/sync/sync.ts` | `UPSERT_ISSUE_SQL` → `json_object()`; remove `d1PayloadTitle` at lines ~376, 812, 995 |
+| Stub resolver | `sync.ts` `resolveStubs` | `payload = {}` |
+| Webhook `issues` | `worker/src/webhook/handlers.ts` | Always `title: null`; remove `isIssueZkSealed` title branch (lines 116–117) |
+| API read | `worker/src/api/graph.ts`, `issues.ts` | `redactIssueTitle` until 0015 applied; after 0015 all titles null server-side |
+| Legacy scrub | PR 11 migration `0015` (separate deploy) | One-shot purge — **not** in PR 6 |
+
+**Gated by `ZK_ACCOUNT_KEY` + `ZK_STRUCTURE_ONLY` env vars** (see Rollout). Structure-only writes disabled when flag off.
+
+---
+
+### Multi-device flows
+
+#### Device 1 — Enroll (new user or first visit post-migration)
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant B as Browser
+  participant API as Worker API
+  participant D1 as D1
+
+  U->>B: Login (OAuth)
+  B->>API: GET /api/me
+  API-->>B: zk_enrolled=false
+  B->>U: Prompt create passphrase
+  U->>B: Passphrase
+  B->>B: Generate accountKey, Argon2id wrap
+  B->>API: PUT /api/zk/key-backup (backup_version=1)
+  API->>D1: INSERT zk_key_backups
+  alt Has legacy ECDH key in IndexedDB
+    B->>B: Decrypt v1 ECIES, re-encrypt v2
+    B->>API: PUT /api/zk/payloads (key_fp)
+  end
+  B->>B: sealGraphTitles (GitHub token if needed)
+```
+
+#### Device 2 — Unlock (post-enrollment)
+
+Only valid **after** Device 1 has enrolled and uploaded `zk_key_backups`. Passphrase unwraps the same `accountKey`; v2 payloads decrypt on any device.
+
+#### Transitional period — pre-migration / v1 ciphertext
+
+**Problem:** v1 ECIES blobs in `zk_payloads` decrypt only with the **originating device’s** ECDH private key. Device 2 cannot unlock with passphrase until Device 1 migrates v1→v2.
+
+| Client state | Server state | UX |
+|--------------|--------------|-----|
+| Device 2, no local ECDH key | `zk_key_backups` absent; payloads may be v1 | **Block:** “Complete encryption setup on your original device first.” |
+| Device 2, no local ECDH key | `zk_key_backups` present; all payloads v2 | Normal unlock flow |
+| Device 2, no local ECDH key | `zk_key_backups` present; mixed v1/v2 | Unlock works for v2 rows; v1 rows show `(needs migration)`; prompt “Use original device or Link GitHub to re-seal” |
+| Any device | v1-only, user has GitHub token | **Recovery:** Link GitHub → `syncZkContentFromGitHub` → seal v2 (no ECDH needed) |
+
+**Server-side v1 detection (optional helper on `GET /api/zk/payloads`):** add `has_v1_payloads: boolean` — true if any row’s `encrypted_payload` parses to `"v":1`. Drives transitional UX without leaking content.
+
+**Rollout comms:** Email/changelog: “Before switching devices, open Roxabi on your primary browser once to complete the encryption upgrade.”
+
+#### Lost passphrase
+
+| Scenario | Recovery |
+|----------|----------|
+| Passphrase forgotten, no export | **No crypto recovery.** New passphrase + new `accountKey` requires `rotation: true` on PUT; old payloads undecryptable. |
+| GitHub access retained | Link GitHub → re-seal from GitHub |
+| `.roxabi-recovery` file (Phase 2) | Import wrapped blob client-side |
+
+---
+
+### Migration: ECDH per-device → `accountKey`
+
+**Trigger:** First successful enrollment on a device with `roxabi-zk-v1` keypair and/or v1 payloads.
+
+**Steps (client-only):**
+
+1. `GET /api/zk/payloads`
+2. Decrypt v1 with local ECDH private key
+3. `PUT /api/zk/key-backup`
+4. Re-encrypt v2; `PUT /api/zk/payloads` with `key_fp`
+5. Delete ECDH keypair; open `roxabi-zk-v2`
+
+**One-way per user:** After step 5, rollback to ECDH decrypt is **impossible** even if feature flag is disabled. v2 read path remains enabled permanently once PR 4 ships.
+
+**Ordering:** PR 1–7 → enrollment (PR 4–5) → structure-only code (PR 6, flag-gated) → **PR 11 (0015 scrub)** after enrollment > 95% → prod flag flip (Phase D).
+
+---
+
+### Hybrid multi-user flows
+
+**Invariant:** `issues.key` is globally unique; `edges` are shared. `zk_payloads` is keyed by `(user_id, issue_key)`. No `tenant_id` on data rows (#141 repo-canonical model).
+
+#### User A seals a repo
+
+1. User A enrolls (`PUT /api/zk/key-backup`), unlocks, optionally links GitHub for bodies.
+2. `PUT /api/zk/payloads` writes ciphertext rows for `user_id=A` with User A’s `accountKey`.
+3. `scrubIssuePayloads` (`worker/src/auth/zk.ts`) sets `issues.payload = {}` for those `issue_key`s.
+4. `loadZkSealedIssueKeys` → `SELECT DISTINCT issue_key FROM zk_payloads` includes those keys.
+5. **All users** receive `title: null` from `/api/graph` and `/api/issues` (`redactIssueTitle`).
+
+#### User B joins same tenant (org installation)
+
+1. User B logs in via same GitHub App installation (shared tenant, shared graph).
+2. User B enrolls with **own passphrase** → distinct `accountKey` and `zk_key_backups` row (`user_id=B`).
+3. Graph loads: structure visible (state, edges, labels, milestone, dev_state).
+4. For issues User A sealed: `applyZkDecryption` (`zk-sync.js`) finds no row for `user_id=B` → UI shows **`(sealed)`** (line 103).
+5. User B clicks **Link GitHub** (`/login?zk=1` → `consumeZkHandoffFromUrl`) → `syncZkContentFromGitHub` fetches title/body with User B’s OAuth token.
+6. User B seals → new `zk_payloads` rows for `user_id=B`; User B decrypts own rows on any enrolled device.
+7. User B **cannot** decrypt User A’s ciphertext (different `accountKey`). User A **cannot** decrypt User B’s.
+
+#### Any user seals → global redaction
+
+`loadZkSealedIssueKeys` uses `SELECT DISTINCT issue_key FROM zk_payloads` — **any** user’s seal redacts D1/API title for that issue for everyone. This matches current `worker/src/auth/zk.ts` behavior and must not change.
+
+```mermaid
+flowchart LR
+  subgraph shared [SHARED in D1]
+    I[issues: state, labels, milestone]
+    E[edges: parent, blocks]
+  end
+  subgraph userA [User A]
+    PA[zk_payloads user_id=A]
+    KA[zk_key_backups user_id=A]
+  end
+  subgraph userB [User B]
+    PB[zk_payloads user_id=B]
+    KB[zk_key_backups user_id=B]
+  end
+  I --- E
+  PA -.->|encrypts titles for A| I
+  PB -.->|encrypts titles for B| I
+```
+
+**Product copy:** “Each teammate encrypts their own view of issue titles. You’ll see (sealed) until you link GitHub and sync.”
+
+**Support FAQ:**
+- *Why does my teammate see my titles but I see (sealed)?* — They sealed with their key; you haven’t yet.
+- *Can we share one team passphrase?* — No (by design). See Alternatives: team key rejected.
+
+---
+
+### Alternatives Considered
+
+| Alternative | Verdict | Rationale |
+|-------------|---------|-----------|
+| **Team/org shared encryption key** | **Rejected** | Single passphrase for org = key escrow, offboarding leaks, violates hybrid decision. High operational burden. |
+| **Gist / GitHub repo key backup** | **Rejected** | Gist URLs leak; revision history; operator can fetch URL. Spike ADR explicit. |
+| **Keep ECDH + QR device pairing only** | **Rejected as primary** | No server backup; pairing requires both devices online. QR viable as Phase 2 supplement only. |
+| **PBKDF2-only KDF (no WASM)** | **Rejected as primary** | GPU-vulnerable at 600k iterations; fails spike Phase-2 go/no-go. Acceptable emergency fallback only. |
+| **Server-side encrypted DEK (INSTALL_TOKEN_KEY-style)** | **Rejected** | Operator holds DEK in Worker secrets → not client-side encryption story. |
+| **Structure-only + keep webhook titles for unsealed** | **Rejected** | Leaves operator-readable window; conflicts with private-mode-always-on direction. |
+| **HMAC backup-update proof (no OAuth re-auth)** | **Rejected for v1** | Proof originates from same compromised browser as XSS; server cannot distinguish attacker. OAuth re-auth requires GitHub interaction. |
+
+---
+
+### Security & Privacy Considerations
+
+#### Threat model
+
+| Threat | Asset | Exposure today | After #216 | Mitigation |
+|--------|-------|----------------|------------|------------|
+| D1 database dump | Ciphertext, wrapped keys | Titles scrubbed if sealed | Ciphertext + wrapped backups; no titles after 0015 | AES-GCM + Argon2id |
+| Weak passphrase | `accountKey` | N/A | Offline brute-force on `wrapped_key` | Argon2id; strength meter |
+| **Active session attacker** | **`zk_key_backups` overwrite** | N/A | Stolen cookie alone cannot UPDATE backup; INSERT-before-victim enroll still possible | **OAuth re-auth for UPDATE, 409 enroll guard, `backup_version` CAS on rotation + passphrase change, 5 PUT/hour, audit log** — residual: XSS+user OAuth, first-enroll race |
+| Operator with Worker deploy | Users | JS exfil | Same | CSP, honest marketing |
+| Operator during cron sync | Issue titles | Plaintext in memory | Not fetched | Structure-only |
+| GitHub App install token | Structure | Metadata | Same minus title | Client fetches content |
+| GitHub user OAuth token | Title, body | sessionStorage | Same | Tab-scoped; 5 min handoff TTL |
+| XSS | `accountKey` in memory | Decrypt/exfil | Same | 15 min idle lock; CSP |
+| JS supply chain | Crypto | CDN trust | Same | Pinned vendor deps |
+| Multi-user cross-decrypt | Ciphertext | Per-user keys | Same | No team key |
+| Metadata inference | Graph | Structure visible | Unchanged | Documented |
+| Lost passphrase | Ciphertext | Permanent | Permanent | UX + GitHub re-seal |
+
+---
+
+### Observability
+
+**Implementation target:** Reuse existing **R2 `LOGS` bucket** pattern from `writeRunAudit` (`worker/src/sync/sync.ts`) — no new Analytics Engine binding in v1.
+
+| Mechanism | Use |
+|-----------|-----|
+| **`console.log` JSON** | Workers Logs (~3 day retention); prefix `[zk]` |
+| **R2 `LOGS`** | Durable audit: `zk/events/YYYY-MM-DD/{ts}.json` for backup updates, enrollment milestones |
+| **Frontend** | `console.info('[zk]', { event, ... })` in dev; staging only |
+
+#### Metrics
+
+| Signal | Launch-blocking? | Implementation |
+|--------|------------------|----------------|
+| `zk.enroll.success` / `.failure` | **Yes** | `console.log` + R2 on enroll |
+| `zk.unlock.failure` | **Yes** | Client log; alert on spike via Workers Logs |
+| `zk.backup.put.409` / `.429` | **Yes** | Worker `console.log` |
+| `zk.kdf.duration_ms` | **Yes** | Client log in staging |
+| `zk.kdf_fallback` | **Yes** | Block prod flag if > 0 |
+| `zk.migrate.v1_to_v2.count` | No (Phase 2) | Client log |
+| `zk.payloads.upsert.batch_size` | No | Worker log |
+| `zk.lock.idle` | No | Client log |
+| `zk.sync.structure_only.title_skipped` | **Yes** (PR 6+) | Worker sync log |
+
+**Logging rules:** Never log passphrase, raw keys, `wrapped_key`, GitHub token, decrypted content.
+
+---
+
+### Rollout Plan
+
+1. **PR 1b:** `ZK_ACCOUNT_KEY` env var + `/api/me` exposure — **default off staging/prod**.
+2. **Phase A (flag on in dev):** PR 1–3, 7, 4–5 — crypto, API, enrollment.
+3. **Phase B:** Enable flag in staging; blocking enrollment for test users.
+4. **Phase C:** Enable `ZK_STRUCTURE_ONLY` in staging (PR 6 code only — no 0015 yet). Verify new syncs write `payload = {}`.
+5. **Phase D:** After enrollment rate > 95% on staging, merge **PR 11** (`0015` migration) → CI auto-applies on `main` → enable `ZK_STRUCTURE_ONLY` in production.
+
+**Migration apply discipline:** CI (`.github/workflows/ci.yml` L125–127) auto-applies **all pending** migrations on merge to `main`. PR 6 must **not** include `0015_*.sql`. PR 11 is held until Phase D criteria are met; document in PR 11 body: “Do not merge until enrollment ≥ 95%.”
+
+#### Rollback (revised)
+
+| Action | Safe? | Effect |
+|--------|-------|--------|
+| Disable `ZK_ACCOUNT_KEY` | Partial | Stops **new** enrollments; existing users keep v2 decrypt path (**always on** post-PR 4) |
+| Disable `ZK_STRUCTURE_ONLY` | **Yes** | Re-adds `title` to GraphQL — **reintroduces operator plaintext exposure** but restores server-side titles for unsealed issues |
+| “Revert to ECDH” | **No** | Impossible after user migrates — ECDH key deleted client-side |
+| Migration 0015 | **No** | Irreversible title purge — run only when client sealing confirmed |
+
+**Migration is one-way per user.** Rollback does not undo ciphertext format or deleted ECDH keys.
+
+---
+
+### Open Questions
+
+1. ~~Argon2id `m` on mobile~~ — **Decided:** `m=65536` fixed everywhere (`t=3`, `p=1`); no adaptive downgrade on mobile (user decision 2026-06-18).
+2. **Enrollment gate strictness** — **Decided:** block dashboard until enrolled when flag on; read-only graph deferred.
+3. ~~Passphrase rotation~~ — **Decided:** re-wrap same `accountKey` (Key Decision #11).
+4. ~~Legacy plaintext~~ — **Decided:** migration `0015` in **PR 11** (separate from PR 6; merge only after enrollment threshold).
+5. ~~Rate limit on PUT~~ — **Decided:** 5/hour/user (Key Decision #12).
+
+---
+
+### References
+
+- `docs/ARCHITECTURE.md`, `artifacts/analyses/zk-encryption-spike-analysis.mdx`
+- `frontend/zk-crypto.js`, `worker/src/api/zk-payloads.ts`, `worker/src/sync/sync.ts`
+- `worker/migrations/0004_tenancy_auth.sql`, `0012_scrub_zk_sealed_payloads.sql`
+- GitHub #142, #141, #216
+
+---
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **`accountKey` (AES-256-GCM) replaces ECDH for content** | Symmetric key enables multi-device via wrapped backup. |
+| 2 | **Passphrase + Argon2id WASM → D1 `zk_key_backups`** | Bitwarden-proven; passphrase never on server. |
+| 3 | **Structure-only server sync** | Closes operator plaintext exposure during cron/webhook. |
+| 4 | **Hybrid multi-user: shared structure, per-user ciphertext** | Matches existing schema; no team key. |
+| 5 | **Global redaction on `DISTINCT issue_key`** | Any seal scrubs `issues.payload` for all. |
+| 6 | **GitHub user token for content; App token for structure** | Minimal server content exposure. |
+| 7 | **Marketing: “client-side encryption” not “zero-knowledge”** | Honest residual trust labeling. |
+| 8 | **Reject team key, Gist, GitHub repo backup** | Escrow / URL leakage. |
+| 9 | **`accountKey` in memory only; 15 min idle lock** | Reduces XSS window; aligned with 8 h session. |
+| 10 | **Client-driven v1→v2 migration; one-way** | Server cannot decrypt ECDH blobs. |
+| 11 | **Passphrase rotation = re-wrap same `accountKey`** | No mass re-encryption; Bitwarden-style. New key only for compromise recovery. |
+| 12 | **Backup UPDATE requires OAuth re-auth proof** | Server-enforceable; blocks passive session hijack on passphrase change and rotation. CAS + 429 are defense-in-depth. |
+| 13 | **`zk_enrolled` replaces `zk_opt_in` for UX gating** | Always-on flag made `zk_opt_in` legacy. |
+| 14 | **0015 in PR 11, not PR 6** | CI auto-applies migrations on `main` merge; decouple scrub from structure-only code. |
+| 15 | **`hash-wasm` vendored ESM; no frontend bundler** | Matches static `[assets]` deployment model. |
+| 16 | **Observability via R2 LOGS + Workers Logs** | Reuses `writeRunAudit` pattern; no new binding in v1. |
+| 17 | **Argon2id `m=65536` fixed on all devices** | No `deviceMemory` branching; one KDF contract, one golden vector, consistent security margin on mobile and desktop. |
+
+---
+
+## PR Plan
+
+> **Order constraint:** PR 7 must land **before** PR 4/5 (frontend sends `key_fp` on enroll). PR 1b (flag) lands **before** PR 4 (rollback lever).
+
+### PR 1 — D1 migration: `zk_key_backups` + `key_fp` column
+
+**Title:** `feat(zk): add zk_key_backups table and key_fp column (#216)`
+
+**Files:** `worker/migrations/0014_zk_key_backups.sql`, `worker/src/migrations.test.ts`
+
+**Dependencies:** None
+
+**Description:** Add `zk_key_backups`. Add nullable `key_fp` to `zk_payloads`; backfill from `pubkey_fp`. Document dual-write transition in migration comment.
+
+---
+
+### PR 1b — Feature flag scaffold (early)
+
+**Title:** `chore(zk): ZK_ACCOUNT_KEY flag on /api/me (#216)`
+
+**Files:** `wrangler.toml`, `worker/src/types.ts`, `worker/src/api/me.ts`, `frontend/app.js` (no-op check)
+
+**Dependencies:** None
+
+**Description:** `ZK_ACCOUNT_KEY` env var (default `0`). Expose `zk_account_key_enabled` on `/api/me`. Frontend skips enrollment UI when flag off. **No behavior change in prod until flipped.**
+
+---
+
+### PR 2 — Worker API: key backup routes + re-auth
+
+**Title:** `feat(zk): GET/PUT /api/zk/key-backup with enroll guard and re-auth (#216)`
+
+**Files:**
+- `worker/migrations/0014_zk_key_backups.sql` — include `zk_reauth_proofs` table (or `0014b` if 0014 already merged)
+- `worker/src/api/zk-key-backup.ts`, `worker/src/api/zk-key-backup.test.ts`
+- `worker/src/api/zk-reauth.ts`, `worker/src/api/zk-reauth.test.ts` (consume-reauth)
+- `worker/src/auth/oauth.ts` — `?reauth=1` branch on callback
+- `worker/src/router.ts`, `worker/src/api/me.ts` (`zk_enrolled`)
+
+**Dependencies:** PR 1
+
+**Description:** Session-gated backup routes. **INSERT** (first enroll) session-only. **UPDATE** (passphrase change or `rotation: true`) requires valid `reauth_proof` + `expected_backup_version` CAS. **409 `enrolled`** on duplicate enroll. **403 `reauth_required`** without proof. **5 PUT/hour/user** rate limit. Tests: enroll, rotate with reauth, rotate without reauth (403), version conflict, 429.
+
+---
+
+### PR 3 — Frontend: hash-wasm + `accountKey` crypto core
+
+**Title:** `feat(zk): accountKey hierarchy with hash-wasm Argon2id (#216)`
+
+**Files:** `frontend/vendor/hash-wasm/esm/`, `frontend/zk-kdf.js`, `frontend/zk-crypto.js`, `frontend/zk-crypto.test.js`
+
+**Dependencies:** None (parallel)
+
+**Description:** Vendored hash-wasm ESM. KDF contract + golden vector (`393129b988be5445dc701ce6901813357b507550eff59d7dae0c023dc1a47a3c` in `frontend/test/fixtures/zk-kdf-vectors.json`). v2 seal/open. v1 dual-read. **Acceptance:** unlock < 3 s mobile staging cold load.
+
+---
+
+### PR 7 — `zk_payloads` API: `key_fp` dual-accept + dual-write
+
+**Title:** `feat(zk): accept key_fp in payloads API with pubkey_fp dual-write (#216)`
+
+**Files:** `worker/src/api/zk-payloads.ts`, `worker/src/api/zk-payloads.test.ts`
+
+**Dependencies:** PR 1
+
+**Description:** Accept `key_fp` or `pubkey_fp` on PUT; dual-write both columns. Validate v2 envelope for new writes when flag on. **Must merge before PR 4.**
+
+---
+
+### PR 4 — Frontend: enrollment + unlock UI
+
+**Title:** `feat(zk): passphrase enrollment and lock screen (#216)`
+
+**Files:** `frontend/zk-enroll.js`, `frontend/zk-sync.js`, `frontend/app.js`, `frontend/index.html`, `frontend/auth.js`
+
+**Dependencies:** PR 1b, PR 2, PR 3, **PR 7**
+
+**Description:** Enrollment gated on `ZK_ACCOUNT_KEY`. 15 min idle lock. Remove `zk_opt_in` toggle from critical path. Transitional Device 2 block UX. Integration with v2 seal path.
+
+---
+
+### PR 5 — Frontend: ECDH → accountKey migration
+
+**Title:** `feat(zk): migrate legacy ECDH payloads to accountKey on enroll (#216)`
+
+**Files:** `frontend/zk-crypto.js`, `frontend/zk-sync.js`, `frontend/zk-crypto.test.js`
+
+**Dependencies:** PR 3, PR 4, PR 7
+
+**Description:** v1→v2 migration on enroll. Clear `roxabi-zk-v1`. Log `zk.migrate.v1_to_v2.count`.
+
+---
+
+### PR 6 — Structure-only sync (code only; no 0015)
+
+**Title:** `feat(sync): structure-only issue sync — no title/body on server path (#216)`
+
+**Files:**
+- `worker/src/sync/queries.ts`
+- `worker/src/sync/sync.ts` (all `d1PayloadTitle` call sites ~376, 812, 995)
+- `worker/src/sync/sync.test.ts` (rewrite `json_object('title', ?)` expectations)
+- `worker/src/webhook/handlers.ts`, `handlers.test.ts` (regression: `issues.opened` → `payload = {}`)
+- `worker/src/api/graph.ts`, `issues.ts`
+- `worker/src/auth/zk.ts`
+- `wrangler.toml` — `ZK_STRUCTURE_ONLY` flag
+
+**Dependencies:** PR 4 (client sealing path), PR 1b
+
+**Description:** Remove `title` from all GraphQL queries when flag on. UPSERT `json_object()`. Webhook always `title: null`. **Does not include 0015 migration** — legacy plaintext remains in D1 until PR 11. Gated by `ZK_STRUCTURE_ONLY`.
+
+---
+
+### PR 8 — Hybrid multi-user UX + docs + integration tests
+
+**Title:** `feat(zk): multi-user UX, docs, and enrollment integration tests (#216)`
+
+**Files:**
+- `frontend/zk-sync.js`, `frontend/auth.js`
+- `docs/ARCHITECTURE.md`, `docs/ZK_ENCRYPTION.md`
+- `worker/src/api/zk-integration.test.ts` (new) — **vitest + `captureDb` / `makeFakeDb`** (`worker/src/test-utils.ts`, same pattern as `zk-payloads.test.ts`): Hono router → enroll → PUT backup → PUT payloads → graphRoute titles null; wrong-passphrase unlock failure
+- `frontend/zk-integration.test.js` — crypto round-trip: wrap → unwrap → seal → open; golden KDF vector
+
+**Dependencies:** PR 4, PR 6
+
+**Description:** User B `(sealed)` UX. Cross-layer happy path using existing FakeD1 harness (no miniflare). Document lifecycle diagram. Miniflare reserved for future full-runtime tests if needed.
+
+---
+
+### PR 9 — Observability hardening
+
+**Title:** `chore(zk): R2 audit events and launch metrics (#216)`
+
+**Files:** `worker/src/observability/zk-events.ts` (new), `worker/src/api/zk-key-backup.ts`, `worker/src/sync/sync.ts`
+
+**Dependencies:** PR 2, PR 6
+
+**Description:** `writeZkAudit` → R2 `zk/events/…`. Wire launch-blocking metrics. Staging alert checklist documented in PR body.
+
+---
+
+### PR 11 — Global title scrub migration (manually gated)
+
+**Title:** `chore(db): migration 0015 scrub all issue titles (#216)`
+
+**Files:** `worker/migrations/0015_scrub_all_issue_titles.sql`, `worker/src/migrations.test.ts`
+
+**Dependencies:** PR 4 (enrollment path live), PR 6 (structure-only code merged)
+
+**Description:** Single SQL: `UPDATE issues SET payload = json_object();`. **Do not merge until enrollment ≥ 95%** on staging. CI auto-applies on `main` merge — treat merge time as production scrub trigger. Runbook step in PR body.
+
+---
+
+### PR 10 (Phase 2 — optional)
+
+**Title:** `feat(zk): recovery file export and WebAuthn PRF unlock (phase 2)`
+
+**Dependencies:** PR 4
+
+---
+
+## Revision Summary
+
+| Date | Change |
+|------|--------|
+| 2026-06-18 | Initial draft |
+| 2026-06-18 | **Review revision 1** — addressed 18 review issues: PR order (7 before 4/5), early PR 1b flag, backup overwrite mitigations, one-way rollback, transitional multi-device UX, observability via R2 LOGS, hash-wasm bundling, pubkey_fp transition table, 0015 global scrub, zk_enrolled lifecycle, passphrase rotation decision, enroll 409 conflict, expanded PR 6 scope, idle lock spec, integration test PR, API auth footnote, KDF contract + test vectors, author placeholder |
+| 2026-06-18 | **Review revision 2** — OAuth re-auth for backup UPDATE; 0015 split to PR 11 (CI auto-apply discipline); PR 8 FakeD1 tests; restored hybrid/alternatives sections; embedded Argon2id golden vector `393129b9…` |
+| 2026-06-18 | **User decision** — Argon2id `m=65536` fixed everywhere; no adaptive mobile downgrade (Key Decision #17) |

--- a/frontend/.assetsignore
+++ b/frontend/.assetsignore
@@ -8,3 +8,4 @@ vitest.config.*
 package.json
 package-lock.json
 node_modules/
+test/

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,8 +7,12 @@ import { MultiSelect } from './multi_select.js';
 import { clearPinned } from './hover.js';
 import { repoTone } from './tone.js';
 import { api, AuthError, requireAuthGate, getSessionProfile } from './auth.js';
-import { applyZkDecryption, syncZkContentFromGitHub } from './zk-sync.js';
 import { consumeZkHandoffFromUrl, getGithubUserToken } from './zk-github.js';
+import {
+  applyZkDecryption,
+  ensurePrivateMode,
+  syncZkContentFromGitHub,
+} from './zk-sync.js';
 
 const $ = id => document.getElementById(id);
 
@@ -338,10 +342,11 @@ async function init() {
   try {
     await consumeZkHandoffFromUrl();
     const me = await getSessionProfile();
-    sessionZkOptIn = Boolean(me.user?.zk_opt_in);
     sessionGithubLogin = me.user?.github_login ?? '';
+    await ensurePrivateMode(sessionGithubLogin);
+    sessionZkOptIn = true;
     await loadAndRender(sessionZkOptIn, sessionGithubLogin);
-    if (sessionZkOptIn && getGithubUserToken()) {
+    if (getGithubUserToken()) {
       try {
         const { synced } = await syncZkContentFromGitHub(
           state.nodes,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11,8 +11,10 @@ import { consumeZkHandoffFromUrl, getGithubUserToken } from './zk-github.js';
 import {
   applyZkDecryption,
   ensurePrivateMode,
+  ensureAccountKeySealing,
   syncZkContentFromGitHub,
 } from './zk-sync.js';
+import { requireZkEnrollmentGate } from './zk-enroll.js';
 
 const $ = id => document.getElementById(id);
 
@@ -343,12 +345,25 @@ async function init() {
     await consumeZkHandoffFromUrl();
     const me = await getSessionProfile();
     sessionGithubLogin = me.user?.github_login ?? '';
-    // PR 1b: account-key enrollment UI gated on this flag (PR 4); no-op when off.
     const zkAccountKeyEnabled = isZkAccountKeyEnabled(me);
-    void zkAccountKeyEnabled;
-    await ensurePrivateMode(sessionGithubLogin);
-    sessionZkOptIn = true;
+
+    if (zkAccountKeyEnabled) {
+      const zkReady = await requireZkEnrollmentGate(me, sessionGithubLogin);
+      if (!zkReady) return;
+      sessionZkOptIn = true;
+    } else {
+      await ensurePrivateMode(sessionGithubLogin);
+      sessionZkOptIn = true;
+    }
+
     await loadAndRender(sessionZkOptIn, sessionGithubLogin);
+
+    if (zkAccountKeyEnabled) {
+      await ensureAccountKeySealing(sessionGithubLogin, state.nodes);
+      await applyZkDecryption(state.nodes, sessionGithubLogin);
+      state.nodesByKey = new Map(state.nodes.map((n) => [n.key, n]));
+      render();
+    }
     if (getGithubUserToken()) {
       try {
         const { synced } = await syncZkContentFromGitHub(

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,12 +7,14 @@ import { MultiSelect } from './multi_select.js';
 import { clearPinned } from './hover.js';
 import { repoTone } from './tone.js';
 import { api, AuthError, requireAuthGate, getSessionProfile, isZkAccountKeyEnabled } from './auth.js';
-import { consumeZkHandoffFromUrl, getGithubUserToken } from './zk-github.js';
+import { consumeZkHandoffFromUrl, consumeZkReauthFromUrl, getGithubUserToken } from './zk-github.js';
+import { isZkUnlocked } from './zk-enroll.js';
 import {
   applyZkDecryption,
   ensurePrivateMode,
   ensureAccountKeySealing,
   syncZkContentFromGitHub,
+  SEALED_TITLE_LABEL,
 } from './zk-sync.js';
 import { requireZkEnrollmentGate } from './zk-enroll.js';
 
@@ -282,14 +284,22 @@ async function loadGraphData() {
 // Re-fetch graph data and re-render, preserving view/filters (held in state).
 // Uses data.repos (Array<{repo,archived}>) from /api/graph; falls back to nodes-derived if absent.
 let sessionZkOptIn = false;
+let sessionZkAccountKeyEnabled = false;
 let sessionGithubLogin = '';
 
-async function loadAndRender(zkOptIn, githubLogin) {
+async function loadAndRender(zkOptIn, githubLogin, zkAccountKeyEnabled = false) {
   const data  = await loadGraphData();
   const nodes = data.nodes || [];
   const edges = data.edges || [];
   if (zkOptIn) {
-    await applyZkDecryption(nodes, githubLogin);
+    const skipDecrypt = zkAccountKeyEnabled && !isZkUnlocked();
+    if (!skipDecrypt) {
+      await applyZkDecryption(nodes, githubLogin, { accountKeyMode: zkAccountKeyEnabled });
+    } else {
+      for (const node of nodes) {
+        if (node.title == null) node.title = SEALED_TITLE_LABEL;
+      }
+    }
   }
   annotateNodes(nodes, edges);
   setState({ nodes, edges });
@@ -321,7 +331,7 @@ function startPolling() {
     try {
       const v = await fetchVersion();
       if (lastVersion !== null && v !== lastVersion) {
-        await loadAndRender(sessionZkOptIn, sessionGithubLogin);
+        await loadAndRender(sessionZkOptIn, sessionGithubLogin, sessionZkAccountKeyEnabled);
       }
       lastVersion = v;
     } catch { /* transient — retry next tick */ }
@@ -343,9 +353,11 @@ async function init() {
   restoreControls();
   try {
     await consumeZkHandoffFromUrl();
+    await consumeZkReauthFromUrl();
     const me = await getSessionProfile();
     sessionGithubLogin = me.user?.github_login ?? '';
     const zkAccountKeyEnabled = isZkAccountKeyEnabled(me);
+    sessionZkAccountKeyEnabled = zkAccountKeyEnabled;
 
     if (zkAccountKeyEnabled) {
       const zkReady = await requireZkEnrollmentGate(me, sessionGithubLogin);
@@ -356,11 +368,11 @@ async function init() {
       sessionZkOptIn = true;
     }
 
-    await loadAndRender(sessionZkOptIn, sessionGithubLogin);
+    await loadAndRender(sessionZkOptIn, sessionGithubLogin, zkAccountKeyEnabled);
 
     if (zkAccountKeyEnabled) {
       await ensureAccountKeySealing(sessionGithubLogin, state.nodes);
-      await applyZkDecryption(state.nodes, sessionGithubLogin);
+      await applyZkDecryption(state.nodes, sessionGithubLogin, { accountKeyMode: true });
       state.nodesByKey = new Map(state.nodes.map((n) => [n.key, n]));
       render();
     }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -172,7 +172,7 @@ function buildGraphSegs() {
   closedSeg.addEventListener('click', () => {
     setState({ showClosedUnderOpenEpic: !state.showClosedUnderOpenEpic });
     buildGraphSegs();
-    loadAndRender(sessionZkOptIn, sessionGithubLogin).catch(e => {
+    loadAndRender(sessionZkOptIn, sessionGithubLogin, sessionZkAccountKeyEnabled).catch(e => {
       errorMsg.hidden = false;
       errorMsg.textContent = `Failed to load graph: ${e.message}`;
     });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6,7 +6,7 @@ import { initGraph, clearSearchHighlight }   from './graph.js';
 import { MultiSelect } from './multi_select.js';
 import { clearPinned } from './hover.js';
 import { repoTone } from './tone.js';
-import { api, AuthError, requireAuthGate, getSessionProfile } from './auth.js';
+import { api, AuthError, requireAuthGate, getSessionProfile, isZkAccountKeyEnabled } from './auth.js';
 import { consumeZkHandoffFromUrl, getGithubUserToken } from './zk-github.js';
 import {
   applyZkDecryption,
@@ -343,6 +343,9 @@ async function init() {
     await consumeZkHandoffFromUrl();
     const me = await getSessionProfile();
     sessionGithubLogin = me.user?.github_login ?? '';
+    // PR 1b: account-key enrollment UI gated on this flag (PR 4); no-op when off.
+    const zkAccountKeyEnabled = isZkAccountKeyEnabled(me);
+    void zkAccountKeyEnabled;
     await ensurePrivateMode(sessionGithubLogin);
     sessionZkOptIn = true;
     await loadAndRender(sessionZkOptIn, sessionGithubLogin);

--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -9,7 +9,8 @@
    overlay (the user cannot reach "Sign in"). Raising specificity to (0,2,0) via
    the attribute selector lets `hidden` win until JS removes it. */
 .auth-view[hidden],
-.consent-gate[hidden] {
+.consent-gate[hidden],
+.zk-gate[hidden] {
   display: none;
 }
 
@@ -145,6 +146,92 @@ body.gated #view-list,
 body.gated #graph-panel,
 body.gated #error-msg {
   display: none;
+}
+
+/* ─── ZK enrollment / unlock gate (#216 PR 4) ─────────────────────────────── */
+
+.zk-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 650;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+[data-theme="light"] .zk-gate {
+  background: rgba(0, 0, 0, 0.48);
+}
+
+.zk-dialog {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 12px;
+  box-shadow: var(--panel-shadow);
+  max-width: 480px;
+  width: 100%;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.zk-dialog h2 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.zk-dialog p {
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.65;
+  margin: 0;
+}
+
+.zk-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.zk-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.zk-field input {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 14px;
+  padding: 9px 12px;
+}
+
+.zk-field input:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.zk-error {
+  color: #e85d5d;
+  font-size: 12px;
+  margin: 0;
+}
+
+.zk-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }
 
 /* ─── Consent warning (beta / secrets notice) ────────────────────────────── */

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -226,6 +226,10 @@ function renderOperatorNotice(_me) {
       to sync issue bodies on this device (token is kept in this tab only).
       When passphrase backup is enabled, unlock first to seal or decrypt content.
     </p>
+    <p class="zk-opt-in-hint">
+      Each teammate encrypts their own view of issue titles.
+      You will see <strong>(sealed)</strong> on issues another teammate sealed until you link GitHub and sync.
+    </p>
   `;
   el.removeAttribute('hidden');
 }

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -224,6 +224,7 @@ function renderOperatorNotice(_me) {
     <p class="zk-opt-in-hint">
       <a href="/login?zk=1" id="zk-github-link">Link GitHub</a>
       to sync issue bodies on this device (token is kept in this tab only).
+      When passphrase backup is enabled, unlock first to seal or decrypt content.
     </p>
   `;
   el.removeAttribute('hidden');

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -65,6 +65,11 @@ export async function getSessionProfile() {
   return fetchMe();
 }
 
+/** True when server exposes ZK_ACCOUNT_KEY feature (#216 PR 1b). */
+export function isZkAccountKeyEnabled(me) {
+  return me?.user?.zk_account_key_enabled === true;
+}
+
 // ─── Internal: render landing ─────────────────────────────────────────────────
 
 function renderLanding() {

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -127,8 +127,8 @@ function renderConsentGate(me) {
           <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">GitHub App settings</a>.
         </p>
         <p class="consent-warning">
-          <strong>During this phase, the operator can read the issue data of the organisations you grant.</strong>
-          Don't paste secrets into issue bodies or titles.
+          <strong>Issue titles and bodies are encrypted client-side before storage.</strong>
+          Graph structure (state, blockers, labels) remains visible to the operator.
         </p>
         <div class="consent-actions">
           <button class="consent-btn-secondary" id="consent-logout">Sign out</button>
@@ -207,63 +207,21 @@ function renderOrgPicker(me) {
 
 // ─── Internal: render operator notice ────────────────────────────────────────
 
-async function enableZkMode(me) {
-  const graphResp = await api('/api/graph');
-  const { nodes } = await graphResp.json();
-  const { sealGraphTitles } = await import('./zk-sync.js');
-  await sealGraphTitles(nodes ?? [], me.user.github_login);
-  await api('/api/zk-opt-in', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ enabled: true }),
-  });
-  location.reload();
-}
-
-function renderOperatorNotice(me) {
+function renderOperatorNotice(_me) {
   const el = $('operator-notice');
-  const zkOn = Boolean(me.user.zk_opt_in);
   el.innerHTML = `
     <div class="operator-notice-main">
-      <strong>Operator read access (this phase):</strong> the operator can read the issue data of the organisations you grant.
-      Don't paste secrets into issue bodies or titles.
-      <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">Manage</a>
+      <strong>Private mode is always on.</strong>
+      Issue titles and bodies are encrypted in your browser before they are stored.
+      Graph structure (state, blockers, milestones) stays visible to the operator.
+      <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">Manage app access</a>
     </div>
-    <div class="zk-opt-in-panel">
-      <label class="zk-opt-in-label">
-        <input type="checkbox" id="zk-opt-in-toggle" ${zkOn ? 'checked' : ''} />
-        Private mode (beta) — encrypt issue content client-side
-      </label>
-      <p class="zk-opt-in-hint" id="zk-opt-in-hint" ${zkOn ? '' : 'hidden'}>
-        <strong>Scope:</strong> content only, not structure. Issue state, blocker edges, and counts stay visible to the operator.
-        Titles and bodies are encrypted client-side; keys stay in this browser.
-        <a href="/login?zk=1" id="zk-github-link">Link GitHub</a> to sync issue bodies.
-      </p>
-    </div>
+    <p class="zk-opt-in-hint">
+      <a href="/login?zk=1" id="zk-github-link">Link GitHub</a>
+      to sync issue bodies on this device (token is kept in this tab only).
+    </p>
   `;
   el.removeAttribute('hidden');
-
-  const toggle = $('zk-opt-in-toggle');
-  const hint = $('zk-opt-in-hint');
-  toggle.addEventListener('change', async () => {
-    const enabled = toggle.checked;
-    toggle.disabled = true;
-    try {
-      if (enabled) {
-        await enableZkMode(me);
-        return;
-      }
-      await api('/api/zk-opt-in', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ enabled: false }),
-      });
-      location.reload();
-    } catch {
-      toggle.checked = !enabled;
-      toggle.disabled = false;
-    }
-  });
 }
 
 // ─── Internal: wire logout ────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,7 @@
         <button id="btn-graph" class="seg"    data-v="graph" aria-pressed="false" title="Graph"><span class="ico">⋈</span> Graph</button>
       </div>
       <select id="org-picker" class="org-picker" aria-label="Active organisation" hidden></select>
+      <button id="zk-lock-btn" class="theme-btn" type="button" hidden title="Lock encryption">Lock</button>
       <button id="logout-btn" class="theme-btn" type="button" hidden>Sign out</button>
       <button id="theme-btn" class="theme-btn" type="button" title="Toggle theme" aria-label="Toggle theme">🌙</button>
     </div>
@@ -115,6 +116,7 @@
 </footer>
 
 <div id="consent-gate" class="consent-gate" hidden></div>
+<div id="zk-gate" class="zk-gate" hidden></div>
 
 <script type="module" src="state.js"></script>
 <script type="module" src="pivot.js"></script>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "roxabi-live-frontend",
       "devDependencies": {
+        "hash-wasm": "4.12.0",
         "jsdom": "^25.0.0",
         "vitest": "^2.1.0"
       }
@@ -1482,6 +1483,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "hash-wasm": "4.12.0",
     "jsdom": "^25.0.0",
     "vitest": "^2.1.0"
   }

--- a/frontend/test/fixtures/zk-kdf-vectors.json
+++ b/frontend/test/fixtures/zk-kdf-vectors.json
@@ -1,0 +1,6 @@
+{
+  "passphrase": "test-passphrase-roxabi",
+  "salt_hex": "0123456789abcdef0123456789abcdef",
+  "params": { "m": 65536, "t": 3, "p": 1 },
+  "output_hex": "393129b988be5445dc701ce6901813357b507550eff59d7dae0c023dc1a47a3c"
+}

--- a/frontend/vendor/hash-wasm/README.md
+++ b/frontend/vendor/hash-wasm/README.md
@@ -1,0 +1,14 @@
+# hash-wasm (vendored)
+
+Pinned from npm `hash-wasm@4.12.0`.
+
+ESM bundle: `esm/index.js` (copied from `dist/index.esm.js`).
+
+Refresh:
+
+```bash
+cd frontend && npm pack hash-wasm@4.12.0
+tar -xf hash-wasm-4.12.0.tgz package/dist/index.esm.js
+cp package/dist/index.esm.js vendor/hash-wasm/esm/index.js
+rm -rf package hash-wasm-4.12.0.tgz
+```

--- a/frontend/vendor/hash-wasm/esm/index.js
+++ b/frontend/vendor/hash-wasm/esm/index.js
@@ -1,0 +1,2671 @@
+/*!
+ * hash-wasm (https://www.npmjs.com/package/hash-wasm)
+ * (c) Dani Biro
+ * @license MIT
+ */
+
+var name$l = "adler32";
+var data$l = "AGFzbQEAAAABDANgAAF/YAAAYAF/AAMHBgABAgEAAgUEAQECAgYOAn8BQYCJBQt/AEGACAsHcAgGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAlIYXNoX0luaXQAAQtIYXNoX1VwZGF0ZQACCkhhc2hfRmluYWwAAw1IYXNoX0dldFN0YXRlAAQOSGFzaF9DYWxjdWxhdGUABQpTVEFURV9TSVpFAwEK6wkGBQBBgAkLCgBBAEEBNgKECAvjCAEHf0EAKAKECCIBQf//A3EhAiABQRB2IQMCQAJAIABBAUcNACACQQAtAIAJaiIBQY+AfGogASABQfD/A0sbIgEgA2oiBEEQdCIFQYCAPGogBSAEQfD/A0sbIAFyIQEMAQsCQAJAAkACQAJAIABBEEkNAEGACSEGIABBsCtJDQFBgAkhBgNAQQAhBQNAIAYgBWoiASgCACIEQf8BcSACaiICIANqIAIgBEEIdkH/AXFqIgJqIAIgBEEQdkH/AXFqIgJqIAIgBEEYdmoiAmogAiABQQRqKAIAIgRB/wFxaiICaiACIARBCHZB/wFxaiICaiACIARBEHZB/wFxaiICaiACIARBGHZqIgJqIAIgAUEIaigCACIEQf8BcWoiAmogAiAEQQh2Qf8BcWoiAmogAiAEQRB2Qf8BcWoiAmogAiAEQRh2aiIEaiAEIAFBDGooAgAiAUH/AXFqIgRqIAQgAUEIdkH/AXFqIgRqIAQgAUEQdkH/AXFqIgRqIAQgAUEYdmoiAmohAyAFQRBqIgVBsCtHDQALIANB8f8DcCEDIAJB8f8DcCECIAZBsCtqIQYgAEHQVGoiAEGvK0sNAAsgAEUNBCAAQQ9LDQEMAgsCQCAARQ0AAkACQCAAQQNxIgUNAEGACSEBIAAhBAwBCyAAQXxxIQRBACEBA0AgAiABQYAJai0AAGoiAiADaiEDIAUgAUEBaiIBRw0ACyAFQYAJaiEBCyAAQQRJDQADQCACIAEtAABqIgUgAS0AAWoiBiABLQACaiIAIAFBA2otAABqIgIgACAGIAUgA2pqamohAyABQQRqIQEgBEF8aiIEDQALCyACQY+AfGogAiACQfD/A0sbIANB8f8DcEEQdHIhAQwECwNAIAYoAgAiAUH/AXEgAmoiBCADaiAEIAFBCHZB/wFxaiIEaiAEIAFBEHZB/wFxaiIEaiAEIAFBGHZqIgRqIAQgBkEEaigCACIBQf8BcWoiBGogBCABQQh2Qf8BcWoiBGogBCABQRB2Qf8BcWoiBGogBCABQRh2aiIEaiAEIAZBCGooAgAiAUH/AXFqIgRqIAQgAUEIdkH/AXFqIgRqIAQgAUEQdkH/AXFqIgRqIAQgAUEYdmoiBGogBCAGQQxqKAIAIgFB/wFxaiIEaiAEIAFBCHZB/wFxaiIEaiAEIAFBEHZB/wFxaiIEaiAEIAFBGHZqIgJqIQMgBkEQaiEGIABBcGoiAEEPSw0ACyAARQ0BCyAAQX9qIQcCQCAAQQNxIgVFDQAgAEF8cSEAIAUhBCAGIQEDQCACIAEtAABqIgIgA2ohAyABQQFqIQEgBEF/aiIEDQALIAYgBWohBgsgB0EDSQ0AA0AgAiAGLQAAaiIBIAYtAAFqIgQgBi0AAmoiBSAGQQNqLQAAaiICIAUgBCABIANqampqIQMgBkEEaiEGIABBfGoiAA0ACwsgA0Hx/wNwIQMgAkHx/wNwIQILIAIgA0EQdHIhAQtBACABNgKECAsxAQF/QQBBACgChAgiAEEYdCAAQYD+A3FBCHRyIABBCHZBgP4DcSAAQRh2cnI2AoAJCwUAQYQICzsAQQBBATYChAggABACQQBBACgChAgiAEEYdCAAQYD+A3FBCHRyIABBCHZBgP4DcSAAQRh2cnI2AoAJCwsVAgBBgAgLBAQAAAAAQYQICwQBAAAA";
+var hash$l = "02ddbd17";
+var wasmJson$l = {
+	name: name$l,
+	data: data$l,
+	hash: hash$l
+};
+
+/******************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise, SuppressedError, Symbol, Iterator */
+
+
+function __awaiter(thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+}
+
+typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+    var e = new Error(message);
+    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
+
+class Mutex {
+    constructor() {
+        this.mutex = Promise.resolve();
+    }
+    lock() {
+        let begin = () => { };
+        this.mutex = this.mutex.then(() => new Promise(begin));
+        return new Promise((res) => {
+            begin = res;
+        });
+    }
+    dispatch(fn) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const unlock = yield this.lock();
+            try {
+                return yield Promise.resolve(fn());
+            }
+            finally {
+                unlock();
+            }
+        });
+    }
+}
+
+var _a;
+function getGlobal() {
+    if (typeof globalThis !== "undefined")
+        return globalThis;
+    if (typeof self !== "undefined")
+        return self;
+    if (typeof window !== "undefined")
+        return window;
+    return global;
+}
+const globalObject = getGlobal();
+const nodeBuffer = (_a = globalObject.Buffer) !== null && _a !== void 0 ? _a : null;
+const textEncoder = globalObject.TextEncoder
+    ? new globalObject.TextEncoder()
+    : null;
+function intArrayToString(arr, len) {
+    return String.fromCharCode(...arr.subarray(0, len));
+}
+function hexCharCodesToInt(a, b) {
+    return ((((a & 0xf) + ((a >> 6) | ((a >> 3) & 0x8))) << 4) |
+        ((b & 0xf) + ((b >> 6) | ((b >> 3) & 0x8))));
+}
+function writeHexToUInt8(buf, str) {
+    const size = str.length >> 1;
+    for (let i = 0; i < size; i++) {
+        const index = i << 1;
+        buf[i] = hexCharCodesToInt(str.charCodeAt(index), str.charCodeAt(index + 1));
+    }
+}
+function hexStringEqualsUInt8(str, buf) {
+    if (str.length !== buf.length * 2) {
+        return false;
+    }
+    for (let i = 0; i < buf.length; i++) {
+        const strIndex = i << 1;
+        if (buf[i] !==
+            hexCharCodesToInt(str.charCodeAt(strIndex), str.charCodeAt(strIndex + 1))) {
+            return false;
+        }
+    }
+    return true;
+}
+const alpha = "a".charCodeAt(0) - 10;
+const digit = "0".charCodeAt(0);
+function getDigestHex(tmpBuffer, input, hashLength) {
+    let p = 0;
+    for (let i = 0; i < hashLength; i++) {
+        let nibble = input[i] >>> 4;
+        tmpBuffer[p++] = nibble > 9 ? nibble + alpha : nibble + digit;
+        nibble = input[i] & 0xf;
+        tmpBuffer[p++] = nibble > 9 ? nibble + alpha : nibble + digit;
+    }
+    return String.fromCharCode.apply(null, tmpBuffer);
+}
+const getUInt8Buffer = nodeBuffer !== null
+    ? (data) => {
+        if (typeof data === "string") {
+            const buf = nodeBuffer.from(data, "utf8");
+            return new Uint8Array(buf.buffer, buf.byteOffset, buf.length);
+        }
+        if (nodeBuffer.isBuffer(data)) {
+            return new Uint8Array(data.buffer, data.byteOffset, data.length);
+        }
+        if (ArrayBuffer.isView(data)) {
+            return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+        }
+        throw new Error("Invalid data type!");
+    }
+    : (data) => {
+        if (typeof data === "string") {
+            return textEncoder.encode(data);
+        }
+        if (ArrayBuffer.isView(data)) {
+            return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+        }
+        throw new Error("Invalid data type!");
+    };
+const base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const base64Lookup = new Uint8Array(256);
+for (let i = 0; i < base64Chars.length; i++) {
+    base64Lookup[base64Chars.charCodeAt(i)] = i;
+}
+function encodeBase64(data, pad = true) {
+    const len = data.length;
+    const extraBytes = len % 3;
+    const parts = [];
+    const len2 = len - extraBytes;
+    for (let i = 0; i < len2; i += 3) {
+        const tmp = ((data[i] << 16) & 0xff0000) +
+            ((data[i + 1] << 8) & 0xff00) +
+            (data[i + 2] & 0xff);
+        const triplet = base64Chars.charAt((tmp >> 18) & 0x3f) +
+            base64Chars.charAt((tmp >> 12) & 0x3f) +
+            base64Chars.charAt((tmp >> 6) & 0x3f) +
+            base64Chars.charAt(tmp & 0x3f);
+        parts.push(triplet);
+    }
+    if (extraBytes === 1) {
+        const tmp = data[len - 1];
+        const a = base64Chars.charAt(tmp >> 2);
+        const b = base64Chars.charAt((tmp << 4) & 0x3f);
+        parts.push(`${a}${b}`);
+        if (pad) {
+            parts.push("==");
+        }
+    }
+    else if (extraBytes === 2) {
+        const tmp = (data[len - 2] << 8) + data[len - 1];
+        const a = base64Chars.charAt(tmp >> 10);
+        const b = base64Chars.charAt((tmp >> 4) & 0x3f);
+        const c = base64Chars.charAt((tmp << 2) & 0x3f);
+        parts.push(`${a}${b}${c}`);
+        if (pad) {
+            parts.push("=");
+        }
+    }
+    return parts.join("");
+}
+function getDecodeBase64Length(data) {
+    let bufferLength = Math.floor(data.length * 0.75);
+    const len = data.length;
+    if (data[len - 1] === "=") {
+        bufferLength -= 1;
+        if (data[len - 2] === "=") {
+            bufferLength -= 1;
+        }
+    }
+    return bufferLength;
+}
+function decodeBase64(data) {
+    const bufferLength = getDecodeBase64Length(data);
+    const len = data.length;
+    const bytes = new Uint8Array(bufferLength);
+    let p = 0;
+    for (let i = 0; i < len; i += 4) {
+        const encoded1 = base64Lookup[data.charCodeAt(i)];
+        const encoded2 = base64Lookup[data.charCodeAt(i + 1)];
+        const encoded3 = base64Lookup[data.charCodeAt(i + 2)];
+        const encoded4 = base64Lookup[data.charCodeAt(i + 3)];
+        bytes[p] = (encoded1 << 2) | (encoded2 >> 4);
+        p += 1;
+        bytes[p] = ((encoded2 & 15) << 4) | (encoded3 >> 2);
+        p += 1;
+        bytes[p] = ((encoded3 & 3) << 6) | (encoded4 & 63);
+        p += 1;
+    }
+    return bytes;
+}
+
+const MAX_HEAP = 16 * 1024;
+const WASM_FUNC_HASH_LENGTH = 4;
+const wasmMutex = new Mutex();
+const wasmModuleCache = new Map();
+function WASMInterface(binary, hashLength) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let wasmInstance = null;
+        let memoryView = null;
+        let initialized = false;
+        if (typeof WebAssembly === "undefined") {
+            throw new Error("WebAssembly is not supported in this environment!");
+        }
+        const writeMemory = (data, offset = 0) => {
+            memoryView.set(data, offset);
+        };
+        const getMemory = () => memoryView;
+        const getExports = () => wasmInstance.exports;
+        const setMemorySize = (totalSize) => {
+            wasmInstance.exports.Hash_SetMemorySize(totalSize);
+            const arrayOffset = wasmInstance.exports.Hash_GetBuffer();
+            const memoryBuffer = wasmInstance.exports.memory.buffer;
+            memoryView = new Uint8Array(memoryBuffer, arrayOffset, totalSize);
+        };
+        const getStateSize = () => {
+            const view = new DataView(wasmInstance.exports.memory.buffer);
+            const stateSize = view.getUint32(wasmInstance.exports.STATE_SIZE, true);
+            return stateSize;
+        };
+        const loadWASMPromise = wasmMutex.dispatch(() => __awaiter(this, void 0, void 0, function* () {
+            if (!wasmModuleCache.has(binary.name)) {
+                const asm = decodeBase64(binary.data);
+                const promise = WebAssembly.compile(asm);
+                wasmModuleCache.set(binary.name, promise);
+            }
+            const module = yield wasmModuleCache.get(binary.name);
+            wasmInstance = yield WebAssembly.instantiate(module, {
+            // env: {
+            //   emscripten_memcpy_big: (dest, src, num) => {
+            //     const memoryBuffer = wasmInstance.exports.memory.buffer;
+            //     const memView = new Uint8Array(memoryBuffer, 0);
+            //     memView.set(memView.subarray(src, src + num), dest);
+            //   },
+            //   print_memory: (offset, len) => {
+            //     const memoryBuffer = wasmInstance.exports.memory.buffer;
+            //     const memView = new Uint8Array(memoryBuffer, 0);
+            //     console.log('print_int32', memView.subarray(offset, offset + len));
+            //   },
+            // },
+            });
+            // wasmInstance.exports._start();
+        }));
+        const setupInterface = () => __awaiter(this, void 0, void 0, function* () {
+            if (!wasmInstance) {
+                yield loadWASMPromise;
+            }
+            const arrayOffset = wasmInstance.exports.Hash_GetBuffer();
+            const memoryBuffer = wasmInstance.exports.memory.buffer;
+            memoryView = new Uint8Array(memoryBuffer, arrayOffset, MAX_HEAP);
+        });
+        const init = (bits = null) => {
+            initialized = true;
+            wasmInstance.exports.Hash_Init(bits);
+        };
+        const updateUInt8Array = (data) => {
+            let read = 0;
+            while (read < data.length) {
+                const chunk = data.subarray(read, read + MAX_HEAP);
+                read += chunk.length;
+                memoryView.set(chunk);
+                wasmInstance.exports.Hash_Update(chunk.length);
+            }
+        };
+        const update = (data) => {
+            if (!initialized) {
+                throw new Error("update() called before init()");
+            }
+            const Uint8Buffer = getUInt8Buffer(data);
+            updateUInt8Array(Uint8Buffer);
+        };
+        const digestChars = new Uint8Array(hashLength * 2);
+        const digest = (outputType, padding = null) => {
+            if (!initialized) {
+                throw new Error("digest() called before init()");
+            }
+            initialized = false;
+            wasmInstance.exports.Hash_Final(padding);
+            if (outputType === "binary") {
+                // the data is copied to allow GC of the original memory object
+                return memoryView.slice(0, hashLength);
+            }
+            return getDigestHex(digestChars, memoryView, hashLength);
+        };
+        const save = () => {
+            if (!initialized) {
+                throw new Error("save() can only be called after init() and before digest()");
+            }
+            const stateOffset = wasmInstance.exports.Hash_GetState();
+            const stateLength = getStateSize();
+            const memoryBuffer = wasmInstance.exports.memory.buffer;
+            const internalState = new Uint8Array(memoryBuffer, stateOffset, stateLength);
+            // prefix is 4 bytes from SHA1 hash of the WASM binary
+            // it is used to detect incompatible internal states between different versions of hash-wasm
+            const prefixedState = new Uint8Array(WASM_FUNC_HASH_LENGTH + stateLength);
+            writeHexToUInt8(prefixedState, binary.hash);
+            prefixedState.set(internalState, WASM_FUNC_HASH_LENGTH);
+            return prefixedState;
+        };
+        const load = (state) => {
+            if (!(state instanceof Uint8Array)) {
+                throw new Error("load() expects an Uint8Array generated by save()");
+            }
+            const stateOffset = wasmInstance.exports.Hash_GetState();
+            const stateLength = getStateSize();
+            const overallLength = WASM_FUNC_HASH_LENGTH + stateLength;
+            const memoryBuffer = wasmInstance.exports.memory.buffer;
+            if (state.length !== overallLength) {
+                throw new Error(`Bad state length (expected ${overallLength} bytes, got ${state.length})`);
+            }
+            if (!hexStringEqualsUInt8(binary.hash, state.subarray(0, WASM_FUNC_HASH_LENGTH))) {
+                throw new Error("This state was written by an incompatible hash implementation");
+            }
+            const internalState = state.subarray(WASM_FUNC_HASH_LENGTH);
+            new Uint8Array(memoryBuffer, stateOffset, stateLength).set(internalState);
+            initialized = true;
+        };
+        const isDataShort = (data) => {
+            if (typeof data === "string") {
+                // worst case is 4 bytes / char
+                return data.length < MAX_HEAP / 4;
+            }
+            return data.byteLength < MAX_HEAP;
+        };
+        let canSimplify = isDataShort;
+        switch (binary.name) {
+            case "argon2":
+            case "scrypt":
+                canSimplify = () => true;
+                break;
+            case "blake2b":
+            case "blake2s":
+                // if there is a key at blake2 then cannot simplify
+                canSimplify = (data, initParam) => initParam <= 512 && isDataShort(data);
+                break;
+            case "blake3":
+                // if there is a key at blake3 then cannot simplify
+                canSimplify = (data, initParam) => initParam === 0 && isDataShort(data);
+                break;
+            case "xxhash64": // cannot simplify
+            case "xxhash3":
+            case "xxhash128":
+            case "crc64":
+                canSimplify = () => false;
+                break;
+        }
+        // shorthand for (init + update + digest) for better performance
+        const calculate = (data, initParam = null, digestParam = null) => {
+            if (!canSimplify(data, initParam)) {
+                init(initParam);
+                update(data);
+                return digest("hex", digestParam);
+            }
+            const buffer = getUInt8Buffer(data);
+            memoryView.set(buffer);
+            wasmInstance.exports.Hash_Calculate(buffer.length, initParam, digestParam);
+            return getDigestHex(digestChars, memoryView, hashLength);
+        };
+        yield setupInterface();
+        return {
+            getMemory,
+            writeMemory,
+            getExports,
+            setMemorySize,
+            init,
+            update,
+            digest,
+            save,
+            load,
+            calculate,
+            hashLength,
+        };
+    });
+}
+
+function lockedCreate(mutex, binary, hashLength) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const unlock = yield mutex.lock();
+        const wasm = yield WASMInterface(binary, hashLength);
+        unlock();
+        return wasm;
+    });
+}
+
+const mutex$l = new Mutex();
+let wasmCache$l = null;
+/**
+ * Calculates Adler-32 hash. The resulting 32-bit hash is stored in
+ * network byte order (big-endian).
+ *
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function adler32(data) {
+    if (wasmCache$l === null) {
+        return lockedCreate(mutex$l, wasmJson$l, 4).then((wasm) => {
+            wasmCache$l = wasm;
+            return wasmCache$l.calculate(data);
+        });
+    }
+    try {
+        const hash = wasmCache$l.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new Adler-32 hash instance
+ */
+function createAdler32() {
+    return WASMInterface(wasmJson$l, 4).then((wasm) => {
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 4,
+            digestSize: 4,
+        };
+        return obj;
+    });
+}
+
+var name$k = "argon2";
+var data$k = "AGFzbQEAAAABKQVgAX8Bf2AAAX9gEH9/f39/f39/f39/f39/f38AYAR/f39/AGACf38AAwYFAAECAwQFBgEBAoCAAgYIAX8BQZCoBAsHQQQGbWVtb3J5AgASSGFzaF9TZXRNZW1vcnlTaXplAAAOSGFzaF9HZXRCdWZmZXIAAQ5IYXNoX0NhbGN1bGF0ZQAECvEyBVgBAn9BACEBAkAgAEEAKAKICCICRg0AAkAgACACayIAQRB2IABBgIB8cSAASWoiAEAAQX9HDQBB/wHADwtBACEBQQBBACkDiAggAEEQdK18NwOICAsgAcALcAECfwJAQQAoAoAIIgANAEEAPwBBEHQiADYCgAhBACgCiAgiAUGAgCBGDQACQEGAgCAgAWsiAEEQdiAAQYCAfHEgAElqIgBAAEF/Rw0AQQAPC0EAQQApA4gIIABBEHStfDcDiAhBACgCgAghAAsgAAvcDgECfiAAIAQpAwAiECAAKQMAIhF8IBFCAYZC/v///x+DIBBC/////w+DfnwiEDcDACAMIBAgDCkDAIVCIIkiEDcDACAIIBAgCCkDACIRfCARQgGGQv7///8fgyAQQv////8Pg358IhA3AwAgBCAQIAQpAwCFQiiJIhA3AwAgACAQIAApAwAiEXwgEEL/////D4MgEUIBhkL+////H4N+fCIQNwMAIAwgECAMKQMAhUIwiSIQNwMAIAggECAIKQMAIhF8IBBC/////w+DIBFCAYZC/v///x+DfnwiEDcDACAEIBAgBCkDAIVCAYk3AwAgASAFKQMAIhAgASkDACIRfCARQgGGQv7///8fgyAQQv////8Pg358IhA3AwAgDSAQIA0pAwCFQiCJIhA3AwAgCSAQIAkpAwAiEXwgEUIBhkL+////H4MgEEL/////D4N+fCIQNwMAIAUgECAFKQMAhUIoiSIQNwMAIAEgECABKQMAIhF8IBBC/////w+DIBFCAYZC/v///x+DfnwiEDcDACANIBAgDSkDAIVCMIkiEDcDACAJIBAgCSkDACIRfCAQQv////8PgyARQgGGQv7///8fg358IhA3AwAgBSAQIAUpAwCFQgGJNwMAIAIgBikDACIQIAIpAwAiEXwgEUIBhkL+////H4MgEEL/////D4N+fCIQNwMAIA4gECAOKQMAhUIgiSIQNwMAIAogECAKKQMAIhF8IBFCAYZC/v///x+DIBBC/////w+DfnwiEDcDACAGIBAgBikDAIVCKIkiEDcDACACIBAgAikDACIRfCAQQv////8PgyARQgGGQv7///8fg358IhA3AwAgDiAQIA4pAwCFQjCJIhA3AwAgCiAQIAopAwAiEXwgEEL/////D4MgEUIBhkL+////H4N+fCIQNwMAIAYgECAGKQMAhUIBiTcDACADIAcpAwAiECADKQMAIhF8IBFCAYZC/v///x+DIBBC/////w+DfnwiEDcDACAPIBAgDykDAIVCIIkiEDcDACALIBAgCykDACIRfCARQgGGQv7///8fgyAQQv////8Pg358IhA3AwAgByAQIAcpAwCFQiiJIhA3AwAgAyAQIAMpAwAiEXwgEEL/////D4MgEUIBhkL+////H4N+fCIQNwMAIA8gECAPKQMAhUIwiSIQNwMAIAsgECALKQMAIhF8IBBC/////w+DIBFCAYZC/v///x+DfnwiEDcDACAHIBAgBykDAIVCAYk3AwAgACAFKQMAIhAgACkDACIRfCARQgGGQv7///8fgyAQQv////8Pg358IhA3AwAgDyAQIA8pAwCFQiCJIhA3AwAgCiAQIAopAwAiEXwgEUIBhkL+////H4MgEEL/////D4N+fCIQNwMAIAUgECAFKQMAhUIoiSIQNwMAIAAgECAAKQMAIhF8IBBC/////w+DIBFCAYZC/v///x+DfnwiEDcDACAPIBAgDykDAIVCMIkiEDcDACAKIBAgCikDACIRfCAQQv////8PgyARQgGGQv7///8fg358IhA3AwAgBSAQIAUpAwCFQgGJNwMAIAEgBikDACIQIAEpAwAiEXwgEUIBhkL+////H4MgEEL/////D4N+fCIQNwMAIAwgECAMKQMAhUIgiSIQNwMAIAsgECALKQMAIhF8IBFCAYZC/v///x+DIBBC/////w+DfnwiEDcDACAGIBAgBikDAIVCKIkiEDcDACABIBAgASkDACIRfCAQQv////8PgyARQgGGQv7///8fg358IhA3AwAgDCAQIAwpAwCFQjCJIhA3AwAgCyAQIAspAwAiEXwgEEL/////D4MgEUIBhkL+////H4N+fCIQNwMAIAYgECAGKQMAhUIBiTcDACACIAcpAwAiECACKQMAIhF8IBFCAYZC/v///x+DIBBC/////w+DfnwiEDcDACANIBAgDSkDAIVCIIkiEDcDACAIIBAgCCkDACIRfCARQgGGQv7///8fgyAQQv////8Pg358IhA3AwAgByAQIAcpAwCFQiiJIhA3AwAgAiAQIAIpAwAiEXwgEEL/////D4MgEUIBhkL+////H4N+fCIQNwMAIA0gECANKQMAhUIwiSIQNwMAIAggECAIKQMAIhF8IBBC/////w+DIBFCAYZC/v///x+DfnwiEDcDACAHIBAgBykDAIVCAYk3AwAgAyAEKQMAIhAgAykDACIRfCARQgGGQv7///8fgyAQQv////8Pg358IhA3AwAgDiAQIA4pAwCFQiCJIhA3AwAgCSAQIAkpAwAiEXwgEUIBhkL+////H4MgEEL/////D4N+fCIQNwMAIAQgECAEKQMAhUIoiSIQNwMAIAMgECADKQMAIhF8IBBC/////w+DIBFCAYZC/v///x+DfnwiEDcDACAOIBAgDikDAIVCMIkiEDcDACAJIBAgCSkDACIRfCAQQv////8PgyARQgGGQv7///8fg358IhA3AwAgBCAQIAQpAwCFQgGJNwMAC98aAQN/QQAhBEEAIAIpAwAgASkDAIU3A5AIQQAgAikDCCABKQMIhTcDmAhBACACKQMQIAEpAxCFNwOgCEEAIAIpAxggASkDGIU3A6gIQQAgAikDICABKQMghTcDsAhBACACKQMoIAEpAyiFNwO4CEEAIAIpAzAgASkDMIU3A8AIQQAgAikDOCABKQM4hTcDyAhBACACKQNAIAEpA0CFNwPQCEEAIAIpA0ggASkDSIU3A9gIQQAgAikDUCABKQNQhTcD4AhBACACKQNYIAEpA1iFNwPoCEEAIAIpA2AgASkDYIU3A/AIQQAgAikDaCABKQNohTcD+AhBACACKQNwIAEpA3CFNwOACUEAIAIpA3ggASkDeIU3A4gJQQAgAikDgAEgASkDgAGFNwOQCUEAIAIpA4gBIAEpA4gBhTcDmAlBACACKQOQASABKQOQAYU3A6AJQQAgAikDmAEgASkDmAGFNwOoCUEAIAIpA6ABIAEpA6ABhTcDsAlBACACKQOoASABKQOoAYU3A7gJQQAgAikDsAEgASkDsAGFNwPACUEAIAIpA7gBIAEpA7gBhTcDyAlBACACKQPAASABKQPAAYU3A9AJQQAgAikDyAEgASkDyAGFNwPYCUEAIAIpA9ABIAEpA9ABhTcD4AlBACACKQPYASABKQPYAYU3A+gJQQAgAikD4AEgASkD4AGFNwPwCUEAIAIpA+gBIAEpA+gBhTcD+AlBACACKQPwASABKQPwAYU3A4AKQQAgAikD+AEgASkD+AGFNwOICkEAIAIpA4ACIAEpA4AChTcDkApBACACKQOIAiABKQOIAoU3A5gKQQAgAikDkAIgASkDkAKFNwOgCkEAIAIpA5gCIAEpA5gChTcDqApBACACKQOgAiABKQOgAoU3A7AKQQAgAikDqAIgASkDqAKFNwO4CkEAIAIpA7ACIAEpA7AChTcDwApBACACKQO4AiABKQO4AoU3A8gKQQAgAikDwAIgASkDwAKFNwPQCkEAIAIpA8gCIAEpA8gChTcD2ApBACACKQPQAiABKQPQAoU3A+AKQQAgAikD2AIgASkD2AKFNwPoCkEAIAIpA+ACIAEpA+AChTcD8ApBACACKQPoAiABKQPoAoU3A/gKQQAgAikD8AIgASkD8AKFNwOAC0EAIAIpA/gCIAEpA/gChTcDiAtBACACKQOAAyABKQOAA4U3A5ALQQAgAikDiAMgASkDiAOFNwOYC0EAIAIpA5ADIAEpA5ADhTcDoAtBACACKQOYAyABKQOYA4U3A6gLQQAgAikDoAMgASkDoAOFNwOwC0EAIAIpA6gDIAEpA6gDhTcDuAtBACACKQOwAyABKQOwA4U3A8ALQQAgAikDuAMgASkDuAOFNwPIC0EAIAIpA8ADIAEpA8ADhTcD0AtBACACKQPIAyABKQPIA4U3A9gLQQAgAikD0AMgASkD0AOFNwPgC0EAIAIpA9gDIAEpA9gDhTcD6AtBACACKQPgAyABKQPgA4U3A/ALQQAgAikD6AMgASkD6AOFNwP4C0EAIAIpA/ADIAEpA/ADhTcDgAxBACACKQP4AyABKQP4A4U3A4gMQQAgAikDgAQgASkDgASFNwOQDEEAIAIpA4gEIAEpA4gEhTcDmAxBACACKQOQBCABKQOQBIU3A6AMQQAgAikDmAQgASkDmASFNwOoDEEAIAIpA6AEIAEpA6AEhTcDsAxBACACKQOoBCABKQOoBIU3A7gMQQAgAikDsAQgASkDsASFNwPADEEAIAIpA7gEIAEpA7gEhTcDyAxBACACKQPABCABKQPABIU3A9AMQQAgAikDyAQgASkDyASFNwPYDEEAIAIpA9AEIAEpA9AEhTcD4AxBACACKQPYBCABKQPYBIU3A+gMQQAgAikD4AQgASkD4ASFNwPwDEEAIAIpA+gEIAEpA+gEhTcD+AxBACACKQPwBCABKQPwBIU3A4ANQQAgAikD+AQgASkD+ASFNwOIDUEAIAIpA4AFIAEpA4AFhTcDkA1BACACKQOIBSABKQOIBYU3A5gNQQAgAikDkAUgASkDkAWFNwOgDUEAIAIpA5gFIAEpA5gFhTcDqA1BACACKQOgBSABKQOgBYU3A7ANQQAgAikDqAUgASkDqAWFNwO4DUEAIAIpA7AFIAEpA7AFhTcDwA1BACACKQO4BSABKQO4BYU3A8gNQQAgAikDwAUgASkDwAWFNwPQDUEAIAIpA8gFIAEpA8gFhTcD2A1BACACKQPQBSABKQPQBYU3A+ANQQAgAikD2AUgASkD2AWFNwPoDUEAIAIpA+AFIAEpA+AFhTcD8A1BACACKQPoBSABKQPoBYU3A/gNQQAgAikD8AUgASkD8AWFNwOADkEAIAIpA/gFIAEpA/gFhTcDiA5BACACKQOABiABKQOABoU3A5AOQQAgAikDiAYgASkDiAaFNwOYDkEAIAIpA5AGIAEpA5AGhTcDoA5BACACKQOYBiABKQOYBoU3A6gOQQAgAikDoAYgASkDoAaFNwOwDkEAIAIpA6gGIAEpA6gGhTcDuA5BACACKQOwBiABKQOwBoU3A8AOQQAgAikDuAYgASkDuAaFNwPIDkEAIAIpA8AGIAEpA8AGhTcD0A5BACACKQPIBiABKQPIBoU3A9gOQQAgAikD0AYgASkD0AaFNwPgDkEAIAIpA9gGIAEpA9gGhTcD6A5BACACKQPgBiABKQPgBoU3A/AOQQAgAikD6AYgASkD6AaFNwP4DkEAIAIpA/AGIAEpA/AGhTcDgA9BACACKQP4BiABKQP4BoU3A4gPQQAgAikDgAcgASkDgAeFNwOQD0EAIAIpA4gHIAEpA4gHhTcDmA9BACACKQOQByABKQOQB4U3A6APQQAgAikDmAcgASkDmAeFNwOoD0EAIAIpA6AHIAEpA6AHhTcDsA9BACACKQOoByABKQOoB4U3A7gPQQAgAikDsAcgASkDsAeFNwPAD0EAIAIpA7gHIAEpA7gHhTcDyA9BACACKQPAByABKQPAB4U3A9APQQAgAikDyAcgASkDyAeFNwPYD0EAIAIpA9AHIAEpA9AHhTcD4A9BACACKQPYByABKQPYB4U3A+gPQQAgAikD4AcgASkD4AeFNwPwD0EAIAIpA+gHIAEpA+gHhTcD+A9BACACKQPwByABKQPwB4U3A4AQQQAgAikD+AcgASkD+AeFNwOIEEGQCEGYCEGgCEGoCEGwCEG4CEHACEHICEHQCEHYCEHgCEHoCEHwCEH4CEGACUGICRACQZAJQZgJQaAJQagJQbAJQbgJQcAJQcgJQdAJQdgJQeAJQegJQfAJQfgJQYAKQYgKEAJBkApBmApBoApBqApBsApBuApBwApByApB0ApB2ApB4ApB6ApB8ApB+ApBgAtBiAsQAkGQC0GYC0GgC0GoC0GwC0G4C0HAC0HIC0HQC0HYC0HgC0HoC0HwC0H4C0GADEGIDBACQZAMQZgMQaAMQagMQbAMQbgMQcAMQcgMQdAMQdgMQeAMQegMQfAMQfgMQYANQYgNEAJBkA1BmA1BoA1BqA1BsA1BuA1BwA1ByA1B0A1B2A1B4A1B6A1B8A1B+A1BgA5BiA4QAkGQDkGYDkGgDkGoDkGwDkG4DkHADkHIDkHQDkHYDkHgDkHoDkHwDkH4DkGAD0GIDxACQZAPQZgPQaAPQagPQbAPQbgPQcAPQcgPQdAPQdgPQeAPQegPQfAPQfgPQYAQQYgQEAJBkAhBmAhBkAlBmAlBkApBmApBkAtBmAtBkAxBmAxBkA1BmA1BkA5BmA5BkA9BmA8QAkGgCEGoCEGgCUGoCUGgCkGoCkGgC0GoC0GgDEGoDEGgDUGoDUGgDkGoDkGgD0GoDxACQbAIQbgIQbAJQbgJQbAKQbgKQbALQbgLQbAMQbgMQbANQbgNQbAOQbgOQbAPQbgPEAJBwAhByAhBwAlByAlBwApByApBwAtByAtBwAxByAxBwA1ByA1BwA5ByA5BwA9ByA8QAkHQCEHYCEHQCUHYCUHQCkHYCkHQC0HYC0HQDEHYDEHQDUHYDUHQDkHYDkHQD0HYDxACQeAIQegIQeAJQegJQeAKQegKQeALQegLQeAMQegMQeANQegNQeAOQegOQeAPQegPEAJB8AhB+AhB8AlB+AlB8ApB+ApB8AtB+AtB8AxB+AxB8A1B+A1B8A5B+A5B8A9B+A8QAkGACUGICUGACkGICkGAC0GIC0GADEGIDEGADUGIDUGADkGIDkGAD0GID0GAEEGIEBACAkACQCADRQ0AA0AgACAEaiIDIAIgBGoiBSkDACABIARqIgYpAwCFIARBkAhqKQMAhSADKQMAhTcDACADQQhqIgMgBUEIaikDACAGQQhqKQMAhSAEQZgIaikDAIUgAykDAIU3AwAgBEEQaiIEQYAIRw0ADAILC0EAIQQDQCAAIARqIgMgAiAEaiIFKQMAIAEgBGoiBikDAIUgBEGQCGopAwCFNwMAIANBCGogBUEIaikDACAGQQhqKQMAhSAEQZgIaikDAIU3AwAgBEEQaiIEQYAIRw0ACwsL5QcMBX8BfgR/An4BfwF+AX8Bfgd/AX4DfwF+AkBBACgCgAgiAiABQQp0aiIDKAIIIAFHDQAgAygCDCEEIAMoAgAhBUEAIAMoAhQiBq03A7gQQQAgBK0iBzcDsBBBACAFIAEgBUECdG4iCGwiCUECdK03A6gQAkACQAJAAkAgBEUNAEF/IQogBUUNASAIQQNsIQsgCEECdCIErSEMIAWtIQ0gBkF/akECSSEOQgAhDwNAQQAgDzcDkBAgD6chEEIAIRFBACEBA0BBACARNwOgECAPIBGEUCIDIA5xIRIgBkEBRiAPUCITIAZBAkYgEUICVHFxciEUQX8gAUEBakEDcSAIbEF/aiATGyEVIAEgEHIhFiABIAhsIRcgA0EBdCEYQgAhGQNAQQBCADcDwBBBACAZNwOYECAYIQECQCASRQ0AQQBCATcDwBBBkBhBkBBBkCBBABADQZAYQZAYQZAgQQAQA0ECIQELAkAgASAITw0AIAQgGaciGmwgF2ogAWohAwNAIANBACAEIAEbQQAgEVAiGxtqQX9qIRwCQAJAIBQNAEEAKAKACCICIBxBCnQiHGohCgwBCwJAIAFB/wBxIgINAEEAQQApA8AQQgF8NwPAEEGQGEGQEEGQIEEAEANBkBhBkBhBkCBBABADCyAcQQp0IRwgAkEDdEGQGGohCkEAKAKACCECCyACIANBCnRqIAIgHGogAiAKKQMAIh1CIIinIAVwIBogFhsiHCAEbCABIAFBACAZIBytUSIcGyIKIBsbIBdqIAogC2ogExsgAUUgHHJrIhsgFWqtIB1C/////w+DIh0gHX5CIIggG61+QiCIfSAMgqdqQQp0akEBEAMgA0EBaiEDIAggAUEBaiIBRw0ACwsgGUIBfCIZIA1SDQALIBFCAXwiEachASARQgRSDQALIA9CAXwiDyAHUg0AC0EAKAKACCECCyAJQQx0QYB4aiEXIAVBf2oiCkUNAgwBC0EAQgM3A6AQQQAgBEF/aq03A5AQQYB4IRcLIAIgF2ohGyAIQQx0IQhBACEcA0AgCCAcQQFqIhxsQYB4aiEEQQAhAQNAIBsgAWoiAyADKQMAIAIgBCABamopAwCFNwMAIANBCGoiAyADKQMAIAIgBCABQQhyamopAwCFNwMAIAFBCGohAyABQRBqIQEgA0H4B0kNAAsgHCAKRw0ACwsgAiAXaiEbQXghAQNAIAIgAWoiA0EIaiAbIAFqIgRBCGopAwA3AwAgA0EQaiAEQRBqKQMANwMAIANBGGogBEEYaikDADcDACADQSBqIARBIGopAwA3AwAgAUEgaiIBQfgHSQ0ACwsL";
+var hash$k = "e4cdc523";
+var wasmJson$k = {
+	name: name$k,
+	data: data$k,
+	hash: hash$k
+};
+
+var name$j = "blake2b";
+var data$j = "AGFzbQEAAAABEQRgAAF/YAJ/fwBgAX8AYAAAAwoJAAECAwECAgABBQQBAQICBg4CfwFBsIsFC38AQYAICwdwCAZtZW1vcnkCAA5IYXNoX0dldEJ1ZmZlcgAACkhhc2hfRmluYWwAAwlIYXNoX0luaXQABQtIYXNoX1VwZGF0ZQAGDUhhc2hfR2V0U3RhdGUABw5IYXNoX0NhbGN1bGF0ZQAIClNUQVRFX1NJWkUDAQrTOAkFAEGACQvrAgIFfwF+AkAgAUEBSA0AAkACQAJAIAFBgAFBACgC4IoBIgJrIgNKDQAgASEEDAELQQBBADYC4IoBAkAgAkH/AEoNACACQeCJAWohBSAAIQRBACEGA0AgBSAELQAAOgAAIARBAWohBCAFQQFqIQUgAyAGQQFqIgZB/wFxSg0ACwtBAEEAKQPAiQEiB0KAAXw3A8CJAUEAQQApA8iJASAHQv9+Vq18NwPIiQFB4IkBEAIgACADaiEAAkAgASADayIEQYEBSA0AIAIgAWohBQNAQQBBACkDwIkBIgdCgAF8NwPAiQFBAEEAKQPIiQEgB0L/flatfDcDyIkBIAAQAiAAQYABaiEAIAVBgH9qIgVBgAJLDQALIAVBgH9qIQQMAQsgBEEATA0BC0EAIQUDQCAFQQAoAuCKAWpB4IkBaiAAIAVqLQAAOgAAIAQgBUEBaiIFQf8BcUoNAAsLQQBBACgC4IoBIARqNgLgigELC78uASR+QQBBACkD0IkBQQApA7CJASIBQQApA5CJAXwgACkDICICfCIDhULr+obav7X2wR+FQiCJIgRCq/DT9K/uvLc8fCIFIAGFQiiJIgYgA3wgACkDKCIBfCIHIASFQjCJIgggBXwiCSAGhUIBiSIKQQApA8iJAUEAKQOoiQEiBEEAKQOIiQF8IAApAxAiA3wiBYVCn9j52cKR2oKbf4VCIIkiC0K7zqqm2NDrs7t/fCIMIASFQiiJIg0gBXwgACkDGCIEfCIOfCAAKQNQIgV8Ig9BACkDwIkBQQApA6CJASIQQQApA4CJASIRfCAAKQMAIgZ8IhKFQtGFmu/6z5SH0QCFQiCJIhNCiJLznf/M+YTqAHwiFCAQhUIoiSIVIBJ8IAApAwgiEHwiFiAThUIwiSIXhUIgiSIYQQApA9iJAUEAKQO4iQEiE0EAKQOYiQF8IAApAzAiEnwiGYVC+cL4m5Gjs/DbAIVCIIkiGkLx7fT4paf9p6V/fCIbIBOFQiiJIhwgGXwgACkDOCITfCIZIBqFQjCJIhogG3wiG3wiHSAKhUIoiSIeIA98IAApA1giCnwiDyAYhUIwiSIYIB18Ih0gDiALhUIwiSIOIAx8Ih8gDYVCAYkiDCAWfCAAKQNAIgt8Ig0gGoVCIIkiFiAJfCIaIAyFQiiJIiAgDXwgACkDSCIJfCIhIBaFQjCJIhYgGyAchUIBiSIMIAd8IAApA2AiB3wiDSAOhUIgiSIOIBcgFHwiFHwiFyAMhUIoiSIbIA18IAApA2giDHwiHCAOhUIwiSIOIBd8IhcgG4VCAYkiGyAZIBQgFYVCAYkiFHwgACkDcCINfCIVIAiFQiCJIhkgH3wiHyAUhUIoiSIUIBV8IAApA3giCHwiFXwgDHwiIoVCIIkiI3wiJCAbhUIoiSIbICJ8IBJ8IiIgFyAYIBUgGYVCMIkiFSAffCIZIBSFQgGJIhQgIXwgDXwiH4VCIIkiGHwiFyAUhUIoiSIUIB98IAV8Ih8gGIVCMIkiGCAXfCIXIBSFQgGJIhR8IAF8IiEgFiAafCIWIBUgHSAehUIBiSIaIBx8IAl8IhyFQiCJIhV8Ih0gGoVCKIkiGiAcfCAIfCIcIBWFQjCJIhWFQiCJIh4gGSAOIBYgIIVCAYkiFiAPfCACfCIPhUIgiSIOfCIZIBaFQiiJIhYgD3wgC3wiDyAOhUIwiSIOIBl8Ihl8IiAgFIVCKIkiFCAhfCAEfCIhIB6FQjCJIh4gIHwiICAiICOFQjCJIiIgJHwiIyAbhUIBiSIbIBx8IAp8IhwgDoVCIIkiDiAXfCIXIBuFQiiJIhsgHHwgE3wiHCAOhUIwiSIOIBkgFoVCAYkiFiAffCAQfCIZICKFQiCJIh8gFSAdfCIVfCIdIBaFQiiJIhYgGXwgB3wiGSAfhUIwiSIfIB18Ih0gFoVCAYkiFiAVIBqFQgGJIhUgD3wgBnwiDyAYhUIgiSIYICN8IhogFYVCKIkiFSAPfCADfCIPfCAHfCIihUIgiSIjfCIkIBaFQiiJIhYgInwgBnwiIiAjhUIwiSIjICR8IiQgFoVCAYkiFiAOIBd8Ig4gDyAYhUIwiSIPICAgFIVCAYkiFCAZfCAKfCIXhUIgiSIYfCIZIBSFQiiJIhQgF3wgC3wiF3wgBXwiICAPIBp8Ig8gHyAOIBuFQgGJIg4gIXwgCHwiGoVCIIkiG3wiHyAOhUIoiSIOIBp8IAx8IhogG4VCMIkiG4VCIIkiISAdIB4gDyAVhUIBiSIPIBx8IAF8IhWFQiCJIhx8Ih0gD4VCKIkiDyAVfCADfCIVIByFQjCJIhwgHXwiHXwiHiAWhUIoiSIWICB8IA18IiAgIYVCMIkiISAefCIeIBogFyAYhUIwiSIXIBl8IhggFIVCAYkiFHwgCXwiGSAchUIgiSIaICR8IhwgFIVCKIkiFCAZfCACfCIZIBqFQjCJIhogHSAPhUIBiSIPICJ8IAR8Ih0gF4VCIIkiFyAbIB98Iht8Ih8gD4VCKIkiDyAdfCASfCIdIBeFQjCJIhcgH3wiHyAPhUIBiSIPIBsgDoVCAYkiDiAVfCATfCIVICOFQiCJIhsgGHwiGCAOhUIoiSIOIBV8IBB8IhV8IAx8IiKFQiCJIiN8IiQgD4VCKIkiDyAifCAHfCIiICOFQjCJIiMgJHwiJCAPhUIBiSIPIBogHHwiGiAVIBuFQjCJIhUgHiAWhUIBiSIWIB18IAR8IhuFQiCJIhx8Ih0gFoVCKIkiFiAbfCAQfCIbfCABfCIeIBUgGHwiFSAXIBogFIVCAYkiFCAgfCATfCIYhUIgiSIXfCIaIBSFQiiJIhQgGHwgCXwiGCAXhUIwiSIXhUIgiSIgIB8gISAVIA6FQgGJIg4gGXwgCnwiFYVCIIkiGXwiHyAOhUIoiSIOIBV8IA18IhUgGYVCMIkiGSAffCIffCIhIA+FQiiJIg8gHnwgBXwiHiAghUIwiSIgICF8IiEgGyAchUIwiSIbIB18IhwgFoVCAYkiFiAYfCADfCIYIBmFQiCJIhkgJHwiHSAWhUIoiSIWIBh8IBJ8IhggGYVCMIkiGSAfIA6FQgGJIg4gInwgAnwiHyAbhUIgiSIbIBcgGnwiF3wiGiAOhUIoiSIOIB98IAZ8Ih8gG4VCMIkiGyAafCIaIA6FQgGJIg4gFSAXIBSFQgGJIhR8IAh8IhUgI4VCIIkiFyAcfCIcIBSFQiiJIhQgFXwgC3wiFXwgBXwiIoVCIIkiI3wiJCAOhUIoiSIOICJ8IAh8IiIgGiAgIBUgF4VCMIkiFSAcfCIXIBSFQgGJIhQgGHwgCXwiGIVCIIkiHHwiGiAUhUIoiSIUIBh8IAZ8IhggHIVCMIkiHCAafCIaIBSFQgGJIhR8IAR8IiAgGSAdfCIZIBUgISAPhUIBiSIPIB98IAN8Ih2FQiCJIhV8Ih8gD4VCKIkiDyAdfCACfCIdIBWFQjCJIhWFQiCJIiEgFyAbIBkgFoVCAYkiFiAefCABfCIZhUIgiSIbfCIXIBaFQiiJIhYgGXwgE3wiGSAbhUIwiSIbIBd8Ihd8Ih4gFIVCKIkiFCAgfCAMfCIgICGFQjCJIiEgHnwiHiAiICOFQjCJIiIgJHwiIyAOhUIBiSIOIB18IBJ8Ih0gG4VCIIkiGyAafCIaIA6FQiiJIg4gHXwgC3wiHSAbhUIwiSIbIBcgFoVCAYkiFiAYfCANfCIXICKFQiCJIhggFSAffCIVfCIfIBaFQiiJIhYgF3wgEHwiFyAYhUIwiSIYIB98Ih8gFoVCAYkiFiAVIA+FQgGJIg8gGXwgCnwiFSAchUIgiSIZICN8IhwgD4VCKIkiDyAVfCAHfCIVfCASfCIihUIgiSIjfCIkIBaFQiiJIhYgInwgBXwiIiAjhUIwiSIjICR8IiQgFoVCAYkiFiAbIBp8IhogFSAZhUIwiSIVIB4gFIVCAYkiFCAXfCADfCIXhUIgiSIZfCIbIBSFQiiJIhQgF3wgB3wiF3wgAnwiHiAVIBx8IhUgGCAaIA6FQgGJIg4gIHwgC3wiGoVCIIkiGHwiHCAOhUIoiSIOIBp8IAR8IhogGIVCMIkiGIVCIIkiICAfICEgFSAPhUIBiSIPIB18IAZ8IhWFQiCJIh18Ih8gD4VCKIkiDyAVfCAKfCIVIB2FQjCJIh0gH3wiH3wiISAWhUIoiSIWIB58IAx8Ih4gIIVCMIkiICAhfCIhIBogFyAZhUIwiSIXIBt8IhkgFIVCAYkiFHwgEHwiGiAdhUIgiSIbICR8Ih0gFIVCKIkiFCAafCAJfCIaIBuFQjCJIhsgHyAPhUIBiSIPICJ8IBN8Ih8gF4VCIIkiFyAYIBx8Ihh8IhwgD4VCKIkiDyAffCABfCIfIBeFQjCJIhcgHHwiHCAPhUIBiSIPIBggDoVCAYkiDiAVfCAIfCIVICOFQiCJIhggGXwiGSAOhUIoiSIOIBV8IA18IhV8IA18IiKFQiCJIiN8IiQgD4VCKIkiDyAifCAMfCIiICOFQjCJIiMgJHwiJCAPhUIBiSIPIBsgHXwiGyAVIBiFQjCJIhUgISAWhUIBiSIWIB98IBB8IhiFQiCJIh18Ih8gFoVCKIkiFiAYfCAIfCIYfCASfCIhIBUgGXwiFSAXIBsgFIVCAYkiFCAefCAHfCIZhUIgiSIXfCIbIBSFQiiJIhQgGXwgAXwiGSAXhUIwiSIXhUIgiSIeIBwgICAVIA6FQgGJIg4gGnwgAnwiFYVCIIkiGnwiHCAOhUIoiSIOIBV8IAV8IhUgGoVCMIkiGiAcfCIcfCIgIA+FQiiJIg8gIXwgBHwiISAehUIwiSIeICB8IiAgGCAdhUIwiSIYIB98Ih0gFoVCAYkiFiAZfCAGfCIZIBqFQiCJIhogJHwiHyAWhUIoiSIWIBl8IBN8IhkgGoVCMIkiGiAcIA6FQgGJIg4gInwgCXwiHCAYhUIgiSIYIBcgG3wiF3wiGyAOhUIoiSIOIBx8IAN8IhwgGIVCMIkiGCAbfCIbIA6FQgGJIg4gFSAXIBSFQgGJIhR8IAt8IhUgI4VCIIkiFyAdfCIdIBSFQiiJIhQgFXwgCnwiFXwgBHwiIoVCIIkiI3wiJCAOhUIoiSIOICJ8IAl8IiIgGyAeIBUgF4VCMIkiFSAdfCIXIBSFQgGJIhQgGXwgDHwiGYVCIIkiHXwiGyAUhUIoiSIUIBl8IAp8IhkgHYVCMIkiHSAbfCIbIBSFQgGJIhR8IAN8Ih4gGiAffCIaIBUgICAPhUIBiSIPIBx8IAd8IhyFQiCJIhV8Ih8gD4VCKIkiDyAcfCAQfCIcIBWFQjCJIhWFQiCJIiAgFyAYIBogFoVCAYkiFiAhfCATfCIahUIgiSIYfCIXIBaFQiiJIhYgGnwgDXwiGiAYhUIwiSIYIBd8Ihd8IiEgFIVCKIkiFCAefCAFfCIeICCFQjCJIiAgIXwiISAiICOFQjCJIiIgJHwiIyAOhUIBiSIOIBx8IAt8IhwgGIVCIIkiGCAbfCIbIA6FQiiJIg4gHHwgEnwiHCAYhUIwiSIYIBcgFoVCAYkiFiAZfCABfCIXICKFQiCJIhkgFSAffCIVfCIfIBaFQiiJIhYgF3wgBnwiFyAZhUIwiSIZIB98Ih8gFoVCAYkiFiAVIA+FQgGJIg8gGnwgCHwiFSAdhUIgiSIaICN8Ih0gD4VCKIkiDyAVfCACfCIVfCANfCIihUIgiSIjfCIkIBaFQiiJIhYgInwgCXwiIiAjhUIwiSIjICR8IiQgFoVCAYkiFiAYIBt8IhggFSAahUIwiSIVICEgFIVCAYkiFCAXfCASfCIXhUIgiSIafCIbIBSFQiiJIhQgF3wgCHwiF3wgB3wiISAVIB18IhUgGSAYIA6FQgGJIg4gHnwgBnwiGIVCIIkiGXwiHSAOhUIoiSIOIBh8IAt8IhggGYVCMIkiGYVCIIkiHiAfICAgFSAPhUIBiSIPIBx8IAp8IhWFQiCJIhx8Ih8gD4VCKIkiDyAVfCAEfCIVIByFQjCJIhwgH3wiH3wiICAWhUIoiSIWICF8IAN8IiEgHoVCMIkiHiAgfCIgIBggFyAahUIwiSIXIBt8IhogFIVCAYkiFHwgBXwiGCAchUIgiSIbICR8IhwgFIVCKIkiFCAYfCABfCIYIBuFQjCJIhsgHyAPhUIBiSIPICJ8IAx8Ih8gF4VCIIkiFyAZIB18Ihl8Ih0gD4VCKIkiDyAffCATfCIfIBeFQjCJIhcgHXwiHSAPhUIBiSIPIBkgDoVCAYkiDiAVfCAQfCIVICOFQiCJIhkgGnwiGiAOhUIoiSIOIBV8IAJ8IhV8IBN8IiKFQiCJIiN8IiQgD4VCKIkiDyAifCASfCIiICOFQjCJIiMgJHwiJCAPhUIBiSIPIBsgHHwiGyAVIBmFQjCJIhUgICAWhUIBiSIWIB98IAt8IhmFQiCJIhx8Ih8gFoVCKIkiFiAZfCACfCIZfCAJfCIgIBUgGnwiFSAXIBsgFIVCAYkiFCAhfCAFfCIahUIgiSIXfCIbIBSFQiiJIhQgGnwgA3wiGiAXhUIwiSIXhUIgiSIhIB0gHiAVIA6FQgGJIg4gGHwgEHwiFYVCIIkiGHwiHSAOhUIoiSIOIBV8IAF8IhUgGIVCMIkiGCAdfCIdfCIeIA+FQiiJIg8gIHwgDXwiICAhhUIwiSIhIB58Ih4gGSAchUIwiSIZIB98IhwgFoVCAYkiFiAafCAIfCIaIBiFQiCJIhggJHwiHyAWhUIoiSIWIBp8IAp8IhogGIVCMIkiGCAdIA6FQgGJIg4gInwgBHwiHSAZhUIgiSIZIBcgG3wiF3wiGyAOhUIoiSIOIB18IAd8Ih0gGYVCMIkiGSAbfCIbIA6FQgGJIg4gFSAXIBSFQgGJIhR8IAx8IhUgI4VCIIkiFyAcfCIcIBSFQiiJIhQgFXwgBnwiFXwgEnwiIoVCIIkiI3wiJCAOhUIoiSIOICJ8IBN8IiIgGyAhIBUgF4VCMIkiFSAcfCIXIBSFQgGJIhQgGnwgBnwiGoVCIIkiHHwiGyAUhUIoiSIUIBp8IBB8IhogHIVCMIkiHCAbfCIbIBSFQgGJIhR8IA18IiEgGCAffCIYIBUgHiAPhUIBiSIPIB18IAJ8Ih2FQiCJIhV8Ih4gD4VCKIkiDyAdfCABfCIdIBWFQjCJIhWFQiCJIh8gFyAZIBggFoVCAYkiFiAgfCADfCIYhUIgiSIZfCIXIBaFQiiJIhYgGHwgBHwiGCAZhUIwiSIZIBd8Ihd8IiAgFIVCKIkiFCAhfCAIfCIhIB+FQjCJIh8gIHwiICAiICOFQjCJIiIgJHwiIyAOhUIBiSIOIB18IAd8Ih0gGYVCIIkiGSAbfCIbIA6FQiiJIg4gHXwgDHwiHSAZhUIwiSIZIBcgFoVCAYkiFiAafCALfCIXICKFQiCJIhogFSAefCIVfCIeIBaFQiiJIhYgF3wgCXwiFyAahUIwiSIaIB58Ih4gFoVCAYkiFiAVIA+FQgGJIg8gGHwgBXwiFSAchUIgiSIYICN8IhwgD4VCKIkiDyAVfCAKfCIVfCACfCIChUIgiSIifCIjIBaFQiiJIhYgAnwgC3wiAiAihUIwiSILICN8IiIgFoVCAYkiFiAZIBt8IhkgFSAYhUIwiSIVICAgFIVCAYkiFCAXfCANfCINhUIgiSIXfCIYIBSFQiiJIhQgDXwgBXwiBXwgEHwiECAVIBx8Ig0gGiAZIA6FQgGJIg4gIXwgDHwiDIVCIIkiFXwiGSAOhUIoiSIOIAx8IBJ8IhIgFYVCMIkiDIVCIIkiFSAeIB8gDSAPhUIBiSINIB18IAl8IgmFQiCJIg98IhogDYVCKIkiDSAJfCAIfCIJIA+FQjCJIgggGnwiD3wiGiAWhUIoiSIWIBB8IAd8IhAgEYUgDCAZfCIHIA6FQgGJIgwgCXwgCnwiCiALhUIgiSILIAUgF4VCMIkiBSAYfCIJfCIOIAyFQiiJIgwgCnwgE3wiEyALhUIwiSIKIA58IguFNwOAiQFBACADIAYgDyANhUIBiSINIAJ8fCICIAWFQiCJIgUgB3wiBiANhUIoiSIHIAJ8fCICQQApA4iJAYUgBCABIBIgCSAUhUIBiSIDfHwiASAIhUIgiSISICJ8IgkgA4VCKIkiAyABfHwiASAShUIwiSIEIAl8IhKFNwOIiQFBACATQQApA5CJAYUgECAVhUIwiSIQIBp8IhOFNwOQiQFBACABQQApA5iJAYUgAiAFhUIwiSICIAZ8IgGFNwOYiQFBACASIAOFQgGJQQApA6CJAYUgAoU3A6CJAUEAIBMgFoVCAYlBACkDqIkBhSAKhTcDqIkBQQAgASAHhUIBiUEAKQOwiQGFIASFNwOwiQFBACALIAyFQgGJQQApA7iJAYUgEIU3A7iJAQvdAgUBfwF+AX8BfgJ/IwBBwABrIgAkAAJAQQApA9CJAUIAUg0AQQBBACkDwIkBIgFBACgC4IoBIgKsfCIDNwPAiQFBAEEAKQPIiQEgAyABVK18NwPIiQECQEEALQDoigFFDQBBAEJ/NwPYiQELQQBCfzcD0IkBAkAgAkH/AEoNAEEAIQQDQCACIARqQeCJAWpBADoAACAEQQFqIgRBgAFBACgC4IoBIgJrSA0ACwtB4IkBEAIgAEEAKQOAiQE3AwAgAEEAKQOIiQE3AwggAEEAKQOQiQE3AxAgAEEAKQOYiQE3AxggAEEAKQOgiQE3AyAgAEEAKQOoiQE3AyggAEEAKQOwiQE3AzAgAEEAKQO4iQE3AzhBACgC5IoBIgVBAUgNAEEAIQRBACECA0AgBEGACWogACAEai0AADoAACAEQQFqIQQgBSACQQFqIgJB/wFxSg0ACwsgAEHAAGokAAv9AwMBfwF+AX8jAEGAAWsiAiQAQQBBgQI7AfKKAUEAIAE6APGKAUEAIAA6APCKAUGQfiEAA0AgAEGAiwFqQgA3AAAgAEH4igFqQgA3AAAgAEHwigFqQgA3AAAgAEEYaiIADQALQQAhAEEAQQApA/CKASIDQoiS853/zPmE6gCFNwOAiQFBAEEAKQP4igFCu86qptjQ67O7f4U3A4iJAUEAQQApA4CLAUKr8NP0r+68tzyFNwOQiQFBAEEAKQOIiwFC8e30+KWn/aelf4U3A5iJAUEAQQApA5CLAULRhZrv+s+Uh9EAhTcDoIkBQQBBACkDmIsBQp/Y+dnCkdqCm3+FNwOoiQFBAEEAKQOgiwFC6/qG2r+19sEfhTcDsIkBQQBBACkDqIsBQvnC+JuRo7Pw2wCFNwO4iQFBACADp0H/AXE2AuSKAQJAIAFBAUgNACACQgA3A3ggAkIANwNwIAJCADcDaCACQgA3A2AgAkIANwNYIAJCADcDUCACQgA3A0ggAkIANwNAIAJCADcDOCACQgA3AzAgAkIANwMoIAJCADcDICACQgA3AxggAkIANwMQIAJCADcDCCACQgA3AwBBACEEA0AgAiAAaiAAQYAJai0AADoAACAAQQFqIQAgBEEBaiIEQf8BcSABSA0ACyACQYABEAELIAJBgAFqJAALEgAgAEEDdkH/P3EgAEEQdhAECwkAQYAJIAAQAQsGAEGAiQELGwAgAUEDdkH/P3EgAUEQdhAEQYAJIAAQARADCwsLAQBBgAgLBPAAAAA=";
+var hash$j = "c6f286e6";
+var wasmJson$j = {
+	name: name$j,
+	data: data$j,
+	hash: hash$j
+};
+
+const mutex$k = new Mutex();
+let wasmCache$k = null;
+function validateBits$4(bits) {
+    if (!Number.isInteger(bits) || bits < 8 || bits > 512 || bits % 8 !== 0) {
+        return new Error("Invalid variant! Valid values: 8, 16, ..., 512");
+    }
+    return null;
+}
+function getInitParam$1(outputBits, keyBits) {
+    return outputBits | (keyBits << 16);
+}
+/**
+ * Calculates BLAKE2b hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param bits Number of output bits, which has to be a number
+ *             divisible by 8, between 8 and 512. Defaults to 512.
+ * @param key Optional key (string, Buffer or TypedArray). Maximum length is 64 bytes.
+ * @returns Computed hash as a hexadecimal string
+ */
+function blake2b(data, bits = 512, key = null) {
+    if (validateBits$4(bits)) {
+        return Promise.reject(validateBits$4(bits));
+    }
+    let keyBuffer = null;
+    let initParam = bits;
+    if (key !== null) {
+        keyBuffer = getUInt8Buffer(key);
+        if (keyBuffer.length > 64) {
+            return Promise.reject(new Error("Max key length is 64 bytes"));
+        }
+        initParam = getInitParam$1(bits, keyBuffer.length);
+    }
+    const hashLength = bits / 8;
+    if (wasmCache$k === null || wasmCache$k.hashLength !== hashLength) {
+        return lockedCreate(mutex$k, wasmJson$j, hashLength).then((wasm) => {
+            wasmCache$k = wasm;
+            if (initParam > 512) {
+                wasmCache$k.writeMemory(keyBuffer);
+            }
+            return wasmCache$k.calculate(data, initParam);
+        });
+    }
+    try {
+        if (initParam > 512) {
+            wasmCache$k.writeMemory(keyBuffer);
+        }
+        const hash = wasmCache$k.calculate(data, initParam);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new BLAKE2b hash instance
+ * @param bits Number of output bits, which has to be a number
+ *             divisible by 8, between 8 and 512. Defaults to 512.
+ * @param key Optional key (string, Buffer or TypedArray). Maximum length is 64 bytes.
+ */
+function createBLAKE2b(bits = 512, key = null) {
+    if (validateBits$4(bits)) {
+        return Promise.reject(validateBits$4(bits));
+    }
+    let keyBuffer = null;
+    let initParam = bits;
+    if (key !== null) {
+        keyBuffer = getUInt8Buffer(key);
+        if (keyBuffer.length > 64) {
+            return Promise.reject(new Error("Max key length is 64 bytes"));
+        }
+        initParam = getInitParam$1(bits, keyBuffer.length);
+    }
+    const outputSize = bits / 8;
+    return WASMInterface(wasmJson$j, outputSize).then((wasm) => {
+        if (initParam > 512) {
+            wasm.writeMemory(keyBuffer);
+        }
+        wasm.init(initParam);
+        const obj = {
+            init: initParam > 512
+                ? () => {
+                    wasm.writeMemory(keyBuffer);
+                    wasm.init(initParam);
+                    return obj;
+                }
+                : () => {
+                    wasm.init(initParam);
+                    return obj;
+                },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 128,
+            digestSize: outputSize,
+        };
+        return obj;
+    });
+}
+
+function encodeResult(salt, options, res) {
+    const parameters = [
+        `m=${options.memorySize}`,
+        `t=${options.iterations}`,
+        `p=${options.parallelism}`,
+    ].join(",");
+    return `$argon2${options.hashType}$v=19$${parameters}$${encodeBase64(salt, false)}$${encodeBase64(res, false)}`;
+}
+const uint32View = new DataView(new ArrayBuffer(4));
+function int32LE(x) {
+    uint32View.setInt32(0, x, true);
+    return new Uint8Array(uint32View.buffer);
+}
+function hashFunc(blake512, buf, len) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (len <= 64) {
+            const blake = yield createBLAKE2b(len * 8);
+            blake.update(int32LE(len));
+            blake.update(buf);
+            return blake.digest("binary");
+        }
+        const r = Math.ceil(len / 32) - 2;
+        const ret = new Uint8Array(len);
+        blake512.init();
+        blake512.update(int32LE(len));
+        blake512.update(buf);
+        let vp = blake512.digest("binary");
+        ret.set(vp.subarray(0, 32), 0);
+        for (let i = 1; i < r; i++) {
+            blake512.init();
+            blake512.update(vp);
+            vp = blake512.digest("binary");
+            ret.set(vp.subarray(0, 32), i * 32);
+        }
+        const partialBytesNeeded = len - 32 * r;
+        let blakeSmall;
+        if (partialBytesNeeded === 64) {
+            blakeSmall = blake512;
+            blakeSmall.init();
+        }
+        else {
+            blakeSmall = yield createBLAKE2b(partialBytesNeeded * 8);
+        }
+        blakeSmall.update(vp);
+        vp = blakeSmall.digest("binary");
+        ret.set(vp.subarray(0, partialBytesNeeded), r * 32);
+        return ret;
+    });
+}
+function getHashType(type) {
+    switch (type) {
+        case "d":
+            return 0;
+        case "i":
+            return 1;
+        default:
+            return 2;
+    }
+}
+function argon2Internal(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var _a;
+        const { parallelism, iterations, hashLength } = options;
+        const password = getUInt8Buffer(options.password);
+        const salt = getUInt8Buffer(options.salt);
+        const version = 0x13;
+        const hashType = getHashType(options.hashType);
+        const { memorySize } = options; // in KB
+        const secret = getUInt8Buffer((_a = options.secret) !== null && _a !== void 0 ? _a : "");
+        const [argon2Interface, blake512] = yield Promise.all([
+            WASMInterface(wasmJson$k, 1024),
+            createBLAKE2b(512),
+        ]);
+        // last block is for storing the init vector
+        argon2Interface.setMemorySize(memorySize * 1024 + 1024);
+        const initVector = new Uint8Array(24);
+        const initVectorView = new DataView(initVector.buffer);
+        initVectorView.setInt32(0, parallelism, true);
+        initVectorView.setInt32(4, hashLength, true);
+        initVectorView.setInt32(8, memorySize, true);
+        initVectorView.setInt32(12, iterations, true);
+        initVectorView.setInt32(16, version, true);
+        initVectorView.setInt32(20, hashType, true);
+        argon2Interface.writeMemory(initVector, memorySize * 1024);
+        blake512.init();
+        blake512.update(initVector);
+        blake512.update(int32LE(password.length));
+        blake512.update(password);
+        blake512.update(int32LE(salt.length));
+        blake512.update(salt);
+        blake512.update(int32LE(secret.length));
+        blake512.update(secret);
+        blake512.update(int32LE(0)); // associatedData length + associatedData
+        const segments = Math.floor(memorySize / (parallelism * 4)); // length of each lane
+        const lanes = segments * 4;
+        const param = new Uint8Array(72);
+        const H0 = blake512.digest("binary");
+        param.set(H0);
+        for (let lane = 0; lane < parallelism; lane++) {
+            param.set(int32LE(0), 64);
+            param.set(int32LE(lane), 68);
+            let position = lane * lanes;
+            let chunk = yield hashFunc(blake512, param, 1024);
+            argon2Interface.writeMemory(chunk, position * 1024);
+            position += 1;
+            param.set(int32LE(1), 64);
+            chunk = yield hashFunc(blake512, param, 1024);
+            argon2Interface.writeMemory(chunk, position * 1024);
+        }
+        const C = new Uint8Array(1024);
+        writeHexToUInt8(C, argon2Interface.calculate(new Uint8Array([]), memorySize));
+        const res = yield hashFunc(blake512, C, hashLength);
+        if (options.outputType === "hex") {
+            const digestChars = new Uint8Array(hashLength * 2);
+            return getDigestHex(digestChars, res, hashLength);
+        }
+        if (options.outputType === "encoded") {
+            return encodeResult(salt, options, res);
+        }
+        // return binary format
+        return res;
+    });
+}
+const validateOptions$3 = (options) => {
+    var _a;
+    if (!options || typeof options !== "object") {
+        throw new Error("Invalid options parameter. It requires an object.");
+    }
+    if (!options.password) {
+        throw new Error("Password must be specified");
+    }
+    options.password = getUInt8Buffer(options.password);
+    if (options.password.length < 1) {
+        throw new Error("Password must be specified");
+    }
+    if (!options.salt) {
+        throw new Error("Salt must be specified");
+    }
+    options.salt = getUInt8Buffer(options.salt);
+    if (options.salt.length < 8) {
+        throw new Error("Salt should be at least 8 bytes long");
+    }
+    options.secret = getUInt8Buffer((_a = options.secret) !== null && _a !== void 0 ? _a : "");
+    if (!Number.isInteger(options.iterations) || options.iterations < 1) {
+        throw new Error("Iterations should be a positive number");
+    }
+    if (!Number.isInteger(options.parallelism) || options.parallelism < 1) {
+        throw new Error("Parallelism should be a positive number");
+    }
+    if (!Number.isInteger(options.hashLength) || options.hashLength < 4) {
+        throw new Error("Hash length should be at least 4 bytes.");
+    }
+    if (!Number.isInteger(options.memorySize)) {
+        throw new Error("Memory size should be specified.");
+    }
+    if (options.memorySize < 8 * options.parallelism) {
+        throw new Error("Memory size should be at least 8 * parallelism.");
+    }
+    if (options.outputType === undefined) {
+        options.outputType = "hex";
+    }
+    if (!["hex", "binary", "encoded"].includes(options.outputType)) {
+        throw new Error(`Insupported output type ${options.outputType}. Valid values: ['hex', 'binary', 'encoded']`);
+    }
+};
+/**
+ * Calculates hash using the argon2i password-hashing function
+ * @returns Computed hash
+ */
+function argon2i(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateOptions$3(options);
+        return argon2Internal(Object.assign(Object.assign({}, options), { hashType: "i" }));
+    });
+}
+/**
+ * Calculates hash using the argon2id password-hashing function
+ * @returns Computed hash
+ */
+function argon2id(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateOptions$3(options);
+        return argon2Internal(Object.assign(Object.assign({}, options), { hashType: "id" }));
+    });
+}
+/**
+ * Calculates hash using the argon2d password-hashing function
+ * @returns Computed hash
+ */
+function argon2d(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateOptions$3(options);
+        return argon2Internal(Object.assign(Object.assign({}, options), { hashType: "d" }));
+    });
+}
+const getHashParameters = (password, encoded, secret) => {
+    const regex = /^\$argon2(id|i|d)\$v=([0-9]+)\$((?:[mtp]=[0-9]+,){2}[mtp]=[0-9]+)\$([A-Za-z0-9+/]+)\$([A-Za-z0-9+/]+)$/;
+    const match = encoded.match(regex);
+    if (!match) {
+        throw new Error("Invalid hash");
+    }
+    const [, hashType, version, parameters, salt, hash] = match;
+    if (version !== "19") {
+        throw new Error(`Unsupported version: ${version}`);
+    }
+    const parsedParameters = {};
+    const paramMap = { m: "memorySize", p: "parallelism", t: "iterations" };
+    for (const x of parameters.split(",")) {
+        const [n, v] = x.split("=");
+        parsedParameters[paramMap[n]] = Number(v);
+    }
+    return Object.assign(Object.assign({}, parsedParameters), { password,
+        secret, hashType: hashType, salt: decodeBase64(salt), hashLength: getDecodeBase64Length(hash), outputType: "encoded" });
+};
+const validateVerifyOptions$1 = (options) => {
+    if (!options || typeof options !== "object") {
+        throw new Error("Invalid options parameter. It requires an object.");
+    }
+    if (options.hash === undefined || typeof options.hash !== "string") {
+        throw new Error("Hash should be specified");
+    }
+};
+/**
+ * Verifies password using the argon2 password-hashing function
+ * @returns True if the encoded hash matches the password
+ */
+function argon2Verify(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateVerifyOptions$1(options);
+        const params = getHashParameters(options.password, options.hash, options.secret);
+        validateOptions$3(params);
+        const hashStart = options.hash.lastIndexOf("$") + 1;
+        const result = (yield argon2Internal(params));
+        return result.substring(hashStart) === options.hash.substring(hashStart);
+    });
+}
+
+var name$i = "blake2s";
+var data$i = "AGFzbQEAAAABEQRgAAF/YAJ/fwBgAX8AYAAAAwkIAAECAwICAAEFBAEBAgIGDgJ/AUGgigULfwBBgAgLB3AIBm1lbW9yeQIADkhhc2hfR2V0QnVmZmVyAAAKSGFzaF9GaW5hbAADCUhhc2hfSW5pdAAEC0hhc2hfVXBkYXRlAAUNSGFzaF9HZXRTdGF0ZQAGDkhhc2hfQ2FsY3VsYXRlAAcKU1RBVEVfU0laRQMBCr4yCAUAQYAJC6gFAQZ/AkAgAUEBSA0AAkACQAJAIAFBwABBACgC8IkBIgJrIgNKDQAgASEDDAELQQBBADYC8IkBAkAgAkHAAEYNACACQbCJAWohBAJAAkAgA0EHcSIFDQAgACEGIAMhBwwBCyAFIQcgACEGA0AgBCAGLQAAOgAAIARBAWohBCAGQQFqIQYgB0F/aiIHDQALQcAAIAIgBWprIQcLIAJBR2pBB0kNAANAIAQgBi0AADoAACAEIAYtAAE6AAEgBCAGLQACOgACIAQgBi0AAzoAAyAEIAYtAAQ6AAQgBCAGLQAFOgAFIAQgBi0ABjoABiAEIAYtAAc6AAcgBEEIaiEEIAZBCGohBiAHQXhqIgcNAAsLQQAhBEEAQQAoAqCJASIGQcAAajYCoIkBQQBBACgCpIkBIAZBv39LajYCpIkBQbCJARACIAAgA2ohAAJAIAEgA2siA0HBAEgNACACIAFqIQQDQEEAQQAoAqCJASIGQcAAajYCoIkBQQBBACgCpIkBIAZBv39LajYCpIkBIAAQAiAAQcAAaiEAIAQiBkFAaiIEQYABSw0ACyAGQYB/aiEDQQAoAvCJASECDAELQQAoAvCJASECIANFDQELIANBf2ohASACQbCJAWohBAJAAkAgA0EHcSIGDQAgAyEHDAELIANBeHEhBwNAIAQgAC0AADoAACAEQQFqIQQgAEEBaiEAIAZBf2oiBg0ACwsCQCABQQdJDQADQCAEIAAtAAA6AAAgBCAALQABOgABIAQgAC0AAjoAAiAEIAAtAAM6AAMgBCAALQAEOgAEIAQgAC0ABToABSAEIAAtAAY6AAYgBCAALQAHOgAHIARBCGohBCAAQQhqIQAgB0F4aiIHDQALC0EAKALwiQEhAiADIQQLQQAgAiAEajYC8IkBCwuXJwoBfgF/An4CfwF+B38DfgZ/AX4Sf0EAQQApA5iJASIBpyICQQApA4iJASIDp2ogACkDECIEpyIFaiIGQQApA6iJAUKrs4/8kaOz8NsAhSIHp3NBEHciCEHy5rvjA2oiCSACc0EUdyIKIAZqIARCIIinIgJqIgsgCHNBGHciDCAJaiINIApzQRl3Ig5BACkDkIkBIgRCIIinIghBACkDgIkBIg9CIIinaiAAKQMIIhCnIgZqIglBACkDoIkBQv+kuYjFkdqCm3+FIhFCIIinc0EQdyISQYXdntt7aiITIAhzQRR3IhQgCWogEEIgiKciCGoiFWogACkDKCIQpyIJaiIWIASnIhcgD6dqIAApAwAiGKciCmoiGSARp3NBEHciGkHnzKfQBmoiGyAXc0EUdyIcIBlqIBhCIIinIhdqIh0gGnNBGHciHnNBEHciHyABQiCIpyIaIANCIIinaiAAKQMYIgGnIhlqIiAgB0IgiKdzQRB3IiFBuuq/qnpqIiIgGnNBFHciIyAgaiABQiCIpyIaaiIgICFzQRh3IiEgImoiImoiJCAOc0EUdyIlIBZqIBBCIIinIg5qIhYgH3NBGHciHyAkaiIkIBUgEnNBGHciFSATaiImIBRzQRl3IhMgHWogACkDICIBpyISaiIUICFzQRB3Ih0gDWoiISATc0EUdyInIBRqIAFCIIinIg1qIhQgHXNBGHciHSAiICNzQRl3IhMgC2ogACkDMCIBpyILaiIiIBVzQRB3IhUgHiAbaiIbaiIeIBNzQRR3IiMgImogAUIgiKciE2oiIiAVc0EYdyIVIB5qIh4gI3NBGXciIyAgIBsgHHNBGXciG2ogACkDOCIBpyIAaiIcIAxzQRB3IiAgJmoiJiAbc0EUdyIbIBxqIAFCIIinIgxqIhxqIBNqIihzQRB3IilqIiogI3NBFHciIyAoaiAZaiIoIB4gHyAcICBzQRh3IhwgJmoiICAbc0EZdyIbIBRqIABqIhRzQRB3Ih9qIh4gG3NBFHciGyAUaiAJaiIUIB9zQRh3Ih8gHmoiHiAbc0EZdyIbaiACaiImIB0gIWoiHSAcICQgJXNBGXciISAiaiANaiIic0EQdyIcaiIkICFzQRR3IiEgImogDGoiIiAcc0EYdyIcc0EQdyIlICAgFSAdICdzQRl3Ih0gFmogBWoiFnNBEHciFWoiICAdc0EUdyIdIBZqIBJqIhYgFXNBGHciFSAgaiIgaiInIBtzQRR3IhsgJmogCGoiJiAlc0EYdyIlICdqIicgKCApc0EYdyIoICpqIikgI3NBGXciIyAiaiAOaiIiIBVzQRB3IhUgHmoiHiAjc0EUdyIjICJqIBpqIiIgFXNBGHciFSAgIB1zQRl3Ih0gFGogF2oiFCAoc0EQdyIgIBwgJGoiHGoiJCAdc0EUdyIdIBRqIAtqIhQgIHNBGHciICAkaiIkIB1zQRl3Ih0gHCAhc0EZdyIcIBZqIApqIhYgH3NBEHciHyApaiIhIBxzQRR3IhwgFmogBmoiFmogC2oiKHNBEHciKWoiKiAdc0EUdyIdIChqIApqIiggKXNBGHciKSAqaiIqIB1zQRl3Ih0gFSAeaiIVIBYgH3NBGHciFiAnIBtzQRl3IhsgFGogDmoiFHNBEHciHmoiHyAbc0EUdyIbIBRqIBJqIhRqIAlqIicgFiAhaiIWICAgFSAjc0EZdyIVICZqIAxqIiFzQRB3IiBqIiMgFXNBFHciFSAhaiATaiIhICBzQRh3IiBzQRB3IiYgJCAlIBYgHHNBGXciFiAiaiACaiIcc0EQdyIiaiIkIBZzQRR3IhYgHGogBmoiHCAic0EYdyIiICRqIiRqIiUgHXNBFHciHSAnaiAAaiInICZzQRh3IiYgJWoiJSAhIBQgHnNBGHciFCAfaiIeIBtzQRl3IhtqIA1qIh8gInNBEHciISAqaiIiIBtzQRR3IhsgH2ogBWoiHyAhc0EYdyIhICQgFnNBGXciFiAoaiAIaiIkIBRzQRB3IhQgICAjaiIgaiIjIBZzQRR3IhYgJGogGWoiJCAUc0EYdyIUICNqIiMgFnNBGXciFiAgIBVzQRl3IhUgHGogGmoiHCApc0EQdyIgIB5qIh4gFXNBFHciFSAcaiAXaiIcaiATaiIoc0EQdyIpaiIqIBZzQRR3IhYgKGogC2oiKCApc0EYdyIpICpqIiogFnNBGXciFiAhICJqIiEgHCAgc0EYdyIcICUgHXNBGXciHSAkaiAIaiIgc0EQdyIiaiIkIB1zQRR3Ih0gIGogF2oiIGogAmoiJSAcIB5qIhwgFCAhIBtzQRl3IhsgJ2ogGmoiHnNBEHciFGoiISAbc0EUdyIbIB5qIA1qIh4gFHNBGHciFHNBEHciJyAjICYgHCAVc0EZdyIVIB9qIA5qIhxzQRB3Ih9qIiMgFXNBFHciFSAcaiAAaiIcIB9zQRh3Ih8gI2oiI2oiJiAWc0EUdyIWICVqIAlqIiUgJ3NBGHciJyAmaiImICAgInNBGHciICAkaiIiIB1zQRl3Ih0gHmogBmoiHiAfc0EQdyIfICpqIiQgHXNBFHciHSAeaiAZaiIeIB9zQRh3Ih8gIyAVc0EZdyIVIChqIAVqIiMgIHNBEHciICAUICFqIhRqIiEgFXNBFHciFSAjaiAKaiIjICBzQRh3IiAgIWoiISAVc0EZdyIVIBwgFCAbc0EZdyIUaiAMaiIbIClzQRB3IhwgImoiIiAUc0EUdyIUIBtqIBJqIhtqIAlqIihzQRB3IilqIiogFXNBFHciFSAoaiAMaiIoICEgJyAbIBxzQRh3IhsgImoiHCAUc0EZdyIUIB5qIA1qIh5zQRB3IiJqIiEgFHNBFHciFCAeaiAKaiIeICJzQRh3IiIgIWoiISAUc0EZdyIUaiAIaiInIB8gJGoiHyAbICYgFnNBGXciFiAjaiAGaiIjc0EQdyIbaiIkIBZzQRR3IhYgI2ogBWoiIyAbc0EYdyIbc0EQdyImIBwgICAfIB1zQRl3Ih0gJWogAmoiH3NBEHciIGoiHCAdc0EUdyIdIB9qIBpqIh8gIHNBGHciICAcaiIcaiIlIBRzQRR3IhQgJ2ogE2oiJyAmc0EYdyImICVqIiUgKCApc0EYdyIoICpqIikgFXNBGXciFSAjaiAZaiIjICBzQRB3IiAgIWoiISAVc0EUdyIVICNqIBJqIiMgIHNBGHciICAcIB1zQRl3IhwgHmogAGoiHSAoc0EQdyIeIBsgJGoiG2oiJCAcc0EUdyIcIB1qIBdqIh0gHnNBGHciHiAkaiIkIBxzQRl3IhwgGyAWc0EZdyIWIB9qIA5qIhsgInNBEHciHyApaiIiIBZzQRR3IhYgG2ogC2oiG2ogGWoiKHNBEHciKWoiKiAcc0EUdyIcIChqIAlqIiggKXNBGHciKSAqaiIqIBxzQRl3IhwgICAhaiIgIBsgH3NBGHciGyAlIBRzQRl3IhQgHWogBmoiHXNBEHciH2oiISAUc0EUdyIUIB1qIAtqIh1qIAVqIiUgGyAiaiIbIB4gICAVc0EZdyIVICdqIBJqIiBzQRB3Ih5qIiIgFXNBFHciFSAgaiAIaiIgIB5zQRh3Ih5zQRB3IicgJCAmIBsgFnNBGXciFiAjaiAKaiIbc0EQdyIjaiIkIBZzQRR3IhYgG2ogDmoiGyAjc0EYdyIjICRqIiRqIiYgHHNBFHciHCAlaiATaiIlICdzQRh3IicgJmoiJiAgIB0gH3NBGHciHSAhaiIfIBRzQRl3IhRqIBdqIiAgI3NBEHciISAqaiIjIBRzQRR3IhQgIGogDWoiICAhc0EYdyIhICQgFnNBGXciFiAoaiAaaiIkIB1zQRB3Ih0gHiAiaiIeaiIiIBZzQRR3IhYgJGogAmoiJCAdc0EYdyIdICJqIiIgFnNBGXciFiAeIBVzQRl3IhUgG2ogDGoiGyApc0EQdyIeIB9qIh8gFXNBFHciFSAbaiAAaiIbaiAAaiIoc0EQdyIpaiIqIBZzQRR3IhYgKGogE2oiKCApc0EYdyIpICpqIiogFnNBGXciFiAhICNqIiEgGyAec0EYdyIbICYgHHNBGXciHCAkaiAXaiIec0EQdyIjaiIkIBxzQRR3IhwgHmogDGoiHmogGWoiJiAbIB9qIhsgHSAhIBRzQRl3IhQgJWogC2oiH3NBEHciHWoiISAUc0EUdyIUIB9qIAJqIh8gHXNBGHciHXNBEHciJSAiICcgGyAVc0EZdyIVICBqIAVqIhtzQRB3IiBqIiIgFXNBFHciFSAbaiAJaiIbICBzQRh3IiAgImoiImoiJyAWc0EUdyIWICZqIAhqIiYgJXNBGHciJSAnaiInIB4gI3NBGHciHiAkaiIjIBxzQRl3IhwgH2ogCmoiHyAgc0EQdyIgICpqIiQgHHNBFHciHCAfaiAaaiIfICBzQRh3IiAgIiAVc0EZdyIVIChqIA1qIiIgHnNBEHciHiAdICFqIh1qIiEgFXNBFHciFSAiaiAGaiIiIB5zQRh3Ih4gIWoiISAVc0EZdyIVIBsgHSAUc0EZdyIUaiASaiIbIClzQRB3Ih0gI2oiIyAUc0EUdyIUIBtqIA5qIhtqIAhqIihzQRB3IilqIiogFXNBFHciFSAoaiANaiIoICEgJSAbIB1zQRh3IhsgI2oiHSAUc0EZdyIUIB9qIBNqIh9zQRB3IiNqIiEgFHNBFHciFCAfaiAOaiIfICNzQRh3IiMgIWoiISAUc0EZdyIUaiAGaiIlICAgJGoiICAbICcgFnNBGXciFiAiaiALaiIic0EQdyIbaiIkIBZzQRR3IhYgImogF2oiIiAbc0EYdyIbc0EQdyInIB0gHiAgIBxzQRl3IhwgJmogGmoiIHNBEHciHmoiHSAcc0EUdyIcICBqIABqIiAgHnNBGHciHiAdaiIdaiImIBRzQRR3IhQgJWogCWoiJSAnc0EYdyInICZqIiYgKCApc0EYdyIoICpqIikgFXNBGXciFSAiaiASaiIiIB5zQRB3Ih4gIWoiISAVc0EUdyIVICJqIBlqIiIgHnNBGHciHiAdIBxzQRl3IhwgH2ogAmoiHSAoc0EQdyIfIBsgJGoiG2oiJCAcc0EUdyIcIB1qIApqIh0gH3NBGHciHyAkaiIkIBxzQRl3IhwgGyAWc0EZdyIWICBqIAxqIhsgI3NBEHciICApaiIjIBZzQRR3IhYgG2ogBWoiG2ogAGoiKHNBEHciKWoiKiAcc0EUdyIcIChqIA1qIiggKXNBGHciKSAqaiIqIBxzQRl3IhwgHiAhaiIeIBsgIHNBGHciGyAmIBRzQRl3IhQgHWogGWoiHXNBEHciIGoiISAUc0EUdyIUIB1qIAxqIh1qIAtqIiYgGyAjaiIbIB8gHiAVc0EZdyIVICVqIApqIh5zQRB3Ih9qIiMgFXNBFHciFSAeaiASaiIeIB9zQRh3Ih9zQRB3IiUgJCAnIBsgFnNBGXciFiAiaiAOaiIbc0EQdyIiaiIkIBZzQRR3IhYgG2ogCGoiGyAic0EYdyIiICRqIiRqIicgHHNBFHciHCAmaiAGaiImICVzQRh3IiUgJ2oiJyAeIB0gIHNBGHciHSAhaiIgIBRzQRl3IhRqIAlqIh4gInNBEHciISAqaiIiIBRzQRR3IhQgHmogAmoiHiAhc0EYdyIhICQgFnNBGXciFiAoaiATaiIkIB1zQRB3Ih0gHyAjaiIfaiIjIBZzQRR3IhYgJGogGmoiJCAdc0EYdyIdICNqIiMgFnNBGXciFiAfIBVzQRl3IhUgG2ogF2oiGyApc0EQdyIfICBqIiAgFXNBFHciFSAbaiAFaiIbaiAaaiIac0EQdyIoaiIpIBZzQRR3IhYgGmogGWoiGSAoc0EYdyIaIClqIiggFnNBGXciFiAhICJqIiEgGyAfc0EYdyIbICcgHHNBGXciHCAkaiASaiISc0EQdyIfaiIiIBxzQRR3IhwgEmogBWoiBWogDWoiEiAbICBqIg0gHSAhIBRzQRl3IhQgJmogCWoiCXNBEHciG2oiHSAUc0EUdyIUIAlqIAZqIgYgG3NBGHciCXNBEHciGyAjICUgDSAVc0EZdyINIB5qIBdqIhdzQRB3IhVqIh4gDXNBFHciDSAXaiACaiICIBVzQRh3IhcgHmoiFWoiHiAWc0EUdyIWIBJqIABqIhKtQiCGIAUgH3NBGHciBSAiaiIAIBxzQRl3IhwgBmogDGoiBiAXc0EQdyIXIChqIgwgHHNBFHciHCAGaiAOaiIGrYQgD4UgAiAJIB1qIgkgFHNBGXciDmogE2oiAiAac0EQdyIaIABqIhMgDnNBFHciDiACaiAKaiICIBpzQRh3IgogE2oiGq1CIIYgFSANc0EZdyINIBlqIAhqIgggBXNBEHciBSAJaiIJIA1zQRR3IhkgCGogC2oiCCAFc0EYdyIFIAlqIgmthIU3A4CJAUEAIAMgAq1CIIYgCK2EhSASIBtzQRh3IgIgHmoiCK1CIIYgBiAXc0EYdyIGIAxqIhethIU3A4iJAUEAIAQgFyAcc0EZd61CIIYgGiAOc0EZd62EhSAFrUIghiACrYSFNwOQiQFBACAJIBlzQRl3rUIghiAIIBZzQRl3rYRBACkDmIkBhSAGrUIghiAKrYSFNwOYiQELnQIBBH8jAEEgayIAJAACQEEAKAKoiQENAEEAQQAoAqCJASIBQQAoAvCJASICaiIDNgKgiQFBAEEAKAKkiQEgAyABSWo2AqSJAQJAQQAtAPiJAUUNAEEAQX82AqyJAQtBAEF/NgKoiQECQCACQT9KDQBBACEBA0AgAiABakGwiQFqQQA6AAAgAUEBaiIBQcAAQQAoAvCJASICa0gNAAsLQbCJARACIABBACkDgIkBNwMAIABBACkDiIkBNwMIIABBACkDkIkBNwMQIABBACkDmIkBNwMYQQAoAvSJASIDQQFIDQBBACEBQQAhAgNAIAFBgAlqIAAgAWotAAA6AAAgAUEBaiEBIAMgAkEBaiICQf8BcUoNAAsLIABBIGokAAuyAwEEfyMAQcAAayIBJABBAEGBAjsBgooBQQAgAEEQdiICOgCBigFBACAAQQN2OgCAigFBiH8hAwJAA0AgA0H4iQFqQQA2AgAgA0UNASADQfyJAWpBADYCACADQQhqIQMMAAsLQQAhA0EAQQAoAoCKASIEQefMp9AGczYCgIkBQQBBACgChIoBQYXdntt7czYChIkBQQBBACgCiIoBQfLmu+MDczYCiIkBQQBBACgCjIoBQbrqv6p6czYCjIkBQQBBACgCkIoBQf+kuYgFczYCkIkBQQBBACgClIoBQYzRldh5czYClIkBQQBBACgCmIoBQauzj/wBczYCmIkBQQAgBEH/AXE2AvSJAUEAQQAoApyKAUGZmoPfBXM2ApyJAQJAIABBgIAESQ0AIAFBOGpCADcDACABQTBqQgA3AwAgAUEoakIANwMAIAFBIGpCADcDACABQRhqQgA3AwAgAUEQakIANwMAIAFCADcDCCABQgA3AwBBACEAA0AgASADaiADQYAJai0AADoAACADQQFqIQMgAiAAQQFqIgBB/wFxSw0ACyABQcAAEAELIAFBwABqJAALCQBBgAkgABABCwYAQYCJAQsPACABEARBgAkgABABEAMLCwsBAEGACAsEfAAAAA==";
+var hash$i = "5c0ff166";
+var wasmJson$i = {
+	name: name$i,
+	data: data$i,
+	hash: hash$i
+};
+
+const mutex$j = new Mutex();
+let wasmCache$j = null;
+function validateBits$3(bits) {
+    if (!Number.isInteger(bits) || bits < 8 || bits > 256 || bits % 8 !== 0) {
+        return new Error("Invalid variant! Valid values: 8, 16, ..., 256");
+    }
+    return null;
+}
+function getInitParam(outputBits, keyBits) {
+    return outputBits | (keyBits << 16);
+}
+/**
+ * Calculates BLAKE2s hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param bits Number of output bits, which has to be a number
+ *             divisible by 8, between 8 and 256. Defaults to 256.
+ * @param key Optional key (string, Buffer or TypedArray). Maximum length is 32 bytes.
+ * @returns Computed hash as a hexadecimal string
+ */
+function blake2s(data, bits = 256, key = null) {
+    if (validateBits$3(bits)) {
+        return Promise.reject(validateBits$3(bits));
+    }
+    let keyBuffer = null;
+    let initParam = bits;
+    if (key !== null) {
+        keyBuffer = getUInt8Buffer(key);
+        if (keyBuffer.length > 32) {
+            return Promise.reject(new Error("Max key length is 32 bytes"));
+        }
+        initParam = getInitParam(bits, keyBuffer.length);
+    }
+    const hashLength = bits / 8;
+    if (wasmCache$j === null || wasmCache$j.hashLength !== hashLength) {
+        return lockedCreate(mutex$j, wasmJson$i, hashLength).then((wasm) => {
+            wasmCache$j = wasm;
+            if (initParam > 512) {
+                wasmCache$j.writeMemory(keyBuffer);
+            }
+            return wasmCache$j.calculate(data, initParam);
+        });
+    }
+    try {
+        if (initParam > 512) {
+            wasmCache$j.writeMemory(keyBuffer);
+        }
+        const hash = wasmCache$j.calculate(data, initParam);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new BLAKE2s hash instance
+ * @param bits Number of output bits, which has to be a number
+ *             divisible by 8, between 8 and 256. Defaults to 256.
+ * @param key Optional key (string, Buffer or TypedArray). Maximum length is 32 bytes.
+ */
+function createBLAKE2s(bits = 256, key = null) {
+    if (validateBits$3(bits)) {
+        return Promise.reject(validateBits$3(bits));
+    }
+    let keyBuffer = null;
+    let initParam = bits;
+    if (key !== null) {
+        keyBuffer = getUInt8Buffer(key);
+        if (keyBuffer.length > 32) {
+            return Promise.reject(new Error("Max key length is 32 bytes"));
+        }
+        initParam = getInitParam(bits, keyBuffer.length);
+    }
+    const outputSize = bits / 8;
+    return WASMInterface(wasmJson$i, outputSize).then((wasm) => {
+        if (initParam > 512) {
+            wasm.writeMemory(keyBuffer);
+        }
+        wasm.init(initParam);
+        const obj = {
+            init: initParam > 512
+                ? () => {
+                    wasm.writeMemory(keyBuffer);
+                    wasm.init(initParam);
+                    return obj;
+                }
+                : () => {
+                    wasm.init(initParam);
+                    return obj;
+                },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: outputSize,
+        };
+        return obj;
+    });
+}
+
+var name$h = "blake3";
+var data$h = "AGFzbQEAAAABMQdgAAF/YAl/f39+f39/f38AYAZ/f39/fn8AYAF/AGADf39/AGABfgBgBX9/fn9/AX8DDg0AAQIDBAUGAwMDAwAEBQQBAQICBg4CfwFBgJgFC38AQYAICwdwCAZtZW1vcnkCAA5IYXNoX0dldEJ1ZmZlcgAACUhhc2hfSW5pdAAIC0hhc2hfVXBkYXRlAAkKSGFzaF9GaW5hbAAKDUhhc2hfR2V0U3RhdGUACw5IYXNoX0NhbGN1bGF0ZQAMClNUQVRFX1NJWkUDAQqQWw0FAEGACQufAwIDfwV+IwBB4ABrIgkkAAJAIAFFDQAgByAFciEKIAdBACACQQFGGyAGciAFciELIARBAEetIQwDQCAAKAIAIQcgCUEAKQOAiQE3AwAgCUEAKQOIiQE3AwggCUEAKQOQiQE3AxAgCUEAKQOYiQE3AxggCUEgaiAJIAdBwAAgAyALEAIgCSAJKQNAIAkpAyCFIg03AwAgCSAJKQNIIAkpAyiFIg43AwggCSAJKQNQIAkpAzCFIg83AxAgCSAJKQNYIAkpAziFIhA3AxggB0HAAGohByACIQQCQANAIAUhBgJAAkAgBEF/aiIEDgIDAAELIAohBgsgCUEgaiAJIAdBwAAgAyAGEAIgCSAJKQNAIAkpAyCFIg03AwAgCSAJKQNIIAkpAyiFIg43AwggCSAJKQNQIAkpAzCFIg83AxAgCSAJKQNYIAkpAziFIhA3AxggB0HAAGohBwwACwsgCCAQNwMYIAggDzcDECAIIA43AwggCCANNwMAIAhBIGohCCAAQQRqIQAgAyAMfCEDIAFBf2oiAQ0ACwsgCUHgAGokAAv4GwIMfh9/IAIpAyghBiACKQM4IQcgAikDMCEIIAIpAxAhCSACKQMgIQogAikDACELIAIpAwghDCACKQMYIQ0gACABKQMAIg43AwAgACABKQMIIg83AwggACABKQMQIhA3AxAgACAPQiCIpyANpyICaiABKQMYIhFCIIinIhJqIhMgDUIgiKciAWogEyAFc0EQdyIUQbrqv6p6aiIVIBJzQRR3IhZqIhcgDqcgC6ciBWogEKciE2oiGCALQiCIpyISaiAYIASnc0EQdyIYQefMp9AGaiIZIBNzQRR3IhNqIhogGHNBGHciGyAZaiIcIBNzQRl3Ih1qIAenIhNqIh4gB0IgiKciGGogHiAPpyAJpyIZaiARpyIfaiIgIAlCIIinIiFqICAgA3NBEHciA0Hy5rvjA2oiICAfc0EUdyIfaiIiIANzQRh3IiNzQRB3IiQgDkIgiKcgDKciA2ogEEIgiKciJWoiJiAMQiCIpyIeaiAmIARCIIinc0EQdyImQYXdntt7aiInICVzQRR3IiVqIiggJnNBGHciJiAnaiInaiIpIB1zQRR3Ih1qIiogGWogFyAUc0EYdyIrIBVqIiwgFnNBGXciFiAiaiAIpyIUaiIXIAhCIIinIhVqIBcgJnNBEHciFyAcaiIcIBZzQRR3IhZqIiIgF3NBGHciJiAcaiItIBZzQRl3Ii5qIhwgFWogJyAlc0EZdyIlIBpqIAqnIhZqIhogCkIgiKciF2ogGiArc0EQdyIaICMgIGoiIGoiIyAlc0EUdyIlaiInIBpzQRh3IisgHHNBEHciLyAgIB9zQRl3Ih8gKGogBqciGmoiICAGQiCIpyIcaiAgIBtzQRB3IhsgLGoiICAfc0EUdyIfaiIoIBtzQRh3IhsgIGoiIGoiLCAuc0EUdyIuaiIwICcgA2ogKiAkc0EYdyIkIClqIicgHXNBGXciHWoiKSACaiAbIClzQRB3IhsgLWoiKSAdc0EUdyIdaiIqIBtzQRh3IhsgKWoiKSAdc0EZdyIdaiAYaiItIBZqIC0gIiABaiAgIB9zQRl3Ih9qIiAgBWogJCAgc0EQdyIgICsgI2oiImoiIyAfc0EUdyIfaiIkICBzQRh3IiBzQRB3IisgKCAeaiAiICVzQRl3IiJqIiUgGmogJiAlc0EQdyIlICdqIiYgInNBFHciImoiJyAlc0EYdyIlICZqIiZqIiggHXNBFHciHWoiLSABaiAwIC9zQRh3Ii8gLGoiLCAuc0EZdyIuICRqIBdqIiQgE2ogJCAlc0EQdyIkIClqIiUgLnNBFHciKWoiLiAkc0EYdyIkICVqIiUgKXNBGXciKWoiMCATaiAmICJzQRl3IiIgKmogEmoiJiAcaiAmIC9zQRB3IiYgICAjaiIgaiIjICJzQRR3IiJqIiogJnNBGHciJiAwc0EQdyIvICAgH3NBGXciHyAnaiAUaiIgICFqICAgG3NBEHciGyAsaiIgIB9zQRR3Ih9qIicgG3NBGHciGyAgaiIgaiIsIClzQRR3IilqIjAgKiAeaiAtICtzQRh3IiogKGoiKCAdc0EZdyIdaiIrIBlqIBsgK3NBEHciGyAlaiIlIB1zQRR3Ih1qIisgG3NBGHciGyAlaiIlIB1zQRl3Ih1qIBZqIi0gEmogLSAuIBVqICAgH3NBGXciH2oiICADaiAqICBzQRB3IiAgJiAjaiIjaiImIB9zQRR3Ih9qIiogIHNBGHciIHNBEHciLSAnIBpqICMgInNBGXciImoiIyAUaiAkICNzQRB3IiMgKGoiJCAic0EUdyIiaiInICNzQRh3IiMgJGoiJGoiKCAdc0EUdyIdaiIuIBVqIDAgL3NBGHciLyAsaiIsIClzQRl3IikgKmogHGoiKiAYaiAqICNzQRB3IiMgJWoiJSApc0EUdyIpaiIqICNzQRh3IiMgJWoiJSApc0EZdyIpaiIwIBhqICQgInNBGXciIiAraiACaiIkICFqICQgL3NBEHciJCAgICZqIiBqIiYgInNBFHciImoiKyAkc0EYdyIkIDBzQRB3Ii8gICAfc0EZdyIfICdqIBdqIiAgBWogICAbc0EQdyIbICxqIiAgH3NBFHciH2oiJyAbc0EYdyIbICBqIiBqIiwgKXNBFHciKWoiMCArIBpqIC4gLXNBGHciKyAoaiIoIB1zQRl3Ih1qIi0gAWogGyAtc0EQdyIbICVqIiUgHXNBFHciHWoiLSAbc0EYdyIbICVqIiUgHXNBGXciHWogEmoiLiACaiAuICogE2ogICAfc0EZdyIfaiIgIB5qICsgIHNBEHciICAkICZqIiRqIiYgH3NBFHciH2oiKiAgc0EYdyIgc0EQdyIrICcgFGogJCAic0EZdyIiaiIkIBdqICMgJHNBEHciIyAoaiIkICJzQRR3IiJqIicgI3NBGHciIyAkaiIkaiIoIB1zQRR3Ih1qIi4gE2ogMCAvc0EYdyIvICxqIiwgKXNBGXciKSAqaiAhaiIqIBZqICogI3NBEHciIyAlaiIlIClzQRR3IilqIiogI3NBGHciIyAlaiIlIClzQRl3IilqIjAgFmogJCAic0EZdyIiIC1qIBlqIiQgBWogJCAvc0EQdyIkICAgJmoiIGoiJiAic0EUdyIiaiItICRzQRh3IiQgMHNBEHciLyAgIB9zQRl3Ih8gJ2ogHGoiICADaiAgIBtzQRB3IhsgLGoiICAfc0EUdyIfaiInIBtzQRh3IhsgIGoiIGoiLCApc0EUdyIpaiIwIC9zQRh3Ii8gLGoiLCApc0EZdyIpICogGGogICAfc0EZdyIfaiIgIBpqIC4gK3NBGHciKiAgc0EQdyIgICQgJmoiJGoiJiAfc0EUdyIfaiIraiAFaiIuIBJqIC4gJyAXaiAkICJzQRl3IiJqIiQgHGogIyAkc0EQdyIjICogKGoiJGoiJyAic0EUdyIiaiIoICNzQRh3IiNzQRB3IiogLSAUaiAkIB1zQRl3Ih1qIiQgFWogGyAkc0EQdyIbICVqIiQgHXNBFHciHWoiJSAbc0EYdyIbICRqIiRqIi0gKXNBFHciKWoiLiAWaiArICBzQRh3IiAgJmoiJiAfc0EZdyIfIChqICFqIiggHmogKCAbc0EQdyIbICxqIiggH3NBFHciH2oiKyAbc0EYdyIbIChqIiggH3NBGXciH2oiLCAUaiAwICQgHXNBGXciHWogAmoiJCAZaiAkICBzQRB3IiAgIyAnaiIjaiIkIB1zQRR3Ih1qIicgIHNBGHciICAsc0EQdyIsICMgInNBGXciIiAlaiABaiIjIANqICMgL3NBEHciIyAmaiIlICJzQRR3IiJqIiYgI3NBGHciIyAlaiIlaiIvIB9zQRR3Ih9qIjAgLHNBGHciLCAvaiIvIB9zQRl3Ih8gKyAcaiAlICJzQRl3IiJqIiUgIWogLiAqc0EYdyIqICVzQRB3IiUgICAkaiIgaiIkICJzQRR3IiJqIitqIAVqIi4gGmogLiAmIBdqICAgHXNBGXciHWoiICATaiAbICBzQRB3IhsgKiAtaiIgaiImIB1zQRR3Ih1qIiogG3NBGHciG3NBEHciLSAnIBhqICAgKXNBGXciIGoiJyASaiAjICdzQRB3IiMgKGoiJyAgc0EUdyIgaiIoICNzQRh3IiMgJ2oiJ2oiKSAfc0EUdyIfaiIuICFqICsgJXNBGHciISAkaiIkICJzQRl3IiIgKmogFWoiJSAeaiAlICNzQRB3IiMgL2oiJSAic0EUdyIiaiIqICNzQRh3IiMgJWoiJSAic0EZdyIiaiIrIAVqICcgIHNBGXciBSAwaiADaiIgIAJqICAgIXNBEHciISAbICZqIhtqIiAgBXNBFHciBWoiJiAhc0EYdyIhICtzQRB3IicgKCAbIB1zQRl3IhtqIBlqIh0gAWogHSAsc0EQdyIdICRqIiQgG3NBFHciG2oiKCAdc0EYdyIdICRqIiRqIisgInNBFHciImoiLCAnc0EYdyInICtqIisgInNBGXciIiAqIBxqICQgG3NBGXciHGoiGyAYaiAuIC1zQRh3IhggG3NBEHciGyAhICBqIiFqIiAgHHNBFHciHGoiJGogE2oiEyAaaiATICggFmogISAFc0EZdyIFaiIhIAJqICMgIXNBEHciAiAYIClqIhhqIiEgBXNBFHciBWoiFiACc0EYdyICc0EQdyITICYgEmogGCAfc0EZdyISaiIYIBdqIB0gGHNBEHciGCAlaiIXIBJzQRR3IhJqIhogGHNBGHciGCAXaiIXaiIdICJzQRR3Ih9qIiI2AgAgACAXIBJzQRl3IhIgLGogA2oiAyAUaiADICQgG3NBGHciFHNBEHciAyACICFqIgJqIiEgEnNBFHciEmoiFyADc0EYdyIDNgIwIAAgFiAUICBqIhQgHHNBGXciHGogAWoiASAVaiABIBhzQRB3IgEgK2oiGCAcc0EUdyIVaiIWIAFzQRh3IgEgGGoiGCAVc0EZdzYCECAAIBc2AgQgACACIAVzQRl3IgIgGmogHmoiBSAZaiAFICdzQRB3IgUgFGoiGSACc0EUdyICaiIeIAVzQRh3IgU2AjQgACAFIBlqIgU2AiAgACAiIBNzQRh3IhMgHWoiGSAfc0EZdzYCFCAAIBg2AiQgACAeNgIIIAAgATYCOCAAIAMgIWoiASASc0EZdzYCGCAAIBk2AiggACAWNgIMIAAgEzYCPCAAIAUgAnNBGXc2AhwgACABNgIsC6USCwN/BH4CfwF+AX8EfgJ/AX4CfwF+BH8jAEHQAmsiASQAAkAgAEUNAAJAAkBBAC0AiYoBQQZ0QQAtAIiKAWoiAg0AQYAJIQMMAQtBoIkBQYAJQYAIIAJrIgIgACACIABJGyICEAQgACACayIARQ0BIAFBoAFqQQApA9CJATcDACABQagBakEAKQPYiQE3AwAgAUEAKQOgiQEiBDcDcCABQQApA6iJASIFNwN4IAFBACkDsIkBIgY3A4ABIAFBACkDuIkBIgc3A4gBIAFBACkDyIkBNwOYAUEALQCKigEhCEEALQCJigEhCUEAKQPAiQEhCkEALQCIigEhCyABQbABakEAKQPgiQE3AwAgAUG4AWpBACkD6IkBNwMAIAFBwAFqQQApA/CJATcDACABQcgBakEAKQP4iQE3AwAgAUHQAWpBACkDgIoBNwMAIAEgCzoA2AEgASAKNwOQASABIAggCUVyQQJyIgg6ANkBIAEgBzcD+AEgASAGNwPwASABIAU3A+gBIAEgBDcD4AEgASABQeABaiABQZgBaiALIAogCEH/AXEQAiABKQMgIQQgASkDACEFIAEpAyghBiABKQMIIQcgASkDMCEMIAEpAxAhDSABKQM4IQ4gASkDGCEPIAoQBUEAQgA3A4CKAUEAQgA3A/iJAUEAQgA3A/CJAUEAQgA3A+iJAUEAQgA3A+CJAUEAQgA3A9iJAUEAQgA3A9CJAUEAQgA3A8iJAUEAQQApA4CJATcDoIkBQQBBACkDiIkBNwOoiQFBAEEAKQOQiQE3A7CJAUEAQQApA5iJATcDuIkBQQBBAC0AkIoBIgtBAWo6AJCKAUEAQQApA8CJAUIBfDcDwIkBIAtBBXQiC0GpigFqIA4gD4U3AwAgC0GhigFqIAwgDYU3AwAgC0GZigFqIAYgB4U3AwAgC0GRigFqIAQgBYU3AwBBAEEAOwGIigEgAkGACWohAwsCQCAAQYEISQ0AQQApA8CJASEEIAFBKGohEANAIARCCoYhCkIBIABBAXKteUI/hYanIQIDQCACIhFBAXYhAiAKIBFBf2qtg0IAUg0ACyARQQp2rSESAkACQCARQYAISw0AIAFBADsB2AEgAUIANwPQASABQgA3A8gBIAFCADcDwAEgAUIANwO4ASABQgA3A7ABIAFCADcDqAEgAUIANwOgASABQgA3A5gBIAFBACkDgIkBNwNwIAFBACkDiIkBNwN4IAFBACkDkIkBNwOAASABQQAtAIqKAToA2gEgAUEAKQOYiQE3A4gBIAEgBDcDkAEgAUHwAGogAyAREAQgASABKQNwIgQ3AwAgASABKQN4IgU3AwggASABKQOAASIGNwMQIAEgASkDiAEiBzcDGCABIAEpA5gBNwMoIAEgASkDoAE3AzAgASABKQOoATcDOCABLQDaASECIAEtANkBIQsgASkDkAEhCiABIAEtANgBIgg6AGggASAKNwMgIAEgASkDsAE3A0AgASABKQO4ATcDSCABIAEpA8ABNwNQIAEgASkDyAE3A1ggASABKQPQATcDYCABIAIgC0VyQQJyIgI6AGkgASAHNwO4AiABIAY3A7ACIAEgBTcDqAIgASAENwOgAiABQeABaiABQaACaiAQIAggCiACQf8BcRACIAEpA4ACIQQgASkD4AEhBSABKQOIAiEGIAEpA+gBIQcgASkDkAIhDCABKQPwASENIAEpA5gCIQ4gASkD+AEhDyAKEAVBAEEALQCQigEiAkEBajoAkIoBIAJBBXQiAkGpigFqIA4gD4U3AwAgAkGhigFqIAwgDYU3AwAgAkGZigFqIAYgB4U3AwAgAkGRigFqIAQgBYU3AwAMAQsCQAJAIAMgESAEQQAtAIqKASICIAEQBiITQQJLDQAgASkDGCEKIAEpAxAhBCABKQMIIQUgASkDACEGDAELIAJBBHIhFEEAKQOYiQEhDUEAKQOQiQEhDkEAKQOIiQEhD0EAKQOAiQEhFQNAIBNBfmoiFkEBdiIXQQFqIhhBA3EhCEEAIQkCQCAWQQZJDQAgGEH8////B3EhGUEAIQkgAUHIAmohAiABIQsDQCACIAs2AgAgAkEMaiALQcABajYCACACQQhqIAtBgAFqNgIAIAJBBGogC0HAAGo2AgAgC0GAAmohCyACQRBqIQIgGSAJQQRqIglHDQALCwJAIAhFDQAgASAJQQZ0aiECIAFByAJqIAlBAnRqIQsDQCALIAI2AgAgAkHAAGohAiALQQRqIQsgCEF/aiIIDQALCyABQcgCaiELIAFBoAJqIQIgGCEIA0AgCygCACEJIAEgDTcD+AEgASAONwPwASABIA83A+gBIAEgFTcD4AEgAUHwAGogAUHgAWogCUHAAEIAIBQQAiABKQOQASEKIAEpA3AhBCABKQOYASEFIAEpA3ghBiABKQOgASEHIAEpA4ABIQwgAkEYaiABKQOoASABKQOIAYU3AwAgAkEQaiAHIAyFNwMAIAJBCGogBSAGhTcDACACIAogBIU3AwAgAkEgaiECIAtBBGohCyAIQX9qIggNAAsCQAJAIBZBfnFBAmogE0kNACAYIRMMAQsgAUGgAmogGEEFdGoiAiABIBhBBnRqIgspAwA3AwAgAiALKQMINwMIIAIgCykDEDcDECACIAspAxg3AxggF0ECaiETCyABIAEpA6ACIgY3AwAgASABKQOoAiIFNwMIIAEgASkDsAIiBDcDECABIAEpA7gCIgo3AxggE0ECSw0ACwsgASkDICEHIAEpAyghDCABKQMwIQ0gASkDOCEOQQApA8CJARAFQQBBAC0AkIoBIgJBAWo6AJCKASACQQV0IgJBqYoBaiAKNwMAIAJBoYoBaiAENwMAIAJBmYoBaiAFNwMAIAJBkYoBaiAGNwMAQQApA8CJASASQgGIfBAFQQBBAC0AkIoBIgJBAWo6AJCKASACQQV0IgJBqYoBaiAONwMAIAJBoYoBaiANNwMAIAJBmYoBaiAMNwMAIAJBkYoBaiAHNwMAC0EAQQApA8CJASASfCIENwPAiQEgAyARaiEDIAAgEWsiAEGACEsNAAsgAEUNAQtBoIkBIAMgABAEQQApA8CJARAFCyABQdACaiQAC4YHAgl/AX4jAEHAAGsiAyQAAkACQCAALQBoIgRFDQACQEHAACAEayIFIAIgBSACSRsiBkUNACAGQQNxIQdBACEFAkAgBkEESQ0AIAAgBGohCCAGQXxxIQlBACEFA0AgCCAFaiIKQShqIAEgBWoiCy0AADoAACAKQSlqIAtBAWotAAA6AAAgCkEqaiALQQJqLQAAOgAAIApBK2ogC0EDai0AADoAACAJIAVBBGoiBUcNAAsLAkAgB0UNACABIAVqIQogBSAEaiAAakEoaiEFA0AgBSAKLQAAOgAAIApBAWohCiAFQQFqIQUgB0F/aiIHDQALCyAALQBoIQQLIAAgBCAGaiIHOgBoIAEgBmohAQJAIAIgBmsiAg0AQQAhAgwCCyADIAAgAEEoakHAACAAKQMgIAAtAGogAEHpAGoiBS0AACIKRXIQAiAAIAMpAyAgAykDAIU3AwAgACADKQMoIAMpAwiFNwMIIAAgAykDMCADKQMQhTcDECAAIAMpAzggAykDGIU3AxggAEEAOgBoIAUgCkEBajoAACAAQeAAakIANwMAIABB2ABqQgA3AwAgAEHQAGpCADcDACAAQcgAakIANwMAIABBwABqQgA3AwAgAEE4akIANwMAIABBMGpCADcDACAAQgA3AygLQQAhByACQcEASQ0AIABB6QBqIgotAAAhBSAALQBqIQsgACkDICEMA0AgAyAAIAFBwAAgDCALIAVB/wFxRXJB/wFxEAIgACADKQMgIAMpAwCFNwMAIAAgAykDKCADKQMIhTcDCCAAIAMpAzAgAykDEIU3AxAgACADKQM4IAMpAxiFNwMYIAogBUEBaiIFOgAAIAFBwABqIQEgAkFAaiICQcAASw0ACwsCQEHAACAHQf8BcSIGayIFIAIgBSACSRsiCUUNACAJQQNxIQtBACEFAkAgCUEESQ0AIAAgBmohByAJQfwAcSEIQQAhBQNAIAcgBWoiAkEoaiABIAVqIgotAAA6AAAgAkEpaiAKQQFqLQAAOgAAIAJBKmogCkECai0AADoAACACQStqIApBA2otAAA6AAAgCCAFQQRqIgVHDQALCwJAIAtFDQAgASAFaiEBIAUgBmogAGpBKGohBQNAIAUgAS0AADoAACABQQFqIQEgBUEBaiEFIAtBf2oiCw0ACwsgAC0AaCEHCyAAIAcgCWo6AGggA0HAAGokAAveAwQFfwN+BX8GfiMAQdABayIBJAACQCAAe6ciAkEALQCQigEiA08NAEEALQCKigFBBHIhBCABQShqIQVBACkDmIkBIQBBACkDkIkBIQZBACkDiIkBIQdBACkDgIkBIQggAyEJA0AgASAANwMYIAEgBjcDECABIAc3AwggASAINwMAIAEgA0EFdCIDQdGJAWoiCikDADcDKCABIANB2YkBaiILKQMANwMwIAEgA0HhiQFqIgwpAwA3AzggASADQemJAWoiDSkDADcDQCABIANB8YkBaikDADcDSCABIANB+YkBaikDADcDUCABIANBgYoBaikDADcDWCADQYmKAWopAwAhDiABQcAAOgBoIAEgDjcDYCABQgA3AyAgASAEOgBpIAEgADcDiAEgASAGNwOAASABIAc3A3ggASAINwNwIAFBkAFqIAFB8ABqIAVBwABCACAEQf8BcRACIAEpA7ABIQ4gASkDkAEhDyABKQO4ASEQIAEpA5gBIREgASkDwAEhEiABKQOgASETIA0gASkDyAEgASkDqAGFNwMAIAwgEiAThTcDACALIBAgEYU3AwAgCiAOIA+FNwMAIAlBf2oiCUH/AXEiAyACSw0AC0EAIAk6AJCKAQsgAUHQAWokAAvHCQIKfwV+IwBB4AJrIgUkAAJAAkAgAUGACEsNACAFIAA2AvwBIAVB/AFqIAFBgAhGIgZBECACQQEgA0EBQQIgBBABIAZBCnQiByABTw0BIAVB4ABqIgZCADcDACAFQdgAaiIIQgA3AwAgBUHQAGoiCUIANwMAIAVByABqIgpCADcDACAFQcAAaiILQgA3AwAgBUE4aiIMQgA3AwAgBUEwaiINQgA3AwAgBSADOgBqIAVCADcDKCAFQQA7AWggBUEAKQOAiQE3AwAgBUEAKQOIiQE3AwggBUEAKQOQiQE3AxAgBUEAKQOYiQE3AxggBSABQYAIRiIOrSACfDcDICAFIAAgB2pBACABIA4bEAQgBUGIAWpBMGogDSkDADcDACAFQYgBakE4aiAMKQMANwMAIAUgBSkDACIPNwOIASAFIAUpAwgiEDcDkAEgBSAFKQMQIhE3A5gBIAUgBSkDGCISNwOgASAFIAUpAyg3A7ABIAUtAGohACAFLQBpIQcgBSkDICECIAUtAGghASAFQYgBakHAAGogCykDADcDACAFQYgBakHIAGogCikDADcDACAFQYgBakHQAGogCSkDADcDACAFQYgBakHYAGogCCkDADcDACAFQYgBakHgAGogBikDADcDACAFIAE6APABIAUgAjcDqAEgBSAAIAdFckECciIAOgDxASAFIBI3A5gCIAUgETcDkAIgBSAQNwOIAiAFIA83A4ACIAVBoAJqIAVBgAJqIAVBsAFqIAEgAiAAQf8BcRACIAUpA8ACIQIgBSkDoAIhDyAFKQPIAiEQIAUpA6gCIREgBSkD0AIhEiAFKQOwAiETIAQgDkEFdGoiASAFKQPYAiAFKQO4AoU3AxggASASIBOFNwMQIAEgECARhTcDCCABIAIgD4U3AwBBAkEBIA4bIQYMAQsgAEIBIAFBf2pBCnZBAXKteUI/hYYiD6dBCnQiDiACIAMgBRAGIQcgACAOaiABIA5rIA9C////AYMgAnwgAyAFQcAAQSAgDkGACEsbahAGIQECQCAHQQFHDQAgBCAFKQMANwMAIAQgBSkDCDcDCCAEIAUpAxA3AxAgBCAFKQMYNwMYIAQgBSkDIDcDICAEIAUpAyg3AyggBCAFKQMwNwMwIAQgBSkDODcDOEECIQYMAQtBACEGQQAhAAJAIAEgB2oiCUECSQ0AIAlBfmoiCkEBdkEBaiIGQQNxIQ5BACEHAkAgCkEGSQ0AIAZB/P///wdxIQhBACEHIAVBiAFqIQEgBSEAA0AgASAANgIAIAFBDGogAEHAAWo2AgAgAUEIaiAAQYABajYCACABQQRqIABBwABqNgIAIABBgAJqIQAgAUEQaiEBIAggB0EEaiIHRw0ACwsgCkF+cSEIAkAgDkUNACAFIAdBBnRqIQEgBUGIAWogB0ECdGohAANAIAAgATYCACABQcAAaiEBIABBBGohACAOQX9qIg4NAAsLIAhBAmohAAsgBUGIAWogBkEBQgBBACADQQRyQQBBACAEEAEgACAJTw0AIAQgBkEFdGoiASAFIAZBBnRqIgApAwA3AwAgASAAKQMINwMIIAEgACkDEDcDECABIAApAxg3AxggBkEBaiEGCyAFQeACaiQAIAYLrRAIAn8EfgF/AX4EfwR+BH8EfiMAQfABayIBJAACQCAARQ0AAkBBAC0AkIoBIgINACABQTBqQQApA9CJATcDACABQThqQQApA9iJATcDACABQQApA6CJASIDNwMAIAFBACkDqIkBIgQ3AwggAUEAKQOwiQEiBTcDECABQQApA7iJASIGNwMYIAFBACkDyIkBNwMoQQAtAIqKASECQQAtAImKASEHQQApA8CJASEIQQAtAIiKASEJIAFBwABqQQApA+CJATcDACABQcgAakEAKQPoiQE3AwAgAUHQAGpBACkD8IkBNwMAIAFB2ABqQQApA/iJATcDACABQeAAakEAKQOAigE3AwAgASAJOgBoIAEgCDcDICABIAIgB0VyIgJBAnI6AGkgAUEoaiEKQgAhCEGACSELIAJBCnJB/wFxIQwDQCABQbABaiABIAogCUH/AXEgCCAMEAIgASABKQPQASINIAEpA7ABhTcDcCABIAEpA9gBIg4gASkDuAGFNwN4IAEgASkD4AEiDyABKQPAAYU3A4ABIAEgASkD6AEiECAGhTcDqAEgASAPIAWFNwOgASABIA4gBIU3A5gBIAEgDSADhTcDkAEgASAQIAEpA8gBhTcDiAEgAEHAACAAQcAASRsiEUF/aiESAkACQCARQQdxIhMNACABQfAAaiECIAshByARIRQMAQsgEUH4AHEhFCABQfAAaiECIAshBwNAIAcgAi0AADoAACAHQQFqIQcgAkEBaiECIBNBf2oiEw0ACwsCQCASQQdJDQADQCAHIAIpAAA3AAAgB0EIaiEHIAJBCGohAiAUQXhqIhQNAAsLIAhCAXwhCCALIBFqIQsgACARayIADQAMAgsLAkACQAJAQQAtAImKASIHQQZ0QQBBAC0AiIoBIhFrRg0AIAEgEToAaCABQQApA4CKATcDYCABQQApA/iJATcDWCABQQApA/CJATcDUCABQQApA+iJATcDSCABQQApA+CJATcDQCABQQApA9iJATcDOCABQQApA9CJATcDMCABQQApA8iJATcDKCABQQApA8CJASIINwMgIAFBACkDuIkBIgM3AxggAUEAKQOwiQEiBDcDECABQQApA6iJASIFNwMIIAFBACkDoIkBIgY3AwAgAUEALQCKigEiEyAHRXJBAnIiCzoAaSATQQRyIRNBACkDmIkBIQ1BACkDkIkBIQ5BACkDiIkBIQ9BACkDgIkBIRAMAQtBwAAhESABQcAAOgBoQgAhCCABQgA3AyAgAUEAKQOYiQEiDTcDGCABQQApA5CJASIONwMQIAFBACkDiIkBIg83AwggAUEAKQOAiQEiEDcDACABQQAtAIqKAUEEciITOgBpIAEgAkF+aiICQQV0IgdByYoBaikDADcDYCABIAdBwYoBaikDADcDWCABIAdBuYoBaikDADcDUCABIAdBsYoBaikDADcDSCABIAdBqYoBaikDADcDQCABIAdBoYoBaikDADcDOCABIAdBmYoBaikDADcDMCABIAdBkYoBaikDADcDKCATIQsgECEGIA8hBSAOIQQgDSEDIAJFDQELIAJBf2oiB0EFdCIUQZGKAWopAwAhFSAUQZmKAWopAwAhFiAUQaGKAWopAwAhFyAUQamKAWopAwAhGCABIAM3A4gBIAEgBDcDgAEgASAFNwN4IAEgBjcDcCABQbABaiABQfAAaiABQShqIhQgESAIIAtB/wFxEAIgASATOgBpIAFBwAA6AGggASAYNwNAIAEgFzcDOCABIBY3AzAgASAVNwMoIAFCADcDICABIA03AxggASAONwMQIAEgDzcDCCABIBA3AwAgASABKQPoASABKQPIAYU3A2AgASABKQPgASABKQPAAYU3A1ggASABKQPYASABKQO4AYU3A1AgASABKQPQASABKQOwAYU3A0ggB0UNACACQQV0QemJAWohAiATQf8BcSERA0AgAkFoaikDACEIIAJBcGopAwAhAyACQXhqKQMAIQQgAikDACEFIAEgDTcDiAEgASAONwOAASABIA83A3ggASAQNwNwIAFBsAFqIAFB8ABqIBRBwABCACAREAIgASATOgBpIAFBwAA6AGggASAFNwNAIAEgBDcDOCABIAM3AzAgASAINwMoIAFCADcDICABIA03AxggASAONwMQIAEgDzcDCCABIBA3AwAgASABKQPoASABKQPIAYU3A2AgASABKQPgASABKQPAAYU3A1ggASABKQPYASABKQO4AYU3A1AgASABKQPQASABKQOwAYU3A0ggAkFgaiECIAdBf2oiBw0ACwsgAUEoaiEJQgAhCEGACSELIBNBCHJB/wFxIQoDQCABQbABaiABIAlBwAAgCCAKEAIgASABKQPQASIDIAEpA7ABhTcDcCABIAEpA9gBIgQgASkDuAGFNwN4IAEgASkD4AEiBSABKQPAAYU3A4ABIAEgDSABKQPoASIGhTcDqAEgASAOIAWFNwOgASABIA8gBIU3A5gBIAEgECADhTcDkAEgASAGIAEpA8gBhTcDiAEgAEHAACAAQcAASRsiEUF/aiESAkACQCARQQdxIhMNACABQfAAaiECIAshByARIRQMAQsgEUH4AHEhFCABQfAAaiECIAshBwNAIAcgAi0AADoAACAHQQFqIQcgAkEBaiECIBNBf2oiEw0ACwsCQCASQQdJDQADQCAHIAIpAAA3AAAgB0EIaiEHIAJBCGohAiAUQXhqIhQNAAsLIAhCAXwhCCALIBFqIQsgACARayIADQALCyABQfABaiQAC6MCAQR+AkACQCAAQSBGDQBCq7OP/JGjs/DbACEBQv+kuYjFkdqCm38hAkLy5rvjo6f9p6V/IQNC58yn0NbQ67O7fyEEQQAhAAwBC0EAKQOYCSEBQQApA5AJIQJBACkDiAkhA0EAKQOACSEEQRAhAAtBACAAOgCKigFBAEIANwOAigFBAEIANwP4iQFBAEIANwPwiQFBAEIANwPoiQFBAEIANwPgiQFBAEIANwPYiQFBAEIANwPQiQFBAEIANwPIiQFBAEIANwPAiQFBACABNwO4iQFBACACNwOwiQFBACADNwOoiQFBACAENwOgiQFBACABNwOYiQFBACACNwOQiQFBACADNwOIiQFBACAENwOAiQFBAEEAOgCQigFBAEEAOwGIigELBgAgABADCwYAIAAQBwsGAEGAiQELqwIBBH4CQAJAIAFBIEYNAEKrs4/8kaOz8NsAIQNC/6S5iMWR2oKbfyEEQvLmu+Ojp/2npX8hBULnzKfQ1tDrs7t/IQZBACEBDAELQQApA5gJIQNBACkDkAkhBEEAKQOICSEFQQApA4AJIQZBECEBC0EAIAE6AIqKAUEAQgA3A4CKAUEAQgA3A/iJAUEAQgA3A/CJAUEAQgA3A+iJAUEAQgA3A+CJAUEAQgA3A9iJAUEAQgA3A9CJAUEAQgA3A8iJAUEAQgA3A8CJAUEAIAM3A7iJAUEAIAQ3A7CJAUEAIAU3A6iJAUEAIAY3A6CJAUEAIAM3A5iJAUEAIAQ3A5CJAUEAIAU3A4iJAUEAIAY3A4CJAUEAQQA6AJCKAUEAQQA7AYiKASAAEAMgAhAHCwsLAQBBgAgLBHgHAAA=";
+var hash$h = "215d875f";
+var wasmJson$h = {
+	name: name$h,
+	data: data$h,
+	hash: hash$h
+};
+
+const mutex$i = new Mutex();
+let wasmCache$i = null;
+function validateBits$2(bits) {
+    if (!Number.isInteger(bits) || bits < 8 || bits % 8 !== 0) {
+        return new Error("Invalid variant! Valid values: 8, 16, ...");
+    }
+    return null;
+}
+/**
+ * Calculates BLAKE3 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param bits Number of output bits, which has to be a number
+ *             divisible by 8. Defaults to 256.
+ * @param key Optional key (string, Buffer or TypedArray). Length should be 32 bytes.
+ * @returns Computed hash as a hexadecimal string
+ */
+function blake3(data, bits = 256, key = null) {
+    if (validateBits$2(bits)) {
+        return Promise.reject(validateBits$2(bits));
+    }
+    let keyBuffer = null;
+    let initParam = 0; // key is empty by default
+    if (key !== null) {
+        keyBuffer = getUInt8Buffer(key);
+        if (keyBuffer.length !== 32) {
+            return Promise.reject(new Error("Key length must be exactly 32 bytes"));
+        }
+        initParam = 32;
+    }
+    const hashLength = bits / 8;
+    const digestParam = hashLength;
+    if (wasmCache$i === null || wasmCache$i.hashLength !== hashLength) {
+        return lockedCreate(mutex$i, wasmJson$h, hashLength).then((wasm) => {
+            wasmCache$i = wasm;
+            if (initParam === 32) {
+                wasmCache$i.writeMemory(keyBuffer);
+            }
+            return wasmCache$i.calculate(data, initParam, digestParam);
+        });
+    }
+    try {
+        if (initParam === 32) {
+            wasmCache$i.writeMemory(keyBuffer);
+        }
+        const hash = wasmCache$i.calculate(data, initParam, digestParam);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new BLAKE3 hash instance
+ * @param bits Number of output bits, which has to be a number
+ *             divisible by 8. Defaults to 256.
+ * @param key Optional key (string, Buffer or TypedArray). Length should be 32 bytes.
+ */
+function createBLAKE3(bits = 256, key = null) {
+    if (validateBits$2(bits)) {
+        return Promise.reject(validateBits$2(bits));
+    }
+    let keyBuffer = null;
+    let initParam = 0; // key is empty by default
+    if (key !== null) {
+        keyBuffer = getUInt8Buffer(key);
+        if (keyBuffer.length !== 32) {
+            return Promise.reject(new Error("Key length must be exactly 32 bytes"));
+        }
+        initParam = 32;
+    }
+    const outputSize = bits / 8;
+    const digestParam = outputSize;
+    return WASMInterface(wasmJson$h, outputSize).then((wasm) => {
+        if (initParam === 32) {
+            wasm.writeMemory(keyBuffer);
+        }
+        wasm.init(initParam);
+        const obj = {
+            init: initParam === 32
+                ? () => {
+                    wasm.writeMemory(keyBuffer);
+                    wasm.init(initParam);
+                    return obj;
+                }
+                : () => {
+                    wasm.init(initParam);
+                    return obj;
+                },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType, digestParam),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: outputSize,
+        };
+        return obj;
+    });
+}
+
+var name$g = "crc32";
+var data$g = "AGFzbQEAAAABEQRgAAF/YAF/AGAAAGACf38AAwgHAAEBAQIAAwUEAQECAgYOAn8BQZDJBQt/AEGACAsHcAgGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAlIYXNoX0luaXQAAgtIYXNoX1VwZGF0ZQADCkhhc2hfRmluYWwABA1IYXNoX0dldFN0YXRlAAUOSGFzaF9DYWxjdWxhdGUABgpTVEFURV9TSVpFAwEKkggHBQBBgAkLwwMBA39BgIkBIQFBACECA0AgAUEAQQBBAEEAQQBBAEEAQQAgAkEBcWsgAHEgAkEBdnMiA0EBcWsgAHEgA0EBdnMiA0EBcWsgAHEgA0EBdnMiA0EBcWsgAHEgA0EBdnMiA0EBcWsgAHEgA0EBdnMiA0EBcWsgAHEgA0EBdnMiA0EBcWsgAHEgA0EBdnMiA0EBcWsgAHEgA0EBdnM2AgAgAUEEaiEBIAJBAWoiAkGAAkcNAAtBACEAA0AgAEGEkQFqIABBhIkBaigCACICQf8BcUECdEGAiQFqKAIAIAJBCHZzIgI2AgAgAEGEmQFqIAJB/wFxQQJ0QYCJAWooAgAgAkEIdnMiAjYCACAAQYShAWogAkH/AXFBAnRBgIkBaigCACACQQh2cyICNgIAIABBhKkBaiACQf8BcUECdEGAiQFqKAIAIAJBCHZzIgI2AgAgAEGEsQFqIAJB/wFxQQJ0QYCJAWooAgAgAkEIdnMiAjYCACAAQYS5AWogAkH/AXFBAnRBgIkBaigCACACQQh2cyICNgIAIABBhMEBaiACQf8BcUECdEGAiQFqKAIAIAJBCHZzNgIAIABBBGoiAEH8B0cNAAsLJwACQEEAKAKAyQEgAEYNACAAEAFBACAANgKAyQELQQBBADYChMkBC4gDAQN/QQAoAoTJAUF/cyEBQYAJIQICQCAAQQhJDQBBgAkhAgNAIAJBBGooAgAiA0EOdkH8B3FBgJEBaigCACADQRZ2QfwHcUGAiQFqKAIAcyADQQZ2QfwHcUGAmQFqKAIAcyADQf8BcUECdEGAoQFqKAIAcyACKAIAIAFzIgFBFnZB/AdxQYCpAWooAgBzIAFBDnZB/AdxQYCxAWooAgBzIAFBBnZB/AdxQYC5AWooAgBzIAFB/wFxQQJ0QYDBAWooAgBzIQEgAkEIaiECIABBeGoiAEEHSw0ACwsCQCAARQ0AAkACQCAAQQFxDQAgACEDDAELIAFB/wFxIAItAABzQQJ0QYCJAWooAgAgAUEIdnMhASACQQFqIQIgAEF/aiEDCyAAQQFGDQADQCABQf8BcSACLQAAc0ECdEGAiQFqKAIAIAFBCHZzIgFB/wFxIAJBAWotAABzQQJ0QYCJAWooAgAgAUEIdnMhASACQQJqIQIgA0F+aiIDDQALC0EAIAFBf3M2AoTJAQsyAQF/QQBBACgChMkBIgBBGHQgAEGA/gNxQQh0ciAAQQh2QYD+A3EgAEEYdnJyNgKACQsGAEGEyQELWQACQEEAKAKAyQEgAUYNACABEAFBACABNgKAyQELQQBBADYChMkBIAAQA0EAQQAoAoTJASIBQRh0IAFBgP4DcUEIdHIgAUEIdkGA/gNxIAFBGHZycjYCgAkLCwsBAEGACAsEBAAAAA==";
+var hash$g = "d2eba587";
+var wasmJson$g = {
+	name: name$g,
+	data: data$g,
+	hash: hash$g
+};
+
+const mutex$h = new Mutex();
+let wasmCache$h = null;
+function validatePoly(poly) {
+    if (!Number.isInteger(poly) || poly < 0 || poly > 0xffffffff) {
+        return new Error("Polynomial must be a valid 32-bit long unsigned integer");
+    }
+    return null;
+}
+/**
+ * Calculates CRC-32 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param polynomial Input polynomial (defaults to 0xedb88320, for CRC32C use 0x82f63b78)
+ * @returns Computed hash as a hexadecimal string
+ */
+function crc32(data, polynomial = 0xedb88320) {
+    if (validatePoly(polynomial)) {
+        return Promise.reject(validatePoly(polynomial));
+    }
+    if (wasmCache$h === null) {
+        return lockedCreate(mutex$h, wasmJson$g, 4).then((wasm) => {
+            wasmCache$h = wasm;
+            return wasmCache$h.calculate(data, polynomial);
+        });
+    }
+    try {
+        const hash = wasmCache$h.calculate(data, polynomial);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new CRC-32 hash instance
+ * @param polynomial Input polynomial (defaults to 0xedb88320, for CRC32C use 0x82f63b78)
+ */
+function createCRC32(polynomial = 0xedb88320) {
+    if (validatePoly(polynomial)) {
+        return Promise.reject(validatePoly(polynomial));
+    }
+    return WASMInterface(wasmJson$g, 4).then((wasm) => {
+        wasm.init(polynomial);
+        const obj = {
+            init: () => {
+                wasm.init(polynomial);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 4,
+            digestSize: 4,
+        };
+        return obj;
+    });
+}
+
+var name$f = "crc64";
+var data$f = "AGFzbQEAAAABDANgAAF/YAAAYAF/AAMHBgABAgEAAQUEAQECAgYOAn8BQZCJBgt/AEGACAsHcAgGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAlIYXNoX0luaXQAAQtIYXNoX1VwZGF0ZQACCkhhc2hfRmluYWwAAw1IYXNoX0dldFN0YXRlAAQOSGFzaF9DYWxjdWxhdGUABQpTVEFURV9TSVpFAwEKgwgGBQBBgAkL9QMDAX4BfwJ+AkBBACkDgIkCQQApA4AJIgBRDQBBgIkBIQFCACECA0AgAUIAQgBCAEIAQgBCAEIAQgAgAkIBg30gAIMgAkIBiIUiA0IBg30gAIMgA0IBiIUiA0IBg30gAIMgA0IBiIUiA0IBg30gAIMgA0IBiIUiA0IBg30gAIMgA0IBiIUiA0IBg30gAIMgA0IBiIUiA0IBg30gAIMgA0IBiIUiA0IBg30gAIMgA0IBiIU3AwAgAUEIaiEBIAJCAXwiAkKAAlINAAtBACEBA0AgAUGImQFqIAFBiIkBaikDACICp0H/AXFBA3RBgIkBaikDACACQgiIhSICNwMAIAFBiKkBaiACp0H/AXFBA3RBgIkBaikDACACQgiIhSICNwMAIAFBiLkBaiACp0H/AXFBA3RBgIkBaikDACACQgiIhSICNwMAIAFBiMkBaiACp0H/AXFBA3RBgIkBaikDACACQgiIhSICNwMAIAFBiNkBaiACp0H/AXFBA3RBgIkBaikDACACQgiIhSICNwMAIAFBiOkBaiACp0H/AXFBA3RBgIkBaikDACACQgiIhSICNwMAIAFBiPkBaiACp0H/AXFBA3RBgIkBaikDACACQgiIhTcDACABQQhqIgFB+A9HDQALQQAgADcDgIkCC0EAQgA3A4iJAguUAwIBfgJ/QQApA4iJAkJ/hSEBQYAJIQICQCAAQQhJDQBBgAkhAgNAIAIpAwAgAYUiAUIwiKdB/wFxQQN0QYCZAWopAwAgAUI4iKdBA3RBgIkBaikDAIUgAUIoiKdB/wFxQQN0QYCpAWopAwCFIAFCIIinQf8BcUEDdEGAuQFqKQMAhSABpyIDQRV2QfgPcUGAyQFqKQMAhSADQQ12QfgPcUGA2QFqKQMAhSADQQV2QfgPcUGA6QFqKQMAhSADQf8BcUEDdEGA+QFqKQMAhSEBIAJBCGohAiAAQXhqIgBBB0sNAAsLAkAgAEUNAAJAAkAgAEEBcQ0AIAAhAwwBCyABQv8BgyACMQAAhadBA3RBgIkBaikDACABQgiIhSEBIAJBAWohAiAAQX9qIQMLIABBAUYNAANAIAFC/wGDIAIxAACFp0EDdEGAiQFqKQMAIAFCCIiFIgFC/wGDIAJBAWoxAACFp0EDdEGAiQFqKQMAIAFCCIiFIQEgAkECaiECIANBfmoiAw0ACwtBACABQn+FNwOIiQILZAEBfkEAQQApA4iJAiIAQjiGIABCgP4Dg0IohoQgAEKAgPwHg0IYhiAAQoCAgPgPg0IIhoSEIABCCIhCgICA+A+DIABCGIhCgID8B4OEIABCKIhCgP4DgyAAQjiIhISENwOACQsGAEGIiQILAgALCwsBAEGACAsECAAAAA==";
+var hash$f = "c5ac6c16";
+var wasmJson$f = {
+	name: name$f,
+	data: data$f,
+	hash: hash$f
+};
+
+const mutex$g = new Mutex();
+let wasmCache$g = null;
+const polyBuffer = new Uint8Array(8);
+function parsePoly(poly) {
+    const errText = "Polynomial must be provided as a 16 char long hex string";
+    if (typeof poly !== "string" || poly.length !== 16) {
+        return { hi: 0, lo: 0, err: new Error(errText) };
+    }
+    const hi = Number(`0x${poly.slice(0, 8)}`);
+    const lo = Number(`0x${poly.slice(8)}`);
+    if (Number.isNaN(hi) || Number.isNaN(lo)) {
+        return { hi, lo, err: new Error(errText) };
+    }
+    return { hi, lo, err: null };
+}
+function writePoly(arr, lo, hi) {
+    // write in little-endian format
+    const buffer = new DataView(arr);
+    buffer.setUint32(0, lo, true);
+    buffer.setUint32(4, hi, true);
+}
+/**
+ * Calculates CRC-64 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param polynomial Input polynomial (defaults to 'c96c5795d7870f42' - ECMA)
+ * @returns Computed hash as a hexadecimal string
+ */
+function crc64(data, polynomial = "c96c5795d7870f42") {
+    const { hi, lo, err } = parsePoly(polynomial);
+    if (err !== null) {
+        return Promise.reject(err);
+    }
+    if (wasmCache$g === null) {
+        return lockedCreate(mutex$g, wasmJson$f, 8).then((wasm) => {
+            wasmCache$g = wasm;
+            writePoly(polyBuffer.buffer, lo, hi);
+            wasmCache$g.writeMemory(polyBuffer);
+            return wasmCache$g.calculate(data);
+        });
+    }
+    try {
+        writePoly(polyBuffer.buffer, lo, hi);
+        wasmCache$g.writeMemory(polyBuffer);
+        const hash = wasmCache$g.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new CRC-64 hash instance
+ * @param polynomial Input polynomial (defaults to 'c96c5795d7870f42' - ECMA)
+ */
+function createCRC64(polynomial = "c96c5795d7870f42") {
+    const { hi, lo, err } = parsePoly(polynomial);
+    if (err !== null) {
+        return Promise.reject(err);
+    }
+    return WASMInterface(wasmJson$f, 8).then((wasm) => {
+        const instanceBuffer = new Uint8Array(8);
+        writePoly(instanceBuffer.buffer, lo, hi);
+        wasm.writeMemory(instanceBuffer);
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.writeMemory(instanceBuffer);
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 8,
+            digestSize: 8,
+        };
+        return obj;
+    });
+}
+
+var name$e = "md4";
+var data$e = "AGFzbQEAAAABEgRgAAF/YAAAYAF/AGACf38BfwMIBwABAgMBAAIFBAEBAgIGDgJ/AUGgigULfwBBgAgLB3AIBm1lbW9yeQIADkhhc2hfR2V0QnVmZmVyAAAJSGFzaF9Jbml0AAELSGFzaF9VcGRhdGUAAgpIYXNoX0ZpbmFsAAQNSGFzaF9HZXRTdGF0ZQAFDkhhc2hfQ2FsY3VsYXRlAAYKU1RBVEVfU0laRQMBCucUBwUAQYAJCy0AQQBC/rnrxemOlZkQNwKQiQFBAEKBxpS6lvHq5m83AoiJAUEAQgA3AoCJAQu+BQEHf0EAQQAoAoCJASIBIABqQf////8BcSICNgKAiQFBAEEAKAKEiQEgAiABSWogAEEddmo2AoSJAQJAAkACQAJAAkACQCABQT9xIgMNAEGACSEEDAELIABBwAAgA2siBUkNASAFQQNxIQZBACEBAkAgA0E/c0EDSQ0AIANBgIkBaiEEIAVB/ABxIQdBACEBA0AgBCABaiICQRhqIAFBgAlqLQAAOgAAIAJBGWogAUGBCWotAAA6AAAgAkEaaiABQYIJai0AADoAACACQRtqIAFBgwlqLQAAOgAAIAcgAUEEaiIBRw0ACwsCQCAGRQ0AIANBmIkBaiECA0AgAiABaiABQYAJai0AADoAACABQQFqIQEgBkF/aiIGDQALC0GYiQFBwAAQAxogACAFayEAIAVBgAlqIQQLIABBwABPDQEgACECDAILIABFDQIgAEEDcSEGQQAhAQJAIABBBEkNACADQYCJAWohBCAAQXxxIQBBACEBA0AgBCABaiICQRhqIAFBgAlqLQAAOgAAIAJBGWogAUGBCWotAAA6AAAgAkEaaiABQYIJai0AADoAACACQRtqIAFBgwlqLQAAOgAAIAAgAUEEaiIBRw0ACwsgBkUNAiADQZiJAWohAgNAIAIgAWogAUGACWotAAA6AAAgAUEBaiEBIAZBf2oiBg0ADAMLCyAAQT9xIQIgBCAAQUBxEAMhBAsgAkUNACACQQNxIQZBACEBAkAgAkEESQ0AIAJBPHEhAEEAIQEDQCABQZiJAWogBCABaiICLQAAOgAAIAFBmYkBaiACQQFqLQAAOgAAIAFBmokBaiACQQJqLQAAOgAAIAFBm4kBaiACQQNqLQAAOgAAIAAgAUEEaiIBRw0ACwsgBkUNAANAIAFBmIkBaiAEIAFqLQAAOgAAIAFBAWohASAGQX9qIgYNAAsLC+sKARd/QQAoApSJASECQQAoApCJASEDQQAoAoyJASEEQQAoAoiJASEFA0AgACgCHCIGIAAoAhQiByAAKAIYIgggACgCECIJIAAoAiwiCiAAKAIoIgsgACgCJCIMIAAoAiAiDSALIAggACgCCCIOIANqIAAoAgQiDyACaiAEIAMgAnNxIAJzIAVqIAAoAgAiEGpBA3ciESAEIANzcSADc2pBB3ciEiARIARzcSAEc2pBC3ciE2ogEiAHaiAJIBFqIAAoAgwiFCAEaiATIBIgEXNxIBFzakETdyIRIBMgEnNxIBJzakEDdyISIBEgE3NxIBNzakEHdyITIBIgEXNxIBFzakELdyIVaiATIAxqIBIgDWogESAGaiAVIBMgEnNxIBJzakETdyIRIBUgE3NxIBNzakEDdyISIBEgFXNxIBVzakEHdyITIBIgEXNxIBFzakELdyIVIAAoAjgiFmogEyAAKAI0IhdqIBIgACgCMCIYaiARIApqIBUgEyASc3EgEnNqQRN3IhIgFSATc3EgE3NqQQN3IhMgEiAVc3EgFXNqQQd3IhUgEyASc3EgEnNqQQt3IhFqIAkgFWogECATaiASIAAoAjwiCWogESAVIBNzcSATc2pBE3ciEiARIBVycSARIBVxcmpBmfOJ1AVqQQN3IhMgEiARcnEgEiARcXJqQZnzidQFakEFdyIRIBMgEnJxIBMgEnFyakGZ84nUBWpBCXciFWogByARaiAPIBNqIBggEmogFSARIBNycSARIBNxcmpBmfOJ1AVqQQ13IhIgFSARcnEgFSARcXJqQZnzidQFakEDdyIRIBIgFXJxIBIgFXFyakGZ84nUBWpBBXciEyARIBJycSARIBJxcmpBmfOJ1AVqQQl3IhVqIAggE2ogDiARaiAXIBJqIBUgEyARcnEgEyARcXJqQZnzidQFakENdyIRIBUgE3JxIBUgE3FyakGZ84nUBWpBA3ciEiARIBVycSARIBVxcmpBmfOJ1AVqQQV3IhMgEiARcnEgEiARcXJqQZnzidQFakEJdyIVaiAGIBNqIBQgEmogFiARaiAVIBMgEnJxIBMgEnFyakGZ84nUBWpBDXciESAVIBNycSAVIBNxcmpBmfOJ1AVqQQN3IhIgESAVcnEgESAVcXJqQZnzidQFakEFdyITIBIgEXJxIBIgEXFyakGZ84nUBWpBCXciFWogECASaiAJIBFqIBUgEyAScnEgEyAScXJqQZnzidQFakENdyIGIBVzIhIgE3NqQaHX5/YGakEDdyIRIAZzIA0gE2ogEiARc2pBodfn9gZqQQl3IhJzakGh1+f2BmpBC3ciE2ogDiARaiATIBJzIBggBmogEiARcyATc2pBodfn9gZqQQ93IhFzakGh1+f2BmpBA3ciFSARcyALIBJqIBEgE3MgFXNqQaHX5/YGakEJdyISc2pBodfn9gZqQQt3IhNqIA8gFWogEyAScyAWIBFqIBIgFXMgE3NqQaHX5/YGakEPdyIRc2pBodfn9gZqQQN3IhUgEXMgDCASaiARIBNzIBVzakGh1+f2BmpBCXciEnNqQaHX5/YGakELdyITaiAUIBVqIBMgEnMgFyARaiASIBVzIBNzakGh1+f2BmpBD3ciEXNqQaHX5/YGakEDdyIVIBFzIAogEmogESATcyAVc2pBodfn9gZqQQl3IhJzakGh1+f2BmpBC3ciEyADaiEDIAkgEWogEiAVcyATc2pBodfn9gZqQQ93IARqIQQgEiACaiECIBUgBWohBSAAQcAAaiEAIAFBQGoiAQ0AC0EAIAI2ApSJAUEAIAM2ApCJAUEAIAQ2AoyJAUEAIAU2AoiJASAAC8gDAQV/QQAoAoCJAUE/cSIAQZiJAWpBgAE6AAAgAEEBaiEBAkACQAJAAkAgAEE/cyICQQdLDQAgAkUNASABQZiJAWpBADoAACACQQFGDQEgAEGaiQFqQQA6AAAgAkECRg0BIABBm4kBakEAOgAAIAJBA0YNASAAQZyJAWpBADoAACACQQRGDQEgAEGdiQFqQQA6AAAgAkEFRg0BIABBnokBakEAOgAAIAJBBkYNASAAQZ+JAWpBADoAAAwBCyACQQhGDQJBNiAAayIDIQQCQCACQQNxIgBFDQBBACAAayEEQQAhAANAIABBz4kBakEAOgAAIAQgAEF/aiIARw0ACyADIABqIQQLIANBA0kNAgwBC0GYiQFBwAAQAxpBACEBQTchBAsgAUGAiQFqIQBBfyECA0AgACAEakEVakEANgAAIABBfGohACAEIAJBBGoiAkcNAAsLQQBBACgChIkBNgLUiQFBAEEAKAKAiQEiAEEVdjoA04kBQQAgAEENdjoA0okBQQAgAEEFdjoA0YkBQQAgAEEDdCIAOgDQiQFBACAANgKAiQFBmIkBQcAAEAMaQQBBACkCiIkBNwOACUEAQQApApCJATcDiAkLBgBBgIkBCzMAQQBC/rnrxemOlZkQNwKQiQFBAEKBxpS6lvHq5m83AoiJAUEAQgA3AoCJASAAEAIQBAsLCwEAQYAICwSYAAAA";
+var hash$e = "bd8ce7c7";
+var wasmJson$e = {
+	name: name$e,
+	data: data$e,
+	hash: hash$e
+};
+
+const mutex$f = new Mutex();
+let wasmCache$f = null;
+/**
+ * Calculates MD4 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function md4(data) {
+    if (wasmCache$f === null) {
+        return lockedCreate(mutex$f, wasmJson$e, 16).then((wasm) => {
+            wasmCache$f = wasm;
+            return wasmCache$f.calculate(data);
+        });
+    }
+    try {
+        const hash = wasmCache$f.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new MD4 hash instance
+ */
+function createMD4() {
+    return WASMInterface(wasmJson$e, 16).then((wasm) => {
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 16,
+        };
+        return obj;
+    });
+}
+
+var name$d = "md5";
+var data$d = "AGFzbQEAAAABEgRgAAF/YAAAYAF/AGACf38BfwMIBwABAgMBAAIFBAEBAgIGDgJ/AUGgigULfwBBgAgLB3AIBm1lbW9yeQIADkhhc2hfR2V0QnVmZmVyAAAJSGFzaF9Jbml0AAELSGFzaF9VcGRhdGUAAgpIYXNoX0ZpbmFsAAQNSGFzaF9HZXRTdGF0ZQAFDkhhc2hfQ2FsY3VsYXRlAAYKU1RBVEVfU0laRQMBCoMaBwUAQYAJCy0AQQBC/rnrxemOlZkQNwKQiQFBAEKBxpS6lvHq5m83AoiJAUEAQgA3AoCJAQu+BQEHf0EAQQAoAoCJASIBIABqQf////8BcSICNgKAiQFBAEEAKAKEiQEgAiABSWogAEEddmo2AoSJAQJAAkACQAJAAkACQCABQT9xIgMNAEGACSEEDAELIABBwAAgA2siBUkNASAFQQNxIQZBACEBAkAgA0E/c0EDSQ0AIANBgIkBaiEEIAVB/ABxIQdBACEBA0AgBCABaiICQRhqIAFBgAlqLQAAOgAAIAJBGWogAUGBCWotAAA6AAAgAkEaaiABQYIJai0AADoAACACQRtqIAFBgwlqLQAAOgAAIAcgAUEEaiIBRw0ACwsCQCAGRQ0AIANBmIkBaiECA0AgAiABaiABQYAJai0AADoAACABQQFqIQEgBkF/aiIGDQALC0GYiQFBwAAQAxogACAFayEAIAVBgAlqIQQLIABBwABPDQEgACECDAILIABFDQIgAEEDcSEGQQAhAQJAIABBBEkNACADQYCJAWohBCAAQXxxIQBBACEBA0AgBCABaiICQRhqIAFBgAlqLQAAOgAAIAJBGWogAUGBCWotAAA6AAAgAkEaaiABQYIJai0AADoAACACQRtqIAFBgwlqLQAAOgAAIAAgAUEEaiIBRw0ACwsgBkUNAiADQZiJAWohAgNAIAIgAWogAUGACWotAAA6AAAgAUEBaiEBIAZBf2oiBg0ADAMLCyAAQT9xIQIgBCAAQUBxEAMhBAsgAkUNACACQQNxIQZBACEBAkAgAkEESQ0AIAJBPHEhAEEAIQEDQCABQZiJAWogBCABaiICLQAAOgAAIAFBmYkBaiACQQFqLQAAOgAAIAFBmokBaiACQQJqLQAAOgAAIAFBm4kBaiACQQNqLQAAOgAAIAAgAUEEaiIBRw0ACwsgBkUNAANAIAFBmIkBaiAEIAFqLQAAOgAAIAFBAWohASAGQX9qIgYNAAsLC4cQARl/QQAoApSJASECQQAoApCJASEDQQAoAoyJASEEQQAoAoiJASEFA0AgACgCCCIGIAAoAhgiByAAKAIoIgggACgCOCIJIAAoAjwiCiAAKAIMIgsgACgCHCIMIAAoAiwiDSAMIAsgCiANIAkgCCAHIAMgBmogAiAAKAIEIg5qIAUgBCACIANzcSACc2ogACgCACIPakH4yKq7fWpBB3cgBGoiECAEIANzcSADc2pB1u6exn5qQQx3IBBqIhEgECAEc3EgBHNqQdvhgaECakERdyARaiISaiAAKAIUIhMgEWogACgCECIUIBBqIAQgC2ogEiARIBBzcSAQc2pB7p33jXxqQRZ3IBJqIhAgEiARc3EgEXNqQa+f8Kt/akEHdyAQaiIRIBAgEnNxIBJzakGqjJ+8BGpBDHcgEWoiEiARIBBzcSAQc2pBk4zBwXpqQRF3IBJqIhVqIAAoAiQiFiASaiAAKAIgIhcgEWogDCAQaiAVIBIgEXNxIBFzakGBqppqakEWdyAVaiIQIBUgEnNxIBJzakHYsYLMBmpBB3cgEGoiESAQIBVzcSAVc2pBr++T2nhqQQx3IBFqIhIgESAQc3EgEHNqQbG3fWpBEXcgEmoiFWogACgCNCIYIBJqIAAoAjAiGSARaiANIBBqIBUgEiARc3EgEXNqQb6v88p4akEWdyAVaiIQIBUgEnNxIBJzakGiosDcBmpBB3cgEGoiESAQIBVzcSAVc2pBk+PhbGpBDHcgEWoiFSARIBBzcSAQc2pBjofls3pqQRF3IBVqIhJqIAcgFWogDiARaiAKIBBqIBIgFSARc3EgEXNqQaGQ0M0EakEWdyASaiIQIBJzIBVxIBJzakHiyviwf2pBBXcgEGoiESAQcyAScSAQc2pBwOaCgnxqQQl3IBFqIhIgEXMgEHEgEXNqQdG0+bICakEOdyASaiIVaiAIIBJqIBMgEWogDyAQaiAVIBJzIBFxIBJzakGqj9vNfmpBFHcgFWoiECAVcyAScSAVc2pB3aC8sX1qQQV3IBBqIhEgEHMgFXEgEHNqQdOokBJqQQl3IBFqIhIgEXMgEHEgEXNqQYHNh8V9akEOdyASaiIVaiAJIBJqIBYgEWogFCAQaiAVIBJzIBFxIBJzakHI98++fmpBFHcgFWoiECAVcyAScSAVc2pB5puHjwJqQQV3IBBqIhEgEHMgFXEgEHNqQdaP3Jl8akEJdyARaiISIBFzIBBxIBFzakGHm9Smf2pBDncgEmoiFWogBiASaiAYIBFqIBcgEGogFSAScyARcSASc2pB7anoqgRqQRR3IBVqIhAgFXMgEnEgFXNqQYXSj896akEFdyAQaiIRIBBzIBVxIBBzakH4x75nakEJdyARaiISIBFzIBBxIBFzakHZhby7BmpBDncgEmoiFWogFyASaiATIBFqIBkgEGogFSAScyARcSASc2pBipmp6XhqQRR3IBVqIhAgFXMiFSASc2pBwvJoakEEdyAQaiIRIBVzakGB7ce7eGpBC3cgEWoiEiARcyIaIBBzakGiwvXsBmpBEHcgEmoiFWogFCASaiAOIBFqIAkgEGogFSAac2pBjPCUb2pBF3cgFWoiECAVcyIVIBJzakHE1PulempBBHcgEGoiESAVc2pBqZ/73gRqQQt3IBFqIhIgEXMiCSAQc2pB4JbttX9qQRB3IBJqIhVqIA8gEmogGCARaiAIIBBqIBUgCXNqQfD4/vV7akEXdyAVaiIQIBVzIhUgEnNqQcb97cQCakEEdyAQaiIRIBVzakH6z4TVfmpBC3cgEWoiEiARcyIIIBBzakGF4bynfWpBEHcgEmoiFWogGSASaiAWIBFqIAcgEGogFSAIc2pBhbqgJGpBF3cgFWoiESAVcyIQIBJzakG5oNPOfWpBBHcgEWoiEiAQc2pB5bPutn5qQQt3IBJqIhUgEnMiByARc2pB+PmJ/QFqQRB3IBVqIhBqIAwgFWogDyASaiAGIBFqIBAgB3NqQeWssaV8akEXdyAQaiIRIBVBf3NyIBBzakHExKShf2pBBncgEWoiEiAQQX9zciARc2pBl/+rmQRqQQp3IBJqIhAgEUF/c3IgEnNqQafH0Nx6akEPdyAQaiIVaiALIBBqIBkgEmogEyARaiAVIBJBf3NyIBBzakG5wM5kakEVdyAVaiIRIBBBf3NyIBVzakHDs+2qBmpBBncgEWoiECAVQX9zciARc2pBkpmz+HhqQQp3IBBqIhIgEUF/c3IgEHNqQf3ov39qQQ93IBJqIhVqIAogEmogFyAQaiAOIBFqIBUgEEF/c3IgEnNqQdG7kax4akEVdyAVaiIQIBJBf3NyIBVzakHP/KH9BmpBBncgEGoiESAVQX9zciAQc2pB4M2zcWpBCncgEWoiEiAQQX9zciARc2pBlIaFmHpqQQ93IBJqIhVqIA0gEmogFCARaiAYIBBqIBUgEUF/c3IgEnNqQaGjoPAEakEVdyAVaiIQIBJBf3NyIBVzakGC/c26f2pBBncgEGoiESAVQX9zciAQc2pBteTr6XtqQQp3IBFqIhIgEEF/c3IgEXNqQbul39YCakEPdyASaiIVIARqIBYgEGogFSARQX9zciASc2pBkaeb3H5qQRV3aiEEIBUgA2ohAyASIAJqIQIgESAFaiEFIABBwABqIQAgAUFAaiIBDQALQQAgAjYClIkBQQAgAzYCkIkBQQAgBDYCjIkBQQAgBTYCiIkBIAALyAMBBX9BACgCgIkBQT9xIgBBmIkBakGAAToAACAAQQFqIQECQAJAAkACQCAAQT9zIgJBB0sNACACRQ0BIAFBmIkBakEAOgAAIAJBAUYNASAAQZqJAWpBADoAACACQQJGDQEgAEGbiQFqQQA6AAAgAkEDRg0BIABBnIkBakEAOgAAIAJBBEYNASAAQZ2JAWpBADoAACACQQVGDQEgAEGeiQFqQQA6AAAgAkEGRg0BIABBn4kBakEAOgAADAELIAJBCEYNAkE2IABrIgMhBAJAIAJBA3EiAEUNAEEAIABrIQRBACEAA0AgAEHPiQFqQQA6AAAgBCAAQX9qIgBHDQALIAMgAGohBAsgA0EDSQ0CDAELQZiJAUHAABADGkEAIQFBNyEECyABQYCJAWohAEF/IQIDQCAAIARqQRVqQQA2AAAgAEF8aiEAIAQgAkEEaiICRw0ACwtBAEEAKAKEiQE2AtSJAUEAQQAoAoCJASIAQRV2OgDTiQFBACAAQQ12OgDSiQFBACAAQQV2OgDRiQFBACAAQQN0IgA6ANCJAUEAIAA2AoCJAUGYiQFBwAAQAxpBAEEAKQKIiQE3A4AJQQBBACkCkIkBNwOICQsGAEGAiQELMwBBAEL+uevF6Y6VmRA3ApCJAUEAQoHGlLqW8ermbzcCiIkBQQBCADcCgIkBIAAQAhAECwsLAQBBgAgLBJgAAAA=";
+var hash$d = "e6508e4b";
+var wasmJson$d = {
+	name: name$d,
+	data: data$d,
+	hash: hash$d
+};
+
+const mutex$e = new Mutex();
+let wasmCache$e = null;
+/**
+ * Calculates MD5 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function md5(data) {
+    if (wasmCache$e === null) {
+        return lockedCreate(mutex$e, wasmJson$d, 16).then((wasm) => {
+            wasmCache$e = wasm;
+            return wasmCache$e.calculate(data);
+        });
+    }
+    try {
+        const hash = wasmCache$e.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new MD5 hash instance
+ */
+function createMD5() {
+    return WASMInterface(wasmJson$d, 16).then((wasm) => {
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 16,
+        };
+        return obj;
+    });
+}
+
+var name$c = "sha1";
+var data$c = "AGFzbQEAAAABEQRgAAF/YAF/AGAAAGACf38AAwkIAAECAwECAAEFBAEBAgIGDgJ/AUHgiQULfwBBgAgLB3AIBm1lbW9yeQIADkhhc2hfR2V0QnVmZmVyAAAJSGFzaF9Jbml0AAILSGFzaF9VcGRhdGUABApIYXNoX0ZpbmFsAAUNSGFzaF9HZXRTdGF0ZQAGDkhhc2hfQ2FsY3VsYXRlAAcKU1RBVEVfU0laRQMBCpoqCAUAQYAJC68iCgF+An8BfgF/AX4DfwF+AX8Bfkd/QQAgACkDECIBQiCIpyICQRh0IAJBgP4DcUEIdHIgAUIoiKdBgP4DcSABQjiIp3JyIgMgACkDCCIEQiCIpyICQRh0IAJBgP4DcUEIdHIgBEIoiKdBgP4DcSAEQjiIp3JyIgVzIAApAygiBkIgiKciAkEYdCACQYD+A3FBCHRyIAZCKIinQYD+A3EgBkI4iKdyciIHcyAEpyICQRh0IAJBgP4DcUEIdHIgAkEIdkGA/gNxIAJBGHZyciIIIAApAwAiBKciAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiCXMgACkDICIKpyICQRh0IAJBgP4DcUEIdHIgAkEIdkGA/gNxIAJBGHZyciILcyAAKQMwIgxCIIinIgJBGHQgAkGA/gNxQQh0ciAMQiiIp0GA/gNxIAxCOIincnIiAnNBAXciDXNBAXciDiAFIARCIIinIg9BGHQgD0GA/gNxQQh0ciAEQiiIp0GA/gNxIARCOIincnIiEHMgCkIgiKciD0EYdCAPQYD+A3FBCHRyIApCKIinQYD+A3EgCkI4iKdyciIRcyAAKQM4IgSnIg9BGHQgD0GA/gNxQQh0ciAPQQh2QYD+A3EgD0EYdnJyIg9zQQF3IhJzIAcgEXMgEnMgCyAAKQMYIgqnIgBBGHQgAEGA/gNxQQh0ciAAQQh2QYD+A3EgAEEYdnJyIhNzIA9zIA5zQQF3IgBzQQF3IhRzIA0gD3MgAHMgAiAHcyAOcyAGpyIVQRh0IBVBgP4DcUEIdHIgFUEIdkGA/gNxIBVBGHZyciIWIAtzIA1zIApCIIinIhVBGHQgFUGA/gNxQQh0ciAKQiiIp0GA/gNxIApCOIincnIiFyADcyACcyABpyIVQRh0IBVBgP4DcUEIdHIgFUEIdkGA/gNxIBVBGHZyciIYIAhzIBZzIARCIIinIhVBGHQgFUGA/gNxQQh0ciAEQiiIp0GA/gNxIARCOIincnIiFXNBAXciGXNBAXciGnNBAXciG3NBAXciHHNBAXciHXNBAXciHiASIBVzIBEgF3MgFXMgEyAYcyAMpyIfQRh0IB9BgP4DcUEIdHIgH0EIdkGA/gNxIB9BGHZyciIgcyASc0EBdyIfc0EBdyIhcyAPICBzIB9zIBRzQQF3IiJzQQF3IiNzIBQgIXMgI3MgACAfcyAicyAec0EBdyIkc0EBdyIlcyAdICJzICRzIBwgFHMgHnMgGyAAcyAdcyAaIA5zIBxzIBkgDXMgG3MgFSACcyAacyAgIBZzIBlzICFzQQF3IiZzQQF3IidzQQF3IihzQQF3IilzQQF3IipzQQF3IitzQQF3IixzQQF3Ii0gIyAncyAhIBpzICdzIB8gGXMgJnMgI3NBAXciLnNBAXciL3MgIiAmcyAucyAlc0EBdyIwc0EBdyIxcyAlIC9zIDFzICQgLnMgMHMgLXNBAXciMnNBAXciM3MgLCAwcyAycyArICVzIC1zICogJHMgLHMgKSAecyArcyAoIB1zICpzICcgHHMgKXMgJiAbcyAocyAvc0EBdyI0c0EBdyI1c0EBdyI2c0EBdyI3c0EBdyI4c0EBdyI5c0EBdyI6c0EBdyI7IDEgNXMgLyApcyA1cyAuIChzIDRzIDFzQQF3IjxzQQF3Ij1zIDAgNHMgPHMgM3NBAXciPnNBAXciP3MgMyA9cyA/cyAyIDxzID5zIDtzQQF3IkBzQQF3IkFzIDogPnMgQHMgOSAzcyA7cyA4IDJzIDpzIDcgLXMgOXMgNiAscyA4cyA1ICtzIDdzIDQgKnMgNnMgPXNBAXciQnNBAXciQ3NBAXciRHNBAXciRXNBAXciRnNBAXciR3NBAXciSHNBAXciSSA+IEJzIDwgNnMgQnMgP3NBAXciSnMgQXNBAXciSyA9IDdzIENzIEpzQQF3IkwgRCA5IDIgMSA0ICkgHSAUIB8gFSAWQQAoAoCJASJNQQV3QQAoApCJASJOaiAJakEAKAKMiQEiT0EAKAKIiQEiCXNBACgChIkBIlBxIE9zakGZ84nUBWoiUUEedyJSIANqIFBBHnciAyAFaiBPIAMgCXMgTXEgCXNqIBBqIFFBBXdqQZnzidQFaiIQIFIgTUEedyIFc3EgBXNqIAkgCGogUSADIAVzcSADc2ogEEEFd2pBmfOJ1AVqIlFBBXdqQZnzidQFaiJTIFFBHnciAyAQQR53IghzcSAIc2ogBSAYaiBRIAggUnNxIFJzaiBTQQV3akGZ84nUBWoiBUEFd2pBmfOJ1AVqIhhBHnciUmogU0EedyIWIAtqIAggE2ogBSAWIANzcSADc2ogGEEFd2pBmfOJ1AVqIgggUiAFQR53IgtzcSALc2ogAyAXaiAYIAsgFnNxIBZzaiAIQQV3akGZ84nUBWoiBUEFd2pBmfOJ1AVqIhMgBUEedyIWIAhBHnciA3NxIANzaiALIBFqIAUgAyBSc3EgUnNqIBNBBXdqQZnzidQFaiIRQQV3akGZ84nUBWoiUkEedyILaiACIBNBHnciFWogByADaiARIBUgFnNxIBZzaiBSQQV3akGZ84nUBWoiByALIBFBHnciAnNxIAJzaiAgIBZqIFIgAiAVc3EgFXNqIAdBBXdqQZnzidQFaiIRQQV3akGZ84nUBWoiFiARQR53IhUgB0EedyIHc3EgB3NqIA8gAmogESAHIAtzcSALc2ogFkEFd2pBmfOJ1AVqIgtBBXdqQZnzidQFaiIRQR53IgJqIBIgFWogESALQR53Ig8gFkEedyISc3EgEnNqIA0gB2ogCyASIBVzcSAVc2ogEUEFd2pBmfOJ1AVqIg1BBXdqQZnzidQFaiIVQR53Ih8gDUEedyIHcyAZIBJqIA0gAiAPc3EgD3NqIBVBBXdqQZnzidQFaiINc2ogDiAPaiAVIAcgAnNxIAJzaiANQQV3akGZ84nUBWoiAkEFd2pBodfn9gZqIg5BHnciD2ogACAfaiACQR53IgAgDUEedyINcyAOc2ogGiAHaiANIB9zIAJzaiAOQQV3akGh1+f2BmoiAkEFd2pBodfn9gZqIg5BHnciEiACQR53IhRzICEgDWogDyAAcyACc2ogDkEFd2pBodfn9gZqIgJzaiAbIABqIBQgD3MgDnNqIAJBBXdqQaHX5/YGaiIAQQV3akGh1+f2BmoiDUEedyIOaiAcIBJqIABBHnciDyACQR53IgJzIA1zaiAmIBRqIAIgEnMgAHNqIA1BBXdqQaHX5/YGaiIAQQV3akGh1+f2BmoiDUEedyISIABBHnciFHMgIiACaiAOIA9zIABzaiANQQV3akGh1+f2BmoiAHNqICcgD2ogFCAOcyANc2ogAEEFd2pBodfn9gZqIgJBBXdqQaHX5/YGaiINQR53Ig5qICggEmogAkEedyIPIABBHnciAHMgDXNqICMgFGogACAScyACc2ogDUEFd2pBodfn9gZqIgJBBXdqQaHX5/YGaiINQR53IhIgAkEedyIUcyAeIABqIA4gD3MgAnNqIA1BBXdqQaHX5/YGaiIAc2ogLiAPaiAUIA5zIA1zaiAAQQV3akGh1+f2BmoiAkEFd2pBodfn9gZqIg1BHnciDmogKiAAQR53IgBqIA4gAkEedyIPcyAkIBRqIAAgEnMgAnNqIA1BBXdqQaHX5/YGaiIUc2ogLyASaiAPIABzIA1zaiAUQQV3akGh1+f2BmoiDUEFd2pBodfn9gZqIgAgDUEedyICciAUQR53IhJxIAAgAnFyaiAlIA9qIBIgDnMgDXNqIABBBXdqQaHX5/YGaiINQQV3akHc+e74eGoiDkEedyIPaiA1IABBHnciAGogKyASaiANIAByIAJxIA0gAHFyaiAOQQV3akHc+e74eGoiEiAPciANQR53Ig1xIBIgD3FyaiAwIAJqIA4gDXIgAHEgDiANcXJqIBJBBXdqQdz57vh4aiIAQQV3akHc+e74eGoiAiAAQR53Ig5yIBJBHnciEnEgAiAOcXJqICwgDWogACASciAPcSAAIBJxcmogAkEFd2pB3Pnu+HhqIgBBBXdqQdz57vh4aiINQR53Ig9qIDwgAkEedyICaiA2IBJqIAAgAnIgDnEgACACcXJqIA1BBXdqQdz57vh4aiISIA9yIABBHnciAHEgEiAPcXJqIC0gDmogDSAAciACcSANIABxcmogEkEFd2pB3Pnu+HhqIgJBBXdqQdz57vh4aiINIAJBHnciDnIgEkEedyIScSANIA5xcmogNyAAaiACIBJyIA9xIAIgEnFyaiANQQV3akHc+e74eGoiAEEFd2pB3Pnu+HhqIgJBHnciD2ogMyANQR53Ig1qID0gEmogACANciAOcSAAIA1xcmogAkEFd2pB3Pnu+HhqIhIgD3IgAEEedyIAcSASIA9xcmogOCAOaiACIAByIA1xIAIgAHFyaiASQQV3akHc+e74eGoiAkEFd2pB3Pnu+HhqIg0gAkEedyIOciASQR53IhJxIA0gDnFyaiBCIABqIAIgEnIgD3EgAiAScXJqIA1BBXdqQdz57vh4aiIAQQV3akHc+e74eGoiAkEedyIPaiBDIA5qIAIgAEEedyIUciANQR53Ig1xIAIgFHFyaiA+IBJqIAAgDXIgDnEgACANcXJqIAJBBXdqQdz57vh4aiIAQQV3akHc+e74eGoiAkEedyISIABBHnciDnMgOiANaiAAIA9yIBRxIAAgD3FyaiACQQV3akHc+e74eGoiAHNqID8gFGogAiAOciAPcSACIA5xcmogAEEFd2pB3Pnu+HhqIgJBBXdqQdaDi9N8aiINQR53Ig9qIEogEmogAkEedyIUIABBHnciAHMgDXNqIDsgDmogACAScyACc2ogDUEFd2pB1oOL03xqIgJBBXdqQdaDi9N8aiINQR53Ig4gAkEedyIScyBFIABqIA8gFHMgAnNqIA1BBXdqQdaDi9N8aiIAc2ogQCAUaiASIA9zIA1zaiAAQQV3akHWg4vTfGoiAkEFd2pB1oOL03xqIg1BHnciD2ogQSAOaiACQR53IhQgAEEedyIAcyANc2ogRiASaiAAIA5zIAJzaiANQQV3akHWg4vTfGoiAkEFd2pB1oOL03xqIg1BHnciDiACQR53IhJzIEIgOHMgRHMgTHNBAXciFSAAaiAPIBRzIAJzaiANQQV3akHWg4vTfGoiAHNqIEcgFGogEiAPcyANc2ogAEEFd2pB1oOL03xqIgJBBXdqQdaDi9N8aiINQR53Ig9qIEggDmogAkEedyIUIABBHnciAHMgDXNqIEMgOXMgRXMgFXNBAXciGSASaiAAIA5zIAJzaiANQQV3akHWg4vTfGoiAkEFd2pB1oOL03xqIg1BHnciDiACQR53IhJzID8gQ3MgTHMgS3NBAXciGiAAaiAPIBRzIAJzaiANQQV3akHWg4vTfGoiAHNqIEQgOnMgRnMgGXNBAXciGyAUaiASIA9zIA1zaiAAQQV3akHWg4vTfGoiAkEFd2pB1oOL03xqIg1BHnciDyBOajYCkIkBQQAgTyBKIERzIBVzIBpzQQF3IhQgEmogAEEedyIAIA5zIAJzaiANQQV3akHWg4vTfGoiEkEedyIVajYCjIkBQQAgCSBFIDtzIEdzIBtzQQF3IA5qIAJBHnciAiAAcyANc2ogEkEFd2pB1oOL03xqIg1BHndqNgKIiQFBACBQIEAgSnMgS3MgSXNBAXcgAGogDyACcyASc2ogDUEFd2pB1oOL03xqIgBqNgKEiQFBACBNIEwgRXMgGXMgFHNBAXdqIAJqIBUgD3MgDXNqIABBBXdqQdaDi9N8ajYCgIkBCzoAQQBC/rnrxemOlZkQNwKIiQFBAEKBxpS6lvHq5m83AoCJAUEAQvDDy54MNwKQiQFBAEEANgKYiQELqAMBCH9BACECQQBBACgClIkBIgMgAUEDdGoiBDYClIkBQQBBACgCmIkBIAQgA0lqIAFBHXZqNgKYiQECQCADQQN2QT9xIgUgAWpBwABJDQBBwAAgBWsiAkEDcSEGQQAhAwJAIAVBP3NBA0kNACAFQYCJAWohByACQfwAcSEIQQAhAwNAIAcgA2oiBEEcaiAAIANqIgktAAA6AAAgBEEdaiAJQQFqLQAAOgAAIARBHmogCUECai0AADoAACAEQR9qIAlBA2otAAA6AAAgCCADQQRqIgNHDQALCwJAIAZFDQAgACADaiEEIAMgBWpBnIkBaiEDA0AgAyAELQAAOgAAIARBAWohBCADQQFqIQMgBkF/aiIGDQALC0GciQEQASAFQf8AcyEDQQAhBSADIAFPDQADQCAAIAJqEAEgAkH/AGohAyACQcAAaiIEIQIgAyABSQ0ACyAEIQILAkAgASACRg0AIAEgAmshCSAAIAJqIQIgBUGciQFqIQNBACEEA0AgAyACLQAAOgAAIAJBAWohAiADQQFqIQMgCSAEQQFqIgRB/wFxSw0ACwsLCQBBgAkgABADC6YDAQJ/IwBBEGsiACQAIABBgAE6AAcgAEEAKAKYiQEiAUEYdCABQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnI2AAggAEEAKAKUiQEiAUEYdCABQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnI2AAwgAEEHakEBEAMCQEEAKAKUiQFB+ANxQcADRg0AA0AgAEEAOgAHIABBB2pBARADQQAoApSJAUH4A3FBwANHDQALCyAAQQhqQQgQA0EAQQAoAoCJASIBQRh0IAFBgP4DcUEIdHIgAUEIdkGA/gNxIAFBGHZycjYCgAlBAEEAKAKEiQEiAUEYdCABQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnI2AoQJQQBBACgCiIkBIgFBGHQgAUGA/gNxQQh0ciABQQh2QYD+A3EgAUEYdnJyNgKICUEAQQAoAoyJASIBQRh0IAFBgP4DcUEIdHIgAUEIdkGA/gNxIAFBGHZycjYCjAlBAEEAKAKQiQEiAUEYdCABQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnI2ApAJIABBEGokAAsGAEGAiQELQwBBAEL+uevF6Y6VmRA3AoiJAUEAQoHGlLqW8ermbzcCgIkBQQBC8MPLngw3ApCJAUEAQQA2ApiJAUGACSAAEAMQBQsLCwEAQYAICwRcAAAA";
+var hash$c = "6b530c24";
+var wasmJson$c = {
+	name: name$c,
+	data: data$c,
+	hash: hash$c
+};
+
+const mutex$d = new Mutex();
+let wasmCache$d = null;
+/**
+ * Calculates SHA-1 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function sha1(data) {
+    if (wasmCache$d === null) {
+        return lockedCreate(mutex$d, wasmJson$c, 20).then((wasm) => {
+            wasmCache$d = wasm;
+            return wasmCache$d.calculate(data);
+        });
+    }
+    try {
+        const hash = wasmCache$d.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new SHA-1 hash instance
+ */
+function createSHA1() {
+    return WASMInterface(wasmJson$c, 20).then((wasm) => {
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 20,
+        };
+        return obj;
+    });
+}
+
+var name$b = "sha3";
+var data$b = "AGFzbQEAAAABFARgAAF/YAF/AGACf38AYAN/f38AAwgHAAEBAgEAAwUEAQECAgYOAn8BQZCNBQt/AEGACAsHcAgGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAlIYXNoX0luaXQAAQtIYXNoX1VwZGF0ZQACCkhhc2hfRmluYWwABA1IYXNoX0dldFN0YXRlAAUOSGFzaF9DYWxjdWxhdGUABgpTVEFURV9TSVpFAwEKpBwHBQBBgAoL1wMAQQBCADcDgI0BQQBCADcD+IwBQQBCADcD8IwBQQBCADcD6IwBQQBCADcD4IwBQQBCADcD2IwBQQBCADcD0IwBQQBCADcDyIwBQQBCADcDwIwBQQBCADcDuIwBQQBCADcDsIwBQQBCADcDqIwBQQBCADcDoIwBQQBCADcDmIwBQQBCADcDkIwBQQBCADcDiIwBQQBCADcDgIwBQQBCADcD+IsBQQBCADcD8IsBQQBCADcD6IsBQQBCADcD4IsBQQBCADcD2IsBQQBCADcD0IsBQQBCADcDyIsBQQBCADcDwIsBQQBCADcDuIsBQQBCADcDsIsBQQBCADcDqIsBQQBCADcDoIsBQQBCADcDmIsBQQBCADcDkIsBQQBCADcDiIsBQQBCADcDgIsBQQBCADcD+IoBQQBCADcD8IoBQQBCADcD6IoBQQBCADcD4IoBQQBCADcD2IoBQQBCADcD0IoBQQBCADcDyIoBQQBCADcDwIoBQQBCADcDuIoBQQBCADcDsIoBQQBCADcDqIoBQQBCADcDoIoBQQBCADcDmIoBQQBCADcDkIoBQQBCADcDiIoBQQBCADcDgIoBQQBBwAwgAEEBdGtBA3Y2AoyNAUEAQQA2AoiNAQuMAwEIfwJAQQAoAoiNASIBQQBIDQBBACABIABqQQAoAoyNASICcDYCiI0BAkACQCABDQBBgAohAwwBCwJAIAIgAWsiBCAAIAQgAEkbIgNFDQAgA0EDcSEFQQAhBgJAIANBBEkNACABQYCKAWohByADQXxxIQhBACEGA0AgByAGaiIDQcgBaiAGQYAKai0AADoAACADQckBaiAGQYEKai0AADoAACADQcoBaiAGQYIKai0AADoAACADQcsBaiAGQYMKai0AADoAACAIIAZBBGoiBkcNAAsLIAVFDQAgAUHIiwFqIQMDQCADIAZqIAZBgApqLQAAOgAAIAZBAWohBiAFQX9qIgUNAAsLIAAgBEkNAUHIiwEgAhADIAAgBGshACAEQYAKaiEDCwJAIAAgAkkNAANAIAMgAhADIAMgAmohAyAAIAJrIgAgAk8NAAsLIABFDQBBACECQcgBIQYDQCAGQYCKAWogAyAGakG4fmotAAA6AAAgBkEBaiEGIAAgAkEBaiICQf8BcUsNAAsLC+ALAS1+IAApA0AhAkEAKQPAigEhAyAAKQM4IQRBACkDuIoBIQUgACkDMCEGQQApA7CKASEHIAApAyghCEEAKQOoigEhCSAAKQMgIQpBACkDoIoBIQsgACkDGCEMQQApA5iKASENIAApAxAhDkEAKQOQigEhDyAAKQMIIRBBACkDiIoBIREgACkDACESQQApA4CKASETQQApA8iKASEUAkACQCABQcgASw0AQQApA+iKASEVQQApA/iKASEWQQApA/CKASEXQQApA4CLASEYQQApA9CKASEZQQApA+CKASEaQQApA9iKASEbDAELQQApA+CKASAAKQNghSEaQQApA9iKASAAKQNYhSEbQQApA9CKASAAKQNQhSEZIBQgACkDSIUhFEEAKQPoigEhFUEAKQP4igEhFkEAKQPwigEhF0EAKQOAiwEhGCABQekASQ0AIBggACkDgAGFIRggFiAAKQN4hSEWIBcgACkDcIUhFyAVIAApA2iFIRUgAUGJAUkNAEEAQQApA4iLASAAKQOIAYU3A4iLAQsgAyAChSEcIAUgBIUhHSAHIAaFIQcgCSAIhSEIIAsgCoUhHiANIAyFIQkgDyAOhSEKIBEgEIUhCyATIBKFIQxBACkDuIsBIRBBACkDkIsBIRFBACkDoIsBIRJBACkDsIsBIRNBACkDiIsBIQ1BACkDwIsBIQ5BACkDmIsBIR9BACkDqIsBIQ9BwH4hAANAIB4gByALhSAbhSAYhSAPhUIBiYUgFIUgF4UgH4UgDoUhAiAMIB0gCoUgGoUgDYUgE4VCAYmFIAiFIBmFIBaFIBKFIgMgB4UhICAJIAggDIUgGYUgFoUgEoVCAYmFIByFIBWFIBGFIBCFIgQgDoUhISAcIAogFCAehSAXhSAfhSAOhUIBiYUgHYUgGoUgDYUgE4UiBYVCN4kiIiALIBwgCYUgFYUgEYUgEIVCAYmFIAeFIBuFIBiFIA+FIgYgCoVCPokiI0J/hYMgAyAPhUICiSIkhSEOIBYgAoVCKYkiJSAEIBeFQieJIiZCf4WDICKFIQ8gECAFhUI4iSIQIAYgDYVCD4kiJ0J/hYMgAyAbhUIKiSIohSENIAQgHoVCG4kiKSAoIAggAoVCJIkiKkJ/hYOFIRYgBiAdhUIGiSIrIAMgC4VCAYkiLEJ/hYMgEiAChUISiSIthSEXICsgBCAfhUIIiSIuIBUgBYVCGYkiFUJ/hYOFIRsgBiAThUI9iSIdIAQgFIVCFIkiBCAJIAWFQhyJIghCf4WDhSEUIAggHUJ/hYMgAyAYhUItiSIDhSEcIB0gA0J/hYMgGSAChUIDiSIJhSEdIAQgAyAJQn+Fg4UhByAJIARCf4WDIAiFIQggDCAChSICICFCDokiA0J/hYMgESAFhUIViSIEhSEJIAYgGoVCK4kiBSADIARCf4WDhSEKIAQgBUJ/hYMgIEIsiSIEhSELIABB0AlqKQMAIAUgBEJ/hYOFIAKFIQwgJyAoQn+FgyAqhSIFIRggAyAEIAJCf4WDhSICIR4gKiApQn+FgyAQhSIDIR8gLSAuQn+FgyAVhSIEIRogJiAkICVCf4WDhSIGIRMgFSArQn+FgyAshSIoIRkgIyAmICJCf4WDhSIiIRIgLiAsIC1Cf4WDhSImIRUgJyApIBBCf4WDhSInIREgIyAkQn+FgyAlhSIjIRAgAEEIaiIADQALQQAgDzcDqIsBQQAgBTcDgIsBQQAgGzcD2IoBQQAgBzcDsIoBQQAgCzcDiIoBQQAgDjcDwIsBQQAgAzcDmIsBQQAgFzcD8IoBQQAgFDcDyIoBQQAgAjcDoIoBQQAgBjcDsIsBQQAgDTcDiIsBQQAgBDcD4IoBQQAgHTcDuIoBQQAgCjcDkIoBQQAgIjcDoIsBQQAgFjcD+IoBQQAgKDcD0IoBQQAgCDcDqIoBQQAgDDcDgIoBQQAgIzcDuIsBQQAgJzcDkIsBQQAgJjcD6IoBQQAgHDcDwIoBQQAgCTcDmIoBC/gCAQV/QeQAQQAoAoyNASIBQQF2ayECAkBBACgCiI0BIgNBAEgNACABIQQCQCABIANGDQAgA0HIiwFqIQVBACEDA0AgBSADakEAOgAAIANBAWoiAyABQQAoAoiNASIEa0kNAAsLIARByIsBaiIDIAMtAAAgAHI6AAAgAUHHiwFqIgMgAy0AAEGAAXI6AABByIsBIAEQA0EAQYCAgIB4NgKIjQELAkAgAkEESQ0AIAJBAnYiA0EDcSEFQQAhBAJAIANBf2pBA0kNACADQfz///8DcSEBQQAhA0EAIQQDQCADQYAKaiADQYCKAWooAgA2AgAgA0GECmogA0GEigFqKAIANgIAIANBiApqIANBiIoBaigCADYCACADQYwKaiADQYyKAWooAgA2AgAgA0EQaiEDIAEgBEEEaiIERw0ACwsgBUUNACAFQQJ0IQEgBEECdCEDA0AgA0GACmogA0GAigFqKAIANgIAIANBBGohAyABQXxqIgENAAsLCwYAQYCKAQvRBgEDf0EAQgA3A4CNAUEAQgA3A/iMAUEAQgA3A/CMAUEAQgA3A+iMAUEAQgA3A+CMAUEAQgA3A9iMAUEAQgA3A9CMAUEAQgA3A8iMAUEAQgA3A8CMAUEAQgA3A7iMAUEAQgA3A7CMAUEAQgA3A6iMAUEAQgA3A6CMAUEAQgA3A5iMAUEAQgA3A5CMAUEAQgA3A4iMAUEAQgA3A4CMAUEAQgA3A/iLAUEAQgA3A/CLAUEAQgA3A+iLAUEAQgA3A+CLAUEAQgA3A9iLAUEAQgA3A9CLAUEAQgA3A8iLAUEAQgA3A8CLAUEAQgA3A7iLAUEAQgA3A7CLAUEAQgA3A6iLAUEAQgA3A6CLAUEAQgA3A5iLAUEAQgA3A5CLAUEAQgA3A4iLAUEAQgA3A4CLAUEAQgA3A/iKAUEAQgA3A/CKAUEAQgA3A+iKAUEAQgA3A+CKAUEAQgA3A9iKAUEAQgA3A9CKAUEAQgA3A8iKAUEAQgA3A8CKAUEAQgA3A7iKAUEAQgA3A7CKAUEAQgA3A6iKAUEAQgA3A6CKAUEAQgA3A5iKAUEAQgA3A5CKAUEAQgA3A4iKAUEAQgA3A4CKAUEAQcAMIAFBAXRrQQN2NgKMjQFBAEEANgKIjQEgABACQeQAQQAoAoyNASIAQQF2ayEDAkBBACgCiI0BIgFBAEgNACAAIQQCQCAAIAFGDQAgAUHIiwFqIQVBACEBA0AgBSABakEAOgAAIAFBAWoiASAAQQAoAoiNASIEa0kNAAsLIARByIsBaiIBIAEtAAAgAnI6AAAgAEHHiwFqIgEgAS0AAEGAAXI6AABByIsBIAAQA0EAQYCAgIB4NgKIjQELAkAgA0EESQ0AIANBAnYiAUEDcSEFQQAhBAJAIAFBf2pBA0kNACABQfz///8DcSEAQQAhAUEAIQQDQCABQYAKaiABQYCKAWooAgA2AgAgAUGECmogAUGEigFqKAIANgIAIAFBiApqIAFBiIoBaigCADYCACABQYwKaiABQYyKAWooAgA2AgAgAUEQaiEBIAAgBEEEaiIERw0ACwsgBUUNACAFQQJ0IQAgBEECdCEBA0AgAUGACmogAUGAigFqKAIANgIAIAFBBGohASAAQXxqIgANAAsLCwvYAQEAQYAIC9ABkAEAAAAAAAAAAAAAAAAAAAEAAAAAAAAAgoAAAAAAAACKgAAAAAAAgACAAIAAAACAi4AAAAAAAAABAACAAAAAAIGAAIAAAACACYAAAAAAAICKAAAAAAAAAIgAAAAAAAAACYAAgAAAAAAKAACAAAAAAIuAAIAAAAAAiwAAAAAAAICJgAAAAAAAgAOAAAAAAACAAoAAAAAAAICAAAAAAAAAgAqAAAAAAAAACgAAgAAAAICBgACAAAAAgICAAAAAAACAAQAAgAAAAAAIgACAAAAAgA==";
+var hash$b = "fb24e536";
+var wasmJson$b = {
+	name: name$b,
+	data: data$b,
+	hash: hash$b
+};
+
+const mutex$c = new Mutex();
+let wasmCache$c = null;
+function validateBits$1(bits) {
+    if (![224, 256, 384, 512].includes(bits)) {
+        return new Error("Invalid variant! Valid values: 224, 256, 384, 512");
+    }
+    return null;
+}
+/**
+ * Calculates SHA-3 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param bits Number of output bits. Valid values: 224, 256, 384, 512
+ * @returns Computed hash as a hexadecimal string
+ */
+function sha3(data, bits = 512) {
+    if (validateBits$1(bits)) {
+        return Promise.reject(validateBits$1(bits));
+    }
+    const hashLength = bits / 8;
+    if (wasmCache$c === null || wasmCache$c.hashLength !== hashLength) {
+        return lockedCreate(mutex$c, wasmJson$b, hashLength).then((wasm) => {
+            wasmCache$c = wasm;
+            return wasmCache$c.calculate(data, bits, 0x06);
+        });
+    }
+    try {
+        const hash = wasmCache$c.calculate(data, bits, 0x06);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new SHA-3 hash instance
+ * @param bits Number of output bits. Valid values: 224, 256, 384, 512
+ */
+function createSHA3(bits = 512) {
+    if (validateBits$1(bits)) {
+        return Promise.reject(validateBits$1(bits));
+    }
+    const outputSize = bits / 8;
+    return WASMInterface(wasmJson$b, outputSize).then((wasm) => {
+        wasm.init(bits);
+        const obj = {
+            init: () => {
+                wasm.init(bits);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType, 0x06),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 200 - 2 * outputSize,
+            digestSize: outputSize,
+        };
+        return obj;
+    });
+}
+
+const mutex$b = new Mutex();
+let wasmCache$b = null;
+function validateBits(bits) {
+    if (![224, 256, 384, 512].includes(bits)) {
+        return new Error("Invalid variant! Valid values: 224, 256, 384, 512");
+    }
+    return null;
+}
+/**
+ * Calculates Keccak hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param bits Number of output bits. Valid values: 224, 256, 384, 512
+ * @returns Computed hash as a hexadecimal string
+ */
+function keccak(data, bits = 512) {
+    if (validateBits(bits)) {
+        return Promise.reject(validateBits(bits));
+    }
+    const hashLength = bits / 8;
+    if (wasmCache$b === null || wasmCache$b.hashLength !== hashLength) {
+        return lockedCreate(mutex$b, wasmJson$b, hashLength).then((wasm) => {
+            wasmCache$b = wasm;
+            return wasmCache$b.calculate(data, bits, 0x01);
+        });
+    }
+    try {
+        const hash = wasmCache$b.calculate(data, bits, 0x01);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new Keccak hash instance
+ * @param bits Number of output bits. Valid values: 224, 256, 384, 512
+ */
+function createKeccak(bits = 512) {
+    if (validateBits(bits)) {
+        return Promise.reject(validateBits(bits));
+    }
+    const outputSize = bits / 8;
+    return WASMInterface(wasmJson$b, outputSize).then((wasm) => {
+        wasm.init(bits);
+        const obj = {
+            init: () => {
+                wasm.init(bits);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType, 0x01),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 200 - 2 * outputSize,
+            digestSize: outputSize,
+        };
+        return obj;
+    });
+}
+
+var name$a = "sha256";
+var data$a = "AGFzbQEAAAABEQRgAAF/YAF/AGAAAGACf38AAwgHAAEBAQIAAwUEAQECAgYOAn8BQfCJBQt/AEGACAsHcAgGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAlIYXNoX0luaXQAAQtIYXNoX1VwZGF0ZQACCkhhc2hfRmluYWwABA1IYXNoX0dldFN0YXRlAAUOSGFzaF9DYWxjdWxhdGUABgpTVEFURV9TSVpFAwEKnEoHBQBBgAkLnQEAQQBCADcDwIkBQQBBHEEgIABB4AFGIgAbNgLoiQFBAEKnn+anxvST/b5/Qquzj/yRo7Pw2wAgABs3A+CJAUEAQrGWgP6fooWs6ABC/6S5iMWR2oKbfyAAGzcD2IkBQQBCl7rDg5Onlod3QvLmu+Ojp/2npX8gABs3A9CJAUEAQti9loj8oLW+NkLnzKfQ1tDrs7t/IAAbNwPIiQEL7wICAX4Gf0EAQQApA8CJASIBIACtfDcDwIkBAkACQAJAIAGnQT9xIgINAEGACSEDDAELAkBBwAAgAmsiBCAAIAQgAEkbIgNFDQAgA0EDcSEFIAJBgIkBaiEGQQAhAgJAIANBBEkNACADQfwAcSEHQQAhAgNAIAYgAmoiAyACQYAJai0AADoAACADQQFqIAJBgQlqLQAAOgAAIANBAmogAkGCCWotAAA6AAAgA0EDaiACQYMJai0AADoAACAHIAJBBGoiAkcNAAsLIAVFDQADQCAGIAJqIAJBgAlqLQAAOgAAIAJBAWohAiAFQX9qIgUNAAsLIAAgBEkNAUGAiQEQAyAAIARrIQAgBEGACWohAwsCQCAAQcAASQ0AA0AgAxADIANBwABqIQMgAEFAaiIAQT9LDQALCyAARQ0AQQAhAkEAIQUDQCACQYCJAWogAyACai0AADoAACACQQFqIQIgACAFQQFqIgVB/wFxSw0ACwsLoz4BRX9BACAAKAI8IgFBGHQgAUGA/gNxQQh0ciABQQh2QYD+A3EgAUEYdnJyIgFBGXcgAUEOd3MgAUEDdnMgACgCOCICQRh0IAJBgP4DcUEIdHIgAkEIdkGA/gNxIAJBGHZyciICaiAAKAIgIgNBGHQgA0GA/gNxQQh0ciADQQh2QYD+A3EgA0EYdnJyIgRBGXcgBEEOd3MgBEEDdnMgACgCHCIDQRh0IANBgP4DcUEIdHIgA0EIdkGA/gNxIANBGHZyciIFaiAAKAIEIgNBGHQgA0GA/gNxQQh0ciADQQh2QYD+A3EgA0EYdnJyIgZBGXcgBkEOd3MgBkEDdnMgACgCACIDQRh0IANBgP4DcUEIdHIgA0EIdkGA/gNxIANBGHZyciIHaiAAKAIkIgNBGHQgA0GA/gNxQQh0ciADQQh2QYD+A3EgA0EYdnJyIghqIAJBD3cgAkENd3MgAkEKdnNqIgNqIAAoAhgiCUEYdCAJQYD+A3FBCHRyIAlBCHZBgP4DcSAJQRh2cnIiCkEZdyAKQQ53cyAKQQN2cyAAKAIUIglBGHQgCUGA/gNxQQh0ciAJQQh2QYD+A3EgCUEYdnJyIgtqIAJqIAAoAhAiCUEYdCAJQYD+A3FBCHRyIAlBCHZBgP4DcSAJQRh2cnIiDEEZdyAMQQ53cyAMQQN2cyAAKAIMIglBGHQgCUGA/gNxQQh0ciAJQQh2QYD+A3EgCUEYdnJyIg1qIAAoAjAiCUEYdCAJQYD+A3FBCHRyIAlBCHZBgP4DcSAJQRh2cnIiDmogACgCCCIJQRh0IAlBgP4DcUEIdHIgCUEIdkGA/gNxIAlBGHZyciIPQRl3IA9BDndzIA9BA3ZzIAZqIAAoAigiCUEYdCAJQYD+A3FBCHRyIAlBCHZBgP4DcSAJQRh2cnIiEGogAUEPdyABQQ13cyABQQp2c2oiCUEPdyAJQQ13cyAJQQp2c2oiEUEPdyARQQ13cyARQQp2c2oiEkEPdyASQQ13cyASQQp2c2oiE2ogACgCNCIUQRh0IBRBgP4DcUEIdHIgFEEIdkGA/gNxIBRBGHZyciIVQRl3IBVBDndzIBVBA3ZzIA5qIBJqIAAoAiwiAEEYdCAAQYD+A3FBCHRyIABBCHZBgP4DcSAAQRh2cnIiFkEZdyAWQQ53cyAWQQN2cyAQaiARaiAIQRl3IAhBDndzIAhBA3ZzIARqIAlqIAVBGXcgBUEOd3MgBUEDdnMgCmogAWogC0EZdyALQQ53cyALQQN2cyAMaiAVaiANQRl3IA1BDndzIA1BA3ZzIA9qIBZqIANBD3cgA0ENd3MgA0EKdnNqIhRBD3cgFEENd3MgFEEKdnNqIhdBD3cgF0ENd3MgF0EKdnNqIhhBD3cgGEENd3MgGEEKdnNqIhlBD3cgGUENd3MgGUEKdnNqIhpBD3cgGkENd3MgGkEKdnNqIhtBD3cgG0ENd3MgG0EKdnNqIhxBGXcgHEEOd3MgHEEDdnMgAkEZdyACQQ53cyACQQN2cyAVaiAYaiAOQRl3IA5BDndzIA5BA3ZzIBZqIBdqIBBBGXcgEEEOd3MgEEEDdnMgCGogFGogE0EPdyATQQ13cyATQQp2c2oiHUEPdyAdQQ13cyAdQQp2c2oiHkEPdyAeQQ13cyAeQQp2c2oiH2ogE0EZdyATQQ53cyATQQN2cyAYaiADQRl3IANBDndzIANBA3ZzIAFqIBlqIB9BD3cgH0ENd3MgH0EKdnNqIiBqIBJBGXcgEkEOd3MgEkEDdnMgF2ogH2ogEUEZdyARQQ53cyARQQN2cyAUaiAeaiAJQRl3IAlBDndzIAlBA3ZzIANqIB1qIBxBD3cgHEENd3MgHEEKdnNqIiFBD3cgIUENd3MgIUEKdnNqIiJBD3cgIkENd3MgIkEKdnNqIiNBD3cgI0ENd3MgI0EKdnNqIiRqIBtBGXcgG0EOd3MgG0EDdnMgHmogI2ogGkEZdyAaQQ53cyAaQQN2cyAdaiAiaiAZQRl3IBlBDndzIBlBA3ZzIBNqICFqIBhBGXcgGEEOd3MgGEEDdnMgEmogHGogF0EZdyAXQQ53cyAXQQN2cyARaiAbaiAUQRl3IBRBDndzIBRBA3ZzIAlqIBpqICBBD3cgIEENd3MgIEEKdnNqIiVBD3cgJUENd3MgJUEKdnNqIiZBD3cgJkENd3MgJkEKdnNqIidBD3cgJ0ENd3MgJ0EKdnNqIihBD3cgKEENd3MgKEEKdnNqIilBD3cgKUENd3MgKUEKdnNqIipBD3cgKkENd3MgKkEKdnNqIitBGXcgK0EOd3MgK0EDdnMgH0EZdyAfQQ53cyAfQQN2cyAbaiAnaiAeQRl3IB5BDndzIB5BA3ZzIBpqICZqIB1BGXcgHUEOd3MgHUEDdnMgGWogJWogJEEPdyAkQQ13cyAkQQp2c2oiLEEPdyAsQQ13cyAsQQp2c2oiLUEPdyAtQQ13cyAtQQp2c2oiLmogJEEZdyAkQQ53cyAkQQN2cyAnaiAgQRl3ICBBDndzICBBA3ZzIBxqIChqIC5BD3cgLkENd3MgLkEKdnNqIi9qICNBGXcgI0EOd3MgI0EDdnMgJmogLmogIkEZdyAiQQ53cyAiQQN2cyAlaiAtaiAhQRl3ICFBDndzICFBA3ZzICBqICxqICtBD3cgK0ENd3MgK0EKdnNqIjBBD3cgMEENd3MgMEEKdnNqIjFBD3cgMUENd3MgMUEKdnNqIjJBD3cgMkENd3MgMkEKdnNqIjNqICpBGXcgKkEOd3MgKkEDdnMgLWogMmogKUEZdyApQQ53cyApQQN2cyAsaiAxaiAoQRl3IChBDndzIChBA3ZzICRqIDBqICdBGXcgJ0EOd3MgJ0EDdnMgI2ogK2ogJkEZdyAmQQ53cyAmQQN2cyAiaiAqaiAlQRl3ICVBDndzICVBA3ZzICFqIClqIC9BD3cgL0ENd3MgL0EKdnNqIjRBD3cgNEENd3MgNEEKdnNqIjVBD3cgNUENd3MgNUEKdnNqIjZBD3cgNkENd3MgNkEKdnNqIjdBD3cgN0ENd3MgN0EKdnNqIjhBD3cgOEENd3MgOEEKdnNqIjlBD3cgOUENd3MgOUEKdnNqIjogOCA0IC4gLCAhIBsgGSADIA4gBEEAKALYiQEiO0EadyA7QRV3cyA7QQd3c0EAKALkiQEiPGpBACgC4IkBIj1BACgC3IkBIj5zIDtxID1zaiAHakGY36iUBGoiB0EAKALUiQEiP2oiACAMaiA7IA1qID4gD2ogPSAGaiAAID4gO3NxID5zaiAAQRp3IABBFXdzIABBB3dzakGRid2JB2oiQEEAKALQiQEiQWoiDCAAIDtzcSA7c2ogDEEadyAMQRV3cyAMQQd3c2pBz/eDrntqIkJBACgCzIkBIkNqIg0gDCAAc3EgAHNqIA1BGncgDUEVd3MgDUEHd3NqQaW3181+aiJEQQAoAsiJASIAaiIPIA0gDHNxIAxzaiAPQRp3IA9BFXdzIA9BB3dzakHbhNvKA2oiRSBBIEMgAHNxIEMgAHFzIABBHncgAEETd3MgAEEKd3NqIAdqIgZqIgdqIAUgD2ogCiANaiALIAxqIAcgDyANc3EgDXNqIAdBGncgB0EVd3MgB0EHd3NqQfGjxM8FaiIKIAYgAHMgQ3EgBiAAcXMgBkEedyAGQRN3cyAGQQp3c2ogQGoiDGoiBCAHIA9zcSAPc2ogBEEadyAEQRV3cyAEQQd3c2pBpIX+kXlqIgsgDCAGcyAAcSAMIAZxcyAMQR53IAxBE3dzIAxBCndzaiBCaiINaiIPIAQgB3NxIAdzaiAPQRp3IA9BFXdzIA9BB3dzakHVvfHYemoiQCANIAxzIAZxIA0gDHFzIA1BHncgDUETd3MgDUEKd3NqIERqIgZqIgcgDyAEc3EgBHNqIAdBGncgB0EVd3MgB0EHd3NqQZjVnsB9aiJCIAYgDXMgDHEgBiANcXMgBkEedyAGQRN3cyAGQQp3c2ogRWoiDGoiBWogFiAHaiAQIA9qIAggBGogBSAHIA9zcSAPc2ogBUEadyAFQRV3cyAFQQd3c2pBgbaNlAFqIgggDCAGcyANcSAMIAZxcyAMQR53IAxBE3dzIAxBCndzaiAKaiINaiIPIAUgB3NxIAdzaiAPQRp3IA9BFXdzIA9BB3dzakG+i8ahAmoiDiANIAxzIAZxIA0gDHFzIA1BHncgDUETd3MgDUEKd3NqIAtqIgZqIgcgDyAFc3EgBXNqIAdBGncgB0EVd3MgB0EHd3NqQcP7sagFaiIQIAYgDXMgDHEgBiANcXMgBkEedyAGQRN3cyAGQQp3c2ogQGoiDGoiBCAHIA9zcSAPc2ogBEEadyAEQRV3cyAEQQd3c2pB9Lr5lQdqIhYgDCAGcyANcSAMIAZxcyAMQR53IAxBE3dzIAxBCndzaiBCaiINaiIFaiABIARqIAIgB2ogFSAPaiAFIAQgB3NxIAdzaiAFQRp3IAVBFXdzIAVBB3dzakH+4/qGeGoiByANIAxzIAZxIA0gDHFzIA1BHncgDUETd3MgDUEKd3NqIAhqIgFqIgYgBSAEc3EgBHNqIAZBGncgBkEVd3MgBkEHd3NqQaeN8N55aiIEIAEgDXMgDHEgASANcXMgAUEedyABQRN3cyABQQp3c2ogDmoiAmoiDCAGIAVzcSAFc2ogDEEadyAMQRV3cyAMQQd3c2pB9OLvjHxqIgUgAiABcyANcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiAQaiIDaiINIAwgBnNxIAZzaiANQRp3IA1BFXdzIA1BB3dzakHB0+2kfmoiCCADIAJzIAFxIAMgAnFzIANBHncgA0ETd3MgA0EKd3NqIBZqIgFqIg8gF2ogESANaiAUIAxqIAkgBmogDyANIAxzcSAMc2ogD0EadyAPQRV3cyAPQQd3c2pBho/5/X5qIgYgASADcyACcSABIANxcyABQR53IAFBE3dzIAFBCndzaiAHaiICaiIJIA8gDXNxIA1zaiAJQRp3IAlBFXdzIAlBB3dzakHGu4b+AGoiDCACIAFzIANxIAIgAXFzIAJBHncgAkETd3MgAkEKd3NqIARqIgNqIhEgCSAPc3EgD3NqIBFBGncgEUEVd3MgEUEHd3NqQczDsqACaiINIAMgAnMgAXEgAyACcXMgA0EedyADQRN3cyADQQp3c2ogBWoiAWoiFCARIAlzcSAJc2ogFEEadyAUQRV3cyAUQQd3c2pB79ik7wJqIg8gASADcyACcSABIANxcyABQR53IAFBE3dzIAFBCndzaiAIaiICaiIXaiATIBRqIBggEWogEiAJaiAXIBQgEXNxIBFzaiAXQRp3IBdBFXdzIBdBB3dzakGqidLTBGoiGCACIAFzIANxIAIgAXFzIAJBHncgAkETd3MgAkEKd3NqIAZqIgNqIgkgFyAUc3EgFHNqIAlBGncgCUEVd3MgCUEHd3NqQdzTwuUFaiIUIAMgAnMgAXEgAyACcXMgA0EedyADQRN3cyADQQp3c2ogDGoiAWoiESAJIBdzcSAXc2ogEUEadyARQRV3cyARQQd3c2pB2pHmtwdqIhcgASADcyACcSABIANxcyABQR53IAFBE3dzIAFBCndzaiANaiICaiISIBEgCXNxIAlzaiASQRp3IBJBFXdzIBJBB3dzakHSovnBeWoiGSACIAFzIANxIAIgAXFzIAJBHncgAkETd3MgAkEKd3NqIA9qIgNqIhNqIB4gEmogGiARaiAdIAlqIBMgEiARc3EgEXNqIBNBGncgE0EVd3MgE0EHd3NqQe2Mx8F6aiIaIAMgAnMgAXEgAyACcXMgA0EedyADQRN3cyADQQp3c2ogGGoiAWoiCSATIBJzcSASc2ogCUEadyAJQRV3cyAJQQd3c2pByM+MgHtqIhggASADcyACcSABIANxcyABQR53IAFBE3dzIAFBCndzaiAUaiICaiIRIAkgE3NxIBNzaiARQRp3IBFBFXdzIBFBB3dzakHH/+X6e2oiFCACIAFzIANxIAIgAXFzIAJBHncgAkETd3MgAkEKd3NqIBdqIgNqIhIgESAJc3EgCXNqIBJBGncgEkEVd3MgEkEHd3NqQfOXgLd8aiIXIAMgAnMgAXEgAyACcXMgA0EedyADQRN3cyADQQp3c2ogGWoiAWoiE2ogICASaiAcIBFqIB8gCWogEyASIBFzcSARc2ogE0EadyATQRV3cyATQQd3c2pBx6KerX1qIhkgASADcyACcSABIANxcyABQR53IAFBE3dzIAFBCndzaiAaaiICaiIJIBMgEnNxIBJzaiAJQRp3IAlBFXdzIAlBB3dzakHRxqk2aiIaIAIgAXMgA3EgAiABcXMgAkEedyACQRN3cyACQQp3c2ogGGoiA2oiESAJIBNzcSATc2ogEUEadyARQRV3cyARQQd3c2pB59KkoQFqIhggAyACcyABcSADIAJxcyADQR53IANBE3dzIANBCndzaiAUaiIBaiISIBEgCXNxIAlzaiASQRp3IBJBFXdzIBJBB3dzakGFldy9AmoiFCABIANzIAJxIAEgA3FzIAFBHncgAUETd3MgAUEKd3NqIBdqIgJqIhMgI2ogJiASaiAiIBFqICUgCWogEyASIBFzcSARc2ogE0EadyATQRV3cyATQQd3c2pBuMLs8AJqIhcgAiABcyADcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiAZaiIDaiIJIBMgEnNxIBJzaiAJQRp3IAlBFXdzIAlBB3dzakH827HpBGoiGSADIAJzIAFxIAMgAnFzIANBHncgA0ETd3MgA0EKd3NqIBpqIgFqIhEgCSATc3EgE3NqIBFBGncgEUEVd3MgEUEHd3NqQZOa4JkFaiIaIAEgA3MgAnEgASADcXMgAUEedyABQRN3cyABQQp3c2ogGGoiAmoiEiARIAlzcSAJc2ogEkEadyASQRV3cyASQQd3c2pB1OapqAZqIhggAiABcyADcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiAUaiIDaiITaiAoIBJqICQgEWogJyAJaiATIBIgEXNxIBFzaiATQRp3IBNBFXdzIBNBB3dzakG7laizB2oiFCADIAJzIAFxIAMgAnFzIANBHncgA0ETd3MgA0EKd3NqIBdqIgFqIgkgEyASc3EgEnNqIAlBGncgCUEVd3MgCUEHd3NqQa6Si454aiIXIAEgA3MgAnEgASADcXMgAUEedyABQRN3cyABQQp3c2ogGWoiAmoiESAJIBNzcSATc2ogEUEadyARQRV3cyARQQd3c2pBhdnIk3lqIhkgAiABcyADcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiAaaiIDaiISIBEgCXNxIAlzaiASQRp3IBJBFXdzIBJBB3dzakGh0f+VemoiGiADIAJzIAFxIAMgAnFzIANBHncgA0ETd3MgA0EKd3NqIBhqIgFqIhNqICogEmogLSARaiApIAlqIBMgEiARc3EgEXNqIBNBGncgE0EVd3MgE0EHd3NqQcvM6cB6aiIYIAEgA3MgAnEgASADcXMgAUEedyABQRN3cyABQQp3c2ogFGoiAmoiCSATIBJzcSASc2ogCUEadyAJQRV3cyAJQQd3c2pB8JauknxqIhQgAiABcyADcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiAXaiIDaiIRIAkgE3NxIBNzaiARQRp3IBFBFXdzIBFBB3dzakGjo7G7fGoiFyADIAJzIAFxIAMgAnFzIANBHncgA0ETd3MgA0EKd3NqIBlqIgFqIhIgESAJc3EgCXNqIBJBGncgEkEVd3MgEkEHd3NqQZnQy4x9aiIZIAEgA3MgAnEgASADcXMgAUEedyABQRN3cyABQQp3c2ogGmoiAmoiE2ogMCASaiAvIBFqICsgCWogEyASIBFzcSARc2ogE0EadyATQRV3cyATQQd3c2pBpIzktH1qIhogAiABcyADcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiAYaiIDaiIJIBMgEnNxIBJzaiAJQRp3IAlBFXdzIAlBB3dzakGF67igf2oiGCADIAJzIAFxIAMgAnFzIANBHncgA0ETd3MgA0EKd3NqIBRqIgFqIhEgCSATc3EgE3NqIBFBGncgEUEVd3MgEUEHd3NqQfDAqoMBaiIUIAEgA3MgAnEgASADcXMgAUEedyABQRN3cyABQQp3c2ogF2oiAmoiEiARIAlzcSAJc2ogEkEadyASQRV3cyASQQd3c2pBloKTzQFqIhcgAiABcyADcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiAZaiIDaiITIDZqIDIgEmogNSARaiAxIAlqIBMgEiARc3EgEXNqIBNBGncgE0EVd3MgE0EHd3NqQYjY3fEBaiIZIAMgAnMgAXEgAyACcXMgA0EedyADQRN3cyADQQp3c2ogGmoiAWoiCSATIBJzcSASc2ogCUEadyAJQRV3cyAJQQd3c2pBzO6hugJqIhogASADcyACcSABIANxcyABQR53IAFBE3dzIAFBCndzaiAYaiICaiIRIAkgE3NxIBNzaiARQRp3IBFBFXdzIBFBB3dzakG1+cKlA2oiGCACIAFzIANxIAIgAXFzIAJBHncgAkETd3MgAkEKd3NqIBRqIgNqIhIgESAJc3EgCXNqIBJBGncgEkEVd3MgEkEHd3NqQbOZ8MgDaiIUIAMgAnMgAXEgAyACcXMgA0EedyADQRN3cyADQQp3c2ogF2oiAWoiE2ogLEEZdyAsQQ53cyAsQQN2cyAoaiA0aiAzQQ93IDNBDXdzIDNBCnZzaiIXIBJqIDcgEWogMyAJaiATIBIgEXNxIBFzaiATQRp3IBNBFXdzIBNBB3dzakHK1OL2BGoiGyABIANzIAJxIAEgA3FzIAFBHncgAUETd3MgAUEKd3NqIBlqIgJqIgkgEyASc3EgEnNqIAlBGncgCUEVd3MgCUEHd3NqQc+U89wFaiIZIAIgAXMgA3EgAiABcXMgAkEedyACQRN3cyACQQp3c2ogGmoiA2oiESAJIBNzcSATc2ogEUEadyARQRV3cyARQQd3c2pB89+5wQZqIhogAyACcyABcSADIAJxcyADQR53IANBE3dzIANBCndzaiAYaiIBaiISIBEgCXNxIAlzaiASQRp3IBJBFXdzIBJBB3dzakHuhb6kB2oiHCABIANzIAJxIAEgA3FzIAFBHncgAUETd3MgAUEKd3NqIBRqIgJqIhNqIC5BGXcgLkEOd3MgLkEDdnMgKmogNmogLUEZdyAtQQ53cyAtQQN2cyApaiA1aiAXQQ93IBdBDXdzIBdBCnZzaiIUQQ93IBRBDXdzIBRBCnZzaiIYIBJqIDkgEWogFCAJaiATIBIgEXNxIBFzaiATQRp3IBNBFXdzIBNBB3dzakHvxpXFB2oiCSACIAFzIANxIAIgAXFzIAJBHncgAkETd3MgAkEKd3NqIBtqIgNqIhEgEyASc3EgEnNqIBFBGncgEUEVd3MgEUEHd3NqQZTwoaZ4aiIbIAMgAnMgAXEgAyACcXMgA0EedyADQRN3cyADQQp3c2ogGWoiAWoiEiARIBNzcSATc2ogEkEadyASQRV3cyASQQd3c2pBiISc5nhqIhkgASADcyACcSABIANxcyABQR53IAFBE3dzIAFBCndzaiAaaiICaiITIBIgEXNxIBFzaiATQRp3IBNBFXdzIBNBB3dzakH6//uFeWoiGiACIAFzIANxIAIgAXFzIAJBHncgAkETd3MgAkEKd3NqIBxqIgNqIhQgPGo2AuSJAUEAID8gAyACcyABcSADIAJxcyADQR53IANBE3dzIANBCndzaiAJaiIBIANzIAJxIAEgA3FzIAFBHncgAUETd3MgAUEKd3NqIBtqIgIgAXMgA3EgAiABcXMgAkEedyACQRN3cyACQQp3c2ogGWoiAyACcyABcSADIAJxcyADQR53IANBE3dzIANBCndzaiAaaiIJajYC1IkBQQAgPSAvQRl3IC9BDndzIC9BA3ZzICtqIDdqIBhBD3cgGEENd3MgGEEKdnNqIhggEWogFCATIBJzcSASc2ogFEEadyAUQRV3cyAUQQd3c2pB69nBonpqIhkgAWoiEWo2AuCJAUEAIEEgCSADcyACcSAJIANxcyAJQR53IAlBE3dzIAlBCndzaiAZaiIBajYC0IkBQQAgPiAwQRl3IDBBDndzIDBBA3ZzIC9qIBdqIDpBD3cgOkENd3MgOkEKdnNqIBJqIBEgFCATc3EgE3NqIBFBGncgEUEVd3MgEUEHd3NqQffH5vd7aiIXIAJqIhJqNgLciQFBACBDIAEgCXMgA3EgASAJcXMgAUEedyABQRN3cyABQQp3c2ogF2oiAmo2AsyJAUEAIDsgNEEZdyA0QQ53cyA0QQN2cyAwaiA4aiAYQQ93IBhBDXdzIBhBCnZzaiATaiASIBEgFHNxIBRzaiASQRp3IBJBFXdzIBJBB3dzakHy8cWzfGoiESADamo2AtiJAUEAIAAgAiABcyAJcSACIAFxcyACQR53IAJBE3dzIAJBCndzaiARamo2AsiJAQuyBgIEfwF+QQAoAsCJASIAQQJ2QQ9xIgFBAnRBgIkBaiICIAIoAgBBfyAAQQN0IgB0QX9zcUGAASAAdHM2AgACQAJAAkAgAUEOSQ0AAkAgAUEORw0AQQBBADYCvIkBC0GAiQEQA0EAIQIMAQsgAUENRg0BIAFBAWohAgsgAiEDAkBBBiACa0EHcSIARQ0AIAIgAGohAyACQQJ0QYCJAWohAQNAIAFBADYCACABQQRqIQEgAEF/aiIADQALCyACQXlqQQdJDQAgA0ECdCEBA0AgAUGYiQFqQgA3AgAgAUGQiQFqQgA3AgAgAUGIiQFqQgA3AgAgAUGAiQFqQgA3AgAgAUEgaiIBQThHDQALC0EAIQFBAEEAKQPAiQEiBKciAEEbdCAAQQt0QYCA/AdxciAAQQV2QYD+A3EgAEEDdEEYdnJyNgK8iQFBACAEQh2IpyIAQRh0IABBgP4DcUEIdHIgAEEIdkGA/gNxIABBGHZycjYCuIkBQYCJARADQQBBACgC5IkBIgBBGHQgAEGA/gNxQQh0ciAAQQh2QYD+A3EgAEEYdnJyNgLkiQFBAEEAKALgiQEiAEEYdCAAQYD+A3FBCHRyIABBCHZBgP4DcSAAQRh2cnI2AuCJAUEAQQAoAtyJASIAQRh0IABBgP4DcUEIdHIgAEEIdkGA/gNxIABBGHZycjYC3IkBQQBBACgC2IkBIgBBGHQgAEGA/gNxQQh0ciAAQQh2QYD+A3EgAEEYdnJyNgLYiQFBAEEAKALUiQEiAEEYdCAAQYD+A3FBCHRyIABBCHZBgP4DcSAAQRh2cnI2AtSJAUEAQQAoAtCJASIAQRh0IABBgP4DcUEIdHIgAEEIdkGA/gNxIABBGHZycjYC0IkBQQBBACgCzIkBIgBBGHQgAEGA/gNxQQh0ciAAQQh2QYD+A3EgAEEYdnJyNgLMiQFBAEEAKALIiQEiAEEYdCAAQYD+A3FBCHRyIABBCHZBgP4DcSAAQRh2cnI2AsiJAQJAQQAoAuiJASICRQ0AQQAhAANAIAFBgAlqIAFByIkBai0AADoAACABQQFqIQEgAiAAQQFqIgBB/wFxSw0ACwsLBgBBgIkBC6MBAEEAQgA3A8CJAUEAQRxBICABQeABRiIBGzYC6IkBQQBCp5/mp8b0k/2+f0Krs4/8kaOz8NsAIAEbNwPgiQFBAEKxloD+n6KFrOgAQv+kuYjFkdqCm38gARs3A9iJAUEAQpe6w4OTp5aHd0Ly5rvjo6f9p6V/IAEbNwPQiQFBAELYvZaI/KC1vjZC58yn0NbQ67O7fyABGzcDyIkBIAAQAhAECwsLAQBBgAgLBHAAAAA=";
+var hash$a = "8c18dd94";
+var wasmJson$a = {
+	name: name$a,
+	data: data$a,
+	hash: hash$a
+};
+
+const mutex$a = new Mutex();
+let wasmCache$a = null;
+/**
+ * Calculates SHA-2 (SHA-224) hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function sha224(data) {
+    if (wasmCache$a === null) {
+        return lockedCreate(mutex$a, wasmJson$a, 28).then((wasm) => {
+            wasmCache$a = wasm;
+            return wasmCache$a.calculate(data, 224);
+        });
+    }
+    try {
+        const hash = wasmCache$a.calculate(data, 224);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new SHA-2 (SHA-224) hash instance
+ */
+function createSHA224() {
+    return WASMInterface(wasmJson$a, 28).then((wasm) => {
+        wasm.init(224);
+        const obj = {
+            init: () => {
+                wasm.init(224);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 28,
+        };
+        return obj;
+    });
+}
+
+const mutex$9 = new Mutex();
+let wasmCache$9 = null;
+/**
+ * Calculates SHA-2 (SHA-256) hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function sha256(data) {
+    if (wasmCache$9 === null) {
+        return lockedCreate(mutex$9, wasmJson$a, 32).then((wasm) => {
+            wasmCache$9 = wasm;
+            return wasmCache$9.calculate(data, 256);
+        });
+    }
+    try {
+        const hash = wasmCache$9.calculate(data, 256);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new SHA-2 (SHA-256) hash instance
+ */
+function createSHA256() {
+    return WASMInterface(wasmJson$a, 32).then((wasm) => {
+        wasm.init(256);
+        const obj = {
+            init: () => {
+                wasm.init(256);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 32,
+        };
+        return obj;
+    });
+}
+
+var name$9 = "sha512";
+var data$9 = "AGFzbQEAAAABEQRgAAF/YAF/AGAAAGACf38AAwgHAAEBAQIAAwUEAQECAgYOAn8BQdCKBQt/AEGACAsHcAgGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAlIYXNoX0luaXQAAQtIYXNoX1VwZGF0ZQACCkhhc2hfRmluYWwABA1IYXNoX0dldFN0YXRlAAUOSGFzaF9DYWxjdWxhdGUABgpTVEFURV9TSVpFAwEKlWgHBQBBgAkLmwIAQQBCADcDgIoBQQBBMEHAACAAQYADRiIAGzYCyIoBQQBCpJ/p99uD0trHAEL5wvibkaOz8NsAIAAbNwPAigFBAEKnn+an1sGLhltC6/qG2r+19sEfIAAbNwO4igFBAEKRquDC9tCS2o5/Qp/Y+dnCkdqCm38gABs3A7CKAUEAQrGWgP7/zMmZ5wBC0YWa7/rPlIfRACAAGzcDqIoBQQBCubK5uI+b+5cVQvHt9Pilp/2npX8gABs3A6CKAUEAQpe6w4Ojq8CskX9Cq/DT9K/uvLc8IAAbNwOYigFBAEKHqvOzo6WKzeIAQrvOqqbY0Ouzu38gABs3A5CKAUEAQti9lojcq+fdS0KIkvOd/8z5hOoAIAAbNwOIigEL8gICAX4Gf0EAQQApA4CKASIBIACtfDcDgIoBAkACQAJAIAGnQf8AcSICDQBBgAkhAwwBCwJAQYABIAJrIgQgACAEIABJGyIDRQ0AIANBA3EhBSACQYCJAWohBkEAIQICQCADQQRJDQAgA0H8AXEhB0EAIQIDQCAGIAJqIgMgAkGACWotAAA6AAAgA0EBaiACQYEJai0AADoAACADQQJqIAJBgglqLQAAOgAAIANBA2ogAkGDCWotAAA6AAAgByACQQRqIgJHDQALCyAFRQ0AA0AgBiACaiACQYAJai0AADoAACACQQFqIQIgBUF/aiIFDQALCyAAIARJDQFBgIkBEAMgACAEayEAIARBgAlqIQMLAkAgAEGAAUkNAANAIAMQAyADQYABaiEDIABBgH9qIgBB/wBLDQALCyAARQ0AQQAhAkEAIQUDQCACQYCJAWogAyACai0AADoAACACQQFqIQIgACAFQQFqIgVB/wFxSw0ACwsL3FYBVn5BACAAKQMIIgFCOIYgAUKA/gODQiiGhCABQoCA/AeDQhiGIAFCgICA+A+DQgiGhIQgAUIIiEKAgID4D4MgAUIYiEKAgPwHg4QgAUIoiEKA/gODIAFCOIiEhIQiAkI/iSACQjiJhSACQgeIhSAAKQMAIgFCOIYgAUKA/gODQiiGhCABQoCA/AeDQhiGIAFCgICA+A+DQgiGhIQgAUIIiEKAgID4D4MgAUIYiEKAgPwHg4QgAUIoiEKA/gODIAFCOIiEhIQiA3wgACkDSCIBQjiGIAFCgP4Dg0IohoQgAUKAgPwHg0IYhiABQoCAgPgPg0IIhoSEIAFCCIhCgICA+A+DIAFCGIhCgID8B4OEIAFCKIhCgP4DgyABQjiIhISEIgR8IAApA3AiAUI4hiABQoD+A4NCKIaEIAFCgID8B4NCGIYgAUKAgID4D4NCCIaEhCABQgiIQoCAgPgPgyABQhiIQoCA/AeDhCABQiiIQoD+A4MgAUI4iISEhCIFQi2JIAVCA4mFIAVCBoiFfCIGQj+JIAZCOImFIAZCB4iFIAApA3giAUI4hiABQoD+A4NCKIaEIAFCgID8B4NCGIYgAUKAgID4D4NCCIaEhCABQgiIQoCAgPgPgyABQhiIQoCA/AeDhCABQiiIQoD+A4MgAUI4iISEhCIHfCAEQj+JIARCOImFIARCB4iFIAApA0AiAUI4hiABQoD+A4NCKIaEIAFCgID8B4NCGIYgAUKAgID4D4NCCIaEhCABQgiIQoCAgPgPgyABQhiIQoCA/AeDhCABQiiIQoD+A4MgAUI4iISEhCIIfCAAKQMQIgFCOIYgAUKA/gODQiiGhCABQoCA/AeDQhiGIAFCgICA+A+DQgiGhIQgAUIIiEKAgID4D4MgAUIYiEKAgPwHg4QgAUIoiEKA/gODIAFCOIiEhIQiCUI/iSAJQjiJhSAJQgeIhSACfCAAKQNQIgFCOIYgAUKA/gODQiiGhCABQoCA/AeDQhiGIAFCgICA+A+DQgiGhIQgAUIIiEKAgID4D4MgAUIYiEKAgPwHg4QgAUIoiEKA/gODIAFCOIiEhIQiCnwgB0ItiSAHQgOJhSAHQgaIhXwiC3wgACkDOCIBQjiGIAFCgP4Dg0IohoQgAUKAgPwHg0IYhiABQoCAgPgPg0IIhoSEIAFCCIhCgICA+A+DIAFCGIhCgID8B4OEIAFCKIhCgP4DgyABQjiIhISEIgxCP4kgDEI4iYUgDEIHiIUgACkDMCIBQjiGIAFCgP4Dg0IohoQgAUKAgPwHg0IYhiABQoCAgPgPg0IIhoSEIAFCCIhCgICA+A+DIAFCGIhCgID8B4OEIAFCKIhCgP4DgyABQjiIhISEIg18IAd8IAApAygiAUI4hiABQoD+A4NCKIaEIAFCgID8B4NCGIYgAUKAgID4D4NCCIaEhCABQgiIQoCAgPgPgyABQhiIQoCA/AeDhCABQiiIQoD+A4MgAUI4iISEhCIOQj+JIA5COImFIA5CB4iFIAApAyAiAUI4hiABQoD+A4NCKIaEIAFCgID8B4NCGIYgAUKAgID4D4NCCIaEhCABQgiIQoCAgPgPgyABQhiIQoCA/AeDhCABQiiIQoD+A4MgAUI4iISEhCIPfCAAKQNoIgFCOIYgAUKA/gODQiiGhCABQoCA/AeDQhiGIAFCgICA+A+DQgiGhIQgAUIIiEKAgID4D4MgAUIYiEKAgPwHg4QgAUIoiEKA/gODIAFCOIiEhIQiEHwgACkDGCIBQjiGIAFCgP4Dg0IohoQgAUKAgPwHg0IYhiABQoCAgPgPg0IIhoSEIAFCCIhCgICA+A+DIAFCGIhCgID8B4OEIAFCKIhCgP4DgyABQjiIhISEIhFCP4kgEUI4iYUgEUIHiIUgCXwgACkDWCIBQjiGIAFCgP4Dg0IohoQgAUKAgPwHg0IYhiABQoCAgPgPg0IIhoSEIAFCCIhCgICA+A+DIAFCGIhCgID8B4OEIAFCKIhCgP4DgyABQjiIhISEIhJ8IAZCLYkgBkIDiYUgBkIGiIV8IhNCLYkgE0IDiYUgE0IGiIV8IhRCLYkgFEIDiYUgFEIGiIV8IhVCLYkgFUIDiYUgFUIGiIV8IhZ8IAVCP4kgBUI4iYUgBUIHiIUgEHwgFXwgACkDYCIBQjiGIAFCgP4Dg0IohoQgAUKAgPwHg0IYhiABQoCAgPgPg0IIhoSEIAFCCIhCgICA+A+DIAFCGIhCgID8B4OEIAFCKIhCgP4DgyABQjiIhISEIhdCP4kgF0I4iYUgF0IHiIUgEnwgFHwgCkI/iSAKQjiJhSAKQgeIhSAEfCATfCAIQj+JIAhCOImFIAhCB4iFIAx8IAZ8IA1CP4kgDUI4iYUgDUIHiIUgDnwgBXwgD0I/iSAPQjiJhSAPQgeIhSARfCAXfCALQi2JIAtCA4mFIAtCBoiFfCIYQi2JIBhCA4mFIBhCBoiFfCIZQi2JIBlCA4mFIBlCBoiFfCIaQi2JIBpCA4mFIBpCBoiFfCIbQi2JIBtCA4mFIBtCBoiFfCIcQi2JIBxCA4mFIBxCBoiFfCIdQi2JIB1CA4mFIB1CBoiFfCIeQj+JIB5COImFIB5CB4iFIAdCP4kgB0I4iYUgB0IHiIUgBXwgGnwgEEI/iSAQQjiJhSAQQgeIhSAXfCAZfCASQj+JIBJCOImFIBJCB4iFIAp8IBh8IBZCLYkgFkIDiYUgFkIGiIV8Ih9CLYkgH0IDiYUgH0IGiIV8IiBCLYkgIEIDiYUgIEIGiIV8IiF8IBZCP4kgFkI4iYUgFkIHiIUgGnwgC0I/iSALQjiJhSALQgeIhSAGfCAbfCAhQi2JICFCA4mFICFCBoiFfCIifCAVQj+JIBVCOImFIBVCB4iFIBl8ICF8IBRCP4kgFEI4iYUgFEIHiIUgGHwgIHwgE0I/iSATQjiJhSATQgeIhSALfCAffCAeQi2JIB5CA4mFIB5CBoiFfCIjQi2JICNCA4mFICNCBoiFfCIkQi2JICRCA4mFICRCBoiFfCIlQi2JICVCA4mFICVCBoiFfCImfCAdQj+JIB1COImFIB1CB4iFICB8ICV8IBxCP4kgHEI4iYUgHEIHiIUgH3wgJHwgG0I/iSAbQjiJhSAbQgeIhSAWfCAjfCAaQj+JIBpCOImFIBpCB4iFIBV8IB58IBlCP4kgGUI4iYUgGUIHiIUgFHwgHXwgGEI/iSAYQjiJhSAYQgeIhSATfCAcfCAiQi2JICJCA4mFICJCBoiFfCInQi2JICdCA4mFICdCBoiFfCIoQi2JIChCA4mFIChCBoiFfCIpQi2JIClCA4mFIClCBoiFfCIqQi2JICpCA4mFICpCBoiFfCIrQi2JICtCA4mFICtCBoiFfCIsQi2JICxCA4mFICxCBoiFfCItQj+JIC1COImFIC1CB4iFICFCP4kgIUI4iYUgIUIHiIUgHXwgKXwgIEI/iSAgQjiJhSAgQgeIhSAcfCAofCAfQj+JIB9COImFIB9CB4iFIBt8ICd8ICZCLYkgJkIDiYUgJkIGiIV8Ii5CLYkgLkIDiYUgLkIGiIV8Ii9CLYkgL0IDiYUgL0IGiIV8IjB8ICZCP4kgJkI4iYUgJkIHiIUgKXwgIkI/iSAiQjiJhSAiQgeIhSAefCAqfCAwQi2JIDBCA4mFIDBCBoiFfCIxfCAlQj+JICVCOImFICVCB4iFICh8IDB8ICRCP4kgJEI4iYUgJEIHiIUgJ3wgL3wgI0I/iSAjQjiJhSAjQgeIhSAifCAufCAtQi2JIC1CA4mFIC1CBoiFfCIyQi2JIDJCA4mFIDJCBoiFfCIzQi2JIDNCA4mFIDNCBoiFfCI0Qi2JIDRCA4mFIDRCBoiFfCI1fCAsQj+JICxCOImFICxCB4iFIC98IDR8ICtCP4kgK0I4iYUgK0IHiIUgLnwgM3wgKkI/iSAqQjiJhSAqQgeIhSAmfCAyfCApQj+JIClCOImFIClCB4iFICV8IC18IChCP4kgKEI4iYUgKEIHiIUgJHwgLHwgJ0I/iSAnQjiJhSAnQgeIhSAjfCArfCAxQi2JIDFCA4mFIDFCBoiFfCI2Qi2JIDZCA4mFIDZCBoiFfCI3Qi2JIDdCA4mFIDdCBoiFfCI4Qi2JIDhCA4mFIDhCBoiFfCI5Qi2JIDlCA4mFIDlCBoiFfCI6Qi2JIDpCA4mFIDpCBoiFfCI7Qi2JIDtCA4mFIDtCBoiFfCI8Qj+JIDxCOImFIDxCB4iFIDBCP4kgMEI4iYUgMEIHiIUgLHwgOHwgL0I/iSAvQjiJhSAvQgeIhSArfCA3fCAuQj+JIC5COImFIC5CB4iFICp8IDZ8IDVCLYkgNUIDiYUgNUIGiIV8Ij1CLYkgPUIDiYUgPUIGiIV8Ij5CLYkgPkIDiYUgPkIGiIV8Ij98IDVCP4kgNUI4iYUgNUIHiIUgOHwgMUI/iSAxQjiJhSAxQgeIhSAtfCA5fCA/Qi2JID9CA4mFID9CBoiFfCJAfCA0Qj+JIDRCOImFIDRCB4iFIDd8ID98IDNCP4kgM0I4iYUgM0IHiIUgNnwgPnwgMkI/iSAyQjiJhSAyQgeIhSAxfCA9fCA8Qi2JIDxCA4mFIDxCBoiFfCJBQi2JIEFCA4mFIEFCBoiFfCJCQi2JIEJCA4mFIEJCBoiFfCJDQi2JIENCA4mFIENCBoiFfCJEfCA7Qj+JIDtCOImFIDtCB4iFID58IEN8IDpCP4kgOkI4iYUgOkIHiIUgPXwgQnwgOUI/iSA5QjiJhSA5QgeIhSA1fCBBfCA4Qj+JIDhCOImFIDhCB4iFIDR8IDx8IDdCP4kgN0I4iYUgN0IHiIUgM3wgO3wgNkI/iSA2QjiJhSA2QgeIhSAyfCA6fCBAQi2JIEBCA4mFIEBCBoiFfCJFQi2JIEVCA4mFIEVCBoiFfCJGQi2JIEZCA4mFIEZCBoiFfCJHQi2JIEdCA4mFIEdCBoiFfCJIQi2JIEhCA4mFIEhCBoiFfCJJQi2JIElCA4mFIElCBoiFfCJKQi2JIEpCA4mFIEpCBoiFfCJLIEkgRSA/ID0gMiAsICogIiAgIBYgBiAXIAhBACkDqIoBIkxCMokgTEIuiYUgTEIXiYVBACkDwIoBIk18QQApA7iKASJOQQApA7CKASJPhSBMgyBOhXwgA3xCotyiuY3zi8XCAHwiA0EAKQOgigEiUHwiASAPfCBMIBF8IE8gCXwgTiACfCABIE8gTIWDIE+FfCABQjKJIAFCLomFIAFCF4mFfELNy72fkpLRm/EAfCJRQQApA5iKASJSfCIJIAEgTIWDIEyFfCAJQjKJIAlCLomFIAlCF4mFfEKv9rTi/vm+4LV/fCJTQQApA5CKASJUfCIPIAkgAYWDIAGFfCAPQjKJIA9CLomFIA9CF4mFfEK8t6eM2PT22ml8IlVBACkDiIoBIgF8IhEgDyAJhYMgCYV8IBFCMokgEUIuiYUgEUIXiYV8Qrjqopq/y7CrOXwiViBSIFQgAYWDIFQgAYOFIAFCJIkgAUIeiYUgAUIZiYV8IAN8IgJ8IgN8IAwgEXwgDSAPfCAOIAl8IAMgESAPhYMgD4V8IANCMokgA0IuiYUgA0IXiYV8Qpmgl7CbvsT42QB8Ig0gAiABhSBUgyACIAGDhSACQiSJIAJCHomFIAJCGYmFfCBRfCIJfCIIIAMgEYWDIBGFfCAIQjKJIAhCLomFIAhCF4mFfEKbn+X4ytTgn5J/fCIOIAkgAoUgAYMgCSACg4UgCUIkiSAJQh6JhSAJQhmJhXwgU3wiD3wiESAIIAOFgyADhXwgEUIyiSARQi6JhSARQheJhXxCmIK2093al46rf3wiUSAPIAmFIAKDIA8gCYOFIA9CJIkgD0IeiYUgD0IZiYV8IFV8IgJ8IgMgESAIhYMgCIV8IANCMokgA0IuiYUgA0IXiYV8QsKEjJiK0+qDWHwiUyACIA+FIAmDIAIgD4OFIAJCJIkgAkIeiYUgAkIZiYV8IFZ8Igl8Igx8IBIgA3wgCiARfCAEIAh8IAwgAyARhYMgEYV8IAxCMokgDEIuiYUgDEIXiYV8Qr7fwauU4NbBEnwiBCAJIAKFIA+DIAkgAoOFIAlCJIkgCUIeiYUgCUIZiYV8IA18Ig98IhEgDCADhYMgA4V8IBFCMokgEUIuiYUgEUIXiYV8Qozlkvfkt+GYJHwiCiAPIAmFIAKDIA8gCYOFIA9CJIkgD0IeiYUgD0IZiYV8IA58IgJ8IgMgESAMhYMgDIV8IANCMokgA0IuiYUgA0IXiYV8QuLp/q+9uJ+G1QB8IhIgAiAPhSAJgyACIA+DhSACQiSJIAJCHomFIAJCGYmFfCBRfCIJfCIIIAMgEYWDIBGFfCAIQjKJIAhCLomFIAhCF4mFfELvku6Tz66X3/IAfCIXIAkgAoUgD4MgCSACg4UgCUIkiSAJQh6JhSAJQhmJhXwgU3wiD3wiDHwgByAIfCAFIAN8IBAgEXwgDCAIIAOFgyADhXwgDEIyiSAMQi6JhSAMQheJhXxCsa3a2OO/rO+Af3wiAyAPIAmFIAKDIA8gCYOFIA9CJIkgD0IeiYUgD0IZiYV8IAR8IgV8IgIgDCAIhYMgCIV8IAJCMokgAkIuiYUgAkIXiYV8QrWknK7y1IHum398IgggBSAPhSAJgyAFIA+DhSAFQiSJIAVCHomFIAVCGYmFfCAKfCIGfCIJIAIgDIWDIAyFfCAJQjKJIAlCLomFIAlCF4mFfEKUzaT7zK78zUF8IgwgBiAFhSAPgyAGIAWDhSAGQiSJIAZCHomFIAZCGYmFfCASfCIHfCIPIAkgAoWDIAKFfCAPQjKJIA9CLomFIA9CF4mFfELSlcX3mbjazWR8IgQgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAXfCIFfCIRIBR8IBggD3wgEyAJfCALIAJ8IBEgDyAJhYMgCYV8IBFCMokgEUIuiYUgEUIXiYV8QuPLvMLj8JHfb3wiAiAFIAeFIAaDIAUgB4OFIAVCJIkgBUIeiYUgBUIZiYV8IAN8IgZ8IgsgESAPhYMgD4V8IAtCMokgC0IuiYUgC0IXiYV8QrWrs9zouOfgD3wiCSAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IAh8Igd8IhMgCyARhYMgEYV8IBNCMokgE0IuiYUgE0IXiYV8QuW4sr3HuaiGJHwiDyAHIAaFIAWDIAcgBoOFIAdCJIkgB0IeiYUgB0IZiYV8IAx8IgV8IhQgEyALhYMgC4V8IBRCMokgFEIuiYUgFEIXiYV8QvWErMn1jcv0LXwiESAFIAeFIAaDIAUgB4OFIAVCJIkgBUIeiYUgBUIZiYV8IAR8IgZ8Ihh8IBogFHwgFSATfCAZIAt8IBggFCAThYMgE4V8IBhCMokgGEIuiYUgGEIXiYV8QoPJm/WmlaG6ygB8IhYgBiAFhSAHgyAGIAWDhSAGQiSJIAZCHomFIAZCGYmFfCACfCIHfCILIBggFIWDIBSFfCALQjKJIAtCLomFIAtCF4mFfELU94fqy7uq2NwAfCIZIAcgBoUgBYMgByAGg4UgB0IkiSAHQh6JhSAHQhmJhXwgCXwiBXwiEyALIBiFgyAYhXwgE0IyiSATQi6JhSATQheJhXxCtafFmKib4vz2AHwiGCAFIAeFIAaDIAUgB4OFIAVCJIkgBUIeiYUgBUIZiYV8IA98IgZ8IhQgEyALhYMgC4V8IBRCMokgFEIuiYUgFEIXiYV8Qqu/m/OuqpSfmH98IhogBiAFhSAHgyAGIAWDhSAGQiSJIAZCHomFIAZCGYmFfCARfCIHfCIVfCAcIBR8IB8gE3wgGyALfCAVIBQgE4WDIBOFfCAVQjKJIBVCLomFIBVCF4mFfEKQ5NDt0s3xmKh/fCIbIAcgBoUgBYMgByAGg4UgB0IkiSAHQh6JhSAHQhmJhXwgFnwiBXwiCyAVIBSFgyAUhXwgC0IyiSALQi6JhSALQheJhXxCv8Lsx4n5yYGwf3wiFiAFIAeFIAaDIAUgB4OFIAVCJIkgBUIeiYUgBUIZiYV8IBl8IgZ8IhMgCyAVhYMgFYV8IBNCMokgE0IuiYUgE0IXiYV8QuSdvPf7+N+sv398IhkgBiAFhSAHgyAGIAWDhSAGQiSJIAZCHomFIAZCGYmFfCAYfCIHfCIUIBMgC4WDIAuFfCAUQjKJIBRCLomFIBRCF4mFfELCn6Lts/6C8EZ8IhggByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAafCIFfCIVfCAeIBR8ICEgE3wgHSALfCAVIBQgE4WDIBOFfCAVQjKJIBVCLomFIBVCF4mFfEKlzqqY+ajk01V8IhogBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCAbfCIGfCILIBUgFIWDIBSFfCALQjKJIAtCLomFIAtCF4mFfELvhI6AnuqY5QZ8IhsgBiAFhSAHgyAGIAWDhSAGQiSJIAZCHomFIAZCGYmFfCAWfCIHfCITIAsgFYWDIBWFfCATQjKJIBNCLomFIBNCF4mFfELw3LnQ8KzKlBR8IhYgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAZfCIFfCIUIBMgC4WDIAuFfCAUQjKJIBRCLomFIBRCF4mFfEL838i21NDC2yd8IhkgBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCAYfCIGfCIVICh8ICQgFHwgJyATfCAjIAt8IBUgFCAThYMgE4V8IBVCMokgFUIuiYUgFUIXiYV8QqaSm+GFp8iNLnwiGCAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBp8Igd8IgsgFSAUhYMgFIV8IAtCMokgC0IuiYUgC0IXiYV8Qu3VkNbFv5uWzQB8IhogByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAbfCIFfCITIAsgFYWDIBWFfCATQjKJIBNCLomFIBNCF4mFfELf59bsuaKDnNMAfCIbIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgFnwiBnwiFCATIAuFgyALhXwgFEIyiSAUQi6JhSAUQheJhXxC3se93cjqnIXlAHwiFiAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBl8Igd8IhV8ICYgFHwgKSATfCAlIAt8IBUgFCAThYMgE4V8IBVCMokgFUIuiYUgFUIXiYV8Qqjl3uOz14K19gB8IhkgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAYfCIFfCILIBUgFIWDIBSFfCALQjKJIAtCLomFIAtCF4mFfELm3ba/5KWy4YF/fCIYIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgGnwiBnwiEyALIBWFgyAVhXwgE0IyiSATQi6JhSATQheJhXxCu+qIpNGQi7mSf3wiGiAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBt8Igd8IhQgEyALhYMgC4V8IBRCMokgFEIuiYUgFEIXiYV8QuSGxOeUlPrfon98IhsgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAWfCIFfCIVfCAvIBR8ICsgE3wgLiALfCAVIBQgE4WDIBOFfCAVQjKJIBVCLomFIBVCF4mFfEKB4Ijiu8mZjah/fCIWIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgGXwiBnwiCyAVIBSFgyAUhXwgC0IyiSALQi6JhSALQheJhXxCka/ih43u4qVCfCIZIAYgBYUgB4MgBiAFg4UgBkIkiSAGQh6JhSAGQhmJhXwgGHwiB3wiEyALIBWFgyAVhXwgE0IyiSATQi6JhSATQheJhXxCsPzSsrC0lLZHfCIYIAcgBoUgBYMgByAGg4UgB0IkiSAHQh6JhSAHQhmJhXwgGnwiBXwiFCATIAuFgyALhXwgFEIyiSAUQi6JhSAUQheJhXxCmKS9t52DuslRfCIaIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgG3wiBnwiFXwgMSAUfCAtIBN8IDAgC3wgFSAUIBOFgyAThXwgFUIyiSAVQi6JhSAVQheJhXxCkNKWq8XEwcxWfCIbIAYgBYUgB4MgBiAFg4UgBkIkiSAGQh6JhSAGQhmJhXwgFnwiB3wiCyAVIBSFgyAUhXwgC0IyiSALQi6JhSALQheJhXxCqsDEu9WwjYd0fCIWIAcgBoUgBYMgByAGg4UgB0IkiSAHQh6JhSAHQhmJhXwgGXwiBXwiEyALIBWFgyAVhXwgE0IyiSATQi6JhSATQheJhXxCuKPvlYOOqLUQfCIZIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgGHwiBnwiFCATIAuFgyALhXwgFEIyiSAUQi6JhSAUQheJhXxCyKHLxuuisNIZfCIYIAYgBYUgB4MgBiAFg4UgBkIkiSAGQh6JhSAGQhmJhXwgGnwiB3wiFSA0fCA3IBR8IDMgE3wgNiALfCAVIBQgE4WDIBOFfCAVQjKJIBVCLomFIBVCF4mFfELT1oaKhYHbmx58IhogByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAbfCIFfCILIBUgFIWDIBSFfCALQjKJIAtCLomFIAtCF4mFfEKZ17v8zemdpCd8IhsgBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCAWfCIGfCITIAsgFYWDIBWFfCATQjKJIBNCLomFIBNCF4mFfEKoke2M3pav2DR8IhYgBiAFhSAHgyAGIAWDhSAGQiSJIAZCHomFIAZCGYmFfCAZfCIHfCIUIBMgC4WDIAuFfCAUQjKJIBRCLomFIBRCF4mFfELjtKWuvJaDjjl8IhkgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAYfCIFfCIVfCA5IBR8IDUgE3wgOCALfCAVIBQgE4WDIBOFfCAVQjKJIBVCLomFIBVCF4mFfELLlYaarsmq7M4AfCIYIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgGnwiBnwiCyAVIBSFgyAUhXwgC0IyiSALQi6JhSALQheJhXxC88aPu/fJss7bAHwiGiAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBt8Igd8IhMgCyAVhYMgFYV8IBNCMokgE0IuiYUgE0IXiYV8QqPxyrW9/puX6AB8IhsgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAWfCIFfCIUIBMgC4WDIAuFfCAUQjKJIBRCLomFIBRCF4mFfEL85b7v5d3gx/QAfCIWIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgGXwiBnwiFXwgOyAUfCA+IBN8IDogC3wgFSAUIBOFgyAThXwgFUIyiSAVQi6JhSAVQheJhXxC4N7cmPTt2NL4AHwiGSAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBh8Igd8IgsgFSAUhYMgFIV8IAtCMokgC0IuiYUgC0IXiYV8QvLWwo/Kgp7khH98IhggByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAafCIFfCITIAsgFYWDIBWFfCATQjKJIBNCLomFIBNCF4mFfELs85DTgcHA44x/fCIaIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgG3wiBnwiFCATIAuFgyALhXwgFEIyiSAUQi6JhSAUQheJhXxCqLyMm6L/v9+Qf3wiGyAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBZ8Igd8IhV8IEEgFHwgQCATfCA8IAt8IBUgFCAThYMgE4V8IBVCMokgFUIuiYUgFUIXiYV8Qun7ivS9nZuopH98IhYgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAZfCIFfCILIBUgFIWDIBSFfCALQjKJIAtCLomFIAtCF4mFfEKV8pmW+/7o/L5/fCIZIAUgB4UgBoMgBSAHg4UgBUIkiSAFQh6JhSAFQhmJhXwgGHwiBnwiEyALIBWFgyAVhXwgE0IyiSATQi6JhSATQheJhXxCq6bJm66e3rhGfCIYIAYgBYUgB4MgBiAFg4UgBkIkiSAGQh6JhSAGQhmJhXwgGnwiB3wiFCATIAuFgyALhXwgFEIyiSAUQi6JhSAUQheJhXxCnMOZ0e7Zz5NKfCIaIAcgBoUgBYMgByAGg4UgB0IkiSAHQh6JhSAHQhmJhXwgG3wiBXwiFSBHfCBDIBR8IEYgE3wgQiALfCAVIBQgE4WDIBOFfCAVQjKJIBVCLomFIBVCF4mFfEKHhIOO8piuw1F8IhsgBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCAWfCIGfCILIBUgFIWDIBSFfCALQjKJIAtCLomFIAtCF4mFfEKe1oPv7Lqf7Wp8IhYgBiAFhSAHgyAGIAWDhSAGQiSJIAZCHomFIAZCGYmFfCAZfCIHfCITIAsgFYWDIBWFfCATQjKJIBNCLomFIBNCF4mFfEL4orvz/u/TvnV8IhkgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAYfCIFfCIUIBMgC4WDIAuFfCAUQjKJIBRCLomFIBRCF4mFfEK6392Qp/WZ+AZ8IhwgBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCAafCIGfCIVfCA9Qj+JID1COImFID1CB4iFIDl8IEV8IERCLYkgREIDiYUgREIGiIV8IhggFHwgSCATfCBEIAt8IBUgFCAThYMgE4V8IBVCMokgFUIuiYUgFUIXiYV8QqaxopbauN+xCnwiGiAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBt8Igd8IgsgFSAUhYMgFIV8IAtCMokgC0IuiYUgC0IXiYV8Qq6b5PfLgOafEXwiGyAHIAaFIAWDIAcgBoOFIAdCJIkgB0IeiYUgB0IZiYV8IBZ8IgV8IhMgCyAVhYMgFYV8IBNCMokgE0IuiYUgE0IXiYV8QpuO8ZjR5sK4G3wiHSAFIAeFIAaDIAUgB4OFIAVCJIkgBUIeiYUgBUIZiYV8IBl8IgZ8IhQgEyALhYMgC4V8IBRCMokgFEIuiYUgFEIXiYV8QoT7kZjS/t3tKHwiHiAGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBx8Igd8IhV8ID9CP4kgP0I4iYUgP0IHiIUgO3wgR3wgPkI/iSA+QjiJhSA+QgeIhSA6fCBGfCAYQi2JIBhCA4mFIBhCBoiFfCIWQi2JIBZCA4mFIBZCBoiFfCIZIBR8IEogE3wgFiALfCAVIBQgE4WDIBOFfCAVQjKJIBVCLomFIBVCF4mFfEKTyZyGtO+q5TJ8IgsgByAGhSAFgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCAafCIFfCITIBUgFIWDIBSFfCATQjKJIBNCLomFIBNCF4mFfEK8/aauocGvzzx8IhogBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCAbfCIGfCIUIBMgFYWDIBWFfCAUQjKJIBRCLomFIBRCF4mFfELMmsDgyfjZjsMAfCIbIAYgBYUgB4MgBiAFg4UgBkIkiSAGQh6JhSAGQhmJhXwgHXwiB3wiFSAUIBOFgyAThXwgFUIyiSAVQi6JhSAVQheJhXxCtoX52eyX9eLMAHwiHCAHIAaFIAWDIAcgBoOFIAdCJIkgB0IeiYUgB0IZiYV8IB58IgV8IhYgTXw3A8CKAUEAIFAgBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCALfCIGIAWFIAeDIAYgBYOFIAZCJIkgBkIeiYUgBkIZiYV8IBp8IgcgBoUgBYMgByAGg4UgB0IkiSAHQh6JhSAHQhmJhXwgG3wiBSAHhSAGgyAFIAeDhSAFQiSJIAVCHomFIAVCGYmFfCAcfCILfDcDoIoBQQAgTiBAQj+JIEBCOImFIEBCB4iFIDx8IEh8IBlCLYkgGUIDiYUgGUIGiIV8IhkgE3wgFiAVIBSFgyAUhXwgFkIyiSAWQi6JhSAWQheJhXxCqvyV48+zyr/ZAHwiGiAGfCITfDcDuIoBQQAgUiALIAWFIAeDIAsgBYOFIAtCJIkgC0IeiYUgC0IZiYV8IBp8IgZ8NwOYigFBACBPIEFCP4kgQUI4iYUgQUIHiIUgQHwgGHwgS0ItiSBLQgOJhSBLQgaIhXwgFHwgEyAWIBWFgyAVhXwgE0IyiSATQi6JhSATQheJhXxC7PXb1rP12+XfAHwiGCAHfCIUfDcDsIoBQQAgVCAGIAuFIAWDIAYgC4OFIAZCJIkgBkIeiYUgBkIZiYV8IBh8Igd8NwOQigFBACBMIEVCP4kgRUI4iYUgRUIHiIUgQXwgSXwgGUItiSAZQgOJhSAZQgaIhXwgFXwgFCATIBaFgyAWhXwgFEIyiSAUQi6JhSAUQheJhXxCl7Cd0sSxhqLsAHwiEyAFfHw3A6iKAUEAIAEgByAGhSALgyAHIAaDhSAHQiSJIAdCHomFIAdCGYmFfCATfHw3A4iKAQvzCQIBfgR/QQApA4CKASIAp0EDdkEPcSIBQQN0QYCJAWoiAiACKQMAQn8gAEIDhiIAhkJ/hYNCgAEgAIaFNwMAIAFBAWohAwJAIAFBDkkNAAJAIANBD0cNAEEAQgA3A/iJAQtBgIkBEANBACEDCyADIQQCQEEHIANrQQdxIgJFDQAgAyACaiEEIANBA3RBgIkBaiEBA0AgAUIANwMAIAFBCGohASACQX9qIgINAAsLAkAgA0F4akEHSQ0AIARBA3QhAQNAIAFBuIkBakIANwMAIAFBsIkBakIANwMAIAFBqIkBakIANwMAIAFBoIkBakIANwMAIAFBmIkBakIANwMAIAFBkIkBakIANwMAIAFBiIkBakIANwMAIAFBgIkBakIANwMAIAFBwABqIgFB+ABHDQALC0EAIQFBAEEAKQOAigEiAEI7hiAAQiuGQoCAgICAgMD/AIOEIABCG4ZCgICAgIDgP4MgAEILhkKAgICA8B+DhIQgAEIFiEKAgID4D4MgAEIViEKAgPwHg4QgAEIliEKA/gODIABCA4ZCOIiEhIQ3A/iJAUGAiQEQA0EAQQApA8CKASIAQjiGIABCgP4Dg0IohoQgAEKAgPwHg0IYhiAAQoCAgPgPg0IIhoSEIABCCIhCgICA+A+DIABCGIhCgID8B4OEIABCKIhCgP4DgyAAQjiIhISENwPAigFBAEEAKQO4igEiAEI4hiAAQoD+A4NCKIaEIABCgID8B4NCGIYgAEKAgID4D4NCCIaEhCAAQgiIQoCAgPgPgyAAQhiIQoCA/AeDhCAAQiiIQoD+A4MgAEI4iISEhDcDuIoBQQBBACkDsIoBIgBCOIYgAEKA/gODQiiGhCAAQoCA/AeDQhiGIABCgICA+A+DQgiGhIQgAEIIiEKAgID4D4MgAEIYiEKAgPwHg4QgAEIoiEKA/gODIABCOIiEhIQ3A7CKAUEAQQApA6iKASIAQjiGIABCgP4Dg0IohoQgAEKAgPwHg0IYhiAAQoCAgPgPg0IIhoSEIABCCIhCgICA+A+DIABCGIhCgID8B4OEIABCKIhCgP4DgyAAQjiIhISENwOoigFBAEEAKQOgigEiAEI4hiAAQoD+A4NCKIaEIABCgID8B4NCGIYgAEKAgID4D4NCCIaEhCAAQgiIQoCAgPgPgyAAQhiIQoCA/AeDhCAAQiiIQoD+A4MgAEI4iISEhDcDoIoBQQBBACkDmIoBIgBCOIYgAEKA/gODQiiGhCAAQoCA/AeDQhiGIABCgICA+A+DQgiGhIQgAEIIiEKAgID4D4MgAEIYiEKAgPwHg4QgAEIoiEKA/gODIABCOIiEhIQ3A5iKAUEAQQApA5CKASIAQjiGIABCgP4Dg0IohoQgAEKAgPwHg0IYhiAAQoCAgPgPg0IIhoSEIABCCIhCgICA+A+DIABCGIhCgID8B4OEIABCKIhCgP4DgyAAQjiIhISENwOQigFBAEEAKQOIigEiAEI4hiAAQoD+A4NCKIaEIABCgID8B4NCGIYgAEKAgID4D4NCCIaEhCAAQgiIQoCAgPgPgyAAQhiIQoCA/AeDhCAAQiiIQoD+A4MgAEI4iISEhDcDiIoBAkBBACgCyIoBIgNFDQBBACECA0AgAUGACWogAUGIigFqLQAAOgAAIAFBAWohASADIAJBAWoiAkH/AXFLDQALCwsGAEGAiQELoQIAQQBCADcDgIoBQQBBMEHAACABQYADRiIBGzYCyIoBQQBCpJ/p99uD0trHAEL5wvibkaOz8NsAIAEbNwPAigFBAEKnn+an1sGLhltC6/qG2r+19sEfIAEbNwO4igFBAEKRquDC9tCS2o5/Qp/Y+dnCkdqCm38gARs3A7CKAUEAQrGWgP7/zMmZ5wBC0YWa7/rPlIfRACABGzcDqIoBQQBCubK5uI+b+5cVQvHt9Pilp/2npX8gARs3A6CKAUEAQpe6w4Ojq8CskX9Cq/DT9K/uvLc8IAEbNwOYigFBAEKHqvOzo6WKzeIAQrvOqqbY0Ouzu38gARs3A5CKAUEAQti9lojcq+fdS0KIkvOd/8z5hOoAIAEbNwOIigEgABACEAQLCwsBAEGACAsE0AAAAA==";
+var hash$9 = "f2e40eb1";
+var wasmJson$9 = {
+	name: name$9,
+	data: data$9,
+	hash: hash$9
+};
+
+const mutex$8 = new Mutex();
+let wasmCache$8 = null;
+/**
+ * Calculates SHA-2 (SHA-384) hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function sha384(data) {
+    if (wasmCache$8 === null) {
+        return lockedCreate(mutex$8, wasmJson$9, 48).then((wasm) => {
+            wasmCache$8 = wasm;
+            return wasmCache$8.calculate(data, 384);
+        });
+    }
+    try {
+        const hash = wasmCache$8.calculate(data, 384);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new SHA-2 (SHA-384) hash instance
+ */
+function createSHA384() {
+    return WASMInterface(wasmJson$9, 48).then((wasm) => {
+        wasm.init(384);
+        const obj = {
+            init: () => {
+                wasm.init(384);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 128,
+            digestSize: 48,
+        };
+        return obj;
+    });
+}
+
+const mutex$7 = new Mutex();
+let wasmCache$7 = null;
+/**
+ * Calculates SHA-2 (SHA-512) hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function sha512(data) {
+    if (wasmCache$7 === null) {
+        return lockedCreate(mutex$7, wasmJson$9, 64).then((wasm) => {
+            wasmCache$7 = wasm;
+            return wasmCache$7.calculate(data, 512);
+        });
+    }
+    try {
+        const hash = wasmCache$7.calculate(data, 512);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new SHA-2 (SHA-512) hash instance
+ */
+function createSHA512() {
+    return WASMInterface(wasmJson$9, 64).then((wasm) => {
+        wasm.init(512);
+        const obj = {
+            init: () => {
+                wasm.init(512);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 128,
+            digestSize: 64,
+        };
+        return obj;
+    });
+}
+
+var name$8 = "xxhash32";
+var data$8 = "AGFzbQEAAAABEQRgAAF/YAF/AGAAAGACf38AAwcGAAEBAgADBQQBAQICBg4CfwFBsIkFC38AQYAICwdwCAZtZW1vcnkCAA5IYXNoX0dldEJ1ZmZlcgAACUhhc2hfSW5pdAABC0hhc2hfVXBkYXRlAAIKSGFzaF9GaW5hbAADDUhhc2hfR2V0U3RhdGUABA5IYXNoX0NhbGN1bGF0ZQAFClNUQVRFX1NJWkUDAQrvEQYFAEGACQtNAEEAQgA3A6iJAUEAIAA2AoiJAUEAIABBz4yijgZqNgKMiQFBACAAQfeUr694ajYChIkBQQAgAEGoiI2hAmo2AoCJAUEAQQA2AqCJAQu4CAEHfwJAIABFDQBBAEEAKQOoiQEgAK18NwOoiQECQEEAKAKgiQEiASAAakEPSw0AAkACQCAAQQNxIgINAEGACSEDIAAhBAwBCyAAQXxxIQRBgAkhAwNAQQBBACgCoIkBIgVBAWo2AqCJASAFQZCJAWogAy0AADoAACADQQFqIQMgAkF/aiICDQALCyAAQQRJDQEDQEEAQQAoAqCJASICQQFqNgKgiQEgAkGQiQFqIAMtAAA6AAAgA0EBai0AACECQQBBACgCoIkBIgVBAWo2AqCJASAFQZCJAWogAjoAACADQQJqLQAAIQJBAEEAKAKgiQEiBUEBajYCoIkBIAVBkIkBaiACOgAAIANBA2otAAAhAkEAQQAoAqCJASIFQQFqNgKgiQEgBUGQiQFqIAI6AAAgA0EEaiEDIARBfGoiBA0ADAILCyAAQfAIaiEGAkACQCABDQBBACgCjIkBIQJBACgCiIkBIQVBACgChIkBIQRBACgCgIkBIQFBgAkhAwwBC0GACSEDAkAgAUEPSw0AQYAJIQMCQAJAQQAgAWtBA3EiBA0AIAEhBQwBCyABIQIDQEEAIAJBAWoiBTYCoIkBIAJBkIkBaiADLQAAOgAAIANBAWohAyAFIQIgBEF/aiIEDQALCyABQXNqQQNJDQBBACEEA0AgAyAEaiIBLQAAIQdBACAFIARqIgJBAWo2AqCJASACQZCJAWogBzoAACABQQFqLQAAIQdBACACQQJqNgKgiQEgAkGRiQFqIAc6AAAgAUECai0AACEHQQAgAkEDajYCoIkBIAJBkokBaiAHOgAAIAFBA2otAAAhAUEAIAJBBGo2AqCJASACQZOJAWogAToAACAFIARBBGoiBGpBEEcNAAsgAyAEaiEDC0EAQQAoApCJAUH3lK+veGxBACgCgIkBakENd0Gx893xeWwiATYCgIkBQQBBACgClIkBQfeUr694bEEAKAKEiQFqQQ13QbHz3fF5bCIENgKEiQFBAEEAKAKYiQFB95Svr3hsQQAoAoiJAWpBDXdBsfPd8XlsIgU2AoiJAUEAQQAoApyJAUH3lK+veGxBACgCjIkBakENd0Gx893xeWwiAjYCjIkBCyAAQYAJaiEAAkAgAyAGSw0AA0AgAygCAEH3lK+veGwgAWpBDXdBsfPd8XlsIQEgA0EMaigCAEH3lK+veGwgAmpBDXdBsfPd8XlsIQIgA0EIaigCAEH3lK+veGwgBWpBDXdBsfPd8XlsIQUgA0EEaigCAEH3lK+veGwgBGpBDXdBsfPd8XlsIQQgA0EQaiIDIAZNDQALC0EAIAI2AoyJAUEAIAU2AoiJAUEAIAQ2AoSJAUEAIAE2AoCJAUEAIAAgA2s2AqCJASAAIANGDQBBACECA0AgAkGQiQFqIAMgAmotAAA6AAAgAkEBaiICQQAoAqCJAUkNAAsLC4MEAgF+Bn9BACkDqIkBIgCnIQECQAJAIABCEFQNAEEAKAKEiQFBB3dBACgCgIkBQQF3akEAKAKIiQFBDHdqQQAoAoyJAUESd2ohAgwBC0EAKAKIiQFBsc/ZsgFqIQILIAIgAWohAkGQiQEhA0GUiQEhAQJAQQAoAqCJASIEQZCJAWoiBUGUiQFJDQBBkIkBIQMCQCAEQXxqIgZBBHENAEEAKAKQiQFBvdzKlXxsIAJqQRF3Qa/W074CbCECQZiJASEBQZSJASEDIAZBBEkNAQsDQCABKAIAQb3cypV8bCADKAIAQb3cypV8bCACakERd0Gv1tO+AmxqQRF3Qa/W074CbCECIAFBBGohAyABQQhqIgEgBU0NAAsgAUF8aiEDCwJAIAMgBUYNACAEQY+JAWohBgJAAkAgBCADa0EBcQ0AIAMhAQwBCyADQQFqIQEgAy0AAEGxz9myAWwgAmpBC3dBsfPd8XlsIQILIAYgA0YNAANAIAFBAWotAABBsc/ZsgFsIAEtAABBsc/ZsgFsIAJqQQt3QbHz3fF5bGpBC3dBsfPd8XlsIQIgAUECaiIBIAVHDQALC0EAIAJBD3YgAnNB95Svr3hsIgFBDXYgAXNBvdzKlXxsIgFBEHYgAXMiAkEYdCACQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnKtNwOACQsGAEGAiQEL0gQCAX4Ef0EAQgA3A6iJAUEAIAE2AoiJAUEAIAFBz4yijgZqNgKMiQFBACABQfeUr694ajYChIkBQQAgAUGoiI2hAmo2AoCJAUEAQQA2AqCJASAAEAJBACkDqIkBIgKnIQECQAJAIAJCEFQNAEEAKAKEiQFBB3dBACgCgIkBQQF3akEAKAKIiQFBDHdqQQAoAoyJAUESd2ohAAwBC0EAKAKIiQFBsc/ZsgFqIQALIAAgAWohAEGQiQEhA0GUiQEhAQJAQQAoAqCJASIEQZCJAWoiBUGUiQFJDQBBkIkBIQMCQCAEQXxqIgZBBHENAEEAKAKQiQFBvdzKlXxsIABqQRF3Qa/W074CbCEAQZiJASEBQZSJASEDIAZBBEkNAQsDQCABKAIAQb3cypV8bCADKAIAQb3cypV8bCAAakERd0Gv1tO+AmxqQRF3Qa/W074CbCEAIAFBBGohAyABQQhqIgEgBU0NAAsgAUF8aiEDCwJAIAMgBUYNACAEQY+JAWohBgJAAkAgBCADa0EBcQ0AIAMhAQwBCyADQQFqIQEgAy0AAEGxz9myAWwgAGpBC3dBsfPd8XlsIQALIAYgA0YNAANAIAFBAWotAABBsc/ZsgFsIAEtAABBsc/ZsgFsIABqQQt3QbHz3fF5bGpBC3dBsfPd8XlsIQAgAUECaiIBIAVHDQALC0EAIABBD3YgAHNB95Svr3hsIgFBDXYgAXNBvdzKlXxsIgFBEHYgAXMiAEEYdCAAQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnKtNwOACQsLCwEAQYAICwQwAAAA";
+var hash$8 = "4bb12485";
+var wasmJson$8 = {
+	name: name$8,
+	data: data$8,
+	hash: hash$8
+};
+
+const mutex$6 = new Mutex();
+let wasmCache$6 = null;
+function validateSeed$3(seed) {
+    if (!Number.isInteger(seed) || seed < 0 || seed > 0xffffffff) {
+        return new Error("Seed must be a valid 32-bit long unsigned integer.");
+    }
+    return null;
+}
+/**
+ * Calculates xxHash32 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param seed Number used to initialize the internal state of the algorithm (defaults to 0)
+ * @returns Computed hash as a hexadecimal string
+ */
+function xxhash32(data, seed = 0) {
+    if (validateSeed$3(seed)) {
+        return Promise.reject(validateSeed$3(seed));
+    }
+    if (wasmCache$6 === null) {
+        return lockedCreate(mutex$6, wasmJson$8, 4).then((wasm) => {
+            wasmCache$6 = wasm;
+            return wasmCache$6.calculate(data, seed);
+        });
+    }
+    try {
+        const hash = wasmCache$6.calculate(data, seed);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new xxHash32 hash instance
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param seed Number used to initialize the internal state of the algorithm (defaults to 0)
+ */
+function createXXHash32(seed = 0) {
+    if (validateSeed$3(seed)) {
+        return Promise.reject(validateSeed$3(seed));
+    }
+    return WASMInterface(wasmJson$8, 4).then((wasm) => {
+        wasm.init(seed);
+        const obj = {
+            init: () => {
+                wasm.init(seed);
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 16,
+            digestSize: 4,
+        };
+        return obj;
+    });
+}
+
+var name$7 = "xxhash64";
+var data$7 = "AGFzbQEAAAABDANgAAF/YAAAYAF/AAMHBgABAgEAAQUEAQECAgYOAn8BQdCJBQt/AEGACAsHcAgGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAlIYXNoX0luaXQAAQtIYXNoX1VwZGF0ZQACCkhhc2hfRmluYWwAAw1IYXNoX0dldFN0YXRlAAQOSGFzaF9DYWxjdWxhdGUABQpTVEFURV9TSVpFAwEKmxEGBQBBgAkLYwEBfkEAQgA3A8iJAUEAQQApA4AJIgA3A5CJAUEAIABC+erQ0OfJoeThAHw3A5iJAUEAIABCz9bTvtLHq9lCfDcDiIkBQQAgAELW64Lu6v2J9eAAfDcDgIkBQQBBADYCwIkBC70IAwV/BH4CfwJAIABFDQBBAEEAKQPIiQEgAK18NwPIiQECQEEAKALAiQEiASAAakEfSw0AAkACQCAAQQNxIgINAEGACSEDIAAhAQwBCyAAQXxxIQFBgAkhAwNAQQBBACgCwIkBIgRBAWo2AsCJASAEQaCJAWogAy0AADoAACADQQFqIQMgAkF/aiICDQALCyAAQQRJDQEDQEEAQQAoAsCJASICQQFqNgLAiQEgAkGgiQFqIAMtAAA6AAAgA0EBai0AACECQQBBACgCwIkBIgRBAWo2AsCJASAEQaCJAWogAjoAACADQQJqLQAAIQJBAEEAKALAiQEiBEEBajYCwIkBIARBoIkBaiACOgAAIANBA2otAAAhAkEAQQAoAsCJASIEQQFqNgLAiQEgBEGgiQFqIAI6AAAgA0EEaiEDIAFBfGoiAQ0ADAILCyAAQeAIaiEFAkACQCABDQBBACkDmIkBIQZBACkDkIkBIQdBACkDiIkBIQhBACkDgIkBIQlBgAkhAwwBC0GACSEDAkAgAUEfSw0AQYAJIQMCQAJAQQAgAWtBA3EiBA0AIAEhAgwBCyABIQIDQCACQaCJAWogAy0AADoAACACQQFqIQIgA0EBaiEDIARBf2oiBA0ACwsgAUFjakEDSQ0AQSAgAmshCkEAIQQDQCACIARqIgFBoIkBaiADIARqIgstAAA6AAAgAUGhiQFqIAtBAWotAAA6AAAgAUGiiQFqIAtBAmotAAA6AAAgAUGjiQFqIAtBA2otAAA6AAAgCiAEQQRqIgRHDQALIAMgBGohAwtBAEEAKQOgiQFCz9bTvtLHq9lCfkEAKQOAiQF8Qh+JQoeVr6+Ytt6bnn9+Igk3A4CJAUEAQQApA6iJAULP1tO+0ser2UJ+QQApA4iJAXxCH4lCh5Wvr5i23puef34iCDcDiIkBQQBBACkDsIkBQs/W077Sx6vZQn5BACkDkIkBfEIfiUKHla+vmLbem55/fiIHNwOQiQFBAEEAKQO4iQFCz9bTvtLHq9lCfkEAKQOYiQF8Qh+JQoeVr6+Ytt6bnn9+IgY3A5iJAQsgAEGACWohAgJAIAMgBUsNAANAIAMpAwBCz9bTvtLHq9lCfiAJfEIfiUKHla+vmLbem55/fiEJIANBGGopAwBCz9bTvtLHq9lCfiAGfEIfiUKHla+vmLbem55/fiEGIANBEGopAwBCz9bTvtLHq9lCfiAHfEIfiUKHla+vmLbem55/fiEHIANBCGopAwBCz9bTvtLHq9lCfiAIfEIfiUKHla+vmLbem55/fiEIIANBIGoiAyAFTQ0ACwtBACAGNwOYiQFBACAHNwOQiQFBACAINwOIiQFBACAJNwOAiQFBACACIANrNgLAiQEgAiADRg0AQQAhAgNAIAJBoIkBaiADIAJqLQAAOgAAIAJBAWoiAkEAKALAiQFJDQALCwvlBwIFfgV/AkACQEEAKQPIiQEiAEIgVA0AQQApA4iJASIBQgeJQQApA4CJASICQgGJfEEAKQOQiQEiA0IMiXxBACkDmIkBIgRCEol8IAJCz9bTvtLHq9lCfkIfiUKHla+vmLbem55/foVCh5Wvr5i23puef35C49zKlfzO8vWFf3wgAULP1tO+0ser2UJ+Qh+JQoeVr6+Ytt6bnn9+hUKHla+vmLbem55/fkLj3MqV/M7y9YV/fCADQs/W077Sx6vZQn5CH4lCh5Wvr5i23puef36FQoeVr6+Ytt6bnn9+QuPcypX8zvL1hX98IARCz9bTvtLHq9lCfkIfiUKHla+vmLbem55/foVCh5Wvr5i23puef35C49zKlfzO8vWFf3whAQwBC0EAKQOQiQFCxc/ZsvHluuonfCEBCyABIAB8IQBBoIkBIQVBqIkBIQYCQEEAKALAiQEiB0GgiQFqIghBqIkBSQ0AQaCJASEFAkAgB0F4aiIJQQhxDQBBACkDoIkBQs/W077Sx6vZQn5CH4lCh5Wvr5i23puef34gAIVCG4lCh5Wvr5i23puef35C49zKlfzO8vWFf3whAEGwiQEhBkGoiQEhBSAJQQhJDQELA0AgBikDAELP1tO+0ser2UJ+Qh+JQoeVr6+Ytt6bnn9+IAUpAwBCz9bTvtLHq9lCfkIfiUKHla+vmLbem55/fiAAhUIbiUKHla+vmLbem55/fkLj3MqV/M7y9YV/fIVCG4lCh5Wvr5i23puef35C49zKlfzO8vWFf3whACAGQQhqIQUgBkEQaiIGIAhNDQALIAZBeGohBQsCQAJAIAVBBGoiCSAITQ0AIAUhCQwBCyAFNQIAQoeVr6+Ytt6bnn9+IACFQheJQs/W077Sx6vZQn5C+fPd8Zn2masWfCEACwJAIAkgCEYNACAHQZ+JAWohBQJAAkAgByAJa0EBcQ0AIAkhBgwBCyAJQQFqIQYgCTEAAELFz9my8eW66id+IACFQguJQoeVr6+Ytt6bnn9+IQALIAUgCUYNAANAIAZBAWoxAABCxc/ZsvHluuonfiAGMQAAQsXP2bLx5brqJ34gAIVCC4lCh5Wvr5i23puef36FQguJQoeVr6+Ytt6bnn9+IQAgBkECaiIGIAhHDQALC0EAIABCIYggAIVCz9bTvtLHq9lCfiIAQh2IIACFQvnz3fGZ9pmrFn4iAEIgiCAAhSIBQjiGIAFCgP4Dg0IohoQgAUKAgPwHg0IYhiABQoCAgPgPg0IIhoSEIABCCIhCgICA+A+DIABCGIhCgID8B4OEIABCKIhCgP4DgyAAQjiIhISENwOACQsGAEGAiQELAgALCwsBAEGACAsEUAAAAA==";
+var hash$7 = "177fbfa3";
+var wasmJson$7 = {
+	name: name$7,
+	data: data$7,
+	hash: hash$7
+};
+
+const mutex$5 = new Mutex();
+let wasmCache$5 = null;
+const seedBuffer$2 = new Uint8Array(8);
+function validateSeed$2(seed) {
+    if (!Number.isInteger(seed) || seed < 0 || seed > 0xffffffff) {
+        return new Error("Seed must be given as two valid 32-bit long unsigned integers (lo + high).");
+    }
+    return null;
+}
+function writeSeed$2(arr, low, high) {
+    // write in little-endian format
+    const buffer = new DataView(arr);
+    buffer.setUint32(0, low, true);
+    buffer.setUint32(4, high, true);
+}
+/**
+ * Calculates xxHash64 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param seedLow Lower 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @param seedHigh Higher 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @returns Computed hash as a hexadecimal string
+ */
+function xxhash64(data, seedLow = 0, seedHigh = 0) {
+    if (validateSeed$2(seedLow)) {
+        return Promise.reject(validateSeed$2(seedLow));
+    }
+    if (validateSeed$2(seedHigh)) {
+        return Promise.reject(validateSeed$2(seedHigh));
+    }
+    if (wasmCache$5 === null) {
+        return lockedCreate(mutex$5, wasmJson$7, 8).then((wasm) => {
+            wasmCache$5 = wasm;
+            writeSeed$2(seedBuffer$2.buffer, seedLow, seedHigh);
+            wasmCache$5.writeMemory(seedBuffer$2);
+            return wasmCache$5.calculate(data);
+        });
+    }
+    try {
+        writeSeed$2(seedBuffer$2.buffer, seedLow, seedHigh);
+        wasmCache$5.writeMemory(seedBuffer$2);
+        const hash = wasmCache$5.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new xxHash64 hash instance
+ * @param seedLow Lower 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @param seedHigh Higher 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ */
+function createXXHash64(seedLow = 0, seedHigh = 0) {
+    if (validateSeed$2(seedLow)) {
+        return Promise.reject(validateSeed$2(seedLow));
+    }
+    if (validateSeed$2(seedHigh)) {
+        return Promise.reject(validateSeed$2(seedHigh));
+    }
+    return WASMInterface(wasmJson$7, 8).then((wasm) => {
+        const instanceBuffer = new Uint8Array(8);
+        writeSeed$2(instanceBuffer.buffer, seedLow, seedHigh);
+        wasm.writeMemory(instanceBuffer);
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.writeMemory(instanceBuffer);
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 32,
+            digestSize: 8,
+        };
+        return obj;
+    });
+}
+
+var name$6 = "xxhash3";
+var data$6 = "AGFzbQEAAAABNAhgAAF/YAR/f39/AGAHf39/f39/fwBgBH9+fn4BfmAEf39/fgF+YAN/f34BfmAAAGABfwADDg0AAQIDBAUFBQYHBgAGBQQBAQICBg4CfwFBwI4FC38AQcAJCwdwCAZtZW1vcnkCAA5IYXNoX0dldEJ1ZmZlcgAACUhhc2hfSW5pdAAIC0hhc2hfVXBkYXRlAAkKSGFzaF9GaW5hbAAKDUhhc2hfR2V0U3RhdGUACw5IYXNoX0NhbGN1bGF0ZQAMClNUQVRFX1NJWkUDAQr6QQ0FAEGACgvkAwMPfgF/AX4CQCADRQ0AIAApAzAhBCAAKQM4IQUgACkDICEGIAApAyghByAAKQMQIQggACkDGCEJIAApAwAhCiAAKQMIIQsDQCAFIAFBMGopAwAiDHwgAkE4aikDACABQThqKQMAIg2FIgVCIIggBUL/////D4N+fCEFIAcgAUEgaikDACIOfCACQShqKQMAIAFBKGopAwAiD4UiB0IgiCAHQv////8Pg358IQcgCSABQRBqKQMAIhB8IAJBGGopAwAgAUEYaikDACIRhSIJQiCIIAlC/////w+DfnwhCSALIAEpAwAiEnwgAkEIaiITKQMAIAFBCGopAwAiFIUiC0IgiCALQv////8Pg358IQsgAkEwaikDACAMhSIMQiCIIAxC/////w+DfiAEfCANfCEEIAJBIGopAwAgDoUiDEIgiCAMQv////8Pg34gBnwgD3whBiACQRBqKQMAIBCFIgxCIIggDEL/////D4N+IAh8IBF8IQggAikDACAShSIMQiCIIAxC/////w+DfiAKfCAUfCEKIAFBwABqIQEgEyECIANBf2oiAw0ACyAAIAk3AxggACAKNwMAIAAgCzcDCCAAIAc3AyggACAINwMQIAAgBTcDOCAAIAY3AyAgACAENwMwCwveAgIBfwF+AkAgBCACIAEoAgAiB2siAkkNACAAIAMgBSAHQQN0aiACEAEgACAFIAZqIgcpAwAgACkDACIIQi+IhSAIhUKx893xCX43AwAgACAHKQMIIAApAwgiCEIviIUgCIVCsfPd8Ql+NwMIIAAgBykDECAAKQMQIghCL4iFIAiFQrHz3fEJfjcDECAAIAcpAxggACkDGCIIQi+IhSAIhUKx893xCX43AxggACAHKQMgIAApAyAiCEIviIUgCIVCsfPd8Ql+NwMgIAAgBykDKCAAKQMoIghCL4iFIAiFQrHz3fEJfjcDKCAAIAcpAzAgACkDMCIIQi+IhSAIhUKx893xCX43AzAgACAHKQM4IAApAzgiCEIviIUgCIVCsfPd8Ql+NwM4IAAgAyACQQZ0aiAFIAQgAmsiBxABIAEgBzYCAA8LIAAgAyAFIAdBA3RqIAQQASABIAcgBGo2AgALhQEBAX8gAiABhSADpyIEQRh0IARBgP4DcUEIdHIgBEEIdkGA/gNxIARBGHZycq1CIIYgA4V9QQA1AoCMAUIghiAAQfyLAWo1AgCEhSIDQjGJIANCGImFIAOFQqW+4/TRjIfZn39+IgNCI4ggAK18IAOFQqW+4/TRjIfZn39+IgNCHIggA4ULZwAgAiABc60gA3wiA0IhiEEALQCAjAFBEHQgAEEIdHIgAEEBdkGAjAFqLQAAQRh0ciAAQf+LAWotAAByrYUgA4VCz9bTvtLHq9lCfiIDQh2IIAOFQvnz3fGZ9pmrFn4iA0IgiCADhQuJAwEEfgJAIABBCUkNAEEAKQOAjAEgASkDICABKQMYhSACfIUiA0I4hiADQoD+A4NCKIaEIANCgID8B4NCGIYgA0KAgID4D4NCCIaEhCADQgiIQoCAgPgPgyADQhiIQoCA/AeDhCADQiiIQoD+A4MgA0I4iISEhCAArXwgAEH4iwFqKQMAIAEpAzAgASkDKIUgAn2FIgJ8IAJC/////w+DIgQgA0IgiCIFfiIGQv////8PgyACQiCIIgIgA0L/////D4MiA358IAQgA34iA0IgiHwiBEIghiADQv////8Pg4QgBkIgiCACIAV+fCAEQiCIfIV8IgNCJYggA4VC+fPd8ZnymasWfiIDQiCIIAOFDwsCQCAAQQRJDQAgACABQQhqKQMAIAFBEGopAwAgAhADDwsCQCAARQ0AIAAgASgCACABQQRqKAIAIAIQBA8LIAEpAzggASkDQIUgAoUiA0IhiCADhULP1tO+0ser2UJ+IgNCHYggA4VC+fPd8Zn2masWfiIDQiCIIAOFC94IAQZ+IACtQoeVr6+Ytt6bnn9+IQMCQCAAQSFJDQACQCAAQcEASQ0AAkAgAEHhAEkNACABKQNoIAJ9QQApA7iMAYUiBEL/////D4MiBSABKQNgIAJ8QQApA7CMAYUiBkIgiCIHfiIIQv////8PgyAEQiCIIgQgBkL/////D4MiBn58IAUgBn4iBUIgiHwiBkIghiAFQv////8Pg4QgCEIgiCAEIAd+fCAGQiCIfIUgA3wgASkDeCACfSAAQciLAWopAwCFIgNC/////w+DIgQgASkDcCACfCAAQcCLAWopAwCFIgVCIIgiBn4iB0L/////D4MgA0IgiCIDIAVC/////w+DIgV+fCAEIAV+IgRCIIh8IgVCIIYgBEL/////D4OEIAdCIIggAyAGfnwgBUIgiHyFfCEDCyABKQNIIAJ9QQApA6iMAYUiBEL/////D4MiBSABKQNAIAJ8QQApA6CMAYUiBkIgiCIHfiIIQv////8PgyAEQiCIIgQgBkL/////D4MiBn58IAUgBn4iBUIgiHwiBkIghiAFQv////8Pg4QgCEIgiCAEIAd+fCAGQiCIfIUgA3wgASkDWCACfSAAQdiLAWopAwCFIgNC/////w+DIgQgASkDUCACfCAAQdCLAWopAwCFIgVCIIgiBn4iB0L/////D4MgA0IgiCIDIAVC/////w+DIgV+fCAEIAV+IgRCIIh8IgVCIIYgBEL/////D4OEIAdCIIggAyAGfnwgBUIgiHyFfCEDCyABKQMoIAJ9QQApA5iMAYUiBEL/////D4MiBSABKQMgIAJ8QQApA5CMAYUiBkIgiCIHfiIIQv////8PgyAEQiCIIgQgBkL/////D4MiBn58IAUgBn4iBUIgiHwiBkIghiAFQv////8Pg4QgCEIgiCAEIAd+fCAGQiCIfIUgA3wgASkDOCACfSAAQeiLAWopAwCFIgNC/////w+DIgQgASkDMCACfCAAQeCLAWopAwCFIgVCIIgiBn4iB0L/////D4MgA0IgiCIDIAVC/////w+DIgV+fCAEIAV+IgRCIIh8IgVCIIYgBEL/////D4OEIAdCIIggAyAGfnwgBUIgiHyFfCEDCyABKQMIIAJ9QQApA4iMAYUiBEL/////D4MiBSABKQMAIAJ8QQApA4CMAYUiBkIgiCIHfiIIQv////8PgyAEQiCIIgQgBkL/////D4MiBn58IAUgBn4iBUIgiHwiBkIghiAFQv////8Pg4QgCEIgiCAEIAd+fCAGQiCIfIUgA3wgASkDGCACfSAAQfiLAWopAwCFIgNC/////w+DIgQgASkDECACfCAAQfCLAWopAwCFIgJCIIgiBX4iBkL/////D4MgA0IgiCIDIAJC/////w+DIgJ+fCAEIAJ+IgJCIIh8IgRCIIYgAkL/////D4OEIAZCIIggAyAFfnwgBEIgiHyFfCICQiWIIAKFQvnz3fGZ8pmrFn4iAkIgiCAChQv8CgQBfwV+An8BfkEAIQMgASkDeCACfUEAKQP4jAGFIgRC/////w+DIgUgASkDcCACfEEAKQPwjAGFIgZCIIgiB34iCEL/////D4MgBEIgiCIEIAZC/////w+DIgZ+fCAFIAZ+IgVCIIh8IgZCIIYgBUL/////D4OEIAhCIIggBCAHfnwgBkIgiHyFIAEpA2ggAn1BACkD6IwBhSIEQv////8PgyIFIAEpA2AgAnxBACkD4IwBhSIGQiCIIgd+IghC/////w+DIARCIIgiBCAGQv////8PgyIGfnwgBSAGfiIFQiCIfCIGQiCGIAVC/////w+DhCAIQiCIIAQgB358IAZCIIh8hSABKQNYIAJ9QQApA9iMAYUiBEL/////D4MiBSABKQNQIAJ8QQApA9CMAYUiBkIgiCIHfiIIQv////8PgyAEQiCIIgQgBkL/////D4MiBn58IAUgBn4iBUIgiHwiBkIghiAFQv////8Pg4QgCEIgiCAEIAd+fCAGQiCIfIUgASkDSCACfUEAKQPIjAGFIgRC/////w+DIgUgASkDQCACfEEAKQPAjAGFIgZCIIgiB34iCEL/////D4MgBEIgiCIEIAZC/////w+DIgZ+fCAFIAZ+IgVCIIh8IgZCIIYgBUL/////D4OEIAhCIIggBCAHfnwgBkIgiHyFIAEpAzggAn1BACkDuIwBhSIEQv////8PgyIFIAEpAzAgAnxBACkDsIwBhSIGQiCIIgd+IghC/////w+DIARCIIgiBCAGQv////8PgyIGfnwgBSAGfiIFQiCIfCIGQiCGIAVC/////w+DhCAIQiCIIAQgB358IAZCIIh8hSABKQMoIAJ9QQApA6iMAYUiBEL/////D4MiBSABKQMgIAJ8QQApA6CMAYUiBkIgiCIHfiIIQv////8PgyAEQiCIIgQgBkL/////D4MiBn58IAUgBn4iBUIgiHwiBkIghiAFQv////8Pg4QgCEIgiCAEIAd+fCAGQiCIfIUgASkDGCACfUEAKQOYjAGFIgRC/////w+DIgUgASkDECACfEEAKQOQjAGFIgZCIIgiB34iCEL/////D4MgBEIgiCIEIAZC/////w+DIgZ+fCAFIAZ+IgVCIIh8IgZCIIYgBUL/////D4OEIAhCIIggBCAHfnwgBkIgiHyFIAEpAwggAn1BACkDiIwBhSIEQv////8PgyIFIAEpAwAgAnxBACkDgIwBhSIGQiCIIgd+IghC/////w+DIARCIIgiBCAGQv////8PgyIGfnwgBSAGfiIFQiCIfCIGQiCGIAVC/////w+DhCAIQiCIIAQgB358IAZCIIh8hSAArUKHla+vmLbem55/fnx8fHx8fHx8IgRCJYggBIVC+fPd8ZnymasWfiIEQiCIIASFIQQCQCAAQZABSA0AIABBBHZBeGohCQNAIAEgA2oiCkELaikDACACfSADQYiNAWopAwCFIgVC/////w+DIgYgCkEDaikDACACfCADQYCNAWopAwCFIgdCIIgiCH4iC0L/////D4MgBUIgiCIFIAdC/////w+DIgd+fCAGIAd+IgZCIIh8IgdCIIYgBkL/////D4OEIAtCIIggBSAIfnwgB0IgiHyFIAR8IQQgA0EQaiEDIAlBf2oiCQ0ACwsgASkDfyACfSAAQfiLAWopAwCFIgVC/////w+DIgYgASkDdyACfCAAQfCLAWopAwCFIgJCIIgiB34iCEL/////D4MgBUIgiCIFIAJC/////w+DIgJ+fCAGIAJ+IgJCIIh8IgZCIIYgAkL/////D4OEIAhCIIggBSAHfnwgBkIgiHyFIAR8IgJCJYggAoVC+fPd8ZnymasWfiICQiCIIAKFC98FAgF+AX8CQAJAQQApA4AKIgBQRQ0AQYAIIQFCACEADAELAkBBACkDoI4BIABSDQBBACEBDAELQQAhAUEAQq+v79e895Kg/gAgAH03A/iLAUEAIABCxZbr+djShYIofDcD8IsBQQBCj/Hjja2P9JhOIAB9NwPoiwFBACAAQqus+MXV79HQfHw3A+CLAUEAQtOt1LKShbW0nn8gAH03A9iLAUEAIABCl5r0jvWWvO3JAHw3A9CLAUEAQsWDgv2v/8SxayAAfTcDyIsBQQAgAELqi7OdyOb09UN8NwPAiwFBAELIv/rLnJveueQAIAB9NwO4iwFBACAAQoqjgd/Ume2sMXw3A7CLAUEAQvm57738+MKnHSAAfTcDqIsBQQAgAEKo9dv7s5ynmj98NwOgiwFBAEK4sry3lNW31lggAH03A5iLAUEAIABC8cihuqm0w/zOAHw3A5CLAUEAQoihl9u445SXo38gAH03A4iLAUEAIABCvNDI2pvysIBLfDcDgIsBQQBC4OvAtJ7QjpPMACAAfTcD+IoBQQAgAEK4kZii9/6Qko5/fDcD8IoBQQBCgrXB7sf5v7khIAB9NwPoigFBACAAQsvzmffEmfDy+AB8NwPgigFBAELygJGl+vbssx8gAH03A9iKAUEAIABC3qm3y76Q5MtbfDcD0IoBQQBC/IKE5PK+yNYcIAB9NwPIigFBACAAQrj9s8uzhOmlvn98NwPAigELQQBCADcDkI4BQQBCADcDiI4BQQBCADcDgI4BQQBCvdzKlQw3A4CKAUEAQoeVr6+Ytt6bnn83A4iKAUEAQs/W077Sx6vZQjcDkIoBQQBC+fPd8Zn2masWNwOYigFBAELj3MqV/M7y9YV/NwOgigFBAEL3lK+vCDcDqIoBQQBCxc/ZsvHluuonNwOwigFBAEKx893xCTcDuIoBQQAgADcDoI4BQQAgATYCsI4BQQBCkICAgIAQNwOYjgEL9AkBCH9BAEEAKQOQjgEgAK18NwOQjgECQAJAAkBBACgCgI4BIgEgAGoiAkGAAksNACABQYCMAWohA0GACiEEAkAgAEEITw0AIAAhAQwCCwJAAkAgAEF4aiIFQQN2QQFqQQdxIgYNAEGACiEEIAAhAQwBCyAGQQN0IQFBgAohBANAIAMgBCkDADcDACADQQhqIQMgBEEIaiEEIAZBf2oiBg0ACyAAIAFrIQELIAVBOEkNAQNAIAMgBCkDADcDACADQQhqIARBCGopAwA3AwAgA0EQaiAEQRBqKQMANwMAIANBGGogBEEYaikDADcDACADQSBqIARBIGopAwA3AwAgA0EoaiAEQShqKQMANwMAIANBMGogBEEwaikDADcDACADQThqIARBOGopAwA3AwAgA0HAAGohAyAEQcAAaiEEIAFBQGoiAUEHSw0ADAILC0GACiEEIABBgApqIQVBACgCsI4BIgNBwIoBIAMbIQYCQCABRQ0AIAFBgIwBaiEDQYAKIQQCQAJAQYACIAFrIgdBCE8NACAHIQAMAQsCQAJAQfgBIAFrIghBA3ZBAWpBB3EiAg0AQYAKIQQgByEADAELQYAKIQQgAkEDdCIAIQIDQCADIAQpAwA3AwAgA0EIaiEDIARBCGohBCACQXhqIgINAAtBgAIgASAAamshAAsgCEE4SQ0AA0AgAyAEKQMANwMAIANBCGogBEEIaikDADcDACADQRBqIARBEGopAwA3AwAgA0EYaiAEQRhqKQMANwMAIANBIGogBEEgaikDADcDACADQShqIARBKGopAwA3AwAgA0EwaiAEQTBqKQMANwMAIANBOGogBEE4aikDADcDACADQcAAaiEDIARBwABqIQQgAEFAaiIAQQdLDQALCwJAIABFDQACQAJAIABBB3EiAg0AIAAhAQwBCyAAQXhxIQEDQCADIAQtAAA6AAAgA0EBaiEDIARBAWohBCACQX9qIgINAAsLIABBCEkNAANAIAMgBCkAADcAACADQQhqIQMgBEEIaiEEIAFBeGoiAQ0ACwtBgIoBQYiOAUEAKAKYjgFBgIwBQQQgBkEAKAKcjgEQAkEAQQA2AoCOASAHQYAKaiEECwJAIARBgAJqIAVPDQAgBUGAfmohAgNAQYCKAUGIjgFBACgCmI4BIAQiA0EEIAZBACgCnI4BEAIgA0GAAmoiBCACSQ0AC0EAIAMpA8ABNwPAjQFBACADKQPIATcDyI0BQQAgAykD0AE3A9CNAUEAIAMpA9gBNwPYjQFBACADKQPgATcD4I0BQQAgAykD6AE3A+iNAUEAIAMpA/ABNwPwjQFBACADKQP4ATcD+I0BC0GAjAEhAwJAAkAgBSAEayICQQhPDQAgAiEGDAELQYCMASEDIAIhBgNAIAMgBCkDADcDACADQQhqIQMgBEEIaiEEIAZBeGoiBkEHSw0ACwsgBkUNAQNAIAMgBC0AADoAACADQQFqIQMgBEEBaiEEIAZBf2oiBg0ADAILCyABRQ0AAkACQCABQQdxIgYNACABIQIMAQsgAUF4cSECA0AgAyAELQAAOgAAIANBAWohAyAEQQFqIQQgBkF/aiIGDQALCwJAIAFBCEkNAANAIAMgBCkAADcAACADQQhqIQMgBEEIaiEEIAJBeGoiAg0ACwtBACgCgI4BIABqIQILQQAgAjYCgI4BC/ISBQR/A34BfxV+BX8jACIAIQEgAEGAAWtBQHEiAiQAQQAoArCOASIAQcCKASAAGyEDAkACQEEAKQOQjgEiBELxAVQNACACQQApA4CKATcDACACQQApA4iKATcDCCACQQApA5CKATcDECACQQApA5iKATcDGCACQQApA6CKATcDICACQQApA6iKATcDKCACQQApA7CKASIFNwMwIAJBACkDuIoBIgY3AzgCQAJAQQAoAoCOASIHQcAASQ0AIAJBACgCiI4BNgJAIAIgAkHAAGpBACgCmI4BQYCMASAHQX9qQQZ2IANBACgCnI4BIgAQAiADIABqIgBBeWopAwAhCCAAKQMJIQkgACkDGSEKIAApAykhCyAHQcCLAWopAwAhBSAAKQMBIQwgB0HIiwFqKQMAIQYgB0HQiwFqKQMAIQ0gACkDESEOIAdB2IsBaikDACEPIAdB4IsBaikDACEQIAApAyEhESAHQeiLAWopAwAhEiACKQMAIRMgAikDECEUIAIpAyAhFSACKQMwIRYgAikDCCEXIAIpAxghGCACKQMoIRkgAiACKQM4IAdB8IsBaikDACIafCAAKQMxIAdB+IsBaikDACIbhSIcQiCIIBxC/////w+Dfnw3AzggGSAQfCARIBKFIhFCIIggEUL/////D4N+fCERIBggDXwgDiAPhSIOQiCIIA5C/////w+DfnwhDiAXIAV8IAwgBoUiDEIgiCAMQv////8Pg358IQwgGyAWIAsgGoUiC0IgiCALQv////8Pg358fCELIBIgFSAKIBCFIhBCIIggEEL/////D4N+fHwhECAPIBQgCSANhSINQiCIIA1C/////w+Dfnx8IRIgBiATIAggBYUiBUIgiCAFQv////8Pg358fCEIDAELIAdBwI0BaiEdQcAAIAdrIR4gAkHAAGohAAJAAkACQCAHQThNDQAgHiEfDAELAkACQEE4IAdrQQN2QQFqQQdxIh8NACACQcAAaiEAIB4hHwwBCyACQcAAaiEAIB9BA3QiICEfA0AgACAdKQMANwMAIABBCGohACAdQQhqIR0gH0F4aiIfDQALQcAAIAcgIGprIR8LAkAgBw0AA0AgACAdKQMANwMAIABBCGogHUEIaikDADcDACAAQRBqIB1BEGopAwA3AwAgAEEYaiAdQRhqKQMANwMAIABBIGogHUEgaikDADcDACAAQShqIB1BKGopAwA3AwAgAEEwaiAdQTBqKQMANwMAIABBOGogHUE4aikDADcDACAAQcAAaiEAIB1BwABqIR0gH0FAaiIfQQdLDQALCyAfRQ0BCyAfQX9qISECQCAfQQdxIiBFDQAgH0F4cSEfA0AgACAdLQAAOgAAIABBAWohACAdQQFqIR0gIEF/aiIgDQALCyAhQQdJDQADQCAAIB0pAAA3AAAgAEEIaiEAIB1BCGohHSAfQXhqIh8NAAsLIAJBwABqIB5qIR1BgIwBIQACQAJAAkAgB0EISQ0AAkAgB0E4akEDdkEBakEHcSIfDQAMAgsgH0EDdCEgQYCMASEAA0AgHSAAKQMANwMAIB1BCGohHSAAQQhqIQAgH0F/aiIfDQALIAcgIGshBwsgB0UNAQJAAkAgB0EHcSIgDQAgByEfDAELIAdBeHEhHwNAIB0gAC0AADoAACAdQQFqIR0gAEEBaiEAICBBf2oiIA0ACwsgB0EISQ0BCwNAIB0gACkAADcAACAdQQhqIR0gAEEIaiEAIB9BeGoiHw0ACwsgA0EAKAKcjgFqIgBBeWopAwAhCiAAKQMJIRMgACkDGSEUIAApAykhCyAAKQMBIQwgACkDESEOIAApAyEhESACKQMAIRUgAikDECEWIAIpAyAhFyACKQMIIRggAikDQCENIAIpA0ghDyACKQMYIRkgAikDUCESIAIpA1ghCCACKQMoIRogAikDYCEQIAIpA2ghCSACIAYgAikDcCIbfCAAKQMxIAIpA3giBoUiHEIgiCAcQv////8Pg358NwM4IBogEHwgESAJhSIRQiCIIBFC/////w+DfnwhESAZIBJ8IA4gCIUiDkIgiCAOQv////8Pg358IQ4gGCANfCAMIA+FIgxCIIggDEL/////D4N+fCEMIAYgCyAbhSILQiCIIAtC/////w+DfiAFfHwhCyAJIBcgFCAQhSIFQiCIIAVC/////w+Dfnx8IRAgCCAWIBMgEoUiBUIgiCAFQv////8Pg358fCESIA8gFSAKIA2FIgVCIIggBUL/////D4N+fHwhCAsgAykDQyACKQM4hSIFQv////8PgyIGIAMpAzsgC4UiC0IgiCINfiIPQv////8PgyAFQiCIIgUgC0L/////D4MiC358IAYgC34iBkIgiHwiC0IghiAGQv////8Pg4QgD0IgiCAFIA1+fCALQiCIfIUgAykDMyARhSIFQv////8PgyIGIAMpAysgEIUiC0IgiCINfiIPQv////8PgyAFQiCIIgUgC0L/////D4MiC358IAYgC34iBkIgiHwiC0IghiAGQv////8Pg4QgD0IgiCAFIA1+fCALQiCIfIUgAykDIyAOhSIFQv////8PgyIGIAMpAxsgEoUiC0IgiCINfiIPQv////8PgyAFQiCIIgUgC0L/////D4MiC358IAYgC34iBkIgiHwiC0IghiAGQv////8Pg4QgD0IgiCAFIA1+fCALQiCIfIUgAykDEyAMhSIFQv////8PgyIGIAMpAwsgCIUiC0IgiCINfiIPQv////8PgyAFQiCIIgUgC0L/////D4MiC358IAYgC34iBkIgiHwiC0IghiAGQv////8Pg4QgD0IgiCAFIA1+fCALQiCIfIUgBEKHla+vmLbem55/fnx8fHwiBEIliCAEhUL5893xmfKZqxZ+IgRCIIggBIUhBAwBCyAEpyEAAkBBACkDoI4BIgRQDQACQCAAQRBLDQAgAEGACCAEEAUhBAwCCwJAIABBgAFLDQAgAEGACCAEEAYhBAwCCyAAQYAIIAQQByEEDAELAkAgAEEQSw0AIAAgA0IAEAUhBAwBCwJAIABBgAFLDQAgACADQgAQBiEEDAELIAAgA0IAEAchBAtBACAEQjiGIARCgP4Dg0IohoQgBEKAgPwHg0IYhiAEQoCAgPgPg0IIhoSEIARCCIhCgICA+A+DIARCGIhCgID8B4OEIARCKIhCgP4DgyAEQjiIhISENwOACiABJAALBgBBgIoBCwIACwvMAQEAQYAIC8QBuP5sOSOkS758AYEs9yGtHN7UbemDkJfbckCkpLezZx/LeeZOzMDleIJa0H3M/3IhuAhGdPdDJI7gNZDmgTomTDwoUruRwwDLiNBlixtTLqNxZEiXog35TjgZ70ap3qzYqPp2P+OcND/53LvHxwtPHYpR4EvNtFkxyJ9+ydl4c2TqxayDNNPrw8WBoP/6E2PrFw3dUbfw2knTFlUmKdRonisWvlh9R6H8j/i40XrQMc5FyzqPlRYEKK/X+8q7S0B+QAIAAA==";
+var hash$6 = "5a2fbdbb";
+var wasmJson$6 = {
+	name: name$6,
+	data: data$6,
+	hash: hash$6
+};
+
+const mutex$4 = new Mutex();
+let wasmCache$4 = null;
+const seedBuffer$1 = new Uint8Array(8);
+function validateSeed$1(seed) {
+    if (!Number.isInteger(seed) || seed < 0 || seed > 0xffffffff) {
+        return new Error("Seed must be given as two valid 32-bit long unsigned integers (lo + high).");
+    }
+    return null;
+}
+function writeSeed$1(arr, low, high) {
+    // write in little-endian format
+    const buffer = new DataView(arr);
+    buffer.setUint32(0, low, true);
+    buffer.setUint32(4, high, true);
+}
+/**
+ * Calculates xxHash3 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param seedLow Lower 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @param seedHigh Higher 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @returns Computed hash as a hexadecimal string
+ */
+function xxhash3(data, seedLow = 0, seedHigh = 0) {
+    if (validateSeed$1(seedLow)) {
+        return Promise.reject(validateSeed$1(seedLow));
+    }
+    if (validateSeed$1(seedHigh)) {
+        return Promise.reject(validateSeed$1(seedHigh));
+    }
+    if (wasmCache$4 === null) {
+        return lockedCreate(mutex$4, wasmJson$6, 8).then((wasm) => {
+            wasmCache$4 = wasm;
+            writeSeed$1(seedBuffer$1.buffer, seedLow, seedHigh);
+            wasmCache$4.writeMemory(seedBuffer$1);
+            return wasmCache$4.calculate(data);
+        });
+    }
+    try {
+        writeSeed$1(seedBuffer$1.buffer, seedLow, seedHigh);
+        wasmCache$4.writeMemory(seedBuffer$1);
+        const hash = wasmCache$4.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new xxHash3 hash instance
+ * @param seedLow Lower 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @param seedHigh Higher 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ */
+function createXXHash3(seedLow = 0, seedHigh = 0) {
+    if (validateSeed$1(seedLow)) {
+        return Promise.reject(validateSeed$1(seedLow));
+    }
+    if (validateSeed$1(seedHigh)) {
+        return Promise.reject(validateSeed$1(seedHigh));
+    }
+    return WASMInterface(wasmJson$6, 8).then((wasm) => {
+        const instanceBuffer = new Uint8Array(8);
+        writeSeed$1(instanceBuffer.buffer, seedLow, seedHigh);
+        wasm.writeMemory(instanceBuffer);
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.writeMemory(instanceBuffer);
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 512,
+            digestSize: 8,
+        };
+        return obj;
+    });
+}
+
+var name$5 = "xxhash128";
+var data$5 = "AGFzbQEAAAABKwdgAAF/YAR/f39/AGAHf39/f39/fwBgA39/fgF+YAR/f39+AGAAAGABfwADDQwAAQIDBAQEBQYFAAUFBAEBAgIGDgJ/AUHAjgULfwBBwAkLB3AIBm1lbW9yeQIADkhhc2hfR2V0QnVmZmVyAAAJSGFzaF9Jbml0AAcLSGFzaF9VcGRhdGUACApIYXNoX0ZpbmFsAAkNSGFzaF9HZXRTdGF0ZQAKDkhhc2hfQ2FsY3VsYXRlAAsKU1RBVEVfU0laRQMBCqBNDAUAQYAKC+QDAw9+AX8BfgJAIANFDQAgACkDMCEEIAApAzghBSAAKQMgIQYgACkDKCEHIAApAxAhCCAAKQMYIQkgACkDACEKIAApAwghCwNAIAUgAUEwaikDACIMfCACQThqKQMAIAFBOGopAwAiDYUiBUIgiCAFQv////8Pg358IQUgByABQSBqKQMAIg58IAJBKGopAwAgAUEoaikDACIPhSIHQiCIIAdC/////w+DfnwhByAJIAFBEGopAwAiEHwgAkEYaikDACABQRhqKQMAIhGFIglCIIggCUL/////D4N+fCEJIAsgASkDACISfCACQQhqIhMpAwAgAUEIaikDACIUhSILQiCIIAtC/////w+DfnwhCyACQTBqKQMAIAyFIgxCIIggDEL/////D4N+IAR8IA18IQQgAkEgaikDACAOhSIMQiCIIAxC/////w+DfiAGfCAPfCEGIAJBEGopAwAgEIUiDEIgiCAMQv////8Pg34gCHwgEXwhCCACKQMAIBKFIgxCIIggDEL/////D4N+IAp8IBR8IQogAUHAAGohASATIQIgA0F/aiIDDQALIAAgCTcDGCAAIAo3AwAgACALNwMIIAAgBzcDKCAAIAg3AxAgACAFNwM4IAAgBjcDICAAIAQ3AzALC94CAgF/AX4CQCAEIAIgASgCACIHayICSQ0AIAAgAyAFIAdBA3RqIAIQASAAIAUgBmoiBykDACAAKQMAIghCL4iFIAiFQrHz3fEJfjcDACAAIAcpAwggACkDCCIIQi+IhSAIhUKx893xCX43AwggACAHKQMQIAApAxAiCEIviIUgCIVCsfPd8Ql+NwMQIAAgBykDGCAAKQMYIghCL4iFIAiFQrHz3fEJfjcDGCAAIAcpAyAgACkDICIIQi+IhSAIhUKx893xCX43AyAgACAHKQMoIAApAygiCEIviIUgCIVCsfPd8Ql+NwMoIAAgBykDMCAAKQMwIghCL4iFIAiFQrHz3fEJfjcDMCAAIAcpAzggACkDOCIIQi+IhSAIhUKx893xCX43AzggACADIAJBBnRqIAUgBCACayIHEAEgASAHNgIADwsgACADIAUgB0EDdGogBBABIAEgByAEajYCAAvtAwEFfiABKQM4IAApAziFIgNC/////w+DIgQgASkDMCAAKQMwhSIFQiCIIgZ+IgdC/////w+DIANCIIgiAyAFQv////8PgyIFfnwgBCAFfiIEQiCIfCIFQiCGIARC/////w+DhCAHQiCIIAMgBn58IAVCIIh8hSABKQMoIAApAyiFIgNC/////w+DIgQgASkDICAAKQMghSIFQiCIIgZ+IgdC/////w+DIANCIIgiAyAFQv////8PgyIFfnwgBCAFfiIEQiCIfCIFQiCGIARC/////w+DhCAHQiCIIAMgBn58IAVCIIh8hSABKQMYIAApAxiFIgNC/////w+DIgQgASkDECAAKQMQhSIFQiCIIgZ+IgdC/////w+DIANCIIgiAyAFQv////8PgyIFfnwgBCAFfiIEQiCIfCIFQiCGIARC/////w+DhCAHQiCIIAMgBn58IAVCIIh8hSABKQMIIAApAwiFIgNC/////w+DIgQgASkDACAAKQMAhSIFQiCIIgZ+IgdC/////w+DIANCIIgiAyAFQv////8PgyIFfnwgBCAFfiIEQiCIfCIFQiCGIARC/////w+DhCAHQiCIIAMgBn58IAVCIIh8hSACfHx8fCICQiWIIAKFQvnz3fGZ8pmrFn4iAkIgiCAChQu6CAIFfgN/AkAgAUEJSQ0AIAAgAUH4iwFqKQMAIgQgAikDOCACKQMwhSADfIUiBUL/////D4NC95Svrwh+IAVCgICAgHCDfEEAKQOAjAEgAikDKCACKQMghSADfYUgBIUiA0IgiCIEQrHz3fEJfnwgBEKHla+vCH4iBEIgiHwgBEL/////D4MgA0L/////D4MiA0Kx893xCX58IANCh5Wvrwh+IgRCIIh8IgVCIIh8IgNCOIYgA0KA/gODQiiGhCADQoCA/AeDQhiGIANCgICA+A+DQgiGhIQgA0IIiEKAgID4D4MgA0IYiEKAgPwHg4QgA0IoiEKA/gODIANCOIiEhIQgBEL/////D4MgAUF/aq1CNoaEIAVCIIZ8hSIEQiCIIgVCz9bTvgJ+IgZC/////w+DIARC/////w+DIgRCvdzKlQx+fCAEQs/W074CfiIEQiCIfCIHQiCGIghCJYggCCAEQv////8Pg4SFQvnz3fGZ8pmrFn4iBEIgiCAEhTcDACAAIAVCvdzKlQx+IANCz9bTvtLHq9lCfnwgBkIgiHwgB0IgiHwiA0IliCADhUL5893xmfKZqxZ+IgNCIIggA4U3AwgPCwJAIAFBBEkNACAAIAIpAxggAikDEIUgA6ciAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnKtQiCGIAOFfCABQfyLAWo1AgBCIIZBADUCgIwBhIUiA0IgiCIEIAFBAnRBh5Wvr3hqrSIFfiIGQiCIIARCsfPd8Ql+fCAGQv////8PgyADQv////8PgyIDQrHz3fEJfnwgAyAFfiIDQiCIfCIEQiCIfCAEQiCGIANC/////w+DhCIEQgGGfCIDQiWIIAOFQvnz3fGZ8pmrFn4iBUIgiCAFhTcDCCAAIANCA4ggBIUiA0IjiCADhUKlvuP00YyH2Z9/fiIDQhyIIAOFNwMADwsCQCABRQ0AIAAgAigCBCACKAIAc60gA3wiBEIhiEEALQCAjAFBEHQgAUEIdHIiCSABQQF2QYCMAWotAABBGHRyIgogAUH/iwFqLQAAIgFyIguthSAEhULP1tO+0ser2UJ+IgRCHYggBIVC+fPd8Zn2masWfiIEQiCIIASFNwMAIAAgAigCDCACKAIIc60gA30iA0IhiCABQRh0IAtBgP4DcUEIdHIgCUEIdkGA/gNxIApBGHZyckENd62FIAOFQs/W077Sx6vZQn4iA0IdiCADhUL5893xmfaZqxZ+IgNCIIggA4U3AwgPCyAAIAIpA1AgAikDWIUgA4UiBEIhiCAEhULP1tO+0ser2UJ+IgRCHYggBIVC+fPd8Zn2masWfiIEQiCIIASFNwMIIAAgAikDQCACKQNIhSADhSIDQiGIIAOFQs/W077Sx6vZQn4iA0IdiCADhUL5893xmfaZqxZ+IgNCIIggA4U3AwALwwoBCn4gAa0iBEKHla+vmLbem55/fiEFAkACQCABQSFPDQBCACEGDAELQgAhBwJAIAFBwQBJDQBCACEHAkAgAUHhAEkNACACQfgAaikDACADfSABQciLAWopAwAiCIUiB0L/////D4MiCSACKQNwIAN8IAFBwIsBaikDACIKhSILQiCIIgx+Ig1CIIggB0IgiCIHIAx+fCANQv////8PgyAHIAtC/////w+DIgt+fCAJIAt+IgdCIIh8IglCIIh8QQApA7iMASILQQApA7CMASIMfIUgCUIghiAHQv////8Pg4SFIQcgAkHoAGopAwAgA30gC4UiCUL/////D4MiCyACKQNgIAN8IAyFIgxCIIgiDX4iBkL/////D4MgCUIgiCIJIAxC/////w+DIgx+fCALIAx+IgtCIIh8IgxCIIYgC0L/////D4OEIAZCIIggCSANfnwgDEIgiHyFIAV8IAggCnyFIQULIAJB2ABqKQMAIAN9IAFB2IsBaikDACIIhSIJQv////8PgyIKIAIpA1AgA3wgAUHQiwFqKQMAIguFIgxCIIgiDX4iBkL/////D4MgCUIgiCIJIAxC/////w+DIgx+fCAKIAx+IgpCIIh8IgxCIIYgCkL/////D4OEIAZCIIggCSANfnwgDEIgiHyFIAd8QQApA6iMASIJQQApA6CMASIKfIUhByACQcgAaikDACADfSAJhSIJQv////8PgyIMIAIpA0AgA3wgCoUiCkIgiCINfiIGQv////8PgyAJQiCIIgkgCkL/////D4MiCn58IAwgCn4iCkIgiHwiDEIghiAKQv////8Pg4QgBkIgiCAJIA1+fCAMQiCIfIUgBXwgCCALfIUhBQsgAkE4aikDACADfSABQeiLAWopAwAiCIUiCUL/////D4MiCiACKQMwIAN8IAFB4IsBaikDACILhSIMQiCIIg1+IgZC/////w+DIAlCIIgiCSAMQv////8PgyIMfnwgCiAMfiIKQiCIfCIMQiCGIApC/////w+DhCAGQiCIIAkgDX58IAxCIIh8hSAHfEEAKQOYjAEiB0EAKQOQjAEiCXyFIQYgAkEoaikDACADfSAHhSIHQv////8PgyIKIAIpAyAgA3wgCYUiCUIgiCIMfiINQv////8PgyAHQiCIIgcgCUL/////D4MiCX58IAogCX4iCUIgiHwiCkIghiAJQv////8Pg4QgDUIgiCAHIAx+fCAKQiCIfIUgBXwgCCALfIUhBQsgACACQRhqKQMAIAN9IAFB+IsBaikDACIHhSIIQv////8PgyIJIAIpAxAgA3wgAUHwiwFqKQMAIgqFIgtCIIgiDH4iDUL/////D4MgCEIgiCIIIAtC/////w+DIgt+fCAJIAt+IglCIIh8IgtCIIYgCUL/////D4OEIA1CIIggCCAMfnwgC0IgiHyFIAZ8QQApA4iMASIIQQApA4CMASIJfIUiCyACQQhqKQMAIAN9IAiFIghC/////w+DIgwgAikDACADfCAJhSIJQiCIIg1+IgZC/////w+DIAhCIIgiCCAJQv////8PgyIJfnwgDCAJfiIJQiCIfCIMQiCGIAlC/////w+DhCAGQiCIIAggDX58IAxCIIh8hSAFfCAHIAp8hSIFfCIHQiWIIAeFQvnz3fGZ8pmrFn4iB0IgiCAHhTcDACAAQgAgBUKHla+vmLbem55/fiAEIAN9Qs/W077Sx6vZQn58IAtC49zKlfzO8vWFf358IgNCJYggA4VC+fPd8ZnymasWfiIDQiCIIAOFfTcDCAuhDwMBfxR+An9BACEEIAJB+ABqKQMAIAN9QQApA/iMASIFhSIGQv////8PgyIHIAIpA3AgA3xBACkD8IwBIgiFIglCIIgiCn4iC0L/////D4MgBkIgiCIGIAlC/////w+DIgl+fCAHIAl+IgdCIIh8IglCIIYgB0L/////D4OEIAtCIIggBiAKfnwgCUIgiHyFIAJB2ABqKQMAIAN9QQApA9iMASIHhSIGQv////8PgyIJIAIpA1AgA3xBACkD0IwBIgqFIgtCIIgiDH4iDUL/////D4MgBkIgiCIGIAtC/////w+DIgt+fCAJIAt+IglCIIh8IgtCIIYgCUL/////D4OEIA1CIIggBiAMfnwgC0IgiHyFIAJBOGopAwAgA31BACkDuIwBIgmFIgZC/////w+DIgsgAikDMCADfEEAKQOwjAEiDIUiDUIgiCIOfiIPQv////8PgyAGQiCIIgYgDUL/////D4MiDX58IAsgDX4iC0IgiHwiDUIghiALQv////8Pg4QgD0IgiCAGIA5+fCANQiCIfIUgAkEYaikDACADfUEAKQOYjAEiC4UiBkL/////D4MiDSACKQMQIAN8QQApA5CMASIOhSIPQiCIIhB+IhFC/////w+DIAZCIIgiBiAPQv////8PgyIPfnwgDSAPfiINQiCIfCIPQiCGIA1C/////w+DhCARQiCIIAYgEH58IA9CIIh8hUEAKQOIjAEiDUEAKQOAjAEiD3yFfEEAKQOojAEiEEEAKQOgjAEiEXyFfEEAKQPIjAEiEkEAKQPAjAEiE3yFfEEAKQPojAEiFEEAKQPgjAEiFXyFIgZCJYggBoVC+fPd8ZnymasWfiIGQiCIIAaFIQYgAkHoAGopAwAgA30gFIUiFEL/////D4MiFiACKQNgIAN8IBWFIhVCIIgiF34iGEL/////D4MgFEIgiCIUIBVC/////w+DIhV+fCAWIBV+IhVCIIh8IhZCIIYgFUL/////D4OEIBhCIIggFCAXfnwgFkIgiHyFIAJByABqKQMAIAN9IBKFIhJC/////w+DIhQgAikDQCADfCAThSITQiCIIhV+IhZC/////w+DIBJCIIgiEiATQv////8PgyITfnwgFCATfiITQiCIfCIUQiCGIBNC/////w+DhCAWQiCIIBIgFX58IBRCIIh8hSACQShqKQMAIAN9IBCFIhBC/////w+DIhIgAikDICADfCARhSIRQiCIIhN+IhRC/////w+DIBBCIIgiECARQv////8PgyIRfnwgEiARfiIRQiCIfCISQiCGIBFC/////w+DhCAUQiCIIBAgE358IBJCIIh8hSACQQhqKQMAIAN9IA2FIg1C/////w+DIhAgAikDACADfCAPhSIPQiCIIhF+IhJC/////w+DIA1CIIgiDSAPQv////8PgyIPfnwgECAPfiIPQiCIfCIQQiCGIA9C/////w+DhCASQiCIIA0gEX58IBBCIIh8hSABrSIPQoeVr6+Ytt6bnn9+fCALIA58hXwgCSAMfIV8IAcgCnyFfCAFIAh8hSIFQiWIIAWFQvnz3fGZ8pmrFn4iBUIgiCAFhSEFAkAgAUGgAUgNACABQQV2QXxqIRkDQCACIARqIhpBG2opAwAgA30gBEGYjQFqKQMAIgeFIghC/////w+DIgkgGkETaikDACADfCAEQZCNAWopAwAiCoUiC0IgiCIMfiINQv////8PgyAIQiCIIgggC0L/////D4MiC358IAkgC34iCUIgiHwiC0IghiAJQv////8Pg4QgDUIgiCAIIAx+fCALQiCIfIUgBnwgBEGIjQFqKQMAIgggBEGAjQFqKQMAIgl8hSEGIBpBC2opAwAgA30gCIUiCEL/////D4MiCyAaQQNqKQMAIAN8IAmFIglCIIgiDH4iDUL/////D4MgCEIgiCIIIAlC/////w+DIgl+fCALIAl+IglCIIh8IgtCIIYgCUL/////D4OEIA1CIIggCCAMfnwgC0IgiHyFIAV8IAcgCnyFIQUgBEEgaiEEIBlBf2oiGQ0ACwsgACACQf8AaikDACADfCABQeiLAWopAwAiB4UiCEL/////D4MiCSACKQN3IAN9IAFB4IsBaikDACIKhSILQiCIIgx+Ig1C/////w+DIAhCIIgiCCALQv////8PgyILfnwgCSALfiIJQiCIfCILQiCGIAlC/////w+DhCANQiCIIAggDH58IAtCIIh8hSAGfCABQfiLAWopAwAiBiABQfCLAWopAwAiCHyFIgkgAkHvAGopAwAgA3wgBoUiBkL/////D4MiCyACKQNnIAN9IAiFIghCIIgiDH4iDUL/////D4MgBkIgiCIGIAhC/////w+DIgh+fCALIAh+IghCIIh8IgtCIIYgCEL/////D4OEIA1CIIggBiAMfnwgC0IgiHyFIAV8IAcgCnyFIgZ8IgVCJYggBYVC+fPd8ZnymasWfiIFQiCIIAWFNwMAIABCACAGQoeVr6+Ytt6bnn9+IA8gA31Cz9bTvtLHq9lCfnwgCULj3MqV/M7y9YV/fnwiA0IliCADhUL5893xmfKZqxZ+IgNCIIggA4V9NwMIC98FAgF+AX8CQAJAQQApA4AKIgBQRQ0AQYAIIQFCACEADAELAkBBACkDoI4BIABSDQBBACEBDAELQQAhAUEAQq+v79e895Kg/gAgAH03A/iLAUEAIABCxZbr+djShYIofDcD8IsBQQBCj/Hjja2P9JhOIAB9NwPoiwFBACAAQqus+MXV79HQfHw3A+CLAUEAQtOt1LKShbW0nn8gAH03A9iLAUEAIABCl5r0jvWWvO3JAHw3A9CLAUEAQsWDgv2v/8SxayAAfTcDyIsBQQAgAELqi7OdyOb09UN8NwPAiwFBAELIv/rLnJveueQAIAB9NwO4iwFBACAAQoqjgd/Ume2sMXw3A7CLAUEAQvm57738+MKnHSAAfTcDqIsBQQAgAEKo9dv7s5ynmj98NwOgiwFBAEK4sry3lNW31lggAH03A5iLAUEAIABC8cihuqm0w/zOAHw3A5CLAUEAQoihl9u445SXo38gAH03A4iLAUEAIABCvNDI2pvysIBLfDcDgIsBQQBC4OvAtJ7QjpPMACAAfTcD+IoBQQAgAEK4kZii9/6Qko5/fDcD8IoBQQBCgrXB7sf5v7khIAB9NwPoigFBACAAQsvzmffEmfDy+AB8NwPgigFBAELygJGl+vbssx8gAH03A9iKAUEAIABC3qm3y76Q5MtbfDcD0IoBQQBC/IKE5PK+yNYcIAB9NwPIigFBACAAQrj9s8uzhOmlvn98NwPAigELQQBCADcDkI4BQQBCADcDiI4BQQBCADcDgI4BQQBCvdzKlQw3A4CKAUEAQoeVr6+Ytt6bnn83A4iKAUEAQs/W077Sx6vZQjcDkIoBQQBC+fPd8Zn2masWNwOYigFBAELj3MqV/M7y9YV/NwOgigFBAEL3lK+vCDcDqIoBQQBCxc/ZsvHluuonNwOwigFBAEKx893xCTcDuIoBQQAgADcDoI4BQQAgATYCsI4BQQBCkICAgIAQNwOYjgEL9AkBCH9BAEEAKQOQjgEgAK18NwOQjgECQAJAAkBBACgCgI4BIgEgAGoiAkGAAksNACABQYCMAWohA0GACiEEAkAgAEEITw0AIAAhAQwCCwJAAkAgAEF4aiIFQQN2QQFqQQdxIgYNAEGACiEEIAAhAQwBCyAGQQN0IQFBgAohBANAIAMgBCkDADcDACADQQhqIQMgBEEIaiEEIAZBf2oiBg0ACyAAIAFrIQELIAVBOEkNAQNAIAMgBCkDADcDACADQQhqIARBCGopAwA3AwAgA0EQaiAEQRBqKQMANwMAIANBGGogBEEYaikDADcDACADQSBqIARBIGopAwA3AwAgA0EoaiAEQShqKQMANwMAIANBMGogBEEwaikDADcDACADQThqIARBOGopAwA3AwAgA0HAAGohAyAEQcAAaiEEIAFBQGoiAUEHSw0ADAILC0GACiEEIABBgApqIQVBACgCsI4BIgNBwIoBIAMbIQYCQCABRQ0AIAFBgIwBaiEDQYAKIQQCQAJAQYACIAFrIgdBCE8NACAHIQAMAQsCQAJAQfgBIAFrIghBA3ZBAWpBB3EiAg0AQYAKIQQgByEADAELQYAKIQQgAkEDdCIAIQIDQCADIAQpAwA3AwAgA0EIaiEDIARBCGohBCACQXhqIgINAAtBgAIgASAAamshAAsgCEE4SQ0AA0AgAyAEKQMANwMAIANBCGogBEEIaikDADcDACADQRBqIARBEGopAwA3AwAgA0EYaiAEQRhqKQMANwMAIANBIGogBEEgaikDADcDACADQShqIARBKGopAwA3AwAgA0EwaiAEQTBqKQMANwMAIANBOGogBEE4aikDADcDACADQcAAaiEDIARBwABqIQQgAEFAaiIAQQdLDQALCwJAIABFDQACQAJAIABBB3EiAg0AIAAhAQwBCyAAQXhxIQEDQCADIAQtAAA6AAAgA0EBaiEDIARBAWohBCACQX9qIgINAAsLIABBCEkNAANAIAMgBCkAADcAACADQQhqIQMgBEEIaiEEIAFBeGoiAQ0ACwtBgIoBQYiOAUEAKAKYjgFBgIwBQQQgBkEAKAKcjgEQAkEAQQA2AoCOASAHQYAKaiEECwJAIARBgAJqIAVPDQAgBUGAfmohAgNAQYCKAUGIjgFBACgCmI4BIAQiA0EEIAZBACgCnI4BEAIgA0GAAmoiBCACSQ0AC0EAIAMpA8ABNwPAjQFBACADKQPIATcDyI0BQQAgAykD0AE3A9CNAUEAIAMpA9gBNwPYjQFBACADKQPgATcD4I0BQQAgAykD6AE3A+iNAUEAIAMpA/ABNwPwjQFBACADKQP4ATcD+I0BC0GAjAEhAwJAAkAgBSAEayICQQhPDQAgAiEGDAELQYCMASEDIAIhBgNAIAMgBCkDADcDACADQQhqIQMgBEEIaiEEIAZBeGoiBkEHSw0ACwsgBkUNAQNAIAMgBC0AADoAACADQQFqIQMgBEEBaiEEIAZBf2oiBg0ADAILCyABRQ0AAkACQCABQQdxIgYNACABIQIMAQsgAUF4cSECA0AgAyAELQAAOgAAIANBAWohAyAEQQFqIQQgBkF/aiIGDQALCwJAIAFBCEkNAANAIAMgBCkAADcAACADQQhqIQMgBEEIaiEEIAJBeGoiAg0ACwtBACgCgI4BIABqIQILQQAgAjYCgI4BC90QBgR/A34BfwN+BX8CfiMAIgAhASAAQYABa0FAcSICJABBACgCsI4BIgBBwIoBIAAbIQMCQAJAQQApA5COASIEQvEBVA0AIAJBACkDgIoBNwMAIAJBACkDiIoBNwMIIAJBACkDkIoBNwMQIAJBACkDmIoBNwMYIAJBACkDoIoBNwMgIAJBACkDqIoBNwMoIAJBACkDsIoBIgU3AzAgAkEAKQO4igEiBjcDOAJAAkBBACgCgI4BIgdBwABJDQAgAkEAKAKIjgE2AkAgAiACQcAAakEAKAKYjgFBgIwBIAdBf2pBBnYgA0EAKAKcjgEiABACIAIgAikDCCAHQcCLAWopAwAiBXwgAyAAaiIAKQMBIAdByIsBaikDACIGhSIIQiCIIAhC/////w+Dfnw3AwggAiACKQMYIAdB0IsBaikDACIIfCAAKQMRIAdB2IsBaikDACIJhSIKQiCIIApC/////w+Dfnw3AxggAiAGIAUgAEF5aikDAIUiBUIgiCAFQv////8Pg34gAikDAHx8NwMAIAIgCSAIIAApAwmFIgVCIIggBUL/////D4N+IAIpAxB8fDcDECAAKQMZIQUgAikDICEGIAIgAikDKCAHQeCLAWopAwAiCHwgACkDISAHQeiLAWopAwAiCYUiCkIgiCAKQv////8Pg358NwMoIAIgCSAGIAUgCIUiBUIgiCAFQv////8Pg358fDcDICACIAIpAzggB0HwiwFqKQMAIgV8IAApAzEgB0H4iwFqKQMAIgaFIghCIIggCEL/////D4N+fDcDOCACIAYgBSAAKQMphSIFQiCIIAVC/////w+DfiACKQMwfHw3AzAMAQsgB0HAjQFqIQtBwAAgB2shDCACQcAAaiEAAkACQAJAIAdBOE0NACAMIQ0MAQsCQAJAQTggB2tBA3ZBAWpBB3EiDQ0AIAJBwABqIQAgDCENDAELIAJBwABqIQAgDUEDdCIOIQ0DQCAAIAspAwA3AwAgAEEIaiEAIAtBCGohCyANQXhqIg0NAAtBwAAgByAOamshDQsCQCAHDQADQCAAIAspAwA3AwAgAEEIaiALQQhqKQMANwMAIABBEGogC0EQaikDADcDACAAQRhqIAtBGGopAwA3AwAgAEEgaiALQSBqKQMANwMAIABBKGogC0EoaikDADcDACAAQTBqIAtBMGopAwA3AwAgAEE4aiALQThqKQMANwMAIABBwABqIQAgC0HAAGohCyANQUBqIg1BB0sNAAsLIA1FDQELIA1Bf2ohDwJAIA1BB3EiDkUNACANQXhxIQ0DQCAAIAstAAA6AAAgAEEBaiEAIAtBAWohCyAOQX9qIg4NAAsLIA9BB0kNAANAIAAgCykAADcAACAAQQhqIQAgC0EIaiELIA1BeGoiDQ0ACwsgAkHAAGogDGohC0GAjAEhAAJAAkACQCAHQQhJDQACQCAHQThqQQN2QQFqQQdxIg0NAAwCCyANQQN0IQ5BgIwBIQADQCALIAApAwA3AwAgC0EIaiELIABBCGohACANQX9qIg0NAAsgByAOayEHCyAHRQ0BAkACQCAHQQdxIg4NACAHIQ0MAQsgB0F4cSENA0AgCyAALQAAOgAAIAtBAWohCyAAQQFqIQAgDkF/aiIODQALCyAHQQhJDQELA0AgCyAAKQAANwAAIAtBCGohCyAAQQhqIQAgDUF4aiINDQALCyACIAIpAwggAikDQCIIfCADQQAoApyOAWoiACkDASACKQNIIgmFIgpCIIggCkL/////D4N+fDcDCCACIAIpAxggAikDUCIKfCAAKQMRIAIpA1giEIUiEUIgiCARQv////8Pg358NwMYIAIgECAKIAApAwmFIgpCIIggCkL/////D4N+IAIpAxB8fDcDECACIAkgCCAAQXlqKQMAhSIIQiCIIAhC/////w+DfiACKQMAfHw3AwAgACkDGSEIIAIpAyAhCSACIAIpAyggAikDYCIKfCAAKQMhIAIpA2giEIUiEUIgiCARQv////8Pg358NwMoIAIgECAJIAggCoUiCEIgiCAIQv////8Pg358fDcDICACIAYgAikDcCIIfCAAKQMxIAIpA3giBoUiCUIgiCAJQv////8Pg358NwM4IAIgBiAIIAApAymFIghCIIggCEL/////D4N+IAV8fDcDMAsgAiACIANBC2ogBEKHla+vmLbem55/fhADNwNAIAIgAiADQQAoApyOAWpBdWogBELP1tO+0ser2UJ+Qn+FEAM3A0gMAQsgBKchAAJAQQApA6COASIEUA0AAkAgAEEQSw0AIAJBwABqIABBgAggBBAEDAILAkAgAEGAAUsNACACQcAAaiAAQYAIIAQQBQwCCyACQcAAaiAAQYAIIAQQBgwBCwJAIABBEEsNACACQcAAaiAAIANCABAEDAELAkAgAEGAAUsNACACQcAAaiAAIANCABAFDAELIAJBwABqIAAgA0IAEAYLQQAgAikDcDcDuApBACACKQNgNwOoCkEAIAIpA1A3A5gKQQAgAkH4AGopAwA3A8AKQQAgAkHoAGopAwA3A7AKQQAgAkHYAGopAwA3A6AKQQAgAikDSCIEQjiGIARCgP4Dg0IohoQgBEKAgPwHg0IYhiAEQoCAgPgPg0IIhoSEIARCCIhCgICA+A+DIARCGIhCgID8B4OEIARCKIhCgP4DgyAEQjiIhISEIgQ3A4AKQQAgBDcDkApBACACKQNAIgRCOIYgBEKA/gODQiiGhCAEQoCA/AeDQhiGIARCgICA+A+DQgiGhIQgBEIIiEKAgID4D4MgBEIYiEKAgPwHg4QgBEIoiEKA/gODIARCOIiEhIQ3A4gKIAEkAAsGAEGAigELAgALC8wBAQBBgAgLxAG4/mw5I6RLvnwBgSz3Ia0c3tRt6YOQl9tyQKSkt7NnH8t55k7MwOV4glrQfcz/ciG4CEZ090MkjuA1kOaBOiZMPChSu5HDAMuI0GWLG1Muo3FkSJeiDflOOBnvRqnerNio+nY/45w0P/ncu8fHC08dilHgS820WTHIn37J2XhzZOrFrIM00+vDxYGg//oTY+sXDd1Rt/DaSdMWVSYp1GieKxa+WH1HofyP+LjRetAxzkXLOo+VFgQor9f7yrtLQH5AAgAA";
+var hash$5 = "b9ab74e2";
+var wasmJson$5 = {
+	name: name$5,
+	data: data$5,
+	hash: hash$5
+};
+
+const mutex$3 = new Mutex();
+let wasmCache$3 = null;
+const seedBuffer = new Uint8Array(8);
+function validateSeed(seed) {
+    if (!Number.isInteger(seed) || seed < 0 || seed > 0xffffffff) {
+        return new Error("Seed must be given as two valid 32-bit long unsigned integers (lo + high).");
+    }
+    return null;
+}
+function writeSeed(arr, low, high) {
+    // write in little-endian format
+    const buffer = new DataView(arr);
+    buffer.setUint32(0, low, true);
+    buffer.setUint32(4, high, true);
+}
+/**
+ * Calculates xxHash128 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @param seedLow Lower 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @param seedHigh Higher 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @returns Computed hash as a hexadecimal string
+ */
+function xxhash128(data, seedLow = 0, seedHigh = 0) {
+    if (validateSeed(seedLow)) {
+        return Promise.reject(validateSeed(seedLow));
+    }
+    if (validateSeed(seedHigh)) {
+        return Promise.reject(validateSeed(seedHigh));
+    }
+    if (wasmCache$3 === null) {
+        return lockedCreate(mutex$3, wasmJson$5, 16).then((wasm) => {
+            wasmCache$3 = wasm;
+            writeSeed(seedBuffer.buffer, seedLow, seedHigh);
+            wasmCache$3.writeMemory(seedBuffer);
+            return wasmCache$3.calculate(data);
+        });
+    }
+    try {
+        writeSeed(seedBuffer.buffer, seedLow, seedHigh);
+        wasmCache$3.writeMemory(seedBuffer);
+        const hash = wasmCache$3.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new xxHash128 hash instance
+ * @param seedLow Lower 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ * @param seedHigh Higher 32 bits of the number used to
+ *  initialize the internal state of the algorithm (defaults to 0)
+ */
+function createXXHash128(seedLow = 0, seedHigh = 0) {
+    if (validateSeed(seedLow)) {
+        return Promise.reject(validateSeed(seedLow));
+    }
+    if (validateSeed(seedHigh)) {
+        return Promise.reject(validateSeed(seedHigh));
+    }
+    return WASMInterface(wasmJson$5, 16).then((wasm) => {
+        const instanceBuffer = new Uint8Array(8);
+        writeSeed(instanceBuffer.buffer, seedLow, seedHigh);
+        wasm.writeMemory(instanceBuffer);
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.writeMemory(instanceBuffer);
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 512,
+            digestSize: 16,
+        };
+        return obj;
+    });
+}
+
+var name$4 = "ripemd160";
+var data$4 = "AGFzbQEAAAABEQRgAAF/YAAAYAF/AGACf38AAwkIAAECAwIBAAIFBAEBAgIGDgJ/AUHgiQULfwBBgAgLB4MBCQZtZW1vcnkCAA5IYXNoX0dldEJ1ZmZlcgAACUhhc2hfSW5pdAABEHJpcGVtZDE2MF91cGRhdGUAAwtIYXNoX1VwZGF0ZQAECkhhc2hfRmluYWwABQ1IYXNoX0dldFN0YXRlAAYOSGFzaF9DYWxjdWxhdGUABwpTVEFURV9TSVpFAwEKzzIIBQBBgAkLOgBBAEHww8uefDYCmIkBQQBC/rnrxemOlZkQNwKQiQFBAEKBxpS6lvHq5m83AoiJAUEAQgA3AoCJAQuPLAEhf0EAIAAoAiQiASAAKAIAIgIgACgCECIDIAIgACgCLCIEIAAoAgwiBSAAKAIEIgYgACgCPCIHIAIgACgCMCIIIAcgACgCCCIJQQAoAoiJASIKQQAoApCJASILQQAoApSJASIMQX9zckEAKAKMiQEiDXNqIAAoAhQiDmpB5peKhQVqQQh3QQAoApiJASIPaiIQQQp3IhFqIAEgDUEKdyISaiACIAtBCnciE2ogDCAAKAIcIhRqIA8gACgCOCIVaiAQIA0gE0F/c3JzakHml4qFBWpBCXcgDGoiFiAQIBJBf3Nyc2pB5peKhQVqQQl3IBNqIhAgFiARQX9zcnNqQeaXioUFakELdyASaiIXIBAgFkEKdyIWQX9zcnNqQeaXioUFakENdyARaiIYIBcgEEEKdyIZQX9zcnNqQeaXioUFakEPdyAWaiIaQQp3IhtqIAAoAhgiECAYQQp3IhxqIAAoAjQiESAXQQp3IhdqIAMgGWogBCAWaiAaIBggF0F/c3JzakHml4qFBWpBD3cgGWoiFiAaIBxBf3Nyc2pB5peKhQVqQQV3IBdqIhcgFiAbQX9zcnNqQeaXioUFakEHdyAcaiIYIBcgFkEKdyIZQX9zcnNqQeaXioUFakEHdyAbaiIaIBggF0EKdyIXQX9zcnNqQeaXioUFakEIdyAZaiIbQQp3IhxqIAUgGkEKdyIdaiAAKAIoIhYgGEEKdyIYaiAGIBdqIAAoAiAiACAZaiAbIBogGEF/c3JzakHml4qFBWpBC3cgF2oiFyAbIB1Bf3Nyc2pB5peKhQVqQQ53IBhqIhggFyAcQX9zcnNqQeaXioUFakEOdyAdaiIZIBggF0EKdyIaQX9zcnNqQeaXioUFakEMdyAcaiIbIBkgGEEKdyIcQX9zcnNqQeaXioUFakEGdyAaaiIdQQp3IhdqIAUgGUEKdyIYaiAQIBpqIBsgGEF/c3FqIB0gGHFqQaSit+IFakEJdyAcaiIaIBdBf3NxaiAEIBxqIB0gG0EKdyIZQX9zcWogGiAZcWpBpKK34gVqQQ13IBhqIhsgF3FqQaSit+IFakEPdyAZaiIcIBtBCnciGEF/c3FqIBQgGWogGyAaQQp3IhlBf3NxaiAcIBlxakGkorfiBWpBB3cgF2oiGyAYcWpBpKK34gVqQQx3IBlqIh1BCnciF2ogFiAcQQp3IhpqIBEgGWogGyAaQX9zcWogHSAacWpBpKK34gVqQQh3IBhqIhwgF0F/c3FqIA4gGGogHSAbQQp3IhhBf3NxaiAcIBhxakGkorfiBWpBCXcgGmoiGiAXcWpBpKK34gVqQQt3IBhqIhsgGkEKdyIZQX9zcWogFSAYaiAaIBxBCnciGEF/c3FqIBsgGHFqQaSit+IFakEHdyAXaiIcIBlxakGkorfiBWpBB3cgGGoiHUEKdyIXaiADIBtBCnciGmogACAYaiAcIBpBf3NxaiAdIBpxakGkorfiBWpBDHcgGWoiGyAXQX9zcWogCCAZaiAdIBxBCnciGEF/c3FqIBsgGHFqQaSit+IFakEHdyAaaiIaIBdxakGkorfiBWpBBncgGGoiHCAaQQp3IhlBf3NxaiABIBhqIBogG0EKdyIYQX9zcWogHCAYcWpBpKK34gVqQQ93IBdqIhogGXFqQaSit+IFakENdyAYaiIbQQp3Ih1qIAYgGkEKdyIeaiAOIBxBCnciF2ogByAZaiAJIBhqIBogF0F/c3FqIBsgF3FqQaSit+IFakELdyAZaiIYIBtBf3NyIB5zakHz/cDrBmpBCXcgF2oiFyAYQX9zciAdc2pB8/3A6wZqQQd3IB5qIhkgF0F/c3IgGEEKdyIYc2pB8/3A6wZqQQ93IB1qIhogGUF/c3IgF0EKdyIXc2pB8/3A6wZqQQt3IBhqIhtBCnciHGogASAaQQp3Ih1qIBAgGUEKdyIZaiAVIBdqIBQgGGogGyAaQX9zciAZc2pB8/3A6wZqQQh3IBdqIhcgG0F/c3IgHXNqQfP9wOsGakEGdyAZaiIYIBdBf3NyIBxzakHz/cDrBmpBBncgHWoiGSAYQX9zciAXQQp3IhdzakHz/cDrBmpBDncgHGoiGiAZQX9zciAYQQp3IhhzakHz/cDrBmpBDHcgF2oiG0EKdyIcaiAWIBpBCnciHWogCSAZQQp3IhlqIAggGGogACAXaiAbIBpBf3NyIBlzakHz/cDrBmpBDXcgGGoiFyAbQX9zciAdc2pB8/3A6wZqQQV3IBlqIhggF0F/c3IgHHNqQfP9wOsGakEOdyAdaiIZIBhBf3NyIBdBCnciF3NqQfP9wOsGakENdyAcaiIaIBlBf3NyIBhBCnciGHNqQfP9wOsGakENdyAXaiIbQQp3IhxqIBEgGGogAyAXaiAbIBpBf3NyIBlBCnciGXNqQfP9wOsGakEHdyAYaiIYIBtBf3NyIBpBCnciGnNqQfP9wOsGakEFdyAZaiIXQQp3IhsgECAaaiAYQQp3Ih0gACAZaiAcIBdBf3NxaiAXIBhxakHp7bXTB2pBD3cgGmoiGEF/c3FqIBggF3FqQenttdMHakEFdyAcaiIXQX9zcWogFyAYcWpB6e210wdqQQh3IB1qIhlBCnciGmogBSAbaiAXQQp3IhwgBiAdaiAYQQp3Ih0gGUF/c3FqIBkgF3FqQenttdMHakELdyAbaiIXQX9zcWogFyAZcWpB6e210wdqQQ53IB1qIhhBCnciGyAHIBxqIBdBCnciHiAEIB1qIBogGEF/c3FqIBggF3FqQenttdMHakEOdyAcaiIXQX9zcWogFyAYcWpB6e210wdqQQZ3IBpqIhhBf3NxaiAYIBdxakHp7bXTB2pBDncgHmoiGUEKdyIaaiAIIBtqIBhBCnciHCAOIB5qIBdBCnciHSAZQX9zcWogGSAYcWpB6e210wdqQQZ3IBtqIhdBf3NxaiAXIBlxakHp7bXTB2pBCXcgHWoiGEEKdyIbIBEgHGogF0EKdyIeIAkgHWogGiAYQX9zcWogGCAXcWpB6e210wdqQQx3IBxqIhdBf3NxaiAXIBhxakHp7bXTB2pBCXcgGmoiGEF/c3FqIBggF3FqQenttdMHakEMdyAeaiIZQQp3IhogB2ogFSAXQQp3IhxqIBogFiAbaiAYQQp3Ih0gFCAeaiAcIBlBf3NxaiAZIBhxakHp7bXTB2pBBXcgG2oiF0F/c3FqIBcgGXFqQenttdMHakEPdyAcaiIYQX9zcWogGCAXcWpB6e210wdqQQh3IB1qIhkgGEEKdyIbcyAdIAhqIBggF0EKdyIXcyAZc2pBCHcgGmoiGHNqQQV3IBdqIhpBCnciHCAAaiAZQQp3IhkgBmogFyAWaiAYIBlzIBpzakEMdyAbaiIXIBxzIBsgA2ogGiAYQQp3IhhzIBdzakEJdyAZaiIZc2pBDHcgGGoiGiAZQQp3IhtzIBggDmogGSAXQQp3IhdzIBpzakEFdyAcaiIYc2pBDncgF2oiGUEKdyIcIBVqIBpBCnciGiAJaiAXIBRqIBggGnMgGXNqQQZ3IBtqIhcgHHMgGyAQaiAZIBhBCnciGHMgF3NqQQh3IBpqIhlzakENdyAYaiIaIBlBCnciG3MgGCARaiAZIBdBCnciGHMgGnNqQQZ3IBxqIhlzakEFdyAYaiIcQQp3Ih0gDGogBCAWIA4gDiARIBYgDiAUIAEgACABIBAgFCAEIBAgBiAPaiATIA1zIAsgDXMgDHMgCmogAmpBC3cgD2oiF3NqQQ53IAxqIh5BCnciH2ogAyASaiAJIAxqIBcgEnMgHnNqQQ93IBNqIgwgH3MgBSATaiAeIBdBCnciE3MgDHNqQQx3IBJqIhJzakEFdyATaiIXIBJBCnciHnMgEyAOaiASIAxBCnciDHMgF3NqQQh3IB9qIhJzakEHdyAMaiITQQp3Ih9qIAEgF0EKdyIXaiAMIBRqIBIgF3MgE3NqQQl3IB5qIgwgH3MgHiAAaiATIBJBCnciEnMgDHNqQQt3IBdqIhNzakENdyASaiIXIBNBCnciHnMgEiAWaiATIAxBCnciDHMgF3NqQQ53IB9qIhJzakEPdyAMaiITQQp3Ih9qIB4gEWogEyASQQp3IiBzIAwgCGogEiAXQQp3IgxzIBNzakEGdyAeaiISc2pBB3cgDGoiE0EKdyIXICAgB2ogEyASQQp3Ih5zIAwgFWogEiAfcyATc2pBCXcgIGoiE3NqQQh3IB9qIgxBf3NxaiAMIBNxakGZ84nUBWpBB3cgHmoiEkEKdyIfaiARIBdqIAxBCnciICADIB5qIBNBCnciEyASQX9zcWogEiAMcWpBmfOJ1AVqQQZ3IBdqIgxBf3NxaiAMIBJxakGZ84nUBWpBCHcgE2oiEkEKdyIXIBYgIGogDEEKdyIeIAYgE2ogHyASQX9zcWogEiAMcWpBmfOJ1AVqQQ13ICBqIgxBf3NxaiAMIBJxakGZ84nUBWpBC3cgH2oiEkF/c3FqIBIgDHFqQZnzidQFakEJdyAeaiITQQp3Ih9qIAUgF2ogEkEKdyIgIAcgHmogDEEKdyIeIBNBf3NxaiATIBJxakGZ84nUBWpBB3cgF2oiDEF/c3FqIAwgE3FqQZnzidQFakEPdyAeaiISQQp3IhcgAiAgaiAMQQp3IiEgCCAeaiAfIBJBf3NxaiASIAxxakGZ84nUBWpBB3cgIGoiDEF/c3FqIAwgEnFqQZnzidQFakEMdyAfaiISQX9zcWogEiAMcWpBmfOJ1AVqQQ93ICFqIhNBCnciHmogCSAXaiASQQp3Ih8gDiAhaiAMQQp3IiAgE0F/c3FqIBMgEnFqQZnzidQFakEJdyAXaiIMQX9zcWogDCATcWpBmfOJ1AVqQQt3ICBqIhJBCnciEyAEIB9qIAxBCnciFyAVICBqIB4gEkF/c3FqIBIgDHFqQZnzidQFakEHdyAfaiIMQX9zcWogDCAScWpBmfOJ1AVqQQ13IB5qIhJBf3MiIHFqIBIgDHFqQZnzidQFakEMdyAXaiIeQQp3Ih9qIAMgEkEKdyISaiAVIAxBCnciDGogFiATaiAFIBdqIB4gIHIgDHNqQaHX5/YGakELdyATaiITIB5Bf3NyIBJzakGh1+f2BmpBDXcgDGoiDCATQX9zciAfc2pBodfn9gZqQQZ3IBJqIhIgDEF/c3IgE0EKdyITc2pBodfn9gZqQQd3IB9qIhcgEkF/c3IgDEEKdyIMc2pBodfn9gZqQQ53IBNqIh5BCnciH2ogCSAXQQp3IiBqIAYgEkEKdyISaiAAIAxqIAcgE2ogHiAXQX9zciASc2pBodfn9gZqQQl3IAxqIgwgHkF/c3IgIHNqQaHX5/YGakENdyASaiISIAxBf3NyIB9zakGh1+f2BmpBD3cgIGoiEyASQX9zciAMQQp3IgxzakGh1+f2BmpBDncgH2oiFyATQX9zciASQQp3IhJzakGh1+f2BmpBCHcgDGoiHkEKdyIfaiAEIBdBCnciIGogESATQQp3IhNqIBAgEmogAiAMaiAeIBdBf3NyIBNzakGh1+f2BmpBDXcgEmoiDCAeQX9zciAgc2pBodfn9gZqQQZ3IBNqIhIgDEF/c3IgH3NqQaHX5/YGakEFdyAgaiITIBJBf3NyIAxBCnciF3NqQaHX5/YGakEMdyAfaiIeIBNBf3NyIBJBCnciEnNqQaHX5/YGakEHdyAXaiIfQQp3IgxqIAEgE0EKdyITaiAIIBdqIB8gHkF/c3IgE3NqQaHX5/YGakEFdyASaiIXIAxBf3NxaiAGIBJqIB8gHkEKdyISQX9zcWogFyAScWpB3Pnu+HhqQQt3IBNqIh4gDHFqQdz57vh4akEMdyASaiIfIB5BCnciE0F/c3FqIAQgEmogHiAXQQp3IhJBf3NxaiAfIBJxakHc+e74eGpBDncgDGoiHiATcWpB3Pnu+HhqQQ93IBJqIiBBCnciDGogCCAfQQp3IhdqIAIgEmogHiAXQX9zcWogICAXcWpB3Pnu+HhqQQ53IBNqIh8gDEF/c3FqIAAgE2ogICAeQQp3IhJBf3NxaiAfIBJxakHc+e74eGpBD3cgF2oiFyAMcWpB3Pnu+HhqQQl3IBJqIh4gF0EKdyITQX9zcWogAyASaiAXIB9BCnciEkF/c3FqIB4gEnFqQdz57vh4akEIdyAMaiIfIBNxakHc+e74eGpBCXcgEmoiIEEKdyIMaiAHIB5BCnciF2ogBSASaiAfIBdBf3NxaiAgIBdxakHc+e74eGpBDncgE2oiHiAMQX9zcWogFCATaiAgIB9BCnciEkF/c3FqIB4gEnFqQdz57vh4akEFdyAXaiIXIAxxakHc+e74eGpBBncgEmoiHyAXQQp3IhNBf3NxaiAVIBJqIBcgHkEKdyISQX9zcWogHyAScWpB3Pnu+HhqQQh3IAxqIhcgE3FqQdz57vh4akEGdyASaiIeQQp3IiBqIAIgF0EKdyIOaiADIB9BCnciDGogCSATaiAeIA5Bf3NxaiAQIBJqIBcgDEF/c3FqIB4gDHFqQdz57vh4akEFdyATaiIDIA5xakHc+e74eGpBDHcgDGoiDCADICBBf3Nyc2pBzvrPynpqQQl3IA5qIg4gDCADQQp3IgNBf3Nyc2pBzvrPynpqQQ93ICBqIhIgDiAMQQp3IgxBf3Nyc2pBzvrPynpqQQV3IANqIhNBCnciF2ogCSASQQp3IhZqIAggDkEKdyIJaiAUIAxqIAEgA2ogEyASIAlBf3Nyc2pBzvrPynpqQQt3IAxqIgMgEyAWQX9zcnNqQc76z8p6akEGdyAJaiIIIAMgF0F/c3JzakHO+s/KempBCHcgFmoiCSAIIANBCnciA0F/c3JzakHO+s/KempBDXcgF2oiDiAJIAhBCnciCEF/c3JzakHO+s/KempBDHcgA2oiFEEKdyIWaiAAIA5BCnciDGogBSAJQQp3IgBqIAYgCGogFSADaiAUIA4gAEF/c3JzakHO+s/KempBBXcgCGoiAyAUIAxBf3Nyc2pBzvrPynpqQQx3IABqIgAgAyAWQX9zcnNqQc76z8p6akENdyAMaiIGIAAgA0EKdyIDQX9zcnNqQc76z8p6akEOdyAWaiIIIAYgAEEKdyIAQX9zcnNqQc76z8p6akELdyADaiIJQQp3IhVqNgKQiQFBACALIBggAmogGSAaQQp3IgJzIBxzakEPdyAbaiIOQQp3IhZqIBAgA2ogCSAIIAZBCnciA0F/c3JzakHO+s/KempBCHcgAGoiBkEKd2o2AoyJAUEAIA0gGyAFaiAcIBlBCnciBXMgDnNqQQ13IAJqIhRBCndqIAcgAGogBiAJIAhBCnciAEF/c3JzakHO+s/KempBBXcgA2oiB2o2AoiJAUEAIAAgCmogAiABaiAOIB1zIBRzakELdyAFaiIBaiARIANqIAcgBiAVQX9zcnNqQc76z8p6akEGd2o2ApiJAUEAIAAgD2ogHWogBSAEaiAUIBZzIAFzakELd2o2ApSJAQuiAwEIfwJAIAFFDQBBACECQQBBACgCgIkBIgMgAWoiBDYCgIkBIANBP3EhBQJAIAQgA08NAEEAQQAoAoSJAUEBajYChIkBCwJAIAVFDQACQCABQcAAIAVrIgZPDQAgBSECDAELIAZBA3EhB0EAIQMCQCAFQT9zQQNJDQAgBUGAiQFqIQggBkH8AHEhCUEAIQMDQCAIIANqIgJBHGogACADaiIELQAAOgAAIAJBHWogBEEBai0AADoAACACQR5qIARBAmotAAA6AAAgAkEfaiAEQQNqLQAAOgAAIAkgA0EEaiIDRw0ACwsCQCAHRQ0AIAAgA2ohAiADIAVqQZyJAWohAwNAIAMgAi0AADoAACACQQFqIQIgA0EBaiEDIAdBf2oiBw0ACwtBnIkBEAIgASAGayEBIAAgBmohAEEAIQILAkAgAUHAAEkNAANAIAAQAiAAQcAAaiEAIAFBQGoiAUE/Sw0ACwsgAUUNACACQZyJAWohA0EAIQIDQCADIAAtAAA6AAAgAEEBaiEAIANBAWohAyABIAJBAWoiAkH/AXFLDQALCwsJAEGACSAAEAMLggEBAn8jAEEQayIAJAAgAEEAKAKAiQEiAUEDdDYCCCAAQQAoAoSJAUEDdCABQR12cjYCDEGQCEE4QfgAIAFBP3EiAUE4SRsgAWsQAyAAQQhqQQgQA0EAQQAoAoiJATYCgAlBAEEAKQKMiQE3AoQJQQBBACkClIkBNwKMCSAAQRBqJAALBgBBgIkBC8EBAQF/IwBBEGsiASQAQQBB8MPLnnw2ApiJAUEAQv6568XpjpWZEDcCkIkBQQBCgcaUupbx6uZvNwKIiQFBAEIANwKAiQFBgAkgABADIAFBACgCgIkBIgBBA3Q2AgggAUEAKAKEiQFBA3QgAEEddnI2AgxBkAhBOEH4ACAAQT9xIgBBOEkbIABrEAMgAUEIakEIEANBAEEAKAKIiQE2AoAJQQBBACkCjIkBNwKECUEAQQApApSJATcCjAkgAUEQaiQACwtXAQBBgAgLUFwAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+var hash$4 = "6abbce74";
+var wasmJson$4 = {
+	name: name$4,
+	data: data$4,
+	hash: hash$4
+};
+
+const mutex$2 = new Mutex();
+let wasmCache$2 = null;
+/**
+ * Calculates RIPEMD-160 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function ripemd160(data) {
+    if (wasmCache$2 === null) {
+        return lockedCreate(mutex$2, wasmJson$4, 20).then((wasm) => {
+            wasmCache$2 = wasm;
+            return wasmCache$2.calculate(data);
+        });
+    }
+    try {
+        const hash = wasmCache$2.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new RIPEMD-160 hash instance
+ */
+function createRIPEMD160() {
+    return WASMInterface(wasmJson$4, 20).then((wasm) => {
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 20,
+        };
+        return obj;
+    });
+}
+
+function calculateKeyBuffer(hasher, key) {
+    const { blockSize } = hasher;
+    const buf = getUInt8Buffer(key);
+    if (buf.length > blockSize) {
+        hasher.update(buf);
+        const uintArr = hasher.digest("binary");
+        hasher.init();
+        return uintArr;
+    }
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.length);
+}
+function calculateHmac(hasher, key) {
+    hasher.init();
+    const { blockSize } = hasher;
+    const keyBuf = calculateKeyBuffer(hasher, key);
+    const keyBuffer = new Uint8Array(blockSize);
+    keyBuffer.set(keyBuf);
+    const opad = new Uint8Array(blockSize);
+    for (let i = 0; i < blockSize; i++) {
+        const v = keyBuffer[i];
+        opad[i] = v ^ 0x5c;
+        keyBuffer[i] = v ^ 0x36;
+    }
+    hasher.update(keyBuffer);
+    const obj = {
+        init: () => {
+            hasher.init();
+            hasher.update(keyBuffer);
+            return obj;
+        },
+        update: (data) => {
+            hasher.update(data);
+            return obj;
+        },
+        digest: ((outputType) => {
+            const uintArr = hasher.digest("binary");
+            hasher.init();
+            hasher.update(opad);
+            hasher.update(uintArr);
+            return hasher.digest(outputType);
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+        }),
+        save: () => {
+            throw new Error("save() not supported");
+        },
+        load: () => {
+            throw new Error("load() not supported");
+        },
+        blockSize: hasher.blockSize,
+        digestSize: hasher.digestSize,
+    };
+    return obj;
+}
+/**
+ * Calculates HMAC hash
+ * @param hash Hash algorithm to use. It has to be the return value of a function like createSHA1()
+ * @param key Key (string, Buffer or TypedArray)
+ */
+function createHMAC(hash, key) {
+    if (!hash || !hash.then) {
+        throw new Error('Invalid hash function is provided! Usage: createHMAC(createMD5(), "key").');
+    }
+    return hash.then((hasher) => calculateHmac(hasher, key));
+}
+
+function calculatePBKDF2(digest, salt, iterations, hashLength, outputType) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const DK = new Uint8Array(hashLength);
+        const block1 = new Uint8Array(salt.length + 4);
+        const block1View = new DataView(block1.buffer);
+        const saltBuffer = getUInt8Buffer(salt);
+        const saltUIntBuffer = new Uint8Array(saltBuffer.buffer, saltBuffer.byteOffset, saltBuffer.length);
+        block1.set(saltUIntBuffer);
+        let destPos = 0;
+        const hLen = digest.digestSize;
+        const l = Math.ceil(hashLength / hLen);
+        let T = null;
+        let U = null;
+        for (let i = 1; i <= l; i++) {
+            block1View.setUint32(salt.length, i);
+            digest.init();
+            digest.update(block1);
+            T = digest.digest("binary");
+            U = T.slice();
+            for (let j = 1; j < iterations; j++) {
+                digest.init();
+                digest.update(U);
+                U = digest.digest("binary");
+                for (let k = 0; k < hLen; k++) {
+                    T[k] ^= U[k];
+                }
+            }
+            DK.set(T.subarray(0, hashLength - destPos), destPos);
+            destPos += hLen;
+        }
+        if (outputType === "binary") {
+            return DK;
+        }
+        const digestChars = new Uint8Array(hashLength * 2);
+        return getDigestHex(digestChars, DK, hashLength);
+    });
+}
+const validateOptions$2 = (options) => {
+    if (!options || typeof options !== "object") {
+        throw new Error("Invalid options parameter. It requires an object.");
+    }
+    if (!options.hashFunction || !options.hashFunction.then) {
+        throw new Error('Invalid hash function is provided! Usage: pbkdf2("password", "salt", 1000, 32, createSHA1()).');
+    }
+    if (!Number.isInteger(options.iterations) || options.iterations < 1) {
+        throw new Error("Iterations should be a positive number");
+    }
+    if (!Number.isInteger(options.hashLength) || options.hashLength < 1) {
+        throw new Error("Hash length should be a positive number");
+    }
+    if (options.outputType === undefined) {
+        options.outputType = "hex";
+    }
+    if (!["hex", "binary"].includes(options.outputType)) {
+        throw new Error(`Insupported output type ${options.outputType}. Valid values: ['hex', 'binary']`);
+    }
+};
+/**
+ * Generates a new PBKDF2 hash for the supplied password
+ */
+function pbkdf2(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateOptions$2(options);
+        const hmac = yield createHMAC(options.hashFunction, options.password);
+        return calculatePBKDF2(hmac, options.salt, options.iterations, options.hashLength, options.outputType);
+    });
+}
+
+var name$3 = "scrypt";
+var data$3 = "AGFzbQEAAAABGwVgAX8Bf2AAAX9gBH9/f38AYAF/AGADf39/AAMGBQABAgMEBQYBAQKAgAIGCAF/AUGQiAQLBzkEBm1lbW9yeQIAEkhhc2hfU2V0TWVtb3J5U2l6ZQAADkhhc2hfR2V0QnVmZmVyAAEGc2NyeXB0AAQK7iYFWAECf0EAIQECQCAAQQAoAogIIgJGDQACQCAAIAJrIgBBEHYgAEGAgHxxIABJaiIAQABBf0cNAEH/AcAPC0EAIQFBAEEAKQOICCAAQRB0rXw3A4gICyABwAtwAQJ/AkBBACgCgAgiAA0AQQA/AEEQdCIANgKACEEAKAKICCIBQYCAIEYNAAJAQYCAICABayIAQRB2IABBgIB8cSAASWoiAEAAQX9HDQBBAA8LQQBBACkDiAggAEEQdK18NwOICEEAKAKACCEACyAAC6QFAQN/IAIgA0EHdCAAakFAaiIEKQMANwMAIAIgBCkDCDcDCCACIAQpAxA3AxAgAiAEKQMYNwMYIAIgBCkDIDcDICACIAQpAyg3AyggAiAEKQMwNwMwIAIgBCkDODcDOAJAIANFDQAgA0EBdCEFIANBBnQhBkEAIQMDQCACIAIpAwAgACkDAIU3AwAgAiACKQMIIABBCGopAwCFNwMIIAIgAikDECAAQRBqKQMAhTcDECACIAIpAxggAEEYaikDAIU3AxggAiACKQMgIABBIGopAwCFNwMgIAIgAikDKCAAQShqKQMAhTcDKCACIAIpAzAgAEEwaikDAIU3AzAgAiACKQM4IABBOGopAwCFNwM4IAIQAyABIAIpAwA3AwAgAUEIaiACKQMINwMAIAFBEGogAikDEDcDACABQRhqIAIpAxg3AwAgAUEgaiACKQMgNwMAIAFBKGogAikDKDcDACABQTBqIAIpAzA3AwAgAUE4aiACKQM4NwMAIAIgAikDACAAQcAAaikDAIU3AwAgAiACKQMIIABByABqKQMAhTcDCCACIAIpAxAgAEHQAGopAwCFNwMQIAIgAikDGCAAQdgAaikDAIU3AxggAiACKQMgIABB4ABqKQMAhTcDICACIAIpAyggAEHoAGopAwCFNwMoIAIgAikDMCAAQfAAaikDAIU3AzAgAiACKQM4IABB+ABqKQMAhTcDOCACEAMgASAGaiIEIAIpAwA3AwAgBEEIaiACKQMINwMAIARBEGogAikDEDcDACAEQRhqIAIpAxg3AwAgBEEgaiACKQMgNwMAIARBKGogAikDKDcDACAEQTBqIAIpAzA3AwAgBEE4aiACKQM4NwMAIABBgAFqIQAgAUHAAGohASADQQJqIgMgBUkNAAsLC7oNCAF+AX8BfgF/AX4BfwF+En8gACAAKAIEIAApAygiAUIgiKciAiAAKQM4IgNCIIinIgRqQQd3IAApAwgiBUIgiKdzIgYgBGpBCXcgACkDGCIHQiCIp3MiCCAGakENdyACcyIJIAenIgogAaciC2pBB3cgA6dzIgIgC2pBCXcgBadzIgwgAmpBDXcgCnMiDSAMakESdyALcyIOIAApAwAiAUIgiKciDyAAKQMQIgNCIIinIhBqQQd3IAApAyAiBUIgiKdzIgtqQQd3cyIKIAkgCGpBEncgBHMiESACakEHdyAAKQMwIgenIgkgAaciEmpBB3cgA6dzIgQgEmpBCXcgBadzIhMgBGpBDXcgCXMiFHMiCSARakEJdyALIBBqQQl3IAdCIIincyIVcyIWIAlqQQ13IAJzIhcgFmpBEncgEXMiEWpBB3cgBiAUIBNqQRJ3IBJzIhJqQQd3IBUgC2pBDXcgD3MiFHMiAiASakEJdyAMcyIPIAJqQQ13IAZzIhhzIgYgEWpBCXcgCCANIBQgFWpBEncgEHMiECAEakEHd3MiDCAQakEJd3MiCHMiFSAGakENdyAKcyIUIAwgCiAOakEJdyATcyITIApqQQ13IAtzIhkgE2pBEncgDnMiCmpBB3cgF3MiCyAKakEJdyAPcyIOIAtqQQ13IAxzIhcgDmpBEncgCnMiDSACIAggDGpBDXcgBHMiDCAIakESdyAQcyIIakEHdyAZcyIKakEHd3MiBCAUIBVqQRJ3IBFzIhAgC2pBB3cgCSAYIA9qQRJ3IBJzIhFqQQd3IAxzIgwgEWpBCXcgE3MiEiAMakENdyAJcyIPcyIJIBBqQQl3IAogCGpBCXcgFnMiE3MiFiAJakENdyALcyIUIBZqQRJ3IBBzIhBqQQd3IAYgDyASakESdyARcyIRakEHdyATIApqQQ13IAJzIgtzIgIgEWpBCXcgDnMiDiACakENdyAGcyIYcyIGIBBqQQl3IBUgFyALIBNqQRJ3IAhzIgggDGpBB3dzIgsgCGpBCXdzIhNzIhUgBmpBDXcgBHMiFyALIAQgDWpBCXcgEnMiEiAEakENdyAKcyIZIBJqQRJ3IA1zIgRqQQd3IBRzIgogBGpBCXcgDnMiDyAKakENdyALcyIUIA9qQRJ3IARzIg0gAiATIAtqQQ13IAxzIgwgE2pBEncgCHMiCGpBB3cgGXMiC2pBB3dzIgQgFyAVakESdyAQcyIQIApqQQd3IAkgGCAOakESdyARcyIOakEHdyAMcyIMIA5qQQl3IBJzIhEgDGpBDXcgCXMiF3MiCSAQakEJdyALIAhqQQl3IBZzIhJzIhMgCWpBDXcgCnMiGCATakESdyAQcyIQakEHdyAGIBcgEWpBEncgDnMiCmpBB3cgEiALakENdyACcyIXcyICIApqQQl3IA9zIg4gAmpBDXcgBnMiFnMiBiAJIBYgDmpBEncgCnMiFmpBB3cgFSAUIBcgEmpBEncgCHMiCCAMakEHd3MiCiAIakEJd3MiEiAKakENdyAMcyIPcyIMIBZqQQl3IAQgDWpBCXcgEXMiEXMiFSAMakENdyAJcyIUIBVqQRJ3IBZzIglqQQd3IAIgDyASakESdyAIcyIIakEHdyARIARqQQ13IAtzIg9zIgsgCGpBCXcgE3MiEyALakENdyACcyIXcyIWajYCBCAAIAAoAgggFiAJakEJdyAKIA8gEWpBEncgDXMiEWpBB3cgGHMiAiARakEJdyAOcyIOcyIPajYCCCAAIAAoAgwgDyAWakENdyAGcyINajYCDCAAIAAoAhAgBiAQakEJdyAScyISIA4gAmpBDXcgCnMiGCAXIBNqQRJ3IAhzIgogDGpBB3dzIgggCmpBCXdzIhYgCGpBDXcgDHMiDGo2AhAgACAAKAIAIA0gD2pBEncgCXNqNgIAIAAgACgCFCAMIBZqQRJ3IApzajYCFCAAIAAoAhggCGo2AhggACAAKAIcIBZqNgIcIAAgACgCICASIAZqQQ13IARzIgkgGCAOakESdyARcyIGIAtqQQd3cyIKIAZqQQl3IBVzIgRqNgIgIAAgACgCJCAEIApqQQ13IAtzIgtqNgIkIAAgACgCKCALIARqQRJ3IAZzajYCKCAAIAAoAiwgCmo2AiwgACAAKAIwIAkgEmpBEncgEHMiBiACakEHdyAUcyILajYCMCAAIAAoAjQgCyAGakEJdyATcyIKajYCNCAAIAAoAjggCiALakENdyACcyICajYCOCAAIAAoAjwgAiAKakESdyAGc2o2AjwLvxIDFX8Bfg5/AkAgAkUNACAAQQd0IgNBQGoiBEEAKAKACCIFIAMgAmwiBmogAyABbGoiByADaiIIaiEJIAAgAkEHdCIKIAFBB3RqIgtsIQwgACALQYABamwhDSAAQQV0IgtBASALQQFLGyILQWBxIQ4gC0EBcSEPIAdBeGohECAHQXBqIREgB0FoaiESIAdBYGohEyAHQVhqIRQgB0FQaiEVIAdBSGohFiAHQUBqIRcgAa1Cf3whGCAEIAdqIRkgByAAQQh0IhpqIRsgACAKQYABamwhHCALQQRJIR1BACEeQQAhHwNAQQAoAoAIIiAgAyAfbGohIQJAIABFDQBBACEiAkAgHQ0AICAgHmohI0EAIQtBACEiA0AgByALaiIEICMgC2oiJCgCADYCACAEQQRqICRBBGooAgA2AgAgBEEIaiAkQQhqKAIANgIAIARBDGogJEEMaigCADYCACALQRBqIQsgDiAiQQRqIiJHDQALCyAPRQ0AIAcgIkECdCILaiAhIAtqKAIANgIACwJAIAFFDQBBACElIBwhIyAGISYDQCAFISQgACEiAkACQCAADQAgGyAXKQMANwMAIBsgFikDADcDCCAbIBUpAwA3AxAgGyAUKQMANwMYIBsgEykDADcDICAbIBIpAwA3AyggGyARKQMANwMwIBsgECkDADcDOAwBCwNAICQgJmoiCyAkIAxqIgQpAwA3AwAgC0EIaiAEQQhqKQMANwMAIAtBEGogBEEQaikDADcDACALQRhqIARBGGopAwA3AwAgC0EgaiAEQSBqKQMANwMAIAtBKGogBEEoaikDADcDACALQTBqIARBMGopAwA3AwAgC0E4aiAEQThqKQMANwMAIAtBwABqIARBwABqKQMANwMAIAtByABqIARByABqKQMANwMAIAtB0ABqIARB0ABqKQMANwMAIAtB2ABqIARB2ABqKQMANwMAIAtB4ABqIARB4ABqKQMANwMAIAtB6ABqIARB6ABqKQMANwMAIAtB8ABqIARB8ABqKQMANwMAIAtB+ABqIARB+ABqKQMANwMAICRBgAFqISQgIkF/aiIiDQALIAcgCCAbIAAQAiAFISQgACEiA0AgJCAjaiILICQgDWoiBCkDADcDACALQQhqIARBCGopAwA3AwAgC0EQaiAEQRBqKQMANwMAIAtBGGogBEEYaikDADcDACALQSBqIARBIGopAwA3AwAgC0EoaiAEQShqKQMANwMAIAtBMGogBEEwaikDADcDACALQThqIARBOGopAwA3AwAgC0HAAGogBEHAAGopAwA3AwAgC0HIAGogBEHIAGopAwA3AwAgC0HQAGogBEHQAGopAwA3AwAgC0HYAGogBEHYAGopAwA3AwAgC0HgAGogBEHgAGopAwA3AwAgC0HoAGogBEHoAGopAwA3AwAgC0HwAGogBEHwAGopAwA3AwAgC0H4AGogBEH4AGopAwA3AwAgJEGAAWohJCAiQX9qIiINAAsLIAggByAbIAAQAiAjIBpqISMgJiAaaiEmICVBAmoiJSABSQ0AC0EAISUDQAJAAkAgAA0AIBsgFykDADcDACAbIBYpAwA3AwggGyAVKQMANwMQIBsgFCkDADcDGCAbIBMpAwA3AyAgGyASKQMANwMoIBsgESkDADcDMCAbIBApAwA3AzgMAQsgACAKIBkpAgAgGIOnQQd0amwhJiAFISQgACEiA0AgJCAMaiILIAspAwAgJCAmaiIEKQMAhTcDACALQQhqIiMgIykDACAEQQhqKQMAhTcDACALQRBqIiMgIykDACAEQRBqKQMAhTcDACALQRhqIiMgIykDACAEQRhqKQMAhTcDACALQSBqIiMgIykDACAEQSBqKQMAhTcDACALQShqIiMgIykDACAEQShqKQMAhTcDACALQTBqIiMgIykDACAEQTBqKQMAhTcDACALQThqIiMgIykDACAEQThqKQMAhTcDACALQcAAaiIjICMpAwAgBEHAAGopAwCFNwMAIAtByABqIiMgIykDACAEQcgAaikDAIU3AwAgC0HQAGoiIyAjKQMAIARB0ABqKQMAhTcDACALQdgAaiIjICMpAwAgBEHYAGopAwCFNwMAIAtB4ABqIiMgIykDACAEQeAAaikDAIU3AwAgC0HoAGoiIyAjKQMAIARB6ABqKQMAhTcDACALQfAAaiIjICMpAwAgBEHwAGopAwCFNwMAIAtB+ABqIgsgCykDACAEQfgAaikDAIU3AwAgJEGAAWohJCAiQX9qIiINAAsgByAIIBsgABACIAAgCiAJKQIAIBiDp0EHdGpsISYgBSEkIAAhIgNAICQgDWoiCyALKQMAICQgJmoiBCkDAIU3AwAgC0EIaiIjICMpAwAgBEEIaikDAIU3AwAgC0EQaiIjICMpAwAgBEEQaikDAIU3AwAgC0EYaiIjICMpAwAgBEEYaikDAIU3AwAgC0EgaiIjICMpAwAgBEEgaikDAIU3AwAgC0EoaiIjICMpAwAgBEEoaikDAIU3AwAgC0EwaiIjICMpAwAgBEEwaikDAIU3AwAgC0E4aiIjICMpAwAgBEE4aikDAIU3AwAgC0HAAGoiIyAjKQMAIARBwABqKQMAhTcDACALQcgAaiIjICMpAwAgBEHIAGopAwCFNwMAIAtB0ABqIiMgIykDACAEQdAAaikDAIU3AwAgC0HYAGoiIyAjKQMAIARB2ABqKQMAhTcDACALQeAAaiIjICMpAwAgBEHgAGopAwCFNwMAIAtB6ABqIiMgIykDACAEQegAaikDAIU3AwAgC0HwAGoiIyAjKQMAIARB8ABqKQMAhTcDACALQfgAaiILIAspAwAgBEH4AGopAwCFNwMAICRBgAFqISQgIkF/aiIiDQALCyAIIAcgGyAAEAIgJUECaiIlIAFJDQALCwJAIABFDQBBACEiAkAgHQ0AICAgHmohI0EAIQtBACEiA0AgIyALaiIEIAcgC2oiJCgCADYCACAEQQRqICRBBGooAgA2AgAgBEEIaiAkQQhqKAIANgIAIARBDGogJEEMaigCADYCACALQRBqIQsgDiAiQQRqIiJHDQALCyAPRQ0AICEgIkECdCILaiAHIAtqKAIANgIACyAeIANqIR4gH0EBaiIfIAJHDQALCws=";
+var hash$3 = "b32721f8";
+var wasmJson$3 = {
+	name: name$3,
+	data: data$3,
+	hash: hash$3
+};
+
+function scryptInternal(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { costFactor, blockSize, parallelism, hashLength } = options;
+        const SHA256Hasher = createSHA256();
+        const blockData = yield pbkdf2({
+            password: options.password,
+            salt: options.salt,
+            iterations: 1,
+            hashLength: 128 * blockSize * parallelism,
+            hashFunction: SHA256Hasher,
+            outputType: "binary",
+        });
+        const scryptInterface = yield WASMInterface(wasmJson$3, 0);
+        // last block is for storing the temporary vectors
+        const VSize = 128 * blockSize * costFactor;
+        const XYSize = 256 * blockSize;
+        scryptInterface.setMemorySize(blockData.length + VSize + XYSize);
+        scryptInterface.writeMemory(blockData, 0);
+        // mix blocks
+        scryptInterface.getExports().scrypt(blockSize, costFactor, parallelism);
+        const expensiveSalt = scryptInterface
+            .getMemory()
+            .subarray(0, 128 * blockSize * parallelism);
+        const outputData = yield pbkdf2({
+            password: options.password,
+            salt: expensiveSalt,
+            iterations: 1,
+            hashLength,
+            hashFunction: SHA256Hasher,
+            outputType: "binary",
+        });
+        if (options.outputType === "hex") {
+            const digestChars = new Uint8Array(hashLength * 2);
+            return getDigestHex(digestChars, outputData, hashLength);
+        }
+        // return binary format
+        return outputData;
+    });
+}
+const isPowerOfTwo = (v) => v && !(v & (v - 1));
+const validateOptions$1 = (options) => {
+    if (!options || typeof options !== "object") {
+        throw new Error("Invalid options parameter. It requires an object.");
+    }
+    if (!Number.isInteger(options.blockSize) || options.blockSize < 1) {
+        throw new Error("Block size should be a positive number");
+    }
+    if (!Number.isInteger(options.costFactor) ||
+        options.costFactor < 2 ||
+        !isPowerOfTwo(options.costFactor)) {
+        throw new Error("Cost factor should be a power of 2, greater than 1");
+    }
+    if (!Number.isInteger(options.parallelism) || options.parallelism < 1) {
+        throw new Error("Parallelism should be a positive number");
+    }
+    if (!Number.isInteger(options.hashLength) || options.hashLength < 1) {
+        throw new Error("Hash length should be a positive number.");
+    }
+    if (options.outputType === undefined) {
+        options.outputType = "hex";
+    }
+    if (!["hex", "binary"].includes(options.outputType)) {
+        throw new Error(`Insupported output type ${options.outputType}. Valid values: ['hex', 'binary']`);
+    }
+};
+/**
+ * Calculates hash using the scrypt password-based key derivation function
+ * @returns Computed hash as a hexadecimal string or as
+ *          Uint8Array depending on the outputType option
+ */
+function scrypt(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateOptions$1(options);
+        return scryptInternal(options);
+    });
+}
+
+var name$2 = "bcrypt";
+var data$2 = "AGFzbQEAAAABFwRgAAF/YAR/f39/AGADf39/AGABfwF/AwUEAAECAwUEAQECAgYIAX8BQZCrBQsHNAQGbWVtb3J5AgAOSGFzaF9HZXRCdWZmZXIAAAZiY3J5cHQAAg1iY3J5cHRfdmVyaWZ5AAMK9WAEBQBBgCsL21kEFH8Bfgh/AX4jAEHwAGshBCACQQA6AAIgAkGq4AA7AAACQCABLQAAQSpHDQAgAS0AAUEwRw0AIAJBMToAAQsCQCABLAAFIAEsAARBCmxqQfB7aiIFQQRJDQAgAS0AB0FgaiIGQd8ASw0AIAZBkAlqLQAAIgZBP0sNACABLQAIQWBqIgdB3wBLDQAgB0GQCWotAAAiB0E/Sw0AIAQgB0EEdiAGQQJ0cjoACCABLQAJQWBqIgZB3wBLDQAgBkGQCWotAAAiBkE/Sw0AIAQgBkECdiAHQQR0cjoACSABLQAKQWBqIgdB3wBLDQAgB0GQCWotAAAiB0E/Sw0AIAQgByAGQQZ0cjoACiABLQALQWBqIgZB3wBLDQAgBkGQCWotAAAiBkE/Sw0AIAEtAAxBYGoiB0HfAEsNACAHQZAJai0AACIHQT9LDQAgBCAHQQR2IAZBAnRyOgALIAEtAA1BYGoiBkHfAEsNACAGQZAJai0AACIGQT9LDQAgBCAGQQJ2IAdBBHRyOgAMIAEtAA5BYGoiB0HfAEsNACAHQZAJai0AACIHQT9LDQAgBCAHIAZBBnRyOgANIAEtAA9BYGoiBkHfAEsNACAGQZAJai0AACIGQT9LDQAgAS0AEEFgaiIHQd8ASw0AIAdBkAlqLQAAIgdBP0sNACAEIAdBBHYgBkECdHI6AA4gAS0AEUFgaiIGQd8ASw0AIAZBkAlqLQAAIgZBP0sNACAEIAZBAnYgB0EEdHI6AA8gAS0AEkFgaiIHQd8ASw0AIAdBkAlqLQAAIgdBP0sNACAEIAcgBkEGdHI6ABAgAS0AE0FgaiIGQd8ASw0AIAZBkAlqLQAAIgZBP0sNACABLQAUQWBqIgdB3wBLDQAgB0GQCWotAAAiB0E/Sw0AIAQgB0EEdiAGQQJ0cjoAESABLQAVQWBqIgZB3wBLDQAgBkGQCWotAAAiBkE/Sw0AIAQgBkECdiAHQQR0cjoAEiABLQAWQWBqIgdB3wBLDQAgB0GQCWotAAAiB0E/Sw0AIAQgByAGQQZ0cjoAEyABLQAXQWBqIgZB3wBLDQAgBkGQCWotAAAiBkE/Sw0AIAEtABhBYGoiB0HfAEsNACAHQZAJai0AACIHQT9LDQAgBCAHQQR2IAZBAnRyOgAUIAEtABlBYGoiBkHfAEsNACAGQZAJai0AACIGQT9LDQAgBCAGQQJ2IAdBBHRyOgAVIAEtABpBYGoiB0HfAEsNACAHQZAJai0AACIHQT9LDQAgBCAHIAZBBnRyOgAWIAEtABtBYGoiBkHfAEsNACAGQZAJai0AACIGQT9LDQAgAS0AHEFgaiIHQd8ASw0AIAdBkAlqLQAAIgdBP0sNAEEBIAV0IQggBCAHQQR2IAZBAnRyOgAXIAQgBCgCCCIFQRh0IAVBgP4DcUEIdHIgBUEIdkGA/gNxIAVBGHZyciIJNgIIIAQgBCgCDCIFQRh0IAVBgP4DcUEIdHIgBUEIdkGA/gNxIAVBGHZyciIKNgIMIAQgBCgCECIFQRh0IAVBgP4DcUEIdHIgBUEIdkGA/gNxIAVBGHZyciILNgIQIAQgBCgCFCIFQRh0IAVBgP4DcUEIdHIgBUEIdkGA/gNxIAVBGHZyciIMNgIUIARB6ABqIAEtAAJBnwdqLQAAIg1BAXFBAnRqIQ5BACEGQQAhB0EAIQ8gACEFA0AgBEIANwJoIAQgBS0AACIQNgJoIAQgBSwAACIRNgJsIAUtAAAhEiAEIBBBCHQiEDYCaCAEIBAgBUEBaiAAIBIbIgUtAAByIhA2AmggBCARQQh0IhE2AmwgBCARIAUsAAAiEnIiETYCbCAFLQAAIRMgBCAQQQh0IhA2AmggBCAQIAVBAWogACATGyIFLQAAciIQNgJoIAQgEUEIdCIRNgJsIAQgESAFLAAAIhNyIhE2AmwgBS0AACEUIAQgEEEIdCIQNgJoIAQgECAFQQFqIAAgFBsiBS0AAHIiEDYCaCAEIBFBCHQiETYCbCAEIBEgBSwAACIUciIRNgJsIAUtAAAhFSAEQSBqIAZqIA4oAgAiFjYCACAGQfApaiIXIBYgFygCAHM2AgAgESAQcyAHciEHIAVBAWogACAVGyEFIBQgEyAScnJBgAFxIA9yIQ8gBkEEaiIGQcgARw0AC0EAQQAoAvApIA9BCXQgDUEPdHFBgIAEIAdB//8DcSAHQRB2cmtxczYC8ClCACEYQX4hBkHwKSEHA0BBACgCrCpBACgCqCpBACgCpCpBACgCoCpBACgCnCpBACgCmCpBACgClCpBACgCkCpBACgCjCpBACgCiCpBACgChCpBACgCgCpBACgC/ClBACgC+ClBACgC9CkgBEEIaiAGQQJqIgZBAnFBAnRqKQMAIBiFIhhCIIinc0EAKALwKSAYp3MiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUH/AXFBAnRB8CFqKAIAIQ8gBUEGdkH8B3FB8BlqKAIAIRAgBUEWdkH8B3FB8AlqKAIAIREgBUEOdkH8B3FB8BFqKAIAIRJBACgCsCohE0EAQQAoArQqIAVzNgKAqwFBACATIA8gECARIBJqc2pzIABzNgKEqwEgB0EAKQOAqwEiGDcCACAHQQhqIQcgBkEQSQ0ACyAYQiCIpyEFIBinIQZB8AkhAANAQQAoAqwqQQAoAqgqQQAoAqQqQQAoAqAqQQAoApwqQQAoApgqQQAoApQqQQAoApAqQQAoAowqQQAoAogqQQAoAoQqQQAoAoAqQQAoAvwpQQAoAvgpIAVBACgC9ClzIAZBACgC8ClzIAtzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgDHMiBkEWdkH8B3FB8AlqKAIAIAZBDnZB/AdxQfARaigCAGogBkEGdkH8B3FB8BlqKAIAcyAGQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIAZzIgZBFnZB/AdxQfAJaigCACAGQQ52QfwHcUHwEWooAgBqIAZBBnZB/AdxQfAZaigCAHMgBkH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAGcyIGQRZ2QfwHcUHwCWooAgAgBkEOdkH8B3FB8BFqKAIAaiAGQQZ2QfwHcUHwGWooAgBzIAZB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgBnMiBkEWdkH8B3FB8AlqKAIAIAZBDnZB/AdxQfARaigCAGogBkEGdkH8B3FB8BlqKAIAcyAGQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIAZzIgZBFnZB/AdxQfAJaigCACAGQQ52QfwHcUHwEWooAgBqIAZBBnZB/AdxQfAZaigCAHMgBkH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAGcyIGQRZ2QfwHcUHwCWooAgAgBkEOdkH8B3FB8BFqKAIAaiAGQQZ2QfwHcUHwGWooAgBzIAZB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgBnMiBkEWdkH8B3FB8AlqKAIAIAZBDnZB/AdxQfARaigCAGogBkEGdkH8B3FB8BlqKAIAcyAGQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIAZzIgZB/wFxQQJ0QfAhaigCACEHIAZBBnZB/AdxQfAZaigCACEPIAZBFnZB/AdxQfAJaigCACEQIAZBDnZB/AdxQfARaigCACERQQAoArAqIRIgAEEAKAK0KiAGcyIGNgIAIABBBGogEiAHIA8gECARanNqcyAFcyIHNgIAQQAoAqwqQQAoAqgqQQAoAqQqQQAoAqAqQQAoApwqQQAoApgqQQAoApQqQQAoApAqQQAoAowqQQAoAogqQQAoAoQqQQAoAoAqQQAoAvwpQQAoAvgpQQAoAvQpIAlBACgC8ClzIAZzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgCnMgB3MiBkEWdkH8B3FB8AlqKAIAIAZBDnZB/AdxQfARaigCAGogBkEGdkH8B3FB8BlqKAIAcyAGQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIAZzIgZBFnZB/AdxQfAJaigCACAGQQ52QfwHcUHwEWooAgBqIAZBBnZB/AdxQfAZaigCAHMgBkH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAGcyIGQRZ2QfwHcUHwCWooAgAgBkEOdkH8B3FB8BFqKAIAaiAGQQZ2QfwHcUHwGWooAgBzIAZB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgBnMiBkEWdkH8B3FB8AlqKAIAIAZBDnZB/AdxQfARaigCAGogBkEGdkH8B3FB8BlqKAIAcyAGQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIAZzIgZBFnZB/AdxQfAJaigCACAGQQ52QfwHcUHwEWooAgBqIAZBBnZB/AdxQfAZaigCAHMgBkH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAGcyIGQRZ2QfwHcUHwCWooAgAgBkEOdkH8B3FB8BFqKAIAaiAGQQZ2QfwHcUHwGWooAgBzIAZB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgBnMiBkEWdkH8B3FB8AlqKAIAIAZBDnZB/AdxQfARaigCAGogBkEGdkH8B3FB8BlqKAIAcyAGQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIAZzIgZB/wFxQQJ0QfAhaigCACEHIAZBBnZB/AdxQfAZaigCACEPIAZBFnZB/AdxQfAJaigCACEQIAZBDnZB/AdxQfARaigCACERQQAoArAqIRIgAEEIakEAKAK0KiAGcyIGNgIAIABBDGogEiAHIA8gECARanNqcyAFcyIFNgIAIABBEGoiAEHsKUkNAAtBACAFNgKEqwFBACAGNgKAqwEgBCgCZCEUIAQoAmAhFSAEKAJcIRYgBCgCWCEXIAQoAlQhCSAEKAJQIQogBCgCTCELIAQoAkghDCAEKAJEIQ4gBCgCQCENIAQoAjwhGSAEKAI4IRogBCgCNCEbIAQoAjAhHCAEKAIsIR0gBCgCKCEeIAQoAiQhHyAEKAIgISAgBCkDECEhIAQpAwghGANAQQBBACgC8CkgIHM2AvApQQBBACgC9CkgH3M2AvQpQQBBACgC+CkgHnM2AvgpQQBBACgC/CkgHXM2AvwpQQBBACgCgCogHHM2AoAqQQBBACgChCogG3M2AoQqQQBBACgCiCogGnM2AogqQQBBACgCjCogGXM2AowqQQBBACgCkCogDXM2ApAqQQBBACgClCogDnM2ApQqQQBBACgCmCogDHM2ApgqQQBBACgCnCogC3M2ApwqQQBBACgCoCogCnM2AqAqQQBBACgCpCogCXM2AqQqQQBBACgCqCogF3M2AqgqQQBBACgCrCogFnM2AqwqQQBBACgCsCogFXM2ArAqQQBBACgCtCogFHM2ArQqQQEhEwNAQQAhAEEAQgA3A4CrAUHwKSEGQQAhBQNAQQAoAqwqQQAoAqgqQQAoAqQqQQAoAqAqQQAoApwqQQAoApgqQQAoApQqQQAoApAqQQAoAowqQQAoAogqQQAoAoQqQQAoAoAqQQAoAvwpQQAoAvgpQQAoAvQpIABzQQAoAvApIAVzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVB/wFxQQJ0QfAhaigCACEHIAVBBnZB/AdxQfAZaigCACEPIAVBFnZB/AdxQfAJaigCACEQIAVBDnZB/AdxQfARaigCACERQQAoArAqIRIgBkEAKAK0KiAFcyIFNgIAIAZBBGogEiAHIA8gECARanNqcyAAcyIANgIAIAZBCGoiBkG4KkkNAAtB8AkhBgNAQQAoAqwqQQAoAqgqQQAoAqQqQQAoAqAqQQAoApwqQQAoApgqQQAoApQqQQAoApAqQQAoAowqQQAoAogqQQAoAoQqQQAoAoAqQQAoAvwpQQAoAvgpQQAoAvQpIABzQQAoAvApIAVzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVB/wFxQQJ0QfAhaigCACEHIAVBBnZB/AdxQfAZaigCACEPIAVBFnZB/AdxQfAJaigCACEQIAVBDnZB/AdxQfARaigCACERQQAoArAqIRIgBkEAKAK0KiAFcyIFNgIAIAZBBGogEiAHIA8gECARanNqcyAAcyIANgIAIAZBCGoiBkHsKUkNAAtBACAANgKEqwFBACAFNgKAqwECQCATQQFxRQ0AQQAhE0EAQQApAvApIBiFNwLwKUEAQQApAvgpICGFNwL4KUEAQQApAoAqIBiFNwKAKkEAQQApAogqICGFNwKIKkEAQQApApAqIBiFNwKQKkEAQQApApgqICGFNwKYKkEAQQApAqAqIBiFNwKgKkEAQQApAqgqICGFNwKoKkEAQQApArAqIBiFNwKwKgwBCwsgCEF/aiIIDQALQQAoArQqIQ9BACgCsCohEEEAKAKsKiERQQAoAqgqIRJBACgCpCohE0EAKAKgKiEIQQAoApwqIRRBACgCmCohFUEAKAKUKiEWQQAoApAqIRdBACgCjCohCUEAKAKIKiEKQQAoAoQqIQtBACgCgCohDEEAKAL8KSEOQQAoAvgpIQ1BACgC9CkhGUEAKALwKSEaQQAhGwNAIBtBAnQiHEGgCGopAwAiGKchACAYQiCIpyEGQUAhBwNAIBAgESASIBMgCCAUIBUgFiAXIAkgCiALIAwgDiANIAYgGXMgACAacyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIgBBFnZB/AdxQfAJaigCACAAQQ52QfwHcUHwEWooAgBqIABBBnZB/AdxQfAZaigCAHMgAEH/AXFBAnRB8CFqKAIAanMgBXMiBUEWdkH8B3FB8AlqKAIAIAVBDnZB/AdxQfARaigCAGogBUEGdkH8B3FB8BlqKAIAcyAFQf8BcUECdEHwIWooAgBqcyAAcyIAQRZ2QfwHcUHwCWooAgAgAEEOdkH8B3FB8BFqKAIAaiAAQQZ2QfwHcUHwGWooAgBzIABB/wFxQQJ0QfAhaigCAGpzIAVzIgVBFnZB/AdxQfAJaigCACAFQQ52QfwHcUHwEWooAgBqIAVBBnZB/AdxQfAZaigCAHMgBUH/AXFBAnRB8CFqKAIAanMgAHMiAEEWdkH8B3FB8AlqKAIAIABBDnZB/AdxQfARaigCAGogAEEGdkH8B3FB8BlqKAIAcyAAQf8BcUECdEHwIWooAgBqcyAFcyIFQRZ2QfwHcUHwCWooAgAgBUEOdkH8B3FB8BFqKAIAaiAFQQZ2QfwHcUHwGWooAgBzIAVB/wFxQQJ0QfAhaigCAGpzIABzIQYgBSAPcyEAIAdBAWoiBw0AC0EAIAY2AoSrAUEAIAA2AoCrASAEQQhqIBxqQQApA4CrATcDACAbQQRJIQAgG0ECaiEbIAANAAsgAiABKAIANgIAIAIgASgCBDYCBCACIAEoAgg2AgggAiABKAIMNgIMIAIgASgCEDYCECACIAEoAhQ2AhQgAiABKAIYNgIYIAIgASwAHEHwCGotAABBMHFBwAhqLQAAOgAcIAQgBCgCCCIBQRh0IAFBgP4DcUEIdHIgAUEIdkGA/gNxIAFBGHZyciIPNgIIIAQgBCgCDCIBQRh0IAFBgP4DcUEIdHIgAUEIdkGA/gNxIAFBGHZyciIBNgIMIAQgBCgCECIAQRh0IABBgP4DcUEIdHIgAEEIdkGA/gNxIABBGHZyciIANgIQIAQgBCgCFCIFQRh0IAVBgP4DcUEIdHIgBUEIdkGA/gNxIAVBGHZyciIGNgIUIAQgBCgCGCIFQRh0IAVBgP4DcUEIdHIgBUEIdkGA/gNxIAVBGHZyciIFNgIYIAQgBCgCHCIHQRh0IAdBgP4DcUEIdHIgB0EIdkGA/gNxIAdBGHZyciIHNgIcAkACQCADDQAgAiAEKQMINwMAIAIgBCkDEDcDCCACIAQpAxg3AxAMAQsgAiAHQT9xQcAIai0AADoAOCACIAZBGnZBwAhqLQAAOgAxIAIgAEE/cUHACGotAAA6ACggAiAPQRp2QcAIai0AADoAISACIAQtAAgiBEECdkHACGotAAA6AB0gAiAHQQ52QTxxQcAIai0AADoAOyACIAdBCnZBP3FBwAhqLQAAOgA5IAIgBUESdkE/cUHACGotAAA6ADUgAiAFQQh2QT9xQcAIai0AADoANCACIAZBEHYiA0E/cUHACGotAAA6ADAgAiAGQfwBcUECdkHACGotAAA6AC0gAiAAQRh2QT9xQcAIai0AADoALCACIABBCnZBP3FBwAhqLQAAOgApIAIgAUESdkE/cUHACGotAAA6ACUgAiABQQh2QT9xQcAIai0AADoAJCACIA9BEHYiEEE/cUHACGotAAA6ACAgAiAHQQZ2QQNxIAVBFnZBPHFyQcAIai0AADoANyACIAVBDHZBMHEgBUEcdnJBwAhqLQAAOgA2IAIgBUECdEE8cSAFQQ52QQNxckHACGotAAA6ADMgAiAFQfABcUEEdiAGQRR2QTBxckHACGotAAA6ADIgAiAGQQR0QTBxIAZBDHZBD3FyQcAIai0AADoALiACIABBDnZBPHEgAEEednJBwAhqLQAAOgArIAIgAEEGdkEDcSABQRZ2QTxxckHACGotAAA6ACcgAiABQQx2QTBxIAFBHHZyQcAIai0AADoAJiACIAFBAnRBPHEgAUEOdkEDcXJBwAhqLQAAOgAjIAIgAUHwAXFBBHYgD0EUdkEwcXJBwAhqLQAAOgAiIAIgBEEEdEEwcSAPQQx2QQ9xckHACGotAAA6AB4gAiAHQRB2QfABcSAHQYAGcXJBBHZBwAhqLQAAOgA6IAIgA0HAAXEgBkGAHnFyQQZ2QcAIai0AADoALyACIABBEHZB8AFxIABBgAZxckEEdkHACGotAAA6ACogAiAQQcABcSAPQYAecXJBBnZBwAhqLQAAOgAfCyACQQA6ADwLC4YGAQZ/IwBB4ABrIgMkAEEAIQQgAEGQK2pBADoAACADQSQ6AEYgAyABQQpuIgBBMGo6AEQgA0Gk5ISjAjYCQCADIABB9gFsIAFqQTByOgBFIANBAC0AgCsiAUECdkHACGotAAA6AEcgA0EALQCCKyIAQT9xQcAIai0AADoASiADQQAtAIMrIgVBAnZBwAhqLQAAOgBLIANBAC0AhSsiBkE/cUHACGotAAA6AE4gA0EALQCBKyIHQQR2IAFBBHRBMHFyQcAIai0AADoASCADIABBBnYgB0ECdEE8cXJBwAhqLQAAOgBJIANBAC0AhCsiAUEEdiAFQQR0QTBxckHACGotAAA6AEwgAyAGQQZ2IAFBAnRBPHFyQcAIai0AADoATSADQQAtAIYrIgFBAnZBwAhqLQAAOgBPIANBAC0AiCsiAEE/cUHACGotAAA6AFIgA0EALQCJKyIFQQJ2QcAIai0AADoAUyADQQAtAIsrIgZBP3FBwAhqLQAAOgBWIANBAC0AjCsiB0ECdkHACGotAAA6AFcgA0EALQCHKyIIQQR2IAFBBHRBMHFyQcAIai0AADoAUCADIABBBnYgCEECdEE8cXJBwAhqLQAAOgBRIANBAC0AiisiAUEEdiAFQQR0QTBxckHACGotAAA6AFQgAyAGQQZ2IAFBAnRBPHFyQcAIai0AADoAVSADQQAtAI0rIgFBBHYgB0EEdEEwcXJBwAhqLQAAOgBYIANBADoAXSADQQAtAI4rIgBBP3FBwAhqLQAAOgBaIANBAC0AjysiBUECdkHACGotAAA6AFsgAyAAQQZ2IAFBAnRBPHFyQcAIai0AADoAWSADIAVBBHRBMHFBwAhqLQAAOgBcQZArIANBwABqIAMgAhABA0AgBEGAK2ogAyAEaiIBLQAAOgAAIARBgStqIAFBAWotAAA6AAAgBEGCK2ogAUECai0AADoAACAEQYMraiABQQNqLQAAOgAAIARBhCtqIAFBBGotAAA6AAAgBEEFaiIEQTxHDQALIANB4ABqJAALhwECAX8IfiMAQcAAayIBJAAgAEG8K2pBADoAAEG8K0GAKyABQQEQAUEAKQOkKyECIAEpAyQhA0EAKQOcKyEEIAEpAxwhBUEAKQOsKyEGIAEpAywhB0EAKQO0KyEIIAEpAzQhCSABQcAAaiQAIAUgBFIgAyACUmogByAGUmpBf0EAIAkgCFIbRgsLxyICAEGACAvwAQIEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQAAAAAAAAAaHByT0JuYWVsb2hlU3JlZER5cmN0YnVvAAAAAAAAAAAuL0FCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5AAAAAAAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQEBAAAE2Nzg5Ojs8PT4/QEBAQEBAQAIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobQEBAQEBAHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDVAQEBAQABB8AkLyCCmCzHRrLXfmNty/S+33xrQ7a/huJZ+JmpFkHy6mX8s8UeZoST3bJGz4vIBCBb8joXYIGljaU5XcaP+WKR+PZP0j3SVDVi2jnJYzYtx7koVgh2kVHu1WVrCOdUwnBNg8iojsNHF8IVgKBh5QcrvONu4sNx5jg4YOmCLDp5sPooesMF3FdcnSzG92i+veGBcYFXzJVXmlKtVqmKYSFdAFOhjajnKVbYQqyo0XMy0zuhBEa+GVKGT6XJ8ERTusyq8b2Ndxakr9jEYdBY+XM4ek4ebM7rWr1zPJGyBUzJ6d4aVKJhIjzuvuUtrG+i/xJMhKGbMCdhhkakh+2CsfEgygOxdXV2E77F1hekCIybciBtl64E+iSPFrJbT829tDzlC9IOCRAsuBCCEpErwyGlemx+eQmjGIZps6fZhnAxn8IjTq9KgUWpoL1TYKKcPlqMzUatsC+9u5Dt6E1DwO7qYKvt+HWXxoXYBrzk+WcpmiA5DghmG7oy0n29Fw6WEfb5eizvYdW/gcyDBhZ9EGkCmasFWYqrTTgZ3PzZy3/4bPQKbQiTX0DdIEgrQ0+oP25vA8UnJclMHexuZgNh51CX33uj2GlD+4ztMeba94GyXugbABLZPqcHEYJ9Awp5cXmMkahmvb/totVNsPuuyORNv7FI7H1H8bSyVMJtERYHMCb1erwTQ4779SjPeBygPZrNLLhlXqMvAD3TIRTlfC9Lb+9O5vcB5VQoyYBrGAKHWeXIsQP4ln2fMox/7+OmljvgiMtvfFnU8FWth/cgeUC+rUgWt+rU9MmCHI/1IezFTgt8APrtXXJ6gjG/KLlaHGttpF9/2qELVw/9+KMYyZ6xzVU+MsCdbachYyrtdo//hoBHwuJg9+hC4gyH9bLX8SlvT0S155FOaZUX4trxJjtKQl/tL2vLd4TN+y6RBE/ti6MbkztrKIO8BTHc2/p5+0LQf8StN2tuVmJGQrnGOreqg1ZNr0NGO0OAlx68vWzyOt5R1jvvi9o9kKxLyEriIiBzwDZCgXq1PHMOPaJHxz9GtwaizGCIvL3cXDr7+LXXqoR8Ciw/MoOXodG+11vOsGJniic7gT6i0t+AT/YE7xHzZqK3SZqJfFgV3lYAUc8yTdxQaIWUgreaG+rV39UJUx881nfsMr83roIk+e9MbQdZJfh6uLQ4lAF6zcSC7AGgir+C4V5s2ZCQeuQnwHZFjVaqm31mJQ8F4f1Na2aJbfSDFueUCdgMmg6nPlWJoGcgRQUpzTsotR7NKqRR7UgBRGxUpU5o/Vw/W5MabvHakYCsAdOaBtW+6CB/pG1dr7JbyFdkNKiFlY7a2+bnnLgU0/2RWhcVdLbBToY+fqZlHughqB4Vu6XB6S0Qps7UuCXXbIyYZxLCmbq1936dJuGDunGay7Y9xjKrs/xeaaWxSZFbhnrHCpQI2GSlMCXVAE1mgPjoY5JqYVD9lnUJb1uSPa9Y/95kHnNKh9TDo7+Y4LU3BXSXwhiDdTCbrcITG6YJjXsweAj9raAnJ77o+FBiXPKFwamuENX9ohuKgUgVTnLc3B1CqHIQHPlyu3n/sRH2OuPIWVzfaOrANDFDwBB8c8P+zAAIa9QyusnS1PFh6gyW9IQnc+ROR0fYvqXxzRzKUAUf1IoHl5Trc2sI3NHa1yKfd85pGYUSpDgPQDz7HyOxBHnWkmc044i8O6juhu4AyMbM+GDiLVE4IuW1PAw1Cb78ECvaQErgseXyXJHKweVavia+8H3ea3hAIk9kSrouzLj/P3B9yElUkcWsu5t0aUIfNhJ8YR1h6F9oIdLyan7yMfUvpOux67PodhdtmQwlj0sNkxEcYHO8I2RUyNztD3Ra6wiRDTaESUcRlKgIAlFDd5DoTnvjfcVVOMRDWd6yBmxkRX/FWNQRrx6PXOxgRPAmlJFnt5o/y+vvxlyy/up5uPBUecEXjhrFv6eoKXg6Gsyo+WhznH3f6Bj1OudxlKQ8d55nWiT6AJchmUnjJTC5qsxCcug4Vxnjq4pRTPPyl9C0KHqdO9/I9Kx02DyY5GWB5whkIpyNSthIT927+retmH8PqlUW844PIe6bRN3+xKP+MAe/dMsOlWmy+hSFYZQKYq2gPpc7uO5Uv26197yqEL25bKLYhFXBhByl1R93sEBWfYTCozBOWvWHrHv40A89jA6qQXHO1OaJwTAuentUU3qrLvIbM7qcsYmCrXKucboTzsq8ei2TK8L0ZuWkjoFC7WmUyWmhAs7QqPNXpnjH3uCHAGQtUm5mgX4d+mfeVqH09YpqIN/h3LeOXX5PtEYESaBYpiDUO1h/mx6Hf3paZulh4pYT1V2NyIhv/w4OblkbCGusKs81UMC5T5EjZjygxvG3v8utY6v/GNGHtKP5zPHzu2RRKXeO3ZOgUXRBC4BM+ILbi7kXqq6qjFU9s29BPy/pC9ELHtbtq7x07T2UFIc1Bnnke2MdNhYZqR0vkUGKBPfKhYs9GJo1boIOI/KO2x8HDJBV/knTLaQuKhEeFspJWAL9bCZ1IGa10sWIUAA6CIyqNQljq9VUMPvStHWFwPyOS8HIzQX6TjfHsX9bbOyJsWTfefGB07sun8oVAbjJ3zoSAB6aeUPgZVdjv6DWX2WGqp2mpwgYMxfyrBFrcyguALnpEnoQ0RcMFZ9X9yZ4eDtPbc9vNiFUQedpfZ0BDZ+NlNMTF2Dg+cZ74KD0g/23x5yE+FUo9sI8rn+Pm962D22haPen3QIGUHCZM9jQpaZT3IBVB99QCdi5r9LxoAKLUcSQI1Gr0IDO31LdDr2EAUC72OR5GRSSXdE8hFECIi78d/JVNr5G1ltPd9HBFL6Bm7Am8v4WXvQPQbax/BIXLMbMn65ZBOf1V5kcl2poKyqsleFAo9CkEU9qGLAr7bbbpYhTcaABpSNekwA5o7o2hJ6L+P0+MrYfoBuCMtbbW9Hp8Hs6q7F8305mjeM5CKmtANZ7+ILmF89mr1znui04SO/f6yR1WGG1LMWajJrKX4+p0+m46MkNb3ffnQWj7IHjKTvUK+5ez/tisVkBFJ5VIujo6U1WHjYMgt6lr/kuVltC8Z6hVWJoVoWMpqcwz2+GZVkoqpvklMT8cfvRefDEpkALo+P1wLycEXBW7gOMsKAVIFcGVIm3G5D8TwUjchg/H7sn5Bw8fBEGkeUdAF26IXetRXzLRwJvVj8G88mQ1EUE0eHslYJwqYKPo+N8bbGMfwrQSDp4y4QLRT2avFYHRyuCVI2vhkj4zYgskOyK5vu4OorKFmQ265owMct4o96ItRXgS0P2Ut5ViCH1k8PXM52+jSVT6SH2HJ/2dwx6NPvNBY0cKdP8umatubzo3/fj0YNwSqPjd66FM4RuZDWtu2xBVe8Y3LGdtO9RlJwTo0NzHDSnxo/8AzJIPObUL7Q9p+597Zpx9284Lz5Ggo14V2YgvE7skrVtRv3mUe+vWO3azLjk3eVkRzJfiJoAtMS70p61CaDsrasbMTHUSHPEueDdCEmrnUZK35ruhBlBj+0sYEGsa+u3KEdi9JT3Jw+HiWRZCRIYTEgpu7AzZKuqr1U5nr2RfqIbaiOm/vv7D5GRXgLydhsD38Ph7eGBNYANgRoP90bAfOPYErkV3zPw21zNrQoNxqx7wh0GAsF9eADy+V6B3JK7ovZlCRlVhLli/j/RYTqL93fI473T0wr2Jh8P5ZlN0jrPIVfJ1tLnZ/EZhJut6hN8di3kOaoTilV+RjlluRnBXtCCRVdWMTN4CyeGsC7nQBYK7SGKoEZ6pdHW2GX+3Cdyp4KEJLWYzRjLEAh9a6Iy+8AkloJlKEP5uHR09uRrfpKULD/KGoWnxaCiD2rfc/gY5V5vO4qFSf81PAV4RUPqDBqfEtQKgJ9DmDSeM+JpBhj93Bkxgw7UGqGEoehfw4Ib1wKpYYABifdww157mEWPqOCOU3cJTNBbCwlbuy7vetryQoX3863YdWc4J5AVviAF8Sz0KcjkkfJJ8X3LjhrmdTXK0W8Ea/Lie03hVVO21pfwI03w92MQPrU1e71Ae+OZhsdkUhaI8E1Fs58fVb8RO4VbOvyo2N8jG3TQymtcSgmOSjvoOZ+AAYEA3zjk6z/X60zd3wqsbLcVanmewXEI3o09AJ4LTvpu8mZ2OEdUVcw+/fhwt1nvEAMdrG4y3RZChIb6xbrK0bjZqL6tIV3lulLzSdqPGyMJJZe74D1N93o1GHQpz1cZN0EzbuzkpUEa6qegmlawE416+8NX6oZpRLWrijO9jIu6GmrjCicD2LiRDqgMepaTQ8py6YcCDTWrpm1AV5Y/WW2S6+aImKOE6OqeGlalL6WJV79PvL8fa91L3aW8EP1kK+ncVqeSAAYawh63mCZuT5T47Wv2Q6ZfXNJ7Zt/AsUYsrAjqs1ZZ9pn0B1j7P0SgtfXzPJZ8fm7jyrXK01lpM9Yhacawp4OalGeD9rLBHm/qT7Y3E0+jMVzsoKWbV+CguE3mRAV94VWB17UQOlveMXtPj1G0FFbpt9IglYaEDvfBkBRWe68OiV5A87BonlyoHOqmbbT8b9SFjHvtmnPUZ89wmKNkzdfX9VbGCNFYDuzy6ihF3USj42QrCZ1HMq1+SrcxRF+hNjtwwOGJYnTeR+SCTwpB66s57PvtkziFRMr5Pd37jtqhGPSnDaVPeSIDmE2QQCK6iJLJt3f0thWlmIQcJCkaas93ARWTP3mxYrsggHN33vltAjVgbfwHSzLvjtGt+aqLdRf9ZOkQKNT7VzbS8qM7qcruEZPquEmaNR288v2Pkm9KeXS9UG3fCrnBjTvaNDQ50VxNb53EWcvhdfVOvCMtAQMzitE5qRtI0hK8VASgEsOEdOpiVtJ+4Bkigbs6COz9vgqsgNUsdGgH4J3InsWAVYdw/k+creTq7vSVFNOE5iKBLec5Rt8kyL8m6H6B+yBzg9tHHvMMRAc/HquihSYeQGpq9T9TL3trQONoK1SrDOQNnNpHGfDH5jU8rseC3WZ73Orv1Q/8Z1fKcRdknLCKXvyr85hVx/JEPJRWUm2GT5frrnLbOWWSowtGouhJeB8G2DGoF42VQ0hBCpAPLDm7s4DvbmBa+oJhMZOl4MjKVH5/fktPgKzSg0x7ycYlBdAobjDSjSyBxvsXYMnbDjZ813y4vmZtHbwvmHfHjD1TaTOWR2Noez3lizm9+Ps1msRgWBR0s/cXSj4SZIvv2V/Mj9SN2MqYxNaiTAs3MVmKB8Ky163ValzYWbsxz0oiSYpbe0Em5gRuQUEwUVsZxvcfG5goUejIG0OFFmnvyw/1TqskAD6hi4r8lu/bSvTUFaRJxIgIEsnzPy7YrnHbNwD4RU9PjQBZgvas48K1HJZwgOLp2zkb3xaGvd2BgdSBO/suF2I3oirD5qnp+qvlMXMJIGYyK+wLkasMB+eHr1mn41JCg3lymLSUJP5/mCMIyYU63W+J3zuPfj1fmcsM6iGo/JNMIo4UuihkTRHNwAyI4CaTQMZ8pmPouCIlsTuzmIShFdxPQOM9mVL5sDOk0tymswN1QfMm11YQ/FwlHtdnVFpIb+3mJ";
+var hash$2 = "8bd8822d";
+var wasmJson$2 = {
+	name: name$2,
+	data: data$2,
+	hash: hash$2
+};
+
+function bcryptInternal(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { costFactor, password, salt } = options;
+        const bcryptInterface = yield WASMInterface(wasmJson$2, 0);
+        bcryptInterface.writeMemory(getUInt8Buffer(salt), 0);
+        const passwordBuffer = getUInt8Buffer(password);
+        bcryptInterface.writeMemory(passwordBuffer, 16);
+        const shouldEncode = options.outputType === "encoded" ? 1 : 0;
+        bcryptInterface
+            .getExports()
+            .bcrypt(passwordBuffer.length, costFactor, shouldEncode);
+        const memory = bcryptInterface.getMemory();
+        if (options.outputType === "encoded") {
+            return intArrayToString(memory, 60);
+        }
+        if (options.outputType === "hex") {
+            const digestChars = new Uint8Array(24 * 2);
+            return getDigestHex(digestChars, memory, 24);
+        }
+        // return binary format
+        // the data is copied to allow GC of the original memory buffer
+        return memory.slice(0, 24);
+    });
+}
+const validateOptions = (options) => {
+    if (!options || typeof options !== "object") {
+        throw new Error("Invalid options parameter. It requires an object.");
+    }
+    if (!Number.isInteger(options.costFactor) ||
+        options.costFactor < 4 ||
+        options.costFactor > 31) {
+        throw new Error("Cost factor should be a number between 4 and 31");
+    }
+    options.password = getUInt8Buffer(options.password);
+    if (options.password.length < 1) {
+        throw new Error("Password should be at least 1 byte long");
+    }
+    if (options.password.length > 72) {
+        throw new Error("Password should be at most 72 bytes long");
+    }
+    options.salt = getUInt8Buffer(options.salt);
+    if (options.salt.length !== 16) {
+        throw new Error("Salt should be 16 bytes long");
+    }
+    if (options.outputType === undefined) {
+        options.outputType = "encoded";
+    }
+    if (!["hex", "binary", "encoded"].includes(options.outputType)) {
+        throw new Error(`Insupported output type ${options.outputType}. Valid values: ['hex', 'binary', 'encoded']`);
+    }
+};
+/**
+ * Calculates hash using the bcrypt password-hashing function
+ * @returns Computed hash
+ */
+function bcrypt(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateOptions(options);
+        return bcryptInternal(options);
+    });
+}
+const validateHashCharacters = (hash) => {
+    if (!/^\$2[axyb]\$[0-3][0-9]\$[./A-Za-z0-9]{53}$/.test(hash)) {
+        return false;
+    }
+    if (hash[4] === "0" && Number(hash[5]) < 4) {
+        return false;
+    }
+    if (hash[4] === "3" && Number(hash[5]) > 1) {
+        return false;
+    }
+    return true;
+};
+const validateVerifyOptions = (options) => {
+    if (!options || typeof options !== "object") {
+        throw new Error("Invalid options parameter. It requires an object.");
+    }
+    if (options.hash === undefined || typeof options.hash !== "string") {
+        throw new Error("Hash should be specified");
+    }
+    if (options.hash.length !== 60) {
+        throw new Error("Hash should be 60 bytes long");
+    }
+    if (!validateHashCharacters(options.hash)) {
+        throw new Error("Invalid hash");
+    }
+    options.password = getUInt8Buffer(options.password);
+    if (options.password.length < 1) {
+        throw new Error("Password should be at least 1 byte long");
+    }
+    if (options.password.length > 72) {
+        throw new Error("Password should be at most 72 bytes long");
+    }
+};
+/**
+ * Verifies password using bcrypt password-hashing function
+ * @returns True if the encoded hash matches the password
+ */
+function bcryptVerify(options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        validateVerifyOptions(options);
+        const { hash, password } = options;
+        const bcryptInterface = yield WASMInterface(wasmJson$2, 0);
+        bcryptInterface.writeMemory(getUInt8Buffer(hash), 0);
+        const passwordBuffer = getUInt8Buffer(password);
+        bcryptInterface.writeMemory(passwordBuffer, 60);
+        return !!bcryptInterface.getExports().bcrypt_verify(passwordBuffer.length);
+    });
+}
+
+var name$1 = "whirlpool";
+var data$1 = "AGFzbQEAAAABEQRgAAF/YAF/AGACf38AYAAAAwkIAAECAwEDAAEFBAEBAgIGDgJ/AUHQmwULfwBBgAgLB3AIBm1lbW9yeQIADkhhc2hfR2V0QnVmZmVyAAAJSGFzaF9Jbml0AAMLSGFzaF9VcGRhdGUABApIYXNoX0ZpbmFsAAUNSGFzaF9HZXRTdGF0ZQAGDkhhc2hfQ2FsY3VsYXRlAAcKU1RBVEVfU0laRQMBCu0bCAUAQYAZC8wGAQl+IAApAwAhAUEAQQApA4CbASICNwPAmQEgACkDGCEDIAApAxAhBCAAKQMIIQVBAEEAKQOYmwEiBjcD2JkBQQBBACkDkJsBIgc3A9CZAUEAQQApA4ibASIINwPImQFBACABIAKFNwOAmgFBACAFIAiFNwOImgFBACAEIAeFNwOQmgFBACADIAaFNwOYmgEgACkDICEDQQBBACkDoJsBIgE3A+CZAUEAIAMgAYU3A6CaASAAKQMoIQRBAEEAKQOomwEiAzcD6JkBQQAgBCADhTcDqJoBIAApAzAhBUEAQQApA7CbASIENwPwmQFBACAFIASFNwOwmgEgACkDOCEJQQBBACkDuJsBIgU3A/iZAUEAIAkgBYU3A7iaAUEAQpjGmMb+kO6AzwA3A4CZAUHAmQFBgJkBEAJBgJoBQcCZARACQQBCtszKrp/v28jSADcDgJkBQcCZAUGAmQEQAkGAmgFBwJkBEAJBAELg+O70uJTDvTU3A4CZAUHAmQFBgJkBEAJBgJoBQcCZARACQQBCncDfluzlkv/XADcDgJkBQcCZAUGAmQEQAkGAmgFBwJkBEAJBAEKV7t2p/pO8pVo3A4CZAUHAmQFBgJkBEAJBgJoBQcCZARACQQBC2JKn0ZCW6LWFfzcDgJkBQcCZAUGAmQEQAkGAmgFBwJkBEAJBAEK9u8Ggv9nPgucANwOAmQFBwJkBQYCZARACQYCaAUHAmQEQAkEAQuTPhNr4tN/KWDcDgJkBQcCZAUGAmQEQAkGAmgFBwJkBEAJBAEL73fOz1vvFo55/NwOAmQFBwJkBQYCZARACQYCaAUHAmQEQAkEAQsrb/L3Q1dbBMzcDgJkBQcCZAUGAmQEQAkGAmgFBwJkBEAJBACACQQApA4CaASAAKQMAhYU3A4CbAUEAIAhBACkDiJoBIAApAwiFhTcDiJsBQQAgB0EAKQOQmgEgACkDEIWFNwOQmwFBACAGQQApA5iaASAAKQMYhYU3A5ibAUEAIAFBACkDoJoBIAApAyCFhTcDoJsBQQAgA0EAKQOomgEgACkDKIWFNwOomwFBACAEQQApA7CaASAAKQMwhYU3A7CbAUEAIAVBACkDuJoBIAApAziFhTcDuJsBC4YMCgF+AX8BfgF/AX4BfwF+AX8EfgN/IAAgACkDACICpyIDQf8BcUEDdEGQCGopAwBCOIkgACkDOCIEpyIFQQV2QfgPcUGQCGopAwCFQjiJIAApAzAiBqciB0ENdkH4D3FBkAhqKQMAhUI4iSAAKQMoIginIglBFXZB+A9xQZAIaikDAIVCOIkgACkDICIKQiCIp0H/AXFBA3RBkAhqKQMAhUI4iSAAKQMYIgtCKIinQf8BcUEDdEGQCGopAwCFQjiJIAApAxAiDEIwiKdB/wFxQQN0QZAIaikDAIVCOIkgACkDCCINQjiIp0EDdEGQCGopAwCFQjiJIAEpAwCFNwMAIAAgDaciDkH/AXFBA3RBkAhqKQMAQjiJIANBBXZB+A9xQZAIaikDAIVCOIkgBUENdkH4D3FBkAhqKQMAhUI4iSAHQRV2QfgPcUGQCGopAwCFQjiJIAhCIIinQf8BcUEDdEGQCGopAwCFQjiJIApCKIinQf8BcUEDdEGQCGopAwCFQjiJIAtCMIinQf8BcUEDdEGQCGopAwCFQjiJIAxCOIinQQN0QZAIaikDAIVCOIkgASkDCIU3AwggACAMpyIPQf8BcUEDdEGQCGopAwBCOIkgDkEFdkH4D3FBkAhqKQMAhUI4iSADQQ12QfgPcUGQCGopAwCFQjiJIAVBFXZB+A9xQZAIaikDAIVCOIkgBkIgiKdB/wFxQQN0QZAIaikDAIVCOIkgCEIoiKdB/wFxQQN0QZAIaikDAIVCOIkgCkIwiKdB/wFxQQN0QZAIaikDAIVCOIkgC0I4iKdBA3RBkAhqKQMAhUI4iSABKQMQhTcDECAAIAunIhBB/wFxQQN0QZAIaikDAEI4iSAPQQV2QfgPcUGQCGopAwCFQjiJIA5BDXZB+A9xQZAIaikDAIVCOIkgA0EVdkH4D3FBkAhqKQMAhUI4iSAEQiCIp0H/AXFBA3RBkAhqKQMAhUI4iSAGQiiIp0H/AXFBA3RBkAhqKQMAhUI4iSAIQjCIp0H/AXFBA3RBkAhqKQMAhUI4iSAKQjiIp0EDdEGQCGopAwCFQjiJIAEpAxiFNwMYIAAgCqciA0H/AXFBA3RBkAhqKQMAQjiJIBBBBXZB+A9xQZAIaikDAIVCOIkgD0ENdkH4D3FBkAhqKQMAhUI4iSAOQRV2QfgPcUGQCGopAwCFQjiJIAJCIIinQf8BcUEDdEGQCGopAwCFQjiJIARCKIinQf8BcUEDdEGQCGopAwCFQjiJIAZCMIinQf8BcUEDdEGQCGopAwCFQjiJIAhCOIinQQN0QZAIaikDAIVCOIkgASkDIIU3AyAgACAJQf8BcUEDdEGQCGopAwBCOIkgA0EFdkH4D3FBkAhqKQMAhUI4iSAQQQ12QfgPcUGQCGopAwCFQjiJIA9BFXZB+A9xQZAIaikDAIVCOIkgDUIgiKdB/wFxQQN0QZAIaikDAIVCOIkgAkIoiKdB/wFxQQN0QZAIaikDAIVCOIkgBEIwiKdB/wFxQQN0QZAIaikDAIVCOIkgBkI4iKdBA3RBkAhqKQMAhUI4iSABKQMohTcDKCAAIAdB/wFxQQN0QZAIaikDAEI4iSAJQQV2QfgPcUGQCGopAwCFQjiJIANBDXZB+A9xQZAIaikDAIVCOIkgEEEVdkH4D3FBkAhqKQMAhUI4iSAMQiCIp0H/AXFBA3RBkAhqKQMAhUI4iSANQiiIp0H/AXFBA3RBkAhqKQMAhUI4iSACQjCIp0H/AXFBA3RBkAhqKQMAhUI4iSAEQjiIp0EDdEGQCGopAwCFQjiJIAEpAzCFNwMwIAAgBUH/AXFBA3RBkAhqKQMAQjiJIAdBBXZB+A9xQZAIaikDAIVCOIkgCUENdkH4D3FBkAhqKQMAhUI4iSADQRV2QfgPcUGQCGopAwCFQjiJIAtCIIinQf8BcUEDdEGQCGopAwCFQjiJIAxCKIinQf8BcUEDdEGQCGopAwCFQjiJIA1CMIinQf8BcUEDdEGQCGopAwCFQjiJIAJCOIinQQN0QZAIaikDAIVCOIkgASkDOIU3AzgLXABBAEIANwPImwFBAEIANwO4mwFBAEIANwOwmwFBAEIANwOomwFBAEIANwOgmwFBAEIANwOYmwFBAEIANwOQmwFBAEIANwOImwFBAEIANwOAmwFBAEEANgLAmwELxgMBB39BACEBQQBBACkDyJsBIACtfDcDyJsBAkBBACgCwJsBIgJFDQBBACEBAkAgAiAAaiIDQcAAIANBwABJGyIEIAJB/wFxIgVNDQAgBCAFayIBQQNxIQYCQAJAIAQgBUF/c2pBA08NAEEAIQEMAQsgAUF8cSEHQQAhAQNAIAUgAWoiAkHAmgFqIAFBgBlqLQAAOgAAIAJBwZoBaiABQYEZai0AADoAACACQcKaAWogAUGCGWotAAA6AAAgAkHDmgFqIAFBgxlqLQAAOgAAIAcgAUEEaiIBRw0ACyAFIAFqIgUhAgsgBkUNACACQf8BcUEBaiECA0AgBUHAmgFqIAFBgBlqLQAAOgAAIAIiBUEBaiECIAFBAWohASAFIQUgBkF/aiIGDQALCwJAIANBP00NAEHAmgEQAUEAIQQLQQAgBDYCwJsBCwJAIAAgAWsiAkHAAEkNAANAIAFBgBlqEAEgAUHAAGohASACQUBqIgJBP0sNAAsLAkAgASAARg0AQQAgAjYCwJsBIAJFDQBBACECQQAhBQNAIAJBwJoBaiACIAFqQYAZai0AADoAAEEAKALAmwEgBUEBaiIFQf8BcSICSw0ACwsL/wMCBH8BfiMAQcAAayIAJAAgAEE4akIANwMAIABBMGpCADcDACAAQShqQgA3AwAgAEEgakIANwMAIABBGGpCADcDACAAQRBqQgA3AwAgAEIANwMIIABCADcDAEEAIQECQAJAQQAoAsCbASICRQ0AQQAhAwNAIAAgAWogAUHAmgFqLQAAOgAAIAFBAWohASACIANBAWoiA0H/AXFLDQALQQAgAkEBajYCwJsBIAAgAmpBgAE6AAAgAkFgcUEgRw0BIAAQASAAQgA3AxggAEIANwMQIABCADcDCCAAQgA3AwAMAQtBAEEBNgLAmwEgAEGAAToAAAtBACkDyJsBIQRBAEIANwPImwEgAEEAOgA2IABBADYBMiAAQgA3ASogAEEAOgApIABCADcAISAAQQA6ACAgACAEQgWIPAA+IAAgBEINiDwAPSAAIARCFYg8ADwgACAEQh2IPAA7IAAgBEIliDwAOiAAIARCLYg8ADkgACAEQjWIPAA4IAAgBEI9iDwANyAAIASnQQN0OgA/IAAQAUEAQQApA4CbATcDgBlBAEEAKQOImwE3A4gZQQBBACkDkJsBNwOQGUEAQQApA5ibATcDmBlBAEEAKQOgmwE3A6AZQQBBACkDqJsBNwOoGUEAQQApA7CbATcDsBlBAEEAKQO4mwE3A7gZIABBwABqJAALBgBBwJoBC2IAQQBCADcDyJsBQQBCADcDuJsBQQBCADcDsJsBQQBCADcDqJsBQQBCADcDoJsBQQBCADcDmJsBQQBCADcDkJsBQQBCADcDiJsBQQBCADcDgJsBQQBBADYCwJsBIAAQBBAFCwuYEAEAQYAIC5AQkAAAAAAAAAAAAAAAAAAAABgYYBjAeDDYIyOMIwWvRibGxj/GfvmRuOjoh+gTb837h4cmh0yhE8u4uNq4qWJtEQEBBAEIBQIJT08hT0Jung02Ntg2re5sm6amoqZZBFH/0tJv0t69uQz19fP1+wb3Dnl5+XnvgPKWb2+hb1/O3jCRkX6R/O8/bVJSVVKqB6T4YGCdYCf9wEe8vMq8iXZlNZubVpuszSs3jo4CjgSMAYqjo7ajcRVb0gwMMAxgPBhse3vxe/+K9oQ1NdQ1teFqgB0ddB3oaTr14OCn4FNH3bPX13vX9qyzIcLCL8Je7ZmcLi64Lm2WXENLSzFLYnqWKf7+3/6jIeFdV1dBV4IWrtUVFVQVqEEqvXd3wXeftu7oNzfcN6XrbpLl5bPle1bXnp+fRp+M2SMT8PDn8NMX/SNKSjVKan+UINraT9qelalEWFh9WPolsKLJyQPJBsqPzykppClVjVJ8CgooClAiFFqxsf6x4U9/UKCguqBpGl3Ja2uxa3/a1hSFhS6FXKsX2b29zr2Bc2c8XV1pXdI0uo8QEEAQgFAgkPT09/TzA/UHy8sLyxbAi90+Pvg+7cZ80wUFFAUoEQotZ2eBZx/mznjk5Lfkc1PVlycnnCclu04CQUEZQTJYgnOLixaLLJ0Lp6enpqdRAVP2fX3pfc+U+rKVlW6V3Ps3SdjYR9iOn61W+/vL+4sw63Du7p/uI3HBzXx87XzHkfi7ZmaFZhfjzHHd3VPdpo6nexcXXBe4Sy6vR0cBRwJGjkWenkKehNwhGsrKD8oexYnULS20LXWZWli/v8a/kXljLgcHHAc4Gw4/ra2OrQEjR6xaWnVa6i+0sIODNoNstRvvMzPMM4X/ZrZjY5FjP/LGXAICCAIQCgQSqqqSqjk4SZNxcdlxr6ji3sjIB8gOz43GGRlkGch9MtFJSTlJcnCSO9nZQ9mGmq9f8vLv8sMd+THj46vjS0jbqFtbcVviKra5iIgaiDSSDbyamlKapMgpPiYmmCYtvkwLMjLIMo36ZL+wsPqw6Up9Wenpg+kbas/yDw88D3gzHnfV1XPV5qa3M4CAOoB0uh30vr7Cvpl8YSfNzRPNJt6H6zQ00DS95GiJSEg9SHp1kDL//9v/qyTjVHp69Xr3j/SNkJB6kPTqPWRfX2Ffwj6+nSAggCAdoEA9aGi9aGfV0A8aGmga0HI0yq6ugq4ZLEG3tLTqtMledX1UVE1UmhmozpOTdpPs5Tt/IiKIIg2qRC9kZI1kB+nIY/Hx4/HbEv8qc3PRc7+i5swSEkgSkFokgkBAHUA6XYB6CAggCEAoEEjDwyvDVuiblezsl+wze8Xf29tL25aQq02hob6hYR9fwI2NDo0cgweRPT30PfXJesiXl2aXzPEzWwAAAAAAAAAAz88bzzbUg/krK6wrRYdWbnZ2xXaXs+zhgoIygmSwGebW1n/W/qmxKBsbbBvYdzbDtbXutcFbd3Svr4avESlDvmpqtWp339QdUFBdULoNoOpFRQlFEkyKV/Pz6/PLGPs4MDDAMJ3wYK3v75vvK3TDxD8//D/lw37aVVVJVZIcqseiorKieRBZ2+rqj+oDZcnpZWWJZQ/symq6utK6uWhpAy8vvC9lk15KwMAnwE7nnY7e3l/evoGhYBwccBzgbDj8/f3T/bsu50ZNTSlNUmSaH5KScpLk4Dl2dXXJdY+86voGBhgGMB4MNoqKEookmAmusrLysvlAeUvm5r/mY1nRhQ4OOA5wNhx+Hx98H/hjPudiYpViN/fEVdTUd9Tuo7U6qKiaqCkyTYGWlmKWxPQxUvn5w/mbOu9ixcUzxWb2l6MlJZQlNbFKEFlZeVnyILKrhIQqhFSuFdByctVyt6fkxTk55DnV3XLsTEwtTFphmBZeXmVeyju8lHh4/XjnhfCfODjgON3YcOWMjAqMFIYFmNHRY9HGsr8XpaWupUELV+Ti4q/iQ03ZoWFhmWEv+MJOs7P2s/FFe0IhIYQhFaVCNJycSpyU1iUIHh54HvBmPO5DQxFDIlKGYcfHO8d2/JOx/PzX/LMr5U8EBBAEIBQIJFFRWVGyCKLjmZlembzHLyVtbaltT8TaIg0NNA1oORpl+vrP+oM16Xnf31vftoSjaX5+5X7Xm/ypJCSQJD20SBk7O+w7xdd2/qurlqsxPUuazs4fzj7RgfAREUQRiFUimY+PBo8MiQODTk4lTkprnAS3t+a30VFzZuvri+sLYMvgPDzwPP3MeMGBgT6BfL8f/ZSUapTU/jVA9/f79+sM8xy5ud65oWdvGBMTTBOYXyaLLCywLH2cWFHT02vT1ri7Befnu+drXNOMbm6lblfL3DnExDfEbvOVqgMDDAMYDwYbVlZFVooTrNxERA1EGkmIXn9/4X/fnv6gqameqSE3T4gqKqgqTYJUZ7u71ruxbWsKwcEjwUbin4dTU1FTogKm8dzcV9yui6VyCwssC1gnFlOdnU6dnNMnAWxsrWxHwdgrMTHEMZX1YqR0dM10h7no8/b2//bjCfEVRkYFRgpDjEysrIqsCSZFpYmJHok8lw+1FBRQFKBEKLTh4aPhW0LfuhYWWBawTiymOjroOs3SdPdpablpb9DSBgkJJAlILRJBcHDdcKet4Ne2tuK22VRxb9DQZ9DOt70e7e2T7Tt+x9bMzBfMLtuF4kJCFUIqV4RomJhamLTCLSykpKqkSQ5V7SgooChdiFB1XFxtXNoxuIb4+Mf4kz/ta4aGIoZEpBHC";
+var hash$1 = "8d8f6035";
+var wasmJson$1 = {
+	name: name$1,
+	data: data$1,
+	hash: hash$1
+};
+
+const mutex$1 = new Mutex();
+let wasmCache$1 = null;
+/**
+ * Calculates Whirlpool hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function whirlpool(data) {
+    if (wasmCache$1 === null) {
+        return lockedCreate(mutex$1, wasmJson$1, 64).then((wasm) => {
+            wasmCache$1 = wasm;
+            return wasmCache$1.calculate(data);
+        });
+    }
+    try {
+        const hash = wasmCache$1.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new Whirlpool hash instance
+ */
+function createWhirlpool() {
+    return WASMInterface(wasmJson$1, 64).then((wasm) => {
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 64,
+        };
+        return obj;
+    });
+}
+
+var name = "sm3";
+var data = "AGFzbQEAAAABDANgAAF/YAAAYAF/AAMIBwABAgIBAAIFBAEBAgIGDgJ/AUHwiQULfwBBgAgLB3AIBm1lbW9yeQIADkhhc2hfR2V0QnVmZmVyAAAJSGFzaF9Jbml0AAELSGFzaF9VcGRhdGUAAgpIYXNoX0ZpbmFsAAQNSGFzaF9HZXRTdGF0ZQAFDkhhc2hfQ2FsY3VsYXRlAAYKU1RBVEVfU0laRQMBCtodBwUAQYAJC1EAQQBCzdy3nO7Jw/2wfzcCoIkBQQBCvOG8y6qVzpgWNwKYiQFBAELXhZG5gcCBxVo3ApCJAUEAQu+sgJyX16yKyQA3AoiJAUEAQgA3AoCJAQvvAwEIfwJAIABFDQBBACEBQQBBACgCgIkBIgIgAGoiAzYCgIkBIAJBP3EhBAJAIAMgAk8NAEEAQQAoAoSJAUEBajYChIkBC0GACSECAkAgBEUNAAJAIABBwAAgBGsiBU8NACAEIQEMAQsgBEE/cyEGIARBqIkBaiECQYAJIQMCQAJAIAVBB3EiBw0AIAUhCAwBCyAHIQgDQCACIAMtAAA6AAAgAkEBaiECIANBAWohAyAIQX9qIggNAAtBwAAgByAEamshCAsCQCAGQQdJDQADQCACIAMpAAA3AAAgAkEIaiECIANBCGohAyAIQXhqIggNAAsLQaiJARADIAVBgAlqIQIgACAFayEACwJAIABBwABJDQADQCACEAMgAkHAAGohAiAAQUBqIgBBP0sNAAsLIABFDQAgAUGoiQFqIQMCQAJAIABBB3EiCA0AIAAhBAwBCyAAQThxIQQDQCADIAItAAA6AAAgA0EBaiEDIAJBAWohAiAIQX9qIggNAAsLIABBCEkNAANAIAMgAi0AADoAACADIAItAAE6AAEgAyACLQACOgACIAMgAi0AAzoAAyADIAItAAQ6AAQgAyACLQAFOgAFIAMgAi0ABjoABiADIAItAAc6AAcgA0EIaiEDIAJBCGohAiAEQXhqIgQNAAsLC+wLARl/IwBBkAJrIgEkACABIAAoAhgiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiAzYCGCABIAAoAhQiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiBDYCFCABIAAoAggiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiBTYCCCABIAAoAhAiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiBjYCECABIAAoAiAiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiBzYCICABIAAoAgQiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiCDYCBCABIAAoAgwiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiCTYCDCABIAAoAhwiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiCjYCHCABIAAoAgAiAkEYdCACQYD+A3FBCHRyIAJBCHZBgP4DcSACQRh2cnIiCzYCACAAKAIkIQIgASAAKAI0IgxBGHQgDEGA/gNxQQh0ciAMQQh2QYD+A3EgDEEYdnJyIg02AjQgASAAKAIoIgxBGHQgDEGA/gNxQQh0ciAMQQh2QYD+A3EgDEEYdnJyIg42AiggASALIA1BD3dzIApzIgxBF3cgDEEPd3MgCUEHd3MgDnMgDHMiCjYCQCABIAAoAjgiDEEYdCAMQYD+A3FBCHRyIAxBCHZBgP4DcSAMQRh2cnIiCzYCOCABIAAoAiwiDEEYdCAMQYD+A3FBCHRyIAxBCHZBgP4DcSAMQRh2cnIiDzYCLCABIAggC0EPd3MgB3MiDEEXdyAMQQ93cyAGQQd3cyAPcyAMczYCRCABIAAoAjwiDEEYdCAMQYD+A3FBCHRyIAxBCHZBgP4DcSAMQRh2cnIiDDYCPCABIAJBGHQgAkGA/gNxQQh0ciACQQh2QYD+A3EgAkEYdnJyIgI2AiQgASAAKAIwIgBBGHQgAEGA/gNxQQh0ciAAQQh2QYD+A3EgAEEYdnJyIgY2AjAgASAFIAxBD3dzIAJzIgBBF3cgAEEPd3MgBEEHd3MgBnMgAHM2AkggASAOIApBD3dzIAlzIgBBF3cgAEEPd3MgA0EHd3MgDXMgAHM2AkxBACEGQSAhByABIQxBACgCiIkBIhAhCUEAKAKkiQEiESEPQQAoAqCJASISIQ1BACgCnIkBIhMhCEEAKAKYiQEiFCEOQQAoApSJASIVIRZBACgCkIkBIhchA0EAKAKMiQEiGCELA0AgCCAOIgJzIA0iBHMgD2ogCSIAQQx3Ig0gAmpBmYqxzgcgB3ZBmYqxzgcgBnRyakEHdyIPaiAMKAIAIhlqIglBEXcgCUEJd3MgCXMhDiADIgUgC3MgAHMgFmogDyANc2ogDEEQaigCACAZc2ohCSAMQQRqIQwgB0F/aiEHIAhBE3chDSALQQl3IQMgBCEPIAIhCCAFIRYgACELIAZBAWoiBkEQRw0AC0EAIQZBECEHA0AgASAGaiIMQdAAaiAMQThqKAIAIAxBLGooAgAgDEEQaigCAHMgDEHEAGooAgAiFkEPd3MiCEEXd3MgCEEPd3MgDEEcaigCAEEHd3MgCHMiGTYCACANIg8gDiIMQX9zcSACIAxxciAEaiAJIghBDHciDSAMakGKu57UByAHd2pBB3ciBGogCmoiCUERdyAJQQl3cyAJcyEOIAggAyILIABycSALIABxciAFaiAEIA1zaiAZIApzaiEJIAZBBGohBiACQRN3IQ0gAEEJdyEDIBYhCiAPIQQgDCECIAshBSAIIQAgB0EBaiIHQcAARw0AC0EAIA8gEXM2AqSJAUEAIA0gEnM2AqCJAUEAIAwgE3M2ApyJAUEAIA4gFHM2ApiJAUEAIAsgFXM2ApSJAUEAIAMgF3M2ApCJAUEAIAggGHM2AoyJAUEAIAkgEHM2AoiJASABQZACaiQAC4ILAQp/IwBBEGsiACQAIABBACgCgIkBIgFBG3QgAUELdEGAgPwHcXIgAUEFdkGA/gNxIAFBA3RBGHZycjYCDCAAQQAoAoSJASICQQN0IgMgAUEddnIiBEEYdCAEQYD+A3FBCHRyIAJBBXZBgP4DcSADQRh2cnI2AggCQEE4QfgAIAFBP3EiBUE4SRsgBWsiA0UNAEEAIAMgAWoiATYCgIkBAkAgASADTw0AQQAgAkEBajYChIkBC0GQCCEBQQAhBgJAIAVFDQACQCADQcAAIAVrIgdPDQAgBSEGDAELIAVBP3MhCCAFQaiJAWohAUGQCCECAkACQCAHQQdxIgkNACAHIQQMAQsgCSEEA0AgASACLQAAOgAAIAFBAWohASACQQFqIQIgBEF/aiIEDQALQcAAIAkgBWprIQQLAkAgCEEHSQ0AA0AgASACKQAANwAAIAFBCGohASACQQhqIQIgBEF4aiIEDQALC0GoiQEQAyAHQZAIaiEBIAMgB2shAwsCQCADQcAASQ0AA0AgARADIAFBwABqIQEgA0FAaiIDQT9LDQALCyADRQ0AIAZBqIkBaiECAkACQCADQQdxIgQNACADIQUMAQsgA0E4cSEFA0AgAiABLQAAOgAAIAJBAWohAiABQQFqIQEgBEF/aiIEDQALCyADQQhJDQADQCACIAEtAAA6AAAgAiABLQABOgABIAIgAS0AAjoAAiACIAEtAAM6AAMgAiABLQAEOgAEIAIgAS0ABToABSACIAEtAAY6AAYgAiABLQAHOgAHIAJBCGohAiABQQhqIQEgBUF4aiIFDQALC0EAQQAoAoCJASICQQhqNgKAiQEgAkE/cSEBAkAgAkF4SQ0AQQBBACgChIkBQQFqNgKEiQELAkACQAJAAkAgAQ0AQQAhAQwBCyABQThJDQAgAUGoiQFqIAAtAAg6AAACQCABQT9GDQAgAUGpiQFqIAAtAAk6AAAgAUE+Rg0AIAFBqokBaiAALQAKOgAAIAFBPUYNACABQauJAWogAC0ACzoAACABQTxGDQAgAUGsiQFqIAAtAAw6AAAgAUE7Rg0AIAFBrYkBaiAALQANOgAAIAFBOkYNACABQa6JAWogAC0ADjoAACABQTlGDQAgAUGviQFqIAAtAA86AABBqIkBEAMMAwtBqIkBEAMgAkEHcSIERQ0CIAFBR2ohBSAAQQhqQcAAIAFraiECIAFBSGohBkGoiQEhASAEIQMDQCABIAItAAA6AAAgAUEBaiEBIAJBAWohAiADQX9qIgMNAAsgBUEHSQ0CIAYgBGshAwwBCyABQaiJAWohASAAQQhqIQJBCCEDCwNAIAEgAikAADcAACABQQhqIQEgAkEIaiECIANBeGoiAw0ACwtBAEEAKAKIiQEiAUEYdCABQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnI2AoAJQQBBACgCjIkBIgFBGHQgAUGA/gNxQQh0ciABQQh2QYD+A3EgAUEYdnJyNgKECUEAQQAoApCJASIBQRh0IAFBgP4DcUEIdHIgAUEIdkGA/gNxIAFBGHZycjYCiAlBAEEAKAKUiQEiAUEYdCABQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnI2AowJQQBBACgCmIkBIgFBGHQgAUGA/gNxQQh0ciABQQh2QYD+A3EgAUEYdnJyNgKQCUEAQQAoApyJASIBQRh0IAFBgP4DcUEIdHIgAUEIdkGA/gNxIAFBGHZycjYClAlBAEEAKAKgiQEiAUEYdCABQYD+A3FBCHRyIAFBCHZBgP4DcSABQRh2cnI2ApgJQQBBACgCpIkBIgFBGHQgAUGA/gNxQQh0ciABQQh2QYD+A3EgAUEYdnJyNgKcCSAAQRBqJAALBgBBgIkBC5UCAQR/QQBCzdy3nO7Jw/2wfzcCoIkBQQBCvOG8y6qVzpgWNwKYiQFBAELXhZG5gcCBxVo3ApCJAUEAQu+sgJyX16yKyQA3AoiJAUEAQgA3AoCJAQJAIABFDQBBACAANgKAiQFBgAkhAQJAIABBwABJDQBBgAkhAQNAIAEQAyABQcAAaiEBIABBQGoiAEE/Sw0ACyAARQ0BCyAAQX9qIQICQAJAIABBB3EiAw0AQaiJASEEDAELIABBeHEhAEGoiQEhBANAIAQgAS0AADoAACAEQQFqIQQgAUEBaiEBIANBf2oiAw0ACwsgAkEHSQ0AA0AgBCABKQAANwAAIARBCGohBCABQQhqIQEgAEF4aiIADQALCxAECwtRAgBBgAgLBGgAAAAAQZAIC0CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+var hash = "b6fb4b8e";
+var wasmJson = {
+	name: name,
+	data: data,
+	hash: hash
+};
+
+const mutex = new Mutex();
+let wasmCache = null;
+/**
+ * Calculates SM3 hash
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+function sm3(data) {
+    if (wasmCache === null) {
+        return lockedCreate(mutex, wasmJson, 32).then((wasm) => {
+            wasmCache = wasm;
+            return wasmCache.calculate(data);
+        });
+    }
+    try {
+        const hash = wasmCache.calculate(data);
+        return Promise.resolve(hash);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+/**
+ * Creates a new SM3 hash instance
+ */
+function createSM3() {
+    return WASMInterface(wasmJson, 32).then((wasm) => {
+        wasm.init();
+        const obj = {
+            init: () => {
+                wasm.init();
+                return obj;
+            },
+            update: (data) => {
+                wasm.update(data);
+                return obj;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: Conflict with IHasher type
+            digest: (outputType) => wasm.digest(outputType),
+            save: () => wasm.save(),
+            load: (data) => {
+                wasm.load(data);
+                return obj;
+            },
+            blockSize: 64,
+            digestSize: 32,
+        };
+        return obj;
+    });
+}
+
+export { adler32, argon2Verify, argon2d, argon2i, argon2id, bcrypt, bcryptVerify, blake2b, blake2s, blake3, crc32, crc64, createAdler32, createBLAKE2b, createBLAKE2s, createBLAKE3, createCRC32, createCRC64, createHMAC, createKeccak, createMD4, createMD5, createRIPEMD160, createSHA1, createSHA224, createSHA256, createSHA3, createSHA384, createSHA512, createSM3, createWhirlpool, createXXHash128, createXXHash3, createXXHash32, createXXHash64, keccak, md4, md5, pbkdf2, ripemd160, scrypt, sha1, sha224, sha256, sha3, sha384, sha512, sm3, whirlpool, xxhash128, xxhash3, xxhash32, xxhash64 };

--- a/frontend/zk-crypto.js
+++ b/frontend/zk-crypto.js
@@ -1,5 +1,10 @@
-// zk-crypto.js — ECIES P-256 + IndexedDB key storage (#142 S2)
-// Ephemeral ECDH-P256 → HKDF-SHA256 → AES-GCM-256
+// zk-crypto.js — ECIES P-256 + accountKey AES-GCM (#142 S2, #216 PR 3)
+// v1: Ephemeral ECDH-P256 → HKDF-SHA256 → AES-GCM-256
+// v2: accountKey (AES-256-GCM) with passphrase-wrapped D1 backup
+
+import { deriveWrappingKey, ARGON2_PARAMS } from './zk-kdf.js';
+
+export { ARGON2_PARAMS };
 
 const DB_NAME = 'roxabi-zk-v1';
 const STORE_NAME = 'keypairs';
@@ -27,6 +32,22 @@ function b64Decode(str) {
   const out = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
   return out;
+}
+
+function hexEncode(buf) {
+  return [...toBytes(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function hexDecode(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function parseEnvelope(envelopeJson) {
+  return typeof envelopeJson === 'string' ? JSON.parse(envelopeJson) : envelopeJson;
 }
 
 function openDb() {
@@ -192,4 +213,139 @@ export async function sealTitle(publicKey, title) {
 export async function openTitle(privateKey, envelopeJson) {
   const obj = await openContent(privateKey, envelopeJson);
   return obj.title ?? null;
+}
+
+// --- accountKey hierarchy (#216) ---
+
+/** Generate a random AES-256-GCM accountKey (extractable for wrapping). */
+export async function generateAccountKey() {
+  return crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/** SHA-256(rawAccountKey)[0:16] hex — stored in zk_payloads.key_fp / zk_key_backups.key_fp. */
+export async function fingerprintAccountKey(accountKey) {
+  const raw = await crypto.subtle.exportKey('raw', accountKey);
+  return fingerprintAccountKeyRaw(raw);
+}
+
+/** Fingerprint from raw 32-byte account key material. */
+export async function fingerprintAccountKeyRaw(rawAccountKey) {
+  const hash = await crypto.subtle.digest('SHA-256', toBytes(rawAccountKey));
+  return hexEncode(new Uint8Array(hash).slice(0, 16));
+}
+
+/** Re-import accountKey as non-extractable session key after wrapping. */
+export async function sessionAccountKey(accountKey) {
+  const raw = await crypto.subtle.exportKey('raw', accountKey);
+  return crypto.subtle.importKey(
+    'raw',
+    raw,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/**
+ * Wrap accountKey with passphrase-derived wrapping key.
+ * @returns {{ kdf_alg: string, kdf_params: string, wrap_iv: string, wrapped_key: string, key_fp: string }}
+ */
+export async function wrapAccountKey(passphrase, accountKey) {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const wrappingKey = await deriveWrappingKey(passphrase, salt, ARGON2_PARAMS);
+  const wrapIv = crypto.getRandomValues(new Uint8Array(12));
+  const rawAccountKey = await crypto.subtle.exportKey('raw', accountKey);
+  const wrapped = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: wrapIv },
+    wrappingKey,
+    rawAccountKey,
+  );
+  return {
+    kdf_alg: 'argon2id',
+    kdf_params: JSON.stringify({
+      m: ARGON2_PARAMS.m,
+      t: ARGON2_PARAMS.t,
+      p: ARGON2_PARAMS.p,
+      salt: hexEncode(salt),
+    }),
+    wrap_iv: b64Encode(wrapIv),
+    wrapped_key: b64Encode(wrapped),
+    key_fp: await fingerprintAccountKeyRaw(rawAccountKey),
+  };
+}
+
+/**
+ * Unwrap accountKey backup blob with passphrase.
+ * @param {string} passphrase
+ * @param {{ kdf_params: string|object, wrap_iv: string, wrapped_key: string }} backup
+ * @returns {Promise<CryptoKey>} non-extractable session accountKey
+ */
+export async function unwrapAccountKey(passphrase, backup) {
+  const params =
+    typeof backup.kdf_params === 'string'
+      ? JSON.parse(backup.kdf_params)
+      : backup.kdf_params;
+  const salt = hexDecode(params.salt);
+  const wrappingKey = await deriveWrappingKey(passphrase, salt, params);
+  const rawAccountKey = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: b64Decode(backup.wrap_iv) },
+    wrappingKey,
+    b64Decode(backup.wrapped_key),
+  );
+  return crypto.subtle.importKey(
+    'raw',
+    rawAccountKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/** v2 envelope encrypt `{ title, body? }` with accountKey. */
+export async function sealWithAccountKey(accountKey, content) {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    accountKey,
+    new TextEncoder().encode(JSON.stringify(content)),
+  );
+  return JSON.stringify({
+    v: 2,
+    alg: 'AES-GCM-256',
+    iv: b64Encode(iv),
+    ct: b64Encode(ct),
+  });
+}
+
+/** v2 envelope decrypt to `{ title, body? }`. */
+export async function openWithAccountKey(accountKey, envelopeJson) {
+  const env = parseEnvelope(envelopeJson);
+  if (env.v !== 2) throw new Error('unsupported envelope version');
+  const plain = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: b64Decode(env.iv) },
+    accountKey,
+    b64Decode(env.ct),
+  );
+  return JSON.parse(new TextDecoder().decode(plain));
+}
+
+/**
+ * Dual-read decrypt: v2 accountKey or v1 ECDH privateKey.
+ * @param {{ accountKey?: CryptoKey, privateKey?: CryptoKey }} keys
+ */
+export async function openContentDual(keys, envelopeJson) {
+  const env = parseEnvelope(envelopeJson);
+  if (env.v === 2) {
+    if (!keys.accountKey) throw new Error('accountKey required for v2 envelope');
+    return openWithAccountKey(keys.accountKey, env);
+  }
+  if (env.v === 1) {
+    if (!keys.privateKey) throw new Error('privateKey required for v1 envelope');
+    return openContent(keys.privateKey, envelopeJson);
+  }
+  throw new Error('unsupported envelope version');
 }

--- a/frontend/zk-crypto.js
+++ b/frontend/zk-crypto.js
@@ -139,6 +139,11 @@ export async function hasZkKeyPair(githubLogin) {
   return Boolean(existing?.publicKey && existing?.privateKey);
 }
 
+/** Delete legacy ECDH key pair after v1→v2 migration (#216 PR 5). */
+export async function deleteZkKeyPair(githubLogin) {
+  await idbDelete(githubLogin);
+}
+
 /**
  * Persist enrollment metadata only — never raw key or passphrase (#216).
  * @param {{ key_fp: string, enrolled_at: string }} meta

--- a/frontend/zk-crypto.js
+++ b/frontend/zk-crypto.js
@@ -8,6 +8,8 @@ export { ARGON2_PARAMS };
 
 const DB_NAME = 'roxabi-zk-v1';
 const STORE_NAME = 'keypairs';
+const META_DB_NAME = 'roxabi-zk-v2';
+const META_STORE_NAME = 'account_meta';
 const HKDF_INFO = new TextEncoder().encode('roxabi-zk-ecies-v1');
 const HKDF_SALT = new Uint8Array(32);
 
@@ -50,6 +52,15 @@ function parseEnvelope(envelopeJson) {
   return typeof envelopeJson === 'string' ? JSON.parse(envelopeJson) : envelopeJson;
 }
 
+/** Return envelope version (1 = ECIES, 2 = accountKey) or null if unparseable. */
+export function parseEnvelopeVersion(envelopeJson) {
+  try {
+    return parseEnvelope(envelopeJson).v ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function openDb() {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, 1);
@@ -79,6 +90,66 @@ async function idbPut(login, record) {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
+}
+
+async function idbDelete(login) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(login);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function openMetaDb() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(META_DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(META_STORE_NAME);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function metaIdbGet(login) {
+  const db = await openMetaDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(META_STORE_NAME, 'readonly');
+    const req = tx.objectStore(META_STORE_NAME).get(login);
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function metaIdbPut(login, record) {
+  const db = await openMetaDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(META_STORE_NAME, 'readwrite');
+    tx.objectStore(META_STORE_NAME).put(record, login);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/** True when a per-device ECDH key pair exists in IndexedDB. */
+export async function hasZkKeyPair(githubLogin) {
+  const existing = await idbGet(githubLogin);
+  return Boolean(existing?.publicKey && existing?.privateKey);
+}
+
+/**
+ * Persist enrollment metadata only — never raw key or passphrase (#216).
+ * @param {{ key_fp: string, enrolled_at: string }} meta
+ */
+export async function saveAccountMeta(githubLogin, meta) {
+  await metaIdbPut(githubLogin, meta);
+}
+
+/** @returns {Promise<{ key_fp: string, enrolled_at: string }|null>} */
+export async function getAccountMeta(githubLogin) {
+  return metaIdbGet(githubLogin);
 }
 
 async function generateKeyPair() {

--- a/frontend/zk-crypto.test.js
+++ b/frontend/zk-crypto.test.js
@@ -162,4 +162,21 @@ describe('zk-crypto ECIES v1 dual-read', () => {
     const content = await openContentDual({ accountKey: session }, envelope);
     expect(content.title).toBe('v2 dual-read');
   });
+
+  it('migrates v1 ECIES envelope to v2 accountKey envelope', async () => {
+    const v1Envelope = await sealContent(publicKey, {
+      title: 'Legacy title',
+      body: 'Legacy body',
+    });
+    expect(JSON.parse(v1Envelope).v).toBe(1);
+
+    const plaintext = await openContent(privateKey, v1Envelope);
+    const v2Envelope = await sealWithAccountKey(accountKey, plaintext);
+    expect(JSON.parse(v2Envelope).v).toBe(2);
+
+    const session = await sessionAccountKey(accountKey);
+    const migrated = await openContentDual({ accountKey: session }, v2Envelope);
+    expect(migrated.title).toBe('Legacy title');
+    expect(migrated.body).toBe('Legacy body');
+  });
 });

--- a/frontend/zk-crypto.test.js
+++ b/frontend/zk-crypto.test.js
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
+import { argon2id } from './vendor/hash-wasm/esm/index.js';
+import { deriveWrappingKey, ARGON2_PARAMS } from './zk-kdf.js';
+import kdfVectors from './test/fixtures/zk-kdf-vectors.json';
 import {
   eciesEncrypt,
   eciesDecrypt,
@@ -7,13 +10,108 @@ import {
   sealContent,
   openContent,
   fingerprintPublicKey,
+  generateAccountKey,
+  wrapAccountKey,
+  unwrapAccountKey,
+  sessionAccountKey,
+  sealWithAccountKey,
+  openWithAccountKey,
+  openContentDual,
+  fingerprintAccountKey,
+  ARGON2_PARAMS as CRYPTO_ARGON2_PARAMS,
 } from './zk-crypto.js';
 
-describe('zk-crypto ECIES', () => {
+function hexDecode(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function hexEncode(buf) {
+  return [...buf].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+describe('zk-kdf Argon2id', () => {
+  it('exports fixed ARGON2_PARAMS', () => {
+    expect(ARGON2_PARAMS).toEqual({ m: 65536, t: 3, p: 1 });
+    expect(CRYPTO_ARGON2_PARAMS).toEqual(ARGON2_PARAMS);
+  });
+
+  it('matches golden KDF vector', async () => {
+    const salt = hexDecode(kdfVectors.salt_hex);
+    const raw = await argon2id({
+      password: kdfVectors.passphrase,
+      salt,
+      parallelism: kdfVectors.params.p,
+      iterations: kdfVectors.params.t,
+      memorySize: kdfVectors.params.m,
+      hashLength: 32,
+      outputType: 'binary',
+    });
+    expect(hexEncode(raw)).toBe(kdfVectors.output_hex);
+  });
+
+  it('deriveWrappingKey imports 32-byte AES-GCM key', async () => {
+    const salt = hexDecode(kdfVectors.salt_hex);
+    const key = await deriveWrappingKey(kdfVectors.passphrase, salt, kdfVectors.params);
+    expect(key.type).toBe('secret');
+    expect(key.algorithm.name).toBe('AES-GCM');
+    expect(key.extractable).toBe(false);
+  });
+});
+
+describe('zk-crypto accountKey v2', () => {
+  /** @type {CryptoKey} */
+  let accountKey;
+
+  beforeAll(async () => {
+    accountKey = await generateAccountKey();
+  });
+
+  it('sealWithAccountKey/openWithAccountKey roundtrips content', async () => {
+    const envelope = await sealWithAccountKey(accountKey, {
+      title: 'Secret issue',
+      body: 'Private body',
+    });
+    const parsed = JSON.parse(envelope);
+    expect(parsed).toMatchObject({ v: 2, alg: 'AES-GCM-256' });
+
+    const session = await sessionAccountKey(accountKey);
+    const content = await openWithAccountKey(session, envelope);
+    expect(content.title).toBe('Secret issue');
+    expect(content.body).toBe('Private body');
+  });
+
+  it('wrapAccountKey/unwrapAccountKey roundtrips accountKey', async () => {
+    const passphrase = 'strong-test-passphrase-216';
+    const backup = await wrapAccountKey(passphrase, accountKey);
+    expect(backup.kdf_alg).toBe('argon2id');
+    expect(backup.key_fp).toMatch(/^[0-9a-f]{32}$/);
+
+    const unwrapped = await unwrapAccountKey(passphrase, backup);
+    expect(unwrapped.extractable).toBe(false);
+
+    const envelope = await sealWithAccountKey(accountKey, { title: 'Wrapped key test' });
+    const content = await openWithAccountKey(unwrapped, envelope);
+    expect(content.title).toBe('Wrapped key test');
+  });
+
+  it('fingerprintAccountKey returns 32 hex chars', async () => {
+    const fp = await fingerprintAccountKey(accountKey);
+    expect(fp).toMatch(/^[0-9a-f]{32}$/);
+    expect(fp).toBe((await wrapAccountKey('x', accountKey)).key_fp);
+  });
+});
+
+describe('zk-crypto ECIES v1 dual-read', () => {
   /** @type {CryptoKey} */
   let publicKey;
   /** @type {CryptoKey} */
   let privateKey;
+  /** @type {CryptoKey} */
+  let accountKey;
 
   beforeAll(async () => {
     const pair = await crypto.subtle.generateKey(
@@ -23,6 +121,7 @@ describe('zk-crypto ECIES', () => {
     );
     publicKey = pair.publicKey;
     privateKey = pair.privateKey;
+    accountKey = await generateAccountKey();
   });
 
   it('roundtrips arbitrary plaintext', async () => {
@@ -49,5 +148,18 @@ describe('zk-crypto ECIES', () => {
   it('fingerprintPublicKey returns 32 hex chars', async () => {
     const fp = await fingerprintPublicKey(publicKey);
     expect(fp).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('openContentDual reads v1 via privateKey', async () => {
+    const envelope = await sealContent(publicKey, { title: 'v1 dual-read' });
+    const content = await openContentDual({ privateKey }, envelope);
+    expect(content.title).toBe('v1 dual-read');
+  });
+
+  it('openContentDual reads v2 via accountKey', async () => {
+    const envelope = await sealWithAccountKey(accountKey, { title: 'v2 dual-read' });
+    const session = await sessionAccountKey(accountKey);
+    const content = await openContentDual({ accountKey: session }, envelope);
+    expect(content.title).toBe('v2 dual-read');
   });
 });

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -1,0 +1,345 @@
+// zk-enroll.js — passphrase enrollment, unlock, lock UI (#216 PR 4)
+
+import { api, escHtml } from './auth.js';
+import {
+  generateAccountKey,
+  wrapAccountKey,
+  unwrapAccountKey,
+  sessionAccountKey,
+  hasZkKeyPair,
+  saveAccountMeta,
+  parseEnvelopeVersion,
+} from './zk-crypto.js';
+import {
+  isZkUnlocked,
+  setZkSession,
+  clearZkSession,
+  wireIdleLock,
+  wirePageHideLock,
+  setZkAutoLockHandler,
+} from './zk-session.js';
+
+const $ = (id) => document.getElementById(id);
+
+function zkLog(event, extra = {}) {
+  console.info('[zk]', { event, ...extra });
+}
+
+export { isZkUnlocked, getSessionAccountKey, getSessionKeyFp } from './zk-session.js';
+
+export function lockZkSession() {
+  if (!isZkUnlocked()) return;
+  clearZkSession();
+  zkLog('zk.lock.explicit');
+  updateLockButton();
+  showUnlockGate().catch(() => {});
+}
+
+async function fetchKeyBackup() {
+  const resp = await api('/api/zk/key-backup');
+  return resp.json();
+}
+
+async function putKeyBackup(body) {
+  const resp = await api('/api/zk/key-backup', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return resp.json();
+}
+
+function payloadsHaveV1(payloads) {
+  for (const row of payloads ?? []) {
+    if (parseEnvelopeVersion(row.encrypted_payload) === 1) return true;
+  }
+  return false;
+}
+
+async function fetchPayloadRows() {
+  try {
+    const resp = await api('/api/zk/payloads');
+    const data = await resp.json();
+    return data.payloads ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Enroll: generate accountKey and upload wrapped backup.
+ * Caller should run ensureAccountKeySealing after gate resolves.
+ */
+export async function enrollAccountKey(passphrase, githubLogin) {
+  const t0 = performance.now();
+  const accountKey = await generateAccountKey();
+  const wrapped = await wrapAccountKey(passphrase, accountKey);
+  await putKeyBackup(wrapped);
+  const session = await sessionAccountKey(accountKey);
+  await saveAccountMeta(githubLogin, {
+    key_fp: wrapped.key_fp,
+    enrolled_at: new Date().toISOString(),
+  });
+  setZkSession(session, wrapped.key_fp);
+  zkLog('zk.enroll.success', {
+    key_fp: wrapped.key_fp,
+    kdf_duration_ms: Math.round(performance.now() - t0),
+  });
+  return { key_fp: wrapped.key_fp };
+}
+
+export async function unlockAccountKey(passphrase) {
+  const t0 = performance.now();
+  const backup = await fetchKeyBackup();
+  try {
+    const accountKey = await unwrapAccountKey(passphrase, backup);
+    setZkSession(accountKey, backup.key_fp);
+    zkLog('zk.unlock.success', {
+      key_fp: backup.key_fp,
+      kdf_duration_ms: Math.round(performance.now() - t0),
+    });
+    return { key_fp: backup.key_fp };
+  } catch (err) {
+    zkLog('zk.unlock.failure');
+    throw err;
+  }
+}
+
+function showZkGate() {
+  document.body.classList.add('gated');
+  const el = $('zk-gate');
+  if (el) el.removeAttribute('hidden');
+}
+
+function hideZkGate() {
+  document.body.classList.remove('gated');
+  const el = $('zk-gate');
+  if (el) {
+    el.setAttribute('hidden', '');
+    el.innerHTML = '';
+  }
+}
+
+function renderZkDialog(title, bodyHtml) {
+  showZkGate();
+  const el = $('zk-gate');
+  el.innerHTML = `
+    <div class="zk-dialog" role="dialog" aria-modal="true" aria-labelledby="zk-dialog-title">
+      <h2 id="zk-dialog-title">${escHtml(title)}</h2>
+      ${bodyHtml}
+    </div>
+  `;
+  return el;
+}
+
+function renderDevice2Block() {
+  renderZkDialog(
+    'Complete setup on your original device',
+    `
+      <p>
+        Encrypted issue titles on this account were sealed on another browser
+        before passphrase backup was configured. This device cannot decrypt them
+        or finish enrollment until you open Roxabi on your <strong>original device</strong>
+        and complete encryption setup there.
+      </p>
+      <p>
+        Alternatively, after setup on the original device, you can
+        <a href="/login?zk=1">Link GitHub</a> here to re-seal content from GitHub.
+      </p>
+      <div class="zk-actions">
+        <button type="button" class="consent-btn-secondary" id="zk-block-reload">Reload</button>
+        <button type="button" class="consent-btn-secondary" id="zk-block-logout">Sign out</button>
+      </div>
+    `,
+  );
+  $('zk-block-reload')?.addEventListener('click', () => location.reload());
+  $('zk-block-logout')?.addEventListener('click', async () => {
+    await api('/logout', { method: 'POST' }).catch(() => {});
+    location.reload();
+  });
+}
+
+export function showEnrollGate(githubLogin) {
+  return new Promise((resolve) => {
+    renderZkDialog(
+      'Set encryption passphrase',
+      `
+        <p>
+          Choose a passphrase to protect your encryption key. It never leaves this browser;
+          only a wrapped backup is stored on the server. You will need this passphrase on
+          every new device and after locking.
+        </p>
+        <form class="zk-form" id="zk-enroll-form">
+          <label class="zk-field">
+            <span>Passphrase</span>
+            <input type="password" id="zk-enroll-pass" autocomplete="new-password" required minlength="8" />
+          </label>
+          <label class="zk-field">
+            <span>Confirm passphrase</span>
+            <input type="password" id="zk-enroll-confirm" autocomplete="new-password" required minlength="8" />
+          </label>
+          <p class="zk-error" id="zk-enroll-error" hidden></p>
+          <div class="zk-actions">
+            <button type="button" class="consent-btn-secondary" id="zk-enroll-logout">Sign out</button>
+            <button type="submit" class="consent-btn-primary" id="zk-enroll-submit">Create backup</button>
+          </div>
+        </form>
+      `,
+    );
+
+    const form = $('zk-enroll-form');
+    const passInput = $('zk-enroll-pass');
+    const confirmInput = $('zk-enroll-confirm');
+    const errorEl = $('zk-enroll-error');
+    const submitBtn = $('zk-enroll-submit');
+
+    passInput?.focus();
+
+    $('zk-enroll-logout')?.addEventListener('click', async () => {
+      await api('/logout', { method: 'POST' }).catch(() => {});
+      location.reload();
+    });
+
+    form?.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errorEl.hidden = true;
+      const pass = passInput.value;
+      const confirm = confirmInput.value;
+      if (pass.length < 8) {
+        errorEl.textContent = 'Passphrase must be at least 8 characters.';
+        errorEl.hidden = false;
+        return;
+      }
+      if (pass !== confirm) {
+        errorEl.textContent = 'Passphrases do not match.';
+        errorEl.hidden = false;
+        return;
+      }
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Creating backup…';
+      try {
+        await enrollAccountKey(pass, githubLogin);
+        hideZkGate();
+        resolve();
+      } catch (err) {
+        if (String(err?.message ?? '').includes('409')) {
+          errorEl.textContent = 'Already enrolled — unlock with your passphrase instead.';
+        } else {
+          errorEl.textContent = err?.message ?? 'Enrollment failed. Try again.';
+        }
+        errorEl.hidden = false;
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Create backup';
+      }
+    });
+  });
+}
+
+export function showUnlockGate() {
+  return new Promise((resolve) => {
+    renderZkDialog(
+      'Unlock encryption',
+      `
+        <p>Enter your encryption passphrase to decrypt issue titles and bodies on this device.</p>
+        <form class="zk-form" id="zk-unlock-form">
+          <label class="zk-field">
+            <span>Passphrase</span>
+            <input type="password" id="zk-unlock-pass" autocomplete="current-password" required />
+          </label>
+          <p class="zk-error" id="zk-unlock-error" hidden></p>
+          <div class="zk-actions">
+            <button type="button" class="consent-btn-secondary" id="zk-unlock-logout">Sign out</button>
+            <button type="submit" class="consent-btn-primary" id="zk-unlock-submit">Unlock</button>
+          </div>
+        </form>
+      `,
+    );
+
+    const form = $('zk-unlock-form');
+    const passInput = $('zk-unlock-pass');
+    const errorEl = $('zk-unlock-error');
+    const submitBtn = $('zk-unlock-submit');
+
+    passInput?.focus();
+
+    $('zk-unlock-logout')?.addEventListener('click', async () => {
+      await api('/logout', { method: 'POST' }).catch(() => {});
+      location.reload();
+    });
+
+    form?.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errorEl.hidden = true;
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Unlocking…';
+      try {
+        await unlockAccountKey(passInput.value);
+        hideZkGate();
+        resolve();
+      } catch {
+        errorEl.textContent = 'Incorrect passphrase. Try again.';
+        errorEl.hidden = false;
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Unlock';
+        passInput.select();
+      }
+    });
+  });
+}
+
+function updateLockButton() {
+  const btn = $('zk-lock-btn');
+  if (!btn) return;
+  if (isZkUnlocked()) {
+    btn.removeAttribute('hidden');
+    btn.textContent = 'Lock';
+    btn.title = 'Lock encryption (clear key from memory)';
+  } else {
+    btn.setAttribute('hidden', '');
+  }
+}
+
+export function wireZkLockButton() {
+  const btn = $('zk-lock-btn');
+  if (!btn || btn.dataset.wired) return;
+  btn.dataset.wired = '1';
+  btn.addEventListener('click', () => lockZkSession());
+  updateLockButton();
+}
+
+/**
+ * Blocks dashboard until enrolled + unlocked when ZK_ACCOUNT_KEY flag is on.
+ * @returns {Promise<boolean>} false when permanently blocked (Device 2 pre-enroll)
+ */
+export async function requireZkEnrollmentGate(me, githubLogin) {
+  wireIdleLock();
+  wirePageHideLock();
+  wireZkLockButton();
+  setZkAutoLockHandler(() => {
+    updateLockButton();
+    showUnlockGate().catch(() => {});
+  });
+
+  const enrolled = me.user?.zk_enrolled === true;
+
+  if (!enrolled) {
+    const payloads = await fetchPayloadRows();
+    const hasV1 = payloadsHaveV1(payloads);
+    const hasLocalKey = await hasZkKeyPair(githubLogin);
+    if (hasV1 && !hasLocalKey) {
+      renderDevice2Block();
+      return false;
+    }
+    await showEnrollGate(githubLogin);
+    return true;
+  }
+
+  if (!isZkUnlocked()) {
+    await showUnlockGate();
+    return true;
+  }
+
+  updateLockButton();
+  return true;
+}

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -18,6 +18,7 @@ import {
   wirePageHideLock,
   setZkAutoLockHandler,
 } from './zk-session.js';
+import { migrateV1PayloadsToAccountKey } from './zk-sync.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -80,12 +81,20 @@ export async function enrollAccountKey(passphrase, githubLogin) {
     key_fp: wrapped.key_fp,
     enrolled_at: new Date().toISOString(),
   });
+
+  const migrated = await migrateV1PayloadsToAccountKey(
+    githubLogin,
+    session,
+    wrapped.key_fp,
+  );
+
   setZkSession(session, wrapped.key_fp);
   zkLog('zk.enroll.success', {
     key_fp: wrapped.key_fp,
     kdf_duration_ms: Math.round(performance.now() - t0),
+    migrated,
   });
-  return { key_fp: wrapped.key_fp };
+  return { key_fp: wrapped.key_fp, migrated };
 }
 
 export async function unlockAccountKey(passphrase) {

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -17,6 +17,7 @@ import {
   wireIdleLock,
   wirePageHideLock,
   setZkAutoLockHandler,
+  setZkPageRestoreHandler,
 } from './zk-session.js';
 import { migrateV1PayloadsToAccountKey } from './zk-sync.js';
 
@@ -328,6 +329,12 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
   setZkAutoLockHandler(() => {
     updateLockButton();
     showUnlockGate().catch(() => {});
+  });
+  setZkPageRestoreHandler(() => {
+    if (me.user?.zk_enrolled === true && !isZkUnlocked()) {
+      updateLockButton();
+      showUnlockGate().catch(() => {});
+    }
   });
 
   const enrolled = me.user?.zk_enrolled === true;

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -20,8 +20,15 @@ import {
   setZkPageRestoreHandler,
 } from './zk-session.js';
 import { migrateV1PayloadsToAccountKey } from './zk-sync.js';
+import {
+  getZkReauthProof,
+  clearZkReauthProof,
+} from './zk-github.js';
 
 const $ = (id) => document.getElementById(id);
+
+/** Set during requireZkEnrollmentGate for migration retry on unlock. */
+let gateGithubLogin = '';
 
 function zkLog(event, extra = {}) {
   console.info('[zk]', { event, ...extra });
@@ -49,6 +56,20 @@ async function putKeyBackup(body) {
     body: JSON.stringify(body),
   });
   return resp.json();
+}
+
+/**
+ * PUT backup update (passphrase change or rotation) — attaches OAuth reauth_proof
+ * from sessionStorage after /login?reauth=1 flow.
+ */
+export async function updateKeyBackup(body) {
+  const reauth_proof = getZkReauthProof();
+  if (!reauth_proof) {
+    throw new Error('reauth_required');
+  }
+  const result = await putKeyBackup({ ...body, reauth_proof });
+  clearZkReauthProof();
+  return result;
 }
 
 function payloadsHaveV1(payloads) {
@@ -104,6 +125,16 @@ export async function unlockAccountKey(passphrase) {
   try {
     const accountKey = await unwrapAccountKey(passphrase, backup);
     setZkSession(accountKey, backup.key_fp);
+    if (gateGithubLogin) {
+      const payloads = await fetchPayloadRows();
+      if (payloadsHaveV1(payloads) && (await hasZkKeyPair(gateGithubLogin))) {
+        await migrateV1PayloadsToAccountKey(
+          gateGithubLogin,
+          accountKey,
+          backup.key_fp,
+        );
+      }
+    }
     zkLog('zk.unlock.success', {
       key_fp: backup.key_fp,
       kdf_duration_ms: Math.round(performance.now() - t0),
@@ -323,6 +354,7 @@ export function wireZkLockButton() {
  * @returns {Promise<boolean>} false when permanently blocked (Device 2 pre-enroll)
  */
 export async function requireZkEnrollmentGate(me, githubLogin) {
+  gateGithubLogin = githubLogin;
   wireIdleLock();
   wirePageHideLock();
   wireZkLockButton();

--- a/frontend/zk-github.js
+++ b/frontend/zk-github.js
@@ -3,6 +3,7 @@
 import { api } from './auth.js';
 
 const TOKEN_KEY = 'roxabi:gh-user-token';
+const REAUTH_KEY = 'roxabi:zk-reauth-proof';
 
 export function getGithubUserToken() {
   return sessionStorage.getItem(TOKEN_KEY);
@@ -11,6 +12,36 @@ export function getGithubUserToken() {
 export function setGithubUserToken(token) {
   if (token) sessionStorage.setItem(TOKEN_KEY, token);
   else sessionStorage.removeItem(TOKEN_KEY);
+}
+
+export function getZkReauthProof() {
+  return sessionStorage.getItem(REAUTH_KEY);
+}
+
+export function clearZkReauthProof() {
+  sessionStorage.removeItem(REAUTH_KEY);
+}
+
+/** Consume ?zk_reauth= from URL after OAuth step-up redirect. */
+export async function consumeZkReauthFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('zk_reauth');
+  if (!code) return false;
+
+  params.delete('zk_reauth');
+  const qs = params.toString();
+  const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
+  window.history.replaceState({}, '', next);
+
+  const resp = await api('/api/zk/consume-reauth', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  });
+  if (!resp.ok) return false;
+  const { reauth_proof } = await resp.json();
+  if (reauth_proof) sessionStorage.setItem(REAUTH_KEY, reauth_proof);
+  return true;
 }
 
 /** Consume ?zk_handoff= from URL after OAuth redirect. */

--- a/frontend/zk-github.js
+++ b/frontend/zk-github.js
@@ -33,15 +33,18 @@ export async function consumeZkReauthFromUrl() {
   const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
   window.history.replaceState({}, '', next);
 
-  const resp = await api('/api/zk/consume-reauth', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code }),
-  });
-  if (!resp.ok) return false;
-  const { reauth_proof } = await resp.json();
-  if (reauth_proof) sessionStorage.setItem(REAUTH_KEY, reauth_proof);
-  return true;
+  try {
+    const resp = await api('/api/zk/consume-reauth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code }),
+    });
+    const { reauth_proof } = await resp.json();
+    if (reauth_proof) sessionStorage.setItem(REAUTH_KEY, reauth_proof);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Consume ?zk_handoff= from URL after OAuth redirect. */

--- a/frontend/zk-github.js
+++ b/frontend/zk-github.js
@@ -22,16 +22,20 @@ export function clearZkReauthProof() {
   sessionStorage.removeItem(REAUTH_KEY);
 }
 
+function stripZkReauthFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has('zk_reauth')) return;
+  params.delete('zk_reauth');
+  const qs = params.toString();
+  const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
+  window.history.replaceState({}, '', next);
+}
+
 /** Consume ?zk_reauth= from URL after OAuth step-up redirect. */
 export async function consumeZkReauthFromUrl() {
   const params = new URLSearchParams(window.location.search);
   const code = params.get('zk_reauth');
   if (!code) return false;
-
-  params.delete('zk_reauth');
-  const qs = params.toString();
-  const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
-  window.history.replaceState({}, '', next);
 
   try {
     const resp = await api('/api/zk/consume-reauth', {
@@ -40,11 +44,18 @@ export async function consumeZkReauthFromUrl() {
       body: JSON.stringify({ code }),
     });
     const { reauth_proof } = await resp.json();
-    if (reauth_proof) sessionStorage.setItem(REAUTH_KEY, reauth_proof);
+    if (!reauth_proof) return false;
+    sessionStorage.setItem(REAUTH_KEY, reauth_proof);
+    stripZkReauthFromUrl();
     return true;
   } catch {
     return false;
   }
+}
+
+export function zkReauthLoginUrl(redirect = '/') {
+  const dest = encodeURIComponent(redirect);
+  return `/login?reauth=1&redirect=${dest}`;
 }
 
 /** Consume ?zk_handoff= from URL after OAuth redirect. */

--- a/frontend/zk-github.test.js
+++ b/frontend/zk-github.test.js
@@ -46,7 +46,7 @@ describe('consumeZkReauthFromUrl', () => {
 
   it('does not store proof when consume-reauth fails', async () => {
     window.history.replaceState({}, '', '/?zk_reauth=bad');
-    apiMock.mockResolvedValue({ ok: false });
+    apiMock.mockRejectedValue(new Error('/api/zk/consume-reauth 410'));
 
     const result = await consumeZkReauthFromUrl();
 

--- a/frontend/zk-github.test.js
+++ b/frontend/zk-github.test.js
@@ -26,10 +26,9 @@ describe('consumeZkReauthFromUrl', () => {
     expect(apiMock).not.toHaveBeenCalled();
   });
 
-  it('strips zk_reauth from URL and stores reauth_proof', async () => {
+  it('strips zk_reauth from URL and stores reauth_proof on success', async () => {
     window.history.replaceState({}, '', '/?zk_reauth=abc123&foo=bar');
     apiMock.mockResolvedValue({
-      ok: true,
       json: async () => ({ reauth_proof: 'proof-token' }),
     });
 
@@ -45,13 +44,25 @@ describe('consumeZkReauthFromUrl', () => {
   });
 
   it('does not store proof when consume-reauth fails', async () => {
-    window.history.replaceState({}, '', '/?zk_reauth=bad');
+    window.history.replaceState({}, '', '/?zk_reauth=bad&foo=bar');
     apiMock.mockRejectedValue(new Error('/api/zk/consume-reauth 410'));
 
     const result = await consumeZkReauthFromUrl();
 
     expect(result).toBe(false);
     expect(getZkReauthProof()).toBeNull();
+    expect(window.location.search).toBe('?zk_reauth=bad&foo=bar');
+  });
+
+  it('returns false when response omits reauth_proof', async () => {
+    window.history.replaceState({}, '', '/?zk_reauth=abc');
+    apiMock.mockResolvedValue({ json: async () => ({}) });
+
+    const result = await consumeZkReauthFromUrl();
+
+    expect(result).toBe(false);
+    expect(getZkReauthProof()).toBeNull();
+    expect(window.location.search).toBe('?zk_reauth=abc');
   });
 
   it('clearZkReauthProof removes stored proof', () => {

--- a/frontend/zk-github.test.js
+++ b/frontend/zk-github.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const apiMock = vi.fn();
+
+vi.mock('./auth.js', () => ({
+  api: (...args) => apiMock(...args),
+}));
+
+const { consumeZkReauthFromUrl, getZkReauthProof, clearZkReauthProof } = await import('./zk-github.js');
+
+describe('consumeZkReauthFromUrl', () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('returns false when zk_reauth param is absent', async () => {
+    const result = await consumeZkReauthFromUrl();
+    expect(result).toBe(false);
+    expect(apiMock).not.toHaveBeenCalled();
+  });
+
+  it('strips zk_reauth from URL and stores reauth_proof', async () => {
+    window.history.replaceState({}, '', '/?zk_reauth=abc123&foo=bar');
+    apiMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ reauth_proof: 'proof-token' }),
+    });
+
+    const result = await consumeZkReauthFromUrl();
+
+    expect(result).toBe(true);
+    expect(window.location.search).toBe('?foo=bar');
+    expect(apiMock).toHaveBeenCalledWith('/api/zk/consume-reauth', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ code: 'abc123' }),
+    }));
+    expect(getZkReauthProof()).toBe('proof-token');
+  });
+
+  it('does not store proof when consume-reauth fails', async () => {
+    window.history.replaceState({}, '', '/?zk_reauth=bad');
+    apiMock.mockResolvedValue({ ok: false });
+
+    const result = await consumeZkReauthFromUrl();
+
+    expect(result).toBe(false);
+    expect(getZkReauthProof()).toBeNull();
+  });
+
+  it('clearZkReauthProof removes stored proof', () => {
+    sessionStorage.setItem('roxabi:zk-reauth-proof', 'x');
+    clearZkReauthProof();
+    expect(getZkReauthProof()).toBeNull();
+  });
+});

--- a/frontend/zk-kdf.js
+++ b/frontend/zk-kdf.js
@@ -1,0 +1,41 @@
+// zk-kdf.js — Argon2id passphrase → AES-GCM wrapping key (#216 PR 3)
+import { argon2id } from './vendor/hash-wasm/esm/index.js';
+
+/** Fixed Argon2id parameters — no mobile downgrade (#216 Key Decision #17). */
+export const ARGON2_PARAMS = { m: 65536, t: 3, p: 1 };
+
+function toBytes(buf) {
+  if (buf instanceof Uint8Array) return buf;
+  if (buf instanceof ArrayBuffer) return new Uint8Array(buf);
+  if (ArrayBuffer.isView(buf)) {
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+  return new Uint8Array(buf);
+}
+
+/**
+ * Derive a non-extractable AES-256-GCM wrapping key from passphrase + salt.
+ * @param {string} passphrase
+ * @param {Uint8Array} salt 16-byte salt
+ * @param {{ m: number, t: number, p: number }} params Argon2id params
+ * @returns {Promise<CryptoKey>}
+ */
+export async function deriveWrappingKey(passphrase, salt, params) {
+  const raw = await argon2id({
+    password: passphrase,
+    salt: toBytes(salt),
+    parallelism: params.p,
+    iterations: params.t,
+    memorySize: params.m,
+    hashLength: 32,
+    outputType: 'binary',
+  });
+  if (raw.byteLength !== 32) throw new Error('KDF output length mismatch');
+  return crypto.subtle.importKey(
+    'raw',
+    raw,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}

--- a/frontend/zk-session.js
+++ b/frontend/zk-session.js
@@ -1,0 +1,81 @@
+// zk-session.js — in-memory accountKey session (#216 PR 4)
+
+const IDLE_MS = 15 * 60 * 1000;
+
+/** @type {CryptoKey|null} */
+let sessionKey = null;
+/** @type {string|null} */
+let sessionKeyFp = null;
+let idleTimer = null;
+let idleWired = false;
+let pageHideWired = false;
+
+/** @type {(() => void)|null} */
+let onAutoLock = null;
+
+export function isZkUnlocked() {
+  return sessionKey !== null;
+}
+
+/** @returns {CryptoKey} */
+export function getSessionAccountKey() {
+  if (!sessionKey) throw new Error('ZK locked');
+  return sessionKey;
+}
+
+export function getSessionKeyFp() {
+  return sessionKeyFp;
+}
+
+export function setZkSession(accountKey, keyFp) {
+  sessionKey = accountKey;
+  sessionKeyFp = keyFp;
+  resetIdleTimer();
+}
+
+export function clearZkSession() {
+  sessionKey = null;
+  sessionKeyFp = null;
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+}
+
+function resetIdleTimer() {
+  if (idleTimer) clearTimeout(idleTimer);
+  if (!sessionKey) return;
+  idleTimer = setTimeout(() => {
+    clearZkSession();
+    console.info('[zk]', { event: 'zk.lock.idle' });
+    onAutoLock?.();
+  }, IDLE_MS);
+}
+
+/** Register callback when idle lock fires (e.g. show unlock gate). */
+export function setZkAutoLockHandler(fn) {
+  onAutoLock = fn;
+}
+
+export function wireIdleLock() {
+  if (idleWired) return;
+  idleWired = true;
+  const bump = () => {
+    if (sessionKey) resetIdleTimer();
+  };
+  for (const ev of ['pointerdown', 'keydown', 'touchstart']) {
+    document.addEventListener(ev, bump, { passive: true });
+  }
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && sessionKey) {
+      resetIdleTimer();
+    }
+  });
+}
+
+export function wirePageHideLock() {
+  if (pageHideWired) return;
+  pageHideWired = true;
+  window.addEventListener('pagehide', clearZkSession);
+  window.addEventListener('beforeunload', clearZkSession);
+}

--- a/frontend/zk-session.js
+++ b/frontend/zk-session.js
@@ -9,9 +9,12 @@ let sessionKeyFp = null;
 let idleTimer = null;
 let idleWired = false;
 let pageHideWired = false;
+let pageShowWired = false;
 
 /** @type {(() => void)|null} */
 let onAutoLock = null;
+/** @type {(() => void)|null} */
+let onPageRestore = null;
 
 export function isZkUnlocked() {
   return sessionKey !== null;
@@ -57,6 +60,11 @@ export function setZkAutoLockHandler(fn) {
   onAutoLock = fn;
 }
 
+/** Register callback when BFCache restores a page after session was cleared. */
+export function setZkPageRestoreHandler(fn) {
+  onPageRestore = fn;
+}
+
 export function wireIdleLock() {
   if (idleWired) return;
   idleWired = true;
@@ -78,4 +86,12 @@ export function wirePageHideLock() {
   pageHideWired = true;
   window.addEventListener('pagehide', clearZkSession);
   window.addEventListener('beforeunload', clearZkSession);
+  if (!pageShowWired) {
+    pageShowWired = true;
+    window.addEventListener('pageshow', (ev) => {
+      if (ev.persisted && !sessionKey) {
+        onPageRestore?.();
+      }
+    });
+  }
 }

--- a/frontend/zk-session.test.js
+++ b/frontend/zk-session.test.js
@@ -5,7 +5,9 @@ const {
   setZkSession,
   isZkUnlocked,
   setZkPageRestoreHandler,
+  setZkAutoLockHandler,
   wirePageHideLock,
+  wireIdleLock,
 } = await import('./zk-session.js');
 
 describe('wirePageHideLock BFCache restore', () => {
@@ -39,5 +41,30 @@ describe('wirePageHideLock BFCache restore', () => {
     window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
 
     expect(restoreHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe('wireIdleLock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clearZkSession();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearZkSession();
+    setZkAutoLockHandler(null);
+  });
+
+  it('fires auto-lock handler after 15 minutes idle', () => {
+    const onLock = vi.fn();
+    setZkAutoLockHandler(onLock);
+    wireIdleLock();
+    setZkSession({}, 'fp12345678');
+
+    vi.advanceTimersByTime(15 * 60 * 1000);
+
+    expect(isZkUnlocked()).toBe(false);
+    expect(onLock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/zk-session.test.js
+++ b/frontend/zk-session.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const {
+  clearZkSession,
+  setZkSession,
+  isZkUnlocked,
+  setZkPageRestoreHandler,
+  wirePageHideLock,
+} = await import('./zk-session.js');
+
+describe('wirePageHideLock BFCache restore', () => {
+  let restoreHandler;
+
+  beforeEach(() => {
+    restoreHandler = vi.fn();
+    setZkPageRestoreHandler(restoreHandler);
+    wirePageHideLock();
+    clearZkSession();
+  });
+
+  afterEach(() => {
+    clearZkSession();
+    setZkPageRestoreHandler(null);
+  });
+
+  it('invokes page restore handler when BFCache restores while locked', () => {
+    setZkSession({}, 'fp12345678');
+    window.dispatchEvent(new PageTransitionEvent('pagehide'));
+    expect(isZkUnlocked()).toBe(false);
+
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+
+    expect(restoreHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke restore handler when session is still unlocked', () => {
+    setZkSession({}, 'fp12345678');
+
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+
+    expect(restoreHandler).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -9,6 +9,7 @@ import {
   openContentDual,
   parseEnvelopeVersion,
   hasZkKeyPair,
+  deleteZkKeyPair,
 } from './zk-crypto.js';
 import {
   isZkUnlocked,
@@ -75,6 +76,43 @@ async function sealNodes(nodes, githubLogin, contentByKey) {
   if (payloads.length > 0) {
     await putPayloadBatches(payloads);
   }
+}
+
+/**
+ * On first enroll: decrypt v1 ECIES payloads with local ECDH key, re-seal v2,
+ * upload with key_fp, then delete roxabi-zk-v1 keypair (#216 PR 5).
+ * @returns {Promise<number>} count of migrated rows
+ */
+export async function migrateV1PayloadsToAccountKey(githubLogin, accountKey, key_fp) {
+  if (!(await hasZkKeyPair(githubLogin))) return 0;
+
+  const resp = await api('/api/zk/payloads');
+  const { payloads } = await resp.json();
+  const { privateKey } = await ensureZkKeyPair(githubLogin);
+  const migrated = [];
+
+  for (const row of payloads ?? []) {
+    if (parseEnvelopeVersion(row.encrypted_payload) !== 1) continue;
+    try {
+      const content = await openContent(privateKey, row.encrypted_payload);
+      const encrypted_payload = await sealWithAccountKey(accountKey, content);
+      migrated.push({
+        issue_key: row.issue_key,
+        key_fp,
+        encrypted_payload,
+      });
+    } catch {
+      /* skip undecryptable rows */
+    }
+  }
+
+  if (migrated.length > 0) {
+    await putPayloadBatches(migrated);
+    console.info('[zk]', { event: 'zk.migrate.v1_to_v2.count', count: migrated.length });
+  }
+
+  await deleteZkKeyPair(githubLogin);
+  return migrated.length;
 }
 
 /**

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -50,6 +50,31 @@ export async function sealGraphTitles(nodes, githubLogin) {
 }
 
 /**
+ * Ensure private mode is active: zk_opt_in on server + seal any unsealed issues.
+ * Safe to call on every dashboard load (idempotent).
+ */
+export async function ensurePrivateMode(githubLogin) {
+  await api('/api/zk-opt-in', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled: true }),
+  });
+
+  const [graphData, payloadResp] = await Promise.all([
+    api('/api/graph').then(r => r.json()),
+    api('/api/zk/payloads').then(r => r.json()).catch(() => ({ payloads: [] })),
+  ]);
+
+  const sealed = new Set((payloadResp.payloads ?? []).map(p => p.issue_key));
+  const toSeal = (graphData.nodes ?? []).filter(
+    n => n.title != null && !sealed.has(n.key),
+  );
+  if (toSeal.length > 0) {
+    await sealGraphTitles(toSeal, githubLogin);
+  }
+}
+
+/**
  * Fetch title+body from GitHub and re-seal zk_payloads (ZK users with user token).
  */
 export async function syncZkContentFromGitHub(nodes, githubLogin, githubToken) {

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -91,11 +91,18 @@ export async function migrateV1PayloadsToAccountKey(githubLogin, accountKey, key
 
   const resp = await api('/api/zk/payloads');
   const { payloads } = await resp.json();
+  const v1Rows = (payloads ?? []).filter(
+    (row) => parseEnvelopeVersion(row.encrypted_payload) === 1,
+  );
+  if (v1Rows.length === 0) {
+    await deleteZkKeyPair(githubLogin);
+    return 0;
+  }
+
   const { privateKey } = await ensureZkKeyPair(githubLogin);
   const migrated = [];
 
-  for (const row of payloads ?? []) {
-    if (parseEnvelopeVersion(row.encrypted_payload) !== 1) continue;
+  for (const row of v1Rows) {
     try {
       const content = await openContent(privateKey, row.encrypted_payload);
       const encrypted_payload = await sealWithAccountKey(accountKey, content);
@@ -114,7 +121,9 @@ export async function migrateV1PayloadsToAccountKey(githubLogin, accountKey, key
     console.info('[zk]', { event: 'zk.migrate.v1_to_v2.count', count: migrated.length });
   }
 
-  await deleteZkKeyPair(githubLogin);
+  if (migrated.length === v1Rows.length) {
+    await deleteZkKeyPair(githubLogin);
+  }
   return migrated.length;
 }
 

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -20,6 +20,9 @@ import { fetchIssueContentMap, getGithubUserToken } from './zk-github.js';
 
 const BULK = 200;
 
+/** Label when graph title was redacted and this user has no ciphertext row (#216 hybrid multi-user). */
+export const SEALED_TITLE_LABEL = '(sealed)';
+
 async function putPayloadBatches(payloads) {
   for (let i = 0; i < payloads.length; i += BULK) {
     await api('/api/zk/payloads', {
@@ -202,7 +205,7 @@ export async function applyZkDecryption(nodes, githubLogin) {
     for (const node of nodes) {
       const row = byKey.get(node.key);
       if (!row) {
-        if (node.title == null) node.title = '(sealed)';
+        if (node.title == null) node.title = SEALED_TITLE_LABEL;
         continue;
       }
       const v = parseEnvelopeVersion(row.encrypted_payload);
@@ -212,7 +215,7 @@ export async function applyZkDecryption(nodes, githubLogin) {
       }
       try {
         const content = await openContentDual(keys, row.encrypted_payload);
-        node.title = content.title ?? '(sealed)';
+        node.title = content.title ?? SEALED_TITLE_LABEL;
         if (content.body != null) node.body = content.body;
       } catch {
         node.title = '(decrypt error)';
@@ -226,12 +229,12 @@ export async function applyZkDecryption(nodes, githubLogin) {
   for (const node of nodes) {
     const row = byKey.get(node.key);
     if (!row) {
-      if (node.title == null) node.title = '(sealed)';
+      if (node.title == null) node.title = SEALED_TITLE_LABEL;
       continue;
     }
     try {
       const content = await openContent(privateKey, row.encrypted_payload);
-      node.title = content.title ?? '(sealed)';
+      node.title = content.title ?? SEALED_TITLE_LABEL;
       if (content.body != null) node.body = content.body;
     } catch {
       node.title = '(decrypt error)';

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -188,8 +188,19 @@ export async function syncZkContentFromGitHub(nodes, githubLogin, githubToken) {
 /**
  * Decrypt server-redacted titles for the current user.
  * @param {Array<{ key: string, title: string|null }>} nodes
+ * @param {string} githubLogin
+ * @param {{ accountKeyMode?: boolean }} [opts]
  */
-export async function applyZkDecryption(nodes, githubLogin) {
+export async function applyZkDecryption(nodes, githubLogin, opts = {}) {
+  const { accountKeyMode = false } = opts;
+
+  if (accountKeyMode && !isZkUnlocked()) {
+    for (const node of nodes) {
+      if (node.title == null) node.title = SEALED_TITLE_LABEL;
+    }
+    return;
+  }
+
   const resp = await api('/api/zk/payloads');
   const { payloads } = await resp.json();
   const byKey = new Map((payloads ?? []).map((p) => [p.issue_key, p]));

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -1,7 +1,20 @@
-// zk-sync.js — seal-on-enable + decrypt-on-load + GitHub content sync (#142 S2/S3)
+// zk-sync.js — seal-on-enable + decrypt-on-load + GitHub content sync (#142 S2/S3, #216 PR 4)
 
 import { api } from './auth.js';
-import { ensureZkKeyPair, sealContent, openContent } from './zk-crypto.js';
+import {
+  ensureZkKeyPair,
+  sealContent,
+  openContent,
+  sealWithAccountKey,
+  openContentDual,
+  parseEnvelopeVersion,
+  hasZkKeyPair,
+} from './zk-crypto.js';
+import {
+  isZkUnlocked,
+  getSessionAccountKey,
+  getSessionKeyFp,
+} from './zk-session.js';
 import { fetchIssueContentMap, getGithubUserToken } from './zk-github.js';
 
 const BULK = 200;
@@ -17,23 +30,46 @@ async function putPayloadBatches(payloads) {
 }
 
 async function sealNodes(nodes, githubLogin, contentByKey) {
-  const { publicKey, pubkeyFp } = await ensureZkKeyPair(githubLogin);
   const payloads = [];
 
-  for (const node of nodes) {
-    const fromGh = contentByKey?.get(node.key);
-    const title = fromGh?.title ?? node.title;
-    if (!title && !fromGh?.body) continue;
+  if (isZkUnlocked()) {
+    const accountKey = getSessionAccountKey();
+    const key_fp = getSessionKeyFp();
+    if (!key_fp) throw new Error('key_fp required for accountKey seal');
 
-    const encrypted_payload = await sealContent(publicKey, {
-      title: title ?? null,
-      body: fromGh?.body ?? null,
-    });
-    payloads.push({
-      issue_key: node.key,
-      pubkey_fp: pubkeyFp,
-      encrypted_payload,
-    });
+    for (const node of nodes) {
+      const fromGh = contentByKey?.get(node.key);
+      const title = fromGh?.title ?? node.title;
+      if (!title && !fromGh?.body) continue;
+
+      const encrypted_payload = await sealWithAccountKey(accountKey, {
+        title: title ?? null,
+        body: fromGh?.body ?? null,
+      });
+      payloads.push({
+        issue_key: node.key,
+        key_fp,
+        encrypted_payload,
+      });
+    }
+  } else {
+    const { publicKey, pubkeyFp } = await ensureZkKeyPair(githubLogin);
+
+    for (const node of nodes) {
+      const fromGh = contentByKey?.get(node.key);
+      const title = fromGh?.title ?? node.title;
+      if (!title && !fromGh?.body) continue;
+
+      const encrypted_payload = await sealContent(publicKey, {
+        title: title ?? null,
+        body: fromGh?.body ?? null,
+      });
+      payloads.push({
+        issue_key: node.key,
+        pubkey_fp: pubkeyFp,
+        encrypted_payload,
+      });
+    }
   }
 
   if (payloads.length > 0) {
@@ -42,7 +78,7 @@ async function sealNodes(nodes, githubLogin, contentByKey) {
 }
 
 /**
- * Seal visible graph titles into zk_payloads (call before enabling zk_opt_in).
+ * Seal visible graph titles into zk_payloads.
  * @param {Array<{ key: string, title: string|null }>} nodes
  */
 export async function sealGraphTitles(nodes, githubLogin) {
@@ -51,7 +87,7 @@ export async function sealGraphTitles(nodes, githubLogin) {
 
 /**
  * Ensure private mode is active: zk_opt_in on server + seal any unsealed issues.
- * Safe to call on every dashboard load (idempotent).
+ * Legacy path when ZK_ACCOUNT_KEY flag is off — uses per-device ECDH v1.
  */
 export async function ensurePrivateMode(githubLogin) {
   await api('/api/zk-opt-in', {
@@ -61,13 +97,15 @@ export async function ensurePrivateMode(githubLogin) {
   });
 
   const [graphData, payloadResp] = await Promise.all([
-    api('/api/graph').then(r => r.json()),
-    api('/api/zk/payloads').then(r => r.json()).catch(() => ({ payloads: [] })),
+    api('/api/graph').then((r) => r.json()),
+    api('/api/zk/payloads')
+      .then((r) => r.json())
+      .catch(() => ({ payloads: [] })),
   ]);
 
-  const sealed = new Set((payloadResp.payloads ?? []).map(p => p.issue_key));
+  const sealed = new Set((payloadResp.payloads ?? []).map((p) => p.issue_key));
   const toSeal = (graphData.nodes ?? []).filter(
-    n => n.title != null && !sealed.has(n.key),
+    (n) => n.title != null && !sealed.has(n.key),
   );
   if (toSeal.length > 0) {
     await sealGraphTitles(toSeal, githubLogin);
@@ -75,7 +113,26 @@ export async function ensurePrivateMode(githubLogin) {
 }
 
 /**
- * Fetch title+body from GitHub and re-seal zk_payloads (ZK users with user token).
+ * Seal any unsealed graph titles with accountKey v2 (flag-on path).
+ * Requires unlocked session.
+ */
+export async function ensureAccountKeySealing(githubLogin, nodes) {
+  if (!isZkUnlocked()) return;
+
+  const payloadResp = await api('/api/zk/payloads')
+    .then((r) => r.json())
+    .catch(() => ({ payloads: [] }));
+  const sealed = new Set((payloadResp.payloads ?? []).map((p) => p.issue_key));
+  const toSeal = (nodes ?? []).filter(
+    (n) => n.title != null && !sealed.has(n.key),
+  );
+  if (toSeal.length > 0) {
+    await sealGraphTitles(toSeal, githubLogin);
+  }
+}
+
+/**
+ * Fetch title+body from GitHub and re-seal zk_payloads.
  */
 export async function syncZkContentFromGitHub(nodes, githubLogin, githubToken) {
   const token = githubToken ?? getGithubUserToken();
@@ -88,13 +145,44 @@ export async function syncZkContentFromGitHub(nodes, githubLogin, githubToken) {
 }
 
 /**
- * Decrypt server-redacted titles for zk_opt_in users.
+ * Decrypt server-redacted titles for the current user.
  * @param {Array<{ key: string, title: string|null }>} nodes
  */
 export async function applyZkDecryption(nodes, githubLogin) {
   const resp = await api('/api/zk/payloads');
   const { payloads } = await resp.json();
   const byKey = new Map((payloads ?? []).map((p) => [p.issue_key, p]));
+
+  if (isZkUnlocked()) {
+    const accountKey = getSessionAccountKey();
+    const keys = { accountKey };
+    if (await hasZkKeyPair(githubLogin)) {
+      const { privateKey } = await ensureZkKeyPair(githubLogin);
+      keys.privateKey = privateKey;
+    }
+
+    for (const node of nodes) {
+      const row = byKey.get(node.key);
+      if (!row) {
+        if (node.title == null) node.title = '(sealed)';
+        continue;
+      }
+      const v = parseEnvelopeVersion(row.encrypted_payload);
+      if (v === 1 && !keys.privateKey) {
+        node.title = '(needs migration)';
+        continue;
+      }
+      try {
+        const content = await openContentDual(keys, row.encrypted_payload);
+        node.title = content.title ?? '(sealed)';
+        if (content.body != null) node.body = content.body;
+      } catch {
+        node.title = '(decrypt error)';
+      }
+    }
+    return;
+  }
+
   const { privateKey } = await ensureZkKeyPair(githubLogin);
 
   for (const node of nodes) {

--- a/frontend/zk-sync.test.js
+++ b/frontend/zk-sync.test.js
@@ -3,6 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const apiMock = vi.fn();
 const isZkUnlockedMock = vi.fn();
 const ensureZkKeyPairMock = vi.fn();
+const hasZkKeyPairMock = vi.fn();
+const deleteZkKeyPairMock = vi.fn();
+const openContentMock = vi.fn();
+const parseEnvelopeVersionMock = vi.fn();
+const sealWithAccountKeyMock = vi.fn();
 
 vi.mock('./auth.js', () => ({
   api: (...args) => apiMock(...args),
@@ -17,16 +22,16 @@ vi.mock('./zk-session.js', () => ({
 
 vi.mock('./zk-crypto.js', () => ({
   ensureZkKeyPair: (...args) => ensureZkKeyPairMock(...args),
-  openContent: vi.fn(),
-  parseEnvelopeVersion: () => 2,
-  hasZkKeyPair: vi.fn(),
+  openContent: (...args) => openContentMock(...args),
+  parseEnvelopeVersion: (...args) => parseEnvelopeVersionMock(...args),
+  hasZkKeyPair: (...args) => hasZkKeyPairMock(...args),
   sealContent: vi.fn(),
-  sealWithAccountKey: vi.fn(),
+  sealWithAccountKey: (...args) => sealWithAccountKeyMock(...args),
   openContentDual: vi.fn(),
-  deleteZkKeyPair: vi.fn(),
+  deleteZkKeyPair: (...args) => deleteZkKeyPairMock(...args),
 }));
 
-const { applyZkDecryption, SEALED_TITLE_LABEL } = await import('./zk-sync.js');
+const { applyZkDecryption, migrateV1PayloadsToAccountKey, SEALED_TITLE_LABEL } = await import('./zk-sync.js');
 
 describe('applyZkDecryption', () => {
   beforeEach(() => {
@@ -44,5 +49,54 @@ describe('applyZkDecryption', () => {
     expect(apiMock).not.toHaveBeenCalled();
     expect(ensureZkKeyPairMock).not.toHaveBeenCalled();
     expect(nodes[0].title).toBe(SEALED_TITLE_LABEL);
+  });
+});
+
+describe('migrateV1PayloadsToAccountKey', () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+    hasZkKeyPairMock.mockReset();
+    deleteZkKeyPairMock.mockReset();
+    openContentMock.mockReset();
+    parseEnvelopeVersionMock.mockReset();
+    sealWithAccountKeyMock.mockReset();
+    ensureZkKeyPairMock.mockReset();
+  });
+
+  it('retains keypair when all v1 rows fail to decrypt', async () => {
+    hasZkKeyPairMock.mockResolvedValue(true);
+    parseEnvelopeVersionMock.mockReturnValue(1);
+    openContentMock.mockRejectedValue(new Error('decrypt failed'));
+    ensureZkKeyPairMock.mockResolvedValue({ privateKey: {} });
+    apiMock.mockResolvedValue({
+      json: async () => ({
+        payloads: [{ issue_key: 'Roxabi/live#1', encrypted_payload: 'v1' }],
+      }),
+    });
+
+    const count = await migrateV1PayloadsToAccountKey('alice', {}, 'fp12345678');
+
+    expect(count).toBe(0);
+    expect(deleteZkKeyPairMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes keypair when all v1 rows migrate successfully', async () => {
+    hasZkKeyPairMock.mockResolvedValue(true);
+    parseEnvelopeVersionMock.mockReturnValue(1);
+    openContentMock.mockResolvedValue({ title: 't', body: null });
+    sealWithAccountKeyMock.mockResolvedValue('v2-payload');
+    ensureZkKeyPairMock.mockResolvedValue({ privateKey: {} });
+    apiMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          payloads: [{ issue_key: 'Roxabi/live#1', encrypted_payload: 'v1' }],
+        }),
+      })
+      .mockResolvedValueOnce({});
+
+    const count = await migrateV1PayloadsToAccountKey('alice', {}, 'fp12345678');
+
+    expect(count).toBe(1);
+    expect(deleteZkKeyPairMock).toHaveBeenCalledWith('alice');
   });
 });

--- a/frontend/zk-sync.test.js
+++ b/frontend/zk-sync.test.js
@@ -80,6 +80,29 @@ describe('migrateV1PayloadsToAccountKey', () => {
     expect(deleteZkKeyPairMock).not.toHaveBeenCalled();
   });
 
+  it('retains keypair on partial v1 migration', async () => {
+    hasZkKeyPairMock.mockResolvedValue(true);
+    parseEnvelopeVersionMock.mockReturnValue(1);
+    openContentMock
+      .mockResolvedValueOnce({ title: 'ok', body: null })
+      .mockRejectedValueOnce(new Error('decrypt failed'));
+    sealWithAccountKeyMock.mockResolvedValue('v2-payload');
+    ensureZkKeyPairMock.mockResolvedValue({ privateKey: {} });
+    apiMock.mockResolvedValue({
+      json: async () => ({
+        payloads: [
+          { issue_key: 'Roxabi/live#1', encrypted_payload: 'v1a' },
+          { issue_key: 'Roxabi/live#2', encrypted_payload: 'v1b' },
+        ],
+      }),
+    });
+
+    const count = await migrateV1PayloadsToAccountKey('alice', {}, 'fp12345678');
+
+    expect(count).toBe(1);
+    expect(deleteZkKeyPairMock).not.toHaveBeenCalled();
+  });
+
   it('deletes keypair when all v1 rows migrate successfully', async () => {
     hasZkKeyPairMock.mockResolvedValue(true);
     parseEnvelopeVersionMock.mockReturnValue(1);

--- a/frontend/zk-sync.test.js
+++ b/frontend/zk-sync.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const apiMock = vi.fn();
+const isZkUnlockedMock = vi.fn();
+const ensureZkKeyPairMock = vi.fn();
+
+vi.mock('./auth.js', () => ({
+  api: (...args) => apiMock(...args),
+}));
+
+vi.mock('./zk-session.js', () => ({
+  isZkUnlocked: () => isZkUnlockedMock(),
+  getSessionAccountKey: () => {
+    throw new Error('ZK locked');
+  },
+}));
+
+vi.mock('./zk-crypto.js', () => ({
+  ensureZkKeyPair: (...args) => ensureZkKeyPairMock(...args),
+  openContent: vi.fn(),
+  parseEnvelopeVersion: () => 2,
+  hasZkKeyPair: vi.fn(),
+  sealContent: vi.fn(),
+  sealWithAccountKey: vi.fn(),
+  openContentDual: vi.fn(),
+  deleteZkKeyPair: vi.fn(),
+}));
+
+const { applyZkDecryption, SEALED_TITLE_LABEL } = await import('./zk-sync.js');
+
+describe('applyZkDecryption', () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+    isZkUnlockedMock.mockReset();
+    ensureZkKeyPairMock.mockReset();
+  });
+
+  it('skips keypair fetch when account key mode is locked', async () => {
+    isZkUnlockedMock.mockReturnValue(false);
+    const nodes = [{ key: 'Roxabi/live#1', title: null }];
+
+    await applyZkDecryption(nodes, 'alice', { accountKeyMode: true });
+
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(ensureZkKeyPairMock).not.toHaveBeenCalled();
+    expect(nodes[0].title).toBe(SEALED_TITLE_LABEL);
+  });
+});

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -4,17 +4,20 @@
 # The declared count is a local cap — exceeding it fails the gate.
 
 # Production sources above QG_FILE_MAX=300 (split deferred; cap prevents growth)
-worker/src/sync/sync.ts  # 1188 lines — #180 sync orchestrator; split tracked separately
-worker/src/webhook/handlers.ts  # 448 lines — #180 issue webhook dispatch surface
+worker/src/sync/sync.ts  # 1290 lines — #180 sync orchestrator; #216 structure-only sync path
+worker/src/api/zk-key-backup.ts  # 340 lines — #216 passphrase backup API (enroll/update/rotation)
+worker/src/webhook/handlers.ts  # 460 lines — #180 issue webhook dispatch surface
 worker/src/webhook/handlers-app.ts  # 369 lines — #180 GitHub App lifecycle handlers
 worker/src/webhook/mutations.ts  # 339 lines — #180 D1 write helpers for webhooks
 
 # Test files (colocated *.test.ts — exempt with local caps, not production code)
-worker/src/sync/sync.test.ts  # 1570 lines — #180 integration harness for runSync
-worker/src/webhook/handlers.test.ts  # 930 lines — #180 webhook handler contract tests
+worker/src/sync/sync.test.ts  # 1715 lines — #180 integration harness for runSync; #216 structure-only
+worker/src/api/zk-key-backup.test.ts  # 385 lines — #216 backup API security + CAS/reauth tests
+worker/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
 worker/src/auth/oauth.test.ts  # 864 lines — #180 OAuth callback + batch tests
-worker/src/api/issues.test.ts  # 659 lines — #180 tenant-scoped issues API tests
-worker/src/api/graph.test.ts  # 737 lines — #180 tenant-scoped graph + #142 S2 zk title redaction + closed_under_open_epic
+worker/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
+worker/src/api/graph.test.ts  # 745 lines — #180 tenant-scoped graph + #142 S2 zk + closed_under_open_epic
+worker/src/migrations.test.ts  # 310 lines — #216 zk_key_backups + zk_reauth_proofs schema tests
 worker/src/webhook/mutations.test.ts  # 587 lines — #180 webhook mutation tests
 worker/src/webhook/handlers-app.test.ts  # 498 lines — #180 app lifecycle handler tests
 worker/src/auth/installToken.test.ts  # 470 lines — #180 install token + pagination tests

--- a/worker/migrations/0013_zk_always_on.sql
+++ b/worker/migrations/0013_zk_always_on.sql
@@ -1,0 +1,4 @@
+-- migration: 0013_zk_always_on.sql
+-- Private mode is always on (#142): enable ZK for all existing users.
+
+UPDATE users SET zk_opt_in = 1 WHERE zk_opt_in = 0;

--- a/worker/migrations/0014_zk_key_backups.sql
+++ b/worker/migrations/0014_zk_key_backups.sql
@@ -1,0 +1,21 @@
+-- migration: 0014_zk_key_backups.sql
+-- Passphrase-wrapped accountKey backup per user (#216 PR 1).
+-- pubkey_fp → key_fp transition: dual-write period until 0017 drops pubkey_fp.
+
+CREATE TABLE IF NOT EXISTS zk_key_backups (
+  user_id        INTEGER NOT NULL REFERENCES users(id) PRIMARY KEY,
+  backup_version INTEGER NOT NULL DEFAULT 1,
+  kdf_alg        TEXT NOT NULL DEFAULT 'argon2id',
+  kdf_params     TEXT NOT NULL,
+  wrap_iv        TEXT NOT NULL,
+  wrapped_key    TEXT NOT NULL,
+  key_fp         TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+ALTER TABLE zk_payloads ADD COLUMN key_fp TEXT;
+
+UPDATE zk_payloads
+SET key_fp = pubkey_fp
+WHERE key_fp IS NULL AND pubkey_fp IS NOT NULL;

--- a/worker/migrations/0015_zk_reauth.sql
+++ b/worker/migrations/0015_zk_reauth.sql
@@ -1,0 +1,14 @@
+-- migration: 0015_zk_reauth.sql
+-- OAuth step-up re-auth proofs for zk_key_backups UPDATE (#216 PR 2).
+
+ALTER TABLE oauth_state ADD COLUMN reauth INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS zk_reauth_proofs (
+  code       TEXT PRIMARY KEY,
+  user_id    INTEGER NOT NULL REFERENCES users(id),
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_zk_reauth_proofs_user_id ON zk_reauth_proofs(user_id);
+CREATE INDEX IF NOT EXISTS ix_zk_reauth_proofs_expires_at ON zk_reauth_proofs(expires_at);

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -57,6 +57,7 @@ function makeGraphEnv(
   repos: unknown[] = [],
   overrideVisible?: string[],
   zkOptIn = false,
+  sealedIssueKeys: string[] = [],
 ): Env {
   const visibleRepos =
     overrideVisible ??
@@ -68,6 +69,7 @@ function makeGraphEnv(
       args,
       dispatchByTable(sql, {
         "zk_opt_in": [{ zk_opt_in: zkOptIn ? 1 : 0 }],
+        "from zk_payloads": sealedIssueKeys.map((issue_key) => ({ issue_key })),
         "tenant_repo_access": visibleRepos.map((repo) => ({
           repo,
           is_private: 0,
@@ -161,7 +163,7 @@ describe("GET /api/graph", () => {
       expect(Array.isArray(body.repos)).toBe(true);
     });
 
-    it("redacts titles when zk_opt_in is enabled", async () => {
+    it("redacts titles when issue is zk-sealed", async () => {
       const issue = {
         key: "Roxabi/roxabi-live#7",
         repo: "Roxabi/roxabi-live",
@@ -180,7 +182,9 @@ describe("GET /api/graph", () => {
       const res = await testApp.request(
         "/api/graph",
         {},
-        makeGraphEnv([], [], [issue], [], [], undefined, true),
+        makeGraphEnv([], [], [issue], [], [], undefined, false, [
+          "Roxabi/roxabi-live#7",
+        ]),
       );
       const body = await res.json<{ nodes: Record<string, unknown>[] }>();
       expect(body.nodes[0].title).toBeNull();

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -16,7 +16,7 @@
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { resolveVisibleRepos } from "../auth/repoAccess";
-import { userZkOptIn } from "../auth/zk";
+import { loadZkSealedIssueKeys, redactIssueTitle } from "../auth/zk";
 import {
   filterNodesByStatus,
   parseClosedUnderOpenEpicQuery,
@@ -122,9 +122,7 @@ interface EdgeRow {
 }
 
 export const graphRoute = async (c: Context<AuthEnv>) => {
-  const s = c.get("session");
-  const redactTitles =
-    s !== undefined && (await userZkOptIn(c.env.DB, s.userId));
+  const sealedKeys = await loadZkSealedIssueKeys(c.env.DB);
 
   const visible = await resolveVisibleRepos(c);
 
@@ -200,7 +198,7 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
       key: row.key,
       repo: row.repo,
       number: row.number,
-      title: redactTitles ? null : row.title,
+      title: redactIssueTitle(row.title, row.key, sealedKeys),
       state: row.state,
       dev_state: devState,
       url: row.url,

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -61,11 +61,28 @@ interface ListEnvOptions {
   rows: unknown[];
   labels?: unknown[];
   zkOptIn?: boolean;
+  sealedIssueKeys?: string[];
 }
 
 interface CapturedCall {
   sql: string;
   args: unknown[];
+}
+
+/** D1 prepare() supports .all()/.first() without .bind() — mirror that in fakes. */
+function d1Prepare(stmt: {
+  first?: () => Promise<unknown>;
+  all?: () => Promise<{ results: unknown[] }>;
+}) {
+  const bound = {
+    first: stmt.first ?? (async () => null),
+    all: stmt.all ?? (async () => ({ results: [] })),
+  };
+  return {
+    bind: (..._args: unknown[]) => bound,
+    first: bound.first,
+    all: bound.all,
+  };
 }
 
 /**
@@ -84,21 +101,36 @@ function makeListEnvWithCapture(
 
   const env = {
     DB: {
-      prepare: (sql: string) => ({
-        bind: (...args: unknown[]) => {
-          // Capture immediately for direct .bind().all() calls (e.g. labels query)
+      prepare: (sql: string) => {
+        const makeBound = (args: unknown[]) => {
           captured.push({ sql, args });
           return {
             _sql: sql,
             _args: args,
             first: async () => null,
             all: async () => {
+              if (sql.includes("FROM zk_payloads")) return { results: [] };
               if (sql.includes("FROM labels")) return { results: labels };
               return { results: [] };
             },
           };
-        },
-      }),
+        };
+        let directCaptured = false;
+        const directAll = async () => {
+          if (!directCaptured) {
+            captured.push({ sql, args: [] });
+            directCaptured = true;
+          }
+          if (sql.includes("FROM zk_payloads")) return { results: [] };
+          if (sql.includes("FROM labels")) return { results: labels };
+          return { results: [] };
+        };
+        return {
+          bind: (...args: unknown[]) => makeBound(args),
+          first: async () => null,
+          all: directAll,
+        };
+      },
       batch: async (_stmts: unknown[]) => {
         // sql/args already captured in bind() above
         return [
@@ -115,22 +147,24 @@ function makeListEnvWithCapture(
 }
 
 function makeListEnv(opts: ListEnvOptions): Env {
-  const { countN, rows, labels = [], zkOptIn = false } = opts;
+  const { countN, rows, labels = [], zkOptIn = false, sealedIssueKeys = [] } = opts;
 
   return {
     DB: {
-      prepare: (sql: string) => ({
-        bind: (..._args: unknown[]) => ({
+      prepare: (sql: string) =>
+        d1Prepare({
           first: async () => {
             if (sql.includes("zk_opt_in")) return { zk_opt_in: zkOptIn ? 1 : 0 };
             return null;
           },
           all: async () => {
+            if (sql.includes("FROM zk_payloads")) {
+              return { results: sealedIssueKeys.map((issue_key) => ({ issue_key })) };
+            }
             if (sql.includes("FROM labels")) return { results: labels };
             return { results: [] };
           },
         }),
-      }),
       batch: async (_stmts: unknown[]) => [
         { results: [{ n: countN }] },
         { results: rows },
@@ -147,6 +181,7 @@ interface GetEnvOptions {
   blocking?: unknown[];
   blockedBy?: unknown[];
   zkOptIn?: boolean;
+  sealedIssueKeys?: string[];
 }
 
 function makeGetEnv(opts: GetEnvOptions): Env {
@@ -156,6 +191,7 @@ function makeGetEnv(opts: GetEnvOptions): Env {
     blocking = [],
     blockedBy = [],
     zkOptIn = false,
+    sealedIssueKeys = [],
   } = opts;
 
   // Dispatch by SQL content — robust to query reordering:
@@ -166,24 +202,23 @@ function makeGetEnv(opts: GetEnvOptions): Env {
 
   return {
     DB: {
-      prepare: (sql: string) => ({
-        bind: (..._args: unknown[]) => ({
+      prepare: (sql: string) =>
+        d1Prepare({
           first: async () => {
             if (sql.includes("zk_opt_in")) return { zk_opt_in: zkOptIn ? 1 : 0 };
             if (sql.includes("FROM issues WHERE key")) return issueRow;
             return null;
           },
           all: async () => {
+            if (sql.includes("FROM zk_payloads")) {
+              return { results: sealedIssueKeys.map((issue_key) => ({ issue_key })) };
+            }
             if (sql.includes("FROM labels WHERE issue_key")) return { results: labels };
             if (sql.includes("e.src_key = ?")) return { results: blocking };
             if (sql.includes("e.dst_key = ?")) return { results: blockedBy };
             return { results: [] };
           },
         }),
-        // fallback — should not be called for getIssue
-        first: async () => null,
-        all: async () => ({ results: [] }),
-      }),
       batch: async () => [],
     },
     ASSETS: { fetch: async () => new Response("asset", { status: 200 }) },
@@ -211,22 +246,19 @@ function makeGetEnvWithCapture(opts: GetEnvOptions): {
     DB: {
       prepare: (sql: string) => {
         capturedSqls.push(sql);
-        return {
-          bind: (..._args: unknown[]) => ({
-            first: async () => {
-              if (sql.includes("FROM issues WHERE key")) return issueRow;
-              return null;
-            },
-            all: async () => {
-              if (sql.includes("FROM labels WHERE issue_key")) return { results: labels };
-              if (sql.includes("e.src_key = ?")) return { results: blocking };
-              if (sql.includes("e.dst_key = ?")) return { results: blockedBy };
-              return { results: [] };
-            },
-          }),
-          first: async () => null,
-          all: async () => ({ results: [] }),
-        };
+        return d1Prepare({
+          first: async () => {
+            if (sql.includes("FROM issues WHERE key")) return issueRow;
+            return null;
+          },
+          all: async () => {
+            if (sql.includes("FROM zk_payloads")) return { results: [] };
+            if (sql.includes("FROM labels WHERE issue_key")) return { results: labels };
+            if (sql.includes("e.src_key = ?")) return { results: blocking };
+            if (sql.includes("e.dst_key = ?")) return { results: blockedBy };
+            return { results: [] };
+          },
+        });
       },
       batch: async () => [],
     },
@@ -256,10 +288,16 @@ function makeRepoFilteredGetEnv(opts: {
             }
             return null;
           },
-          all: async () => ({ results: [] }),
+          all: async () => {
+            if (sql.includes("FROM zk_payloads")) return { results: [] };
+            return { results: [] };
+          },
         }),
         first: async () => null,
-        all: async () => ({ results: [] }),
+        all: async () => {
+          if (sql.includes("FROM zk_payloads")) return { results: [] };
+          return { results: [] };
+        },
       }),
       batch: async () => [],
     },
@@ -379,12 +417,16 @@ describe("GET /api/issues", () => {
       expect(body.issues[0].is_stub).toBe(false);
     });
 
-    it("redacts titles when zk_opt_in is enabled", async () => {
+    it("redacts titles when issue is zk-sealed", async () => {
       const row = makeIssueRow({ title: "Secret title" });
       const res = await app.request(
         "/api/issues",
         {},
-        makeListEnv({ countN: 1, rows: [row], zkOptIn: true }),
+        makeListEnv({
+          countN: 1,
+          rows: [row],
+          sealedIssueKeys: [row.key as string],
+        }),
       );
       const body = await res.json<{ issues: Record<string, unknown>[] }>();
       expect(body.issues[0].title).toBeNull();
@@ -514,12 +556,12 @@ describe("GET /api/issues/:key", () => {
       expect(Array.isArray(body.blocked_by)).toBe(true);
     });
 
-    it("redacts title when zk_opt_in is enabled", async () => {
+    it("redacts title when issue is zk-sealed", async () => {
       const row = makeIssueRow({ title: "Secret title" });
       const res = await app.request(
         "/api/issues/Roxabi/roxabi-live%231",
         {},
-        makeGetEnv({ issueRow: row, zkOptIn: true }),
+        makeGetEnv({ issueRow: row, sealedIssueKeys: [row.key as string] }),
       );
       const body = await res.json<Record<string, unknown>>();
       expect(body.title).toBeNull();
@@ -776,6 +818,7 @@ describe("#148 tenant scoping", () => {
             first: async () =>
               sql.includes("FROM issues WHERE key") ? makeIssueRow() : null,
             all: async () => {
+              if (sql.includes("FROM zk_payloads")) return { results: [] };
               if (sql.includes("e.dst_key = ?")) {
                 return { results: args.includes(hiddenBlocker.repo) ? [hiddenBlocker] : [] };
               }
@@ -783,7 +826,10 @@ describe("#148 tenant scoping", () => {
             },
           }),
           first: async () => null,
-          all: async () => ({ results: [] }),
+          all: async () => {
+            if (sql.includes("FROM zk_payloads")) return { results: [] };
+            return { results: [] };
+          },
         }),
         batch: async () => [],
       },

--- a/worker/src/api/issues.ts
+++ b/worker/src/api/issues.ts
@@ -11,7 +11,7 @@
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { resolveVisibleRepos } from "../auth/repoAccess";
-import { userZkOptIn } from "../auth/zk";
+import { loadZkSealedIssueKeys, redactIssueTitle } from "../auth/zk";
 
 const ISSUE_KEY_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+#[0-9]+$/;
 
@@ -45,9 +45,7 @@ interface EdgeJoinRow {
 }
 
 export const listIssuesRoute = async (c: Context<AuthEnv>) => {
-  const s = c.get("session");
-  const redactTitles =
-    s !== undefined && (await userZkOptIn(c.env.DB, s.userId));
+  const sealedKeys = await loadZkSealedIssueKeys(c.env.DB);
 
   const visible = await resolveVisibleRepos(c);
 
@@ -130,7 +128,7 @@ export const listIssuesRoute = async (c: Context<AuthEnv>) => {
     key: row.key,
     repo: row.repo,
     number: row.number,
-    title: redactTitles ? null : row.title,
+    title: redactIssueTitle(row.title, row.key, sealedKeys),
     state: row.state,
     url: row.url,
     labels: labelsByKey.get(row.key) ?? [],
@@ -145,9 +143,7 @@ export const listIssuesRoute = async (c: Context<AuthEnv>) => {
 };
 
 export const getIssueRoute = async (c: Context<AuthEnv>) => {
-  const s = c.get("session");
-  const redactTitles =
-    s !== undefined && (await userZkOptIn(c.env.DB, s.userId));
+  const sealedKeys = await loadZkSealedIssueKeys(c.env.DB);
 
   const visible = await resolveVisibleRepos(c);
 
@@ -221,7 +217,7 @@ export const getIssueRoute = async (c: Context<AuthEnv>) => {
     key: row.key,
     repo: row.repo,
     number: row.number,
-    title: redactTitles ? null : row.title,
+    title: redactIssueTitle(row.title, row.key, sealedKeys),
     state: row.state,
     url: row.url,
     labels,

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -64,6 +64,36 @@ describe("meRoute", () => {
     expect(body.user.zk_opt_in).toBe(false);
   });
 
+  it("includes zk_account_key_enabled and zk_enrolled defaults", async () => {
+    const { db } = captureDb();
+    const app = makeApp(db);
+    const res = await app.request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as {
+      user: { zk_account_key_enabled: boolean; zk_enrolled: boolean };
+    };
+    expect(body.user.zk_account_key_enabled).toBe(false);
+    expect(body.user.zk_enrolled).toBe(false);
+  });
+
+  it("returns zk_enrolled true when backup row exists", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_key_backups")) return [{ ok: 1 }];
+      if (sql.includes("zk_opt_in")) return [{ zk_opt_in: 1 }];
+      return [];
+    });
+    const res = await makeApp(db).request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as { user: { zk_enrolled: boolean } };
+    expect(body.user.zk_enrolled).toBe(true);
+  });
+
+  it("returns zk_account_key_enabled when env flag set", async () => {
+    const { db } = captureDb();
+    const env = { ...makeEnv(db), ZK_ACCOUNT_KEY: "1" };
+    const res = await makeApp(db).request("/api/me", {}, env);
+    const body = await res.json() as { user: { zk_account_key_enabled: boolean } };
+    expect(body.user.zk_account_key_enabled).toBe(true);
+  });
+
   it("returns zk_opt_in true when users row has flag set", async () => {
     const { db } = captureDb((sql) => {
       if (sql.toLowerCase().includes("zk_opt_in")) {

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -7,6 +7,7 @@ import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { readSessionToken, clearSessionCookie } from "../auth/cookies";
 import { deleteSession } from "../auth/session";
+import { zkAccountKeyEnabled } from "../auth/zk-flags";
 
 // ---------------------------------------------------------------------------
 // GET /api/me
@@ -27,6 +28,13 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
     .bind(s.userId)
     .first<{ zk_opt_in: number }>();
 
+  const enrolledRow = await c.env.DB
+    .prepare(
+      `SELECT 1 AS ok FROM zk_key_backups WHERE user_id = ? LIMIT 1`,
+    )
+    .bind(s.userId)
+    .first<{ ok: number }>();
+
   const rows = await c.env.DB
     .prepare(
       `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
@@ -40,6 +48,8 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
       github_id: s.githubId,
       github_login: s.githubLogin,
       zk_opt_in: userRow?.zk_opt_in === 1,
+      zk_enrolled: enrolledRow != null,
+      zk_account_key_enabled: zkAccountKeyEnabled(c.env),
     },
     active_tenant_id: s.tenantId,
     installations: rows.results,

--- a/worker/src/api/zk-integration.test.ts
+++ b/worker/src/api/zk-integration.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Cross-route ZK enrollment integration (#216 PR 8).
+ * Hono harness + stateful FakeD1: enroll → seal payloads → graph redaction.
+ */
+
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { putZkKeyBackupRoute } from "./zk-key-backup";
+import { putZkPayloadsRoute } from "./zk-payloads";
+import { graphRoute } from "./graph";
+import { makeFakeDb, makeFakeStmt } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+const ISSUE_KEY = "Roxabi/live#42";
+const REPO = "Roxabi/live";
+
+const VALID_BACKUP = {
+  key_fp: "deadbeef12345678",
+  kdf_params: JSON.stringify({ m: 65536, t: 3, p: 1 }),
+  wrap_iv: "iv-b64",
+  wrapped_key: "wrapped-b64",
+  backup_version: 1,
+};
+
+interface IntegrationState {
+  backup: { backup_version: number; key_fp: string } | null;
+  payloads: Array<{
+    user_id: number;
+    issue_key: string;
+    pubkey_fp: string;
+    key_fp: string;
+    encrypted_payload: string;
+  }>;
+  issues: Map<
+    string,
+    {
+      key: string;
+      repo: string;
+      number: number;
+      title: string;
+      state: string;
+      url: string | null;
+      milestone: string | null;
+      lane: string | null;
+      priority: string | null;
+      size: string | null;
+      status: string | null;
+      is_stub: number;
+      has_active_branch: number;
+    }
+  >;
+  backupPutCount: number;
+}
+
+function seedState(): IntegrationState {
+  return {
+    backup: null,
+    payloads: [],
+    issues: new Map([
+      [
+        ISSUE_KEY,
+        {
+          key: ISSUE_KEY,
+          repo: REPO,
+          number: 42,
+          title: "Secret sprint title",
+          state: "open",
+          url: `https://github.com/${REPO}/issues/42`,
+          milestone: null,
+          lane: null,
+          priority: null,
+          size: null,
+          status: null,
+          is_stub: 0,
+          has_active_branch: 0,
+        },
+      ],
+    ]),
+    backupPutCount: 0,
+  };
+}
+
+function makeIntegrationDb(state: IntegrationState): D1Database {
+  return makeFakeDb((sql, args) => {
+    const lower = sql.toLowerCase();
+
+    if (lower.includes("sync_control") && lower.includes("select")) {
+      return makeFakeStmt(sql, args, []);
+    }
+
+    if (lower.includes("insert into sync_control")) {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      stmt.run = vi.fn(async () => {
+        state.backupPutCount += 1;
+        return { meta: { changes: 1 } };
+      });
+      return stmt;
+    }
+
+    if (lower.includes("from zk_key_backups") && lower.includes("select")) {
+      if (!state.backup) return makeFakeStmt(sql, args, []);
+      return makeFakeStmt(sql, args, [
+        {
+          backup_version: state.backup.backup_version,
+          key_fp: state.backup.key_fp,
+          kdf_alg: "argon2id",
+          kdf_params: VALID_BACKUP.kdf_params,
+          wrap_iv: VALID_BACKUP.wrap_iv,
+          wrapped_key: VALID_BACKUP.wrapped_key,
+          created_at: "2026-06-18T00:00:00Z",
+          updated_at: "2026-06-18T00:00:00Z",
+        },
+      ]);
+    }
+
+    if (lower.includes("insert into zk_key_backups")) {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      stmt.run = vi.fn(async () => {
+        state.backup = { backup_version: 1, key_fp: String(args[5]) };
+        return { meta: { changes: 1 } };
+      });
+      return stmt;
+    }
+
+    if (lower.includes("insert into zk_payloads")) {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      stmt.run = vi.fn(async () => {
+        const user_id = Number(args[0]);
+        const issue_key = String(args[1]);
+        const pubkey_fp = String(args[2]);
+        const key_fp = String(args[3]);
+        const encrypted_payload = String(args[4]);
+        const idx = state.payloads.findIndex(
+          (p) => p.user_id === user_id && p.issue_key === issue_key,
+        );
+        const row = {
+          user_id,
+          issue_key,
+          pubkey_fp,
+          key_fp,
+          encrypted_payload,
+        };
+        if (idx >= 0) state.payloads[idx] = row;
+        else state.payloads.push(row);
+        return { meta: { changes: 1 } };
+      });
+      return stmt;
+    }
+
+    if (lower.includes("update issues set payload = json_object()")) {
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      stmt.run = vi.fn(async () => {
+        for (let i = 0; i < args.length; i += 1) {
+          const key = String(args[i]);
+          const issue = state.issues.get(key);
+          if (issue) issue.title = "";
+        }
+        return { meta: { changes: 1 } };
+      });
+      return stmt;
+    }
+
+    if (lower.includes("distinct issue_key from zk_payloads")) {
+      const keys = [...new Set(state.payloads.map((p) => p.issue_key))];
+      return makeFakeStmt(
+        sql,
+        args,
+        keys.map((issue_key) => ({ issue_key })),
+      );
+    }
+
+    if (lower.includes("tenant_repo_access")) {
+      return makeFakeStmt(sql, args, [{ repo: REPO, is_private: 0 }]);
+    }
+
+    if (lower.includes("from labels")) {
+      return makeFakeStmt(sql, args, []);
+    }
+
+    if (lower.includes("from pr_state")) {
+      return makeFakeStmt(sql, args, []);
+    }
+
+    if (lower.includes("from edges")) {
+      return makeFakeStmt(sql, args, []);
+    }
+
+    if (lower.includes("from repos")) {
+      return makeFakeStmt(sql, args, [{ repo: REPO, archived: 0 }]);
+    }
+
+    if (lower.includes("from issues")) {
+      const issue = state.issues.get(ISSUE_KEY);
+      return makeFakeStmt(sql, args, issue ? [{ ...issue }] : []);
+    }
+
+    return makeFakeStmt(sql, args, []);
+  });
+}
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("ok") } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.put("/api/zk/key-backup", putZkKeyBackupRoute);
+  app.put("/api/zk/payloads", putZkPayloadsRoute);
+  app.get("/api/graph", graphRoute);
+  return app;
+}
+
+describe("ZK enrollment integration (#216 PR 8)", () => {
+  it("enroll → seal payloads → graph returns null titles for sealed issues", async () => {
+    const state = seedState();
+    const db = makeIntegrationDb(state);
+    const app = makeApp(db);
+    const env = makeEnv(db);
+
+    const enrollRes = await app.request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_BACKUP),
+      },
+      env,
+    );
+    expect(enrollRes.status).toBe(200);
+    const enrollBody = (await enrollRes.json()) as {
+      backup_version: number;
+      key_fp: string;
+    };
+    expect(enrollBody).toEqual({
+      backup_version: 1,
+      key_fp: VALID_BACKUP.key_fp,
+    });
+    expect(state.backup).toEqual({
+      backup_version: 1,
+      key_fp: VALID_BACKUP.key_fp,
+    });
+
+    const sealRes = await app.request(
+      "/api/zk/payloads",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          payloads: [
+            {
+              issue_key: ISSUE_KEY,
+              key_fp: VALID_BACKUP.key_fp,
+              encrypted_payload: JSON.stringify({ v: 2, ct: "cipher" }),
+            },
+          ],
+        }),
+      },
+      env,
+    );
+    expect(sealRes.status).toBe(200);
+    expect(state.payloads).toHaveLength(1);
+    expect(state.payloads[0].issue_key).toBe(ISSUE_KEY);
+
+    const graphRes = await app.request("/api/graph", {}, env);
+    expect(graphRes.status).toBe(200);
+    const graph = (await graphRes.json()) as {
+      nodes: Array<{ key: string; title: string | null }>;
+    };
+    const node = graph.nodes.find((n) => n.key === ISSUE_KEY);
+    expect(node).toBeDefined();
+    expect(node!.title).toBeNull();
+  });
+});

--- a/worker/src/api/zk-integration.test.ts
+++ b/worker/src/api/zk-integration.test.ts
@@ -215,6 +215,7 @@ function makeEnv(db: D1Database): Env {
     DB: db,
     ASSETS: { fetch: async () => new Response("ok") } as unknown as Fetcher,
     GITHUB_WEBHOOK_SECRET: "",
+    ZK_ACCOUNT_KEY: "1",
   } as unknown as Env;
 }
 

--- a/worker/src/api/zk-integration.test.ts
+++ b/worker/src/api/zk-integration.test.ts
@@ -10,7 +10,7 @@ import type { AuthEnv, SessionContext } from "../auth/types";
 import { putZkKeyBackupRoute } from "./zk-key-backup";
 import { putZkPayloadsRoute } from "./zk-payloads";
 import { graphRoute } from "./graph";
-import { makeFakeDb, makeFakeStmt } from "../test-utils";
+import { makeFakeDb, makeFakeStmt, type FakeStmt } from "../test-utils";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -126,11 +126,14 @@ function makeIntegrationDb(state: IntegrationState): D1Database {
     }
 
     if (lower.includes("insert into zk_key_backups")) {
-      const stmt = makeFakeStmt(sql, args, [], 1);
-      stmt.run = vi.fn(async () => {
-        state.backup = { backup_version: 1, key_fp: String(args[5]) };
-        return { meta: { changes: 1 } };
-      });
+      const userId = Number(args[0]);
+      const keyFp = String(args[5]);
+      const stmt = makeFakeStmt(sql, args, [{ user_id: userId }], 1);
+      stmt.first = vi.fn(async () => {
+        if (state.backup) return null;
+        state.backup = { backup_version: 1, key_fp: keyFp };
+        return { user_id: userId };
+      }) as FakeStmt["first"];
       return stmt;
     }
 

--- a/worker/src/api/zk-key-backup.test.ts
+++ b/worker/src/api/zk-key-backup.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import {
+  getZkKeyBackupRoute,
+  putZkKeyBackupRoute,
+} from "./zk-key-backup";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { captureDb } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+const VALID_BODY = {
+  key_fp: "deadbeef12345678",
+  kdf_params: JSON.stringify({ m: 65536, t: 3, p: 1 }),
+  wrap_iv: "iv-b64",
+  wrapped_key: "wrapped-b64",
+  backup_version: 1,
+};
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("ok") } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.get("/api/zk/key-backup", getZkKeyBackupRoute);
+  app.put("/api/zk/key-backup", putZkKeyBackupRoute);
+  return app;
+}
+
+describe("getZkKeyBackupRoute", () => {
+  it("returns 404 when not enrolled", async () => {
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request("/api/zk/key-backup", {}, makeEnv(db));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns backup row when enrolled", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_key_backups")) {
+        return [{
+          backup_version: 1,
+          kdf_alg: "argon2id",
+          kdf_params: "{}",
+          wrap_iv: "iv",
+          wrapped_key: "wk",
+          key_fp: "abcd1234",
+          created_at: "t1",
+          updated_at: "t2",
+        }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request("/api/zk/key-backup", {}, makeEnv(db));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { key_fp: string };
+    expect(body.key_fp).toBe("abcd1234");
+  });
+});
+
+describe("putZkKeyBackupRoute", () => {
+  it("inserts on first enroll", async () => {
+    const { db, stmts } = captureDb((sql) => {
+      if (sql.includes("zk_key_backups") && sql.includes("SELECT")) return [];
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_BODY),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const insert = stmts().find((s) => s.sql.includes("INSERT INTO zk_key_backups"));
+    expect(insert).toBeDefined();
+  });
+
+  it("returns 409 enrolled when different key_fp without rotation", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
+        return [{ backup_version: 1, key_fp: "original1234" }];
+      }
+      if (sql.includes("zk_reauth_proofs") && sql.includes("DELETE")) {
+        return [{ code: "0123456789abcdef0123456789abcdef" }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          expected_backup_version: 1,
+          reauth_proof: "0123456789abcdef0123456789abcdef",
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("enrolled");
+  });
+
+  it("returns 403 reauth_required on update without proof", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
+        return [{ backup_version: 1, key_fp: VALID_BODY.key_fp }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          expected_backup_version: 1,
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("reauth_required");
+  });
+});

--- a/worker/src/api/zk-key-backup.test.ts
+++ b/worker/src/api/zk-key-backup.test.ts
@@ -6,7 +6,7 @@ import {
   putZkKeyBackupRoute,
 } from "./zk-key-backup";
 import type { AuthEnv, SessionContext } from "../auth/types";
-import { captureDb } from "../test-utils";
+import { captureDb, makeFakeDb, makeFakeStmt } from "../test-utils";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -124,6 +124,23 @@ describe("putZkKeyBackupRoute", () => {
     expect(body.error).toBe("invalid kdf_params");
   });
 
+  it("rejects excessive kdf_params", async () => {
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          kdf_params: JSON.stringify({ m: 131072, t: 3, p: 1 }),
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("does not increment rate limit on validation failure", async () => {
     const { db, stmts } = captureDb((sql) => {
       if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
@@ -154,6 +171,7 @@ describe("putZkKeyBackupRoute", () => {
   it("inserts on first enroll", async () => {
     const { db, stmts } = captureDb((sql) => {
       if (sql.includes("zk_key_backups") && sql.includes("SELECT")) return [];
+      if (sql.includes("INSERT INTO zk_key_backups")) return [{ user_id: 7 }];
       return [];
     });
     const res = await makeApp(db).request(
@@ -171,7 +189,7 @@ describe("putZkKeyBackupRoute", () => {
   });
 
   it("returns 409 enrolled when different key_fp without rotation", async () => {
-    const { db } = captureDb((sql) => {
+    const { db, stmts } = captureDb((sql) => {
       if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
         return [{ backup_version: 1, key_fp: "original1234" }];
       }
@@ -196,6 +214,54 @@ describe("putZkKeyBackupRoute", () => {
     expect(res.status).toBe(409);
     const body = await res.json() as { error: string };
     expect(body.error).toBe("enrolled");
+    const deleteProof = stmts().find(
+      (s) => s.sql.includes("zk_reauth_proofs") && s.sql.includes("DELETE"),
+    );
+    expect(deleteProof).toBeUndefined();
+  });
+
+  it("updates backup when reauth_proof is valid", async () => {
+    const proof = "0123456789abcdef0123456789abcdef";
+    const captured: ReturnType<typeof makeFakeStmt>[] = [];
+    const db = makeFakeDb((sql, args) => {
+      let rows: Record<string, unknown>[] = [];
+      let changes = 0;
+      if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
+        rows = [{ backup_version: 1, key_fp: VALID_BODY.key_fp }];
+      } else if (sql.includes("zk_reauth_proofs") && sql.includes("DELETE")) {
+        rows = [{ code: proof }];
+        changes = 1;
+      } else if (sql.includes("UPDATE zk_key_backups")) {
+        changes = 1;
+      } else if (sql.includes("sync_control")) {
+        changes = 1;
+      } else if (sql.includes("INSERT INTO zk_key_backups")) {
+        rows = [{ user_id: 7 }];
+        changes = 1;
+      }
+      const stmt = makeFakeStmt(sql, args, rows, changes);
+      captured.push(stmt);
+      return stmt;
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          expected_backup_version: 1,
+          reauth_proof: proof,
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { backup_version: number };
+    expect(body.backup_version).toBe(2);
+    const update = captured.find((s) => s.sql.includes("UPDATE zk_key_backups"));
+    expect(update?.sql).toContain("backup_version = ?");
+    expect(update?.args).toContain(1);
   });
 
   it("returns 403 reauth_required on update without proof", async () => {

--- a/worker/src/api/zk-key-backup.test.ts
+++ b/worker/src/api/zk-key-backup.test.ts
@@ -228,6 +228,8 @@ describe("putZkKeyBackupRoute", () => {
       let changes = 0;
       if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
         rows = [{ backup_version: 1, key_fp: VALID_BODY.key_fp }];
+      } else if (sql.includes("zk_reauth_proofs") && sql.includes("SELECT")) {
+        rows = [{ ok: 1 }];
       } else if (sql.includes("zk_reauth_proofs") && sql.includes("DELETE")) {
         rows = [{ code: proof }];
         changes = 1;
@@ -262,6 +264,113 @@ describe("putZkKeyBackupRoute", () => {
     const update = captured.find((s) => s.sql.includes("UPDATE zk_key_backups"));
     expect(update?.sql).toContain("backup_version = ?");
     expect(update?.args).toContain(1);
+    const deleteProof = captured.find(
+      (s) => s.sql.includes("zk_reauth_proofs") && s.sql.includes("DELETE"),
+    );
+    expect(deleteProof).toBeDefined();
+    const updateIdx = captured.findIndex((s) => s.sql.includes("UPDATE zk_key_backups"));
+    const deleteIdx = captured.findIndex(
+      (s) => s.sql.includes("zk_reauth_proofs") && s.sql.includes("DELETE"),
+    );
+    expect(deleteIdx).toBeGreaterThan(updateIdx);
+  });
+
+  it("returns 409 backup_version_conflict without consuming reauth on CAS miss", async () => {
+    const proof = "0123456789abcdef0123456789abcdef";
+    const { db, stmts } = captureDb((sql) => {
+      if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
+        return [{ backup_version: 1, key_fp: VALID_BODY.key_fp }];
+      }
+      if (sql.includes("zk_reauth_proofs") && sql.includes("SELECT")) {
+        return [{ ok: 1 }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          expected_backup_version: 1,
+          reauth_proof: proof,
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("backup_version_conflict");
+    const deleteProof = stmts().find(
+      (s) => s.sql.includes("zk_reauth_proofs") && s.sql.includes("DELETE"),
+    );
+    expect(deleteProof).toBeUndefined();
+  });
+
+  it("rotates key_fp when rotation=true and reauth valid", async () => {
+    const proof = "0123456789abcdef0123456789abcdef";
+    const newFp = "cafebabe12345678";
+    const captured: ReturnType<typeof makeFakeStmt>[] = [];
+    const db = makeFakeDb((sql, args) => {
+      let rows: Record<string, unknown>[] = [];
+      let changes = 0;
+      if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
+        rows = [{ backup_version: 2, key_fp: VALID_BODY.key_fp }];
+      } else if (sql.includes("zk_reauth_proofs") && sql.includes("SELECT")) {
+        rows = [{ ok: 1 }];
+      } else if (sql.includes("zk_reauth_proofs") && sql.includes("DELETE")) {
+        rows = [{ code: proof }];
+        changes = 1;
+      } else if (sql.includes("UPDATE zk_key_backups")) {
+        changes = 1;
+      } else if (sql.includes("sync_control")) {
+        changes = 1;
+      }
+      const stmt = makeFakeStmt(sql, args, rows, changes);
+      captured.push(stmt);
+      return stmt;
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          key_fp: newFp,
+          rotation: true,
+          expected_backup_version: 2,
+          reauth_proof: proof,
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { backup_version: number; key_fp: string };
+    expect(body.backup_version).toBe(3);
+    expect(body.key_fp).toBe(newFp);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("sync_control") && sql.includes("SELECT")) {
+        return [{ value: JSON.stringify({ hour: new Date().toISOString().slice(0, 13), count: 5 }) }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_BODY),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(429);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("rate_limited");
   });
 
   it("returns 403 reauth_required on update without proof", async () => {

--- a/worker/src/api/zk-key-backup.test.ts
+++ b/worker/src/api/zk-key-backup.test.ts
@@ -27,11 +27,13 @@ const VALID_BODY = {
   backup_version: 1,
 };
 
-function makeEnv(db: D1Database): Env {
+function makeEnv(db: D1Database, overrides: Partial<Env> = {}): Env {
   return {
     DB: db,
     ASSETS: { fetch: async () => new Response("ok") } as unknown as Fetcher,
     GITHUB_WEBHOOK_SECRET: "",
+    ZK_ACCOUNT_KEY: "1",
+    ...overrides,
   } as unknown as Env;
 }
 
@@ -47,6 +49,18 @@ function makeApp(db: D1Database): Hono<AuthEnv> {
 }
 
 describe("getZkKeyBackupRoute", () => {
+  it("returns 403 when ZK_ACCOUNT_KEY flag is off", async () => {
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {},
+      makeEnv(db, { ZK_ACCOUNT_KEY: "0" }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("zk_account_key_disabled");
+  });
+
   it("returns 404 when not enrolled", async () => {
     const { db } = captureDb(() => []);
     const res = await makeApp(db).request("/api/zk/key-backup", {}, makeEnv(db));
@@ -77,6 +91,66 @@ describe("getZkKeyBackupRoute", () => {
 });
 
 describe("putZkKeyBackupRoute", () => {
+  it("returns 403 when ZK_ACCOUNT_KEY flag is off", async () => {
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_BODY),
+      },
+      makeEnv(db, { ZK_ACCOUNT_KEY: "0" }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects weak kdf_params", async () => {
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          kdf_params: JSON.stringify({ m: 8192, t: 3, p: 1 }),
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("invalid kdf_params");
+  });
+
+  it("does not increment rate limit on validation failure", async () => {
+    const { db, stmts } = captureDb((sql) => {
+      if (sql.includes("zk_key_backups") && sql.includes("SELECT")) {
+        return [{ backup_version: 1, key_fp: VALID_BODY.key_fp }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/key-backup",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...VALID_BODY,
+          kdf_params: JSON.stringify({ m: 1024, t: 1, p: 1 }),
+          expected_backup_version: 1,
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(400);
+    const rateStmt = stmts().find(
+      (s) => s.sql.includes("sync_control") && s.sql.includes("INSERT"),
+    );
+    expect(rateStmt).toBeUndefined();
+  });
+
   it("inserts on first enroll", async () => {
     const { db, stmts } = captureDb((sql) => {
       if (sql.includes("zk_key_backups") && sql.includes("SELECT")) return [];

--- a/worker/src/api/zk-key-backup.ts
+++ b/worker/src/api/zk-key-backup.ts
@@ -1,0 +1,275 @@
+/**
+ * GET/PUT /api/zk/key-backup — passphrase-wrapped accountKey (#216 PR 2).
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/types";
+import { consumeReauthProof } from "../auth/zk-reauth";
+
+const KEY_FP_RE = /^[0-9a-f]{8,64}$/;
+const MAX_WRAPPED_BYTES = 8 * 1024;
+const MAX_PUT_PER_HOUR = 5;
+
+interface BackupRow {
+  backup_version: number;
+  kdf_alg: string;
+  kdf_params: string;
+  wrap_iv: string;
+  wrapped_key: string;
+  key_fp: string;
+  created_at: string;
+  updated_at: string;
+}
+
+async function checkBackupPutRateLimit(
+  db: D1Database,
+  userId: number,
+): Promise<boolean> {
+  const hourKey = new Date().toISOString().slice(0, 13);
+  const rowKey = `zk_backup_put:${userId}`;
+  const row = await db
+    .prepare(
+      `SELECT value FROM sync_control WHERE tenant_id = 0 AND key = ?`,
+    )
+    .bind(rowKey)
+    .first<{ value: string }>();
+
+  let count = 0;
+  let storedHour = hourKey;
+  if (row?.value) {
+    try {
+      const parsed = JSON.parse(row.value) as { hour?: string; count?: number };
+      storedHour = parsed.hour ?? hourKey;
+      count = typeof parsed.count === "number" ? parsed.count : 0;
+    } catch {
+      count = 0;
+    }
+  }
+
+  if (storedHour !== hourKey) {
+    count = 0;
+  }
+  if (count >= MAX_PUT_PER_HOUR) {
+    return false;
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO sync_control (tenant_id, key, value, updated_at)
+       VALUES (0, ?, ?, datetime('now'))
+       ON CONFLICT(tenant_id, key) DO UPDATE SET
+         value = excluded.value,
+         updated_at = datetime('now')`,
+    )
+    .bind(rowKey, JSON.stringify({ hour: hourKey, count: count + 1 }))
+    .run();
+
+  return true;
+}
+
+function logBackupEvent(
+  event: string,
+  userId: number,
+  keyFp: string,
+  backupVersion: number,
+  rotation: boolean,
+): void {
+  console.log(
+    JSON.stringify({
+      prefix: "[zk]",
+      event,
+      user_id: userId,
+      key_fp: keyFp,
+      backup_version: backupVersion,
+      rotation,
+    }),
+  );
+}
+
+export async function getZkKeyBackupRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+
+  const row = await c.env.DB
+    .prepare(
+      `SELECT backup_version, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp,
+              created_at, updated_at
+       FROM zk_key_backups WHERE user_id = ?`,
+    )
+    .bind(s.userId)
+    .first<BackupRow>();
+
+  if (!row) {
+    return c.json({ error: "not_enrolled" }, 404);
+  }
+
+  return c.json({
+    backup_version: row.backup_version,
+    kdf_alg: row.kdf_alg,
+    kdf_params: row.kdf_params,
+    wrap_iv: row.wrap_iv,
+    wrapped_key: row.wrapped_key,
+    key_fp: row.key_fp,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  });
+}
+
+export async function putZkKeyBackupRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+
+  if (!(await checkBackupPutRateLimit(c.env.DB, s.userId))) {
+    return c.json({ error: "rate_limited" }, 429);
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid body" }, 400);
+  }
+
+  if (body === null || typeof body !== "object") {
+    return c.json({ error: "invalid body" }, 400);
+  }
+
+  const b = body as Record<string, unknown>;
+  const key_fp = b.key_fp;
+  const kdf_params = b.kdf_params;
+  const wrap_iv = b.wrap_iv;
+  const wrapped_key = b.wrapped_key;
+  const kdf_alg =
+    typeof b.kdf_alg === "string" && b.kdf_alg.length > 0
+      ? b.kdf_alg
+      : "argon2id";
+  const rotation = b.rotation === true;
+  const reauth_proof =
+    typeof b.reauth_proof === "string" ? b.reauth_proof : null;
+  const expected_backup_version =
+    typeof b.expected_backup_version === "number"
+      ? b.expected_backup_version
+      : typeof b.backup_version === "number"
+        ? b.backup_version
+        : null;
+
+  if (typeof key_fp !== "string" || !KEY_FP_RE.test(key_fp)) {
+    return c.json({ error: "invalid key_fp" }, 400);
+  }
+  if (typeof kdf_params !== "string" || kdf_params.length === 0 || kdf_params.length > 512) {
+    return c.json({ error: "invalid kdf_params" }, 400);
+  }
+  if (typeof wrap_iv !== "string" || wrap_iv.length === 0 || wrap_iv.length > 256) {
+    return c.json({ error: "invalid wrap_iv" }, 400);
+  }
+  if (
+    typeof wrapped_key !== "string" ||
+    wrapped_key.length === 0 ||
+    wrapped_key.length > MAX_WRAPPED_BYTES
+  ) {
+    return c.json({ error: "invalid wrapped_key" }, 400);
+  }
+
+  const existing = await c.env.DB
+    .prepare(
+      `SELECT backup_version, key_fp FROM zk_key_backups WHERE user_id = ?`,
+    )
+    .bind(s.userId)
+    .first<{ backup_version: number; key_fp: string }>();
+
+  if (!existing) {
+    if (expected_backup_version != null && expected_backup_version !== 1) {
+      return c.json({ error: "backup_version_conflict" }, 409);
+    }
+    await c.env.DB
+      .prepare(
+        `INSERT INTO zk_key_backups
+         (user_id, backup_version, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp)
+         VALUES (?, 1, ?, ?, ?, ?, ?)`,
+      )
+      .bind(s.userId, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp)
+      .run();
+    logBackupEvent("zk.backup.enrolled", s.userId, key_fp, 1, false);
+    return c.json({ backup_version: 1, key_fp });
+  }
+
+  if (!reauth_proof) {
+    return c.json({ error: "reauth_required" }, 403);
+  }
+  if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
+    return c.json({ error: "reauth_required" }, 403);
+  }
+
+  if (rotation) {
+    if (expected_backup_version == null) {
+      return c.json({ error: "backup_version_conflict" }, 409);
+    }
+    if (expected_backup_version !== existing.backup_version) {
+      return c.json({ error: "backup_version_conflict" }, 409);
+    }
+    const nextVersion = existing.backup_version + 1;
+    await c.env.DB
+      .prepare(
+        `UPDATE zk_key_backups SET
+           backup_version = ?,
+           kdf_alg = ?,
+           kdf_params = ?,
+           wrap_iv = ?,
+           wrapped_key = ?,
+           key_fp = ?,
+           updated_at = datetime('now')
+         WHERE user_id = ?`,
+      )
+      .bind(
+        nextVersion,
+        kdf_alg,
+        kdf_params,
+        wrap_iv,
+        wrapped_key,
+        key_fp,
+        s.userId,
+      )
+      .run();
+    logBackupEvent("zk.backup.rotated", s.userId, key_fp, nextVersion, true);
+    return c.json({ backup_version: nextVersion, key_fp });
+  }
+
+  if (key_fp !== existing.key_fp) {
+    return c.json({ error: "enrolled" }, 409);
+  }
+
+  if (expected_backup_version == null) {
+    return c.json({ error: "backup_version_conflict" }, 409);
+  }
+  if (expected_backup_version !== existing.backup_version) {
+    return c.json({ error: "backup_version_conflict" }, 409);
+  }
+
+  const nextVersion = existing.backup_version + 1;
+  await c.env.DB
+    .prepare(
+      `UPDATE zk_key_backups SET
+         backup_version = ?,
+         kdf_alg = ?,
+         kdf_params = ?,
+         wrap_iv = ?,
+         wrapped_key = ?,
+         updated_at = datetime('now')
+       WHERE user_id = ?`,
+    )
+    .bind(
+      nextVersion,
+      kdf_alg,
+      kdf_params,
+      wrap_iv,
+      wrapped_key,
+      s.userId,
+    )
+    .run();
+  logBackupEvent("zk.backup.updated", s.userId, key_fp, nextVersion, false);
+  return c.json({ backup_version: nextVersion, key_fp });
+}

--- a/worker/src/api/zk-key-backup.ts
+++ b/worker/src/api/zk-key-backup.ts
@@ -5,7 +5,7 @@
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { zkAccountKeyEnabled } from "../auth/zk-flags";
-import { consumeReauthProof } from "../auth/zk-reauth";
+import { consumeReauthProof, issueReauthProof } from "../auth/zk-reauth";
 import { writeZkAudit } from "../observability/zk-events";
 
 const KEY_FP_RE = /^[0-9a-f]{8,64}$/;
@@ -289,7 +289,7 @@ export async function putZkKeyBackupRoute(
   if (!REAUTH_PROOF_RE.test(reauth_proof)) {
     return c.json({ error: "reauth_required" }, 403);
   }
-  if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
+  if (!(await issueReauthProof(c.env, s.userId, reauth_proof))) {
     return c.json({ error: "reauth_required" }, 403);
   }
 
@@ -323,6 +323,9 @@ export async function putZkKeyBackupRoute(
     if (result.meta.changes === 0) {
       return c.json({ error: "backup_version_conflict" }, 409);
     }
+    if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
+      return c.json({ error: "reauth_required" }, 403);
+    }
     await recordBackupPutSuccess(c.env.DB, s.userId);
     await logBackupEvent(c.env, "zk.backup.rotated", s.userId, key_fp, nextVersion, true);
     return c.json({ backup_version: nextVersion, key_fp });
@@ -351,6 +354,9 @@ export async function putZkKeyBackupRoute(
     .run();
   if (result.meta.changes === 0) {
     return c.json({ error: "backup_version_conflict" }, 409);
+  }
+  if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
+    return c.json({ error: "reauth_required" }, 403);
   }
   await recordBackupPutSuccess(c.env.DB, s.userId);
   await logBackupEvent(c.env, "zk.backup.updated", s.userId, key_fp, nextVersion, false);

--- a/worker/src/api/zk-key-backup.ts
+++ b/worker/src/api/zk-key-backup.ts
@@ -13,8 +13,12 @@ const MAX_WRAPPED_BYTES = 8 * 1024;
 const MAX_PUT_PER_HOUR = 5;
 const KDF_ALG = "argon2id";
 const KDF_M_MIN = 65536;
+const KDF_M_MAX = 65536;
 const KDF_T_MIN = 3;
+const KDF_T_MAX = 3;
 const KDF_P_MIN = 1;
+const KDF_P_MAX = 1;
+const REAUTH_PROOF_RE = /^[0-9a-f]{32}$/;
 
 function validateKdfParams(
   kdf_alg: string,
@@ -36,12 +40,15 @@ function validateKdfParams(
     typeof m === "number" &&
     Number.isInteger(m) &&
     m >= KDF_M_MIN &&
+    m <= KDF_M_MAX &&
     typeof t === "number" &&
     Number.isInteger(t) &&
     t >= KDF_T_MIN &&
+    t <= KDF_T_MAX &&
     typeof par === "number" &&
     Number.isInteger(par) &&
-    par >= KDF_P_MIN
+    par >= KDF_P_MIN &&
+    par <= KDF_P_MAX
   );
 }
 
@@ -238,23 +245,25 @@ export async function putZkKeyBackupRoute(
     if (expected_backup_version != null && expected_backup_version !== 1) {
       return c.json({ error: "backup_version_conflict" }, 409);
     }
-    await c.env.DB
+    const inserted = await c.env.DB
       .prepare(
         `INSERT INTO zk_key_backups
          (user_id, backup_version, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp)
-         VALUES (?, 1, ?, ?, ?, ?, ?)`,
+         VALUES (?, 1, ?, ?, ?, ?, ?)
+         ON CONFLICT(user_id) DO NOTHING
+         RETURNING user_id`,
       )
       .bind(s.userId, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp)
-      .run();
+      .first<{ user_id: number }>();
+    if (!inserted) {
+      return c.json({ error: "enrolled" }, 409);
+    }
     await recordBackupPutSuccess(c.env.DB, s.userId);
     await logBackupEvent(c.env, "zk.backup.enrolled", s.userId, key_fp, 1, false);
     return c.json({ backup_version: 1, key_fp });
   }
 
   if (!reauth_proof) {
-    return c.json({ error: "reauth_required" }, 403);
-  }
-  if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
     return c.json({ error: "reauth_required" }, 403);
   }
 
@@ -265,8 +274,30 @@ export async function putZkKeyBackupRoute(
     if (expected_backup_version !== existing.backup_version) {
       return c.json({ error: "backup_version_conflict" }, 409);
     }
-    const nextVersion = existing.backup_version + 1;
-    await c.env.DB
+  } else {
+    if (key_fp !== existing.key_fp) {
+      return c.json({ error: "enrolled" }, 409);
+    }
+    if (expected_backup_version == null) {
+      return c.json({ error: "backup_version_conflict" }, 409);
+    }
+    if (expected_backup_version !== existing.backup_version) {
+      return c.json({ error: "backup_version_conflict" }, 409);
+    }
+  }
+
+  if (!REAUTH_PROOF_RE.test(reauth_proof)) {
+    return c.json({ error: "reauth_required" }, 403);
+  }
+  if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
+    return c.json({ error: "reauth_required" }, 403);
+  }
+
+  const casVersion = existing.backup_version;
+  const nextVersion = existing.backup_version + 1;
+
+  if (rotation) {
+    const result = await c.env.DB
       .prepare(
         `UPDATE zk_key_backups SET
            backup_version = ?,
@@ -276,7 +307,7 @@ export async function putZkKeyBackupRoute(
            wrapped_key = ?,
            key_fp = ?,
            updated_at = datetime('now')
-         WHERE user_id = ?`,
+         WHERE user_id = ? AND backup_version = ?`,
       )
       .bind(
         nextVersion,
@@ -286,26 +317,18 @@ export async function putZkKeyBackupRoute(
         wrapped_key,
         key_fp,
         s.userId,
+        casVersion,
       )
       .run();
+    if (result.meta.changes === 0) {
+      return c.json({ error: "backup_version_conflict" }, 409);
+    }
     await recordBackupPutSuccess(c.env.DB, s.userId);
     await logBackupEvent(c.env, "zk.backup.rotated", s.userId, key_fp, nextVersion, true);
     return c.json({ backup_version: nextVersion, key_fp });
   }
 
-  if (key_fp !== existing.key_fp) {
-    return c.json({ error: "enrolled" }, 409);
-  }
-
-  if (expected_backup_version == null) {
-    return c.json({ error: "backup_version_conflict" }, 409);
-  }
-  if (expected_backup_version !== existing.backup_version) {
-    return c.json({ error: "backup_version_conflict" }, 409);
-  }
-
-  const nextVersion = existing.backup_version + 1;
-  await c.env.DB
+  const result = await c.env.DB
     .prepare(
       `UPDATE zk_key_backups SET
          backup_version = ?,
@@ -314,7 +337,7 @@ export async function putZkKeyBackupRoute(
          wrap_iv = ?,
          wrapped_key = ?,
          updated_at = datetime('now')
-       WHERE user_id = ?`,
+       WHERE user_id = ? AND backup_version = ?`,
     )
     .bind(
       nextVersion,
@@ -323,8 +346,12 @@ export async function putZkKeyBackupRoute(
       wrap_iv,
       wrapped_key,
       s.userId,
+      casVersion,
     )
     .run();
+  if (result.meta.changes === 0) {
+    return c.json({ error: "backup_version_conflict" }, 409);
+  }
   await recordBackupPutSuccess(c.env.DB, s.userId);
   await logBackupEvent(c.env, "zk.backup.updated", s.userId, key_fp, nextVersion, false);
   return c.json({ backup_version: nextVersion, key_fp });

--- a/worker/src/api/zk-key-backup.ts
+++ b/worker/src/api/zk-key-backup.ts
@@ -4,12 +4,46 @@
 
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
+import { zkAccountKeyEnabled } from "../auth/zk-flags";
 import { consumeReauthProof } from "../auth/zk-reauth";
 import { writeZkAudit } from "../observability/zk-events";
 
 const KEY_FP_RE = /^[0-9a-f]{8,64}$/;
 const MAX_WRAPPED_BYTES = 8 * 1024;
 const MAX_PUT_PER_HOUR = 5;
+const KDF_ALG = "argon2id";
+const KDF_M_MIN = 65536;
+const KDF_T_MIN = 3;
+const KDF_P_MIN = 1;
+
+function validateKdfParams(
+  kdf_alg: string,
+  kdf_params: string,
+): boolean {
+  if (kdf_alg !== KDF_ALG) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(kdf_params);
+  } catch {
+    return false;
+  }
+  if (parsed === null || typeof parsed !== "object") return false;
+  const p = parsed as Record<string, unknown>;
+  const m = p.m;
+  const t = p.t;
+  const par = p.p;
+  return (
+    typeof m === "number" &&
+    Number.isInteger(m) &&
+    m >= KDF_M_MIN &&
+    typeof t === "number" &&
+    Number.isInteger(t) &&
+    t >= KDF_T_MIN &&
+    typeof par === "number" &&
+    Number.isInteger(par) &&
+    par >= KDF_P_MIN
+  );
+}
 
 interface BackupRow {
   backup_version: number;
@@ -22,10 +56,10 @@ interface BackupRow {
   updated_at: string;
 }
 
-async function checkBackupPutRateLimit(
+async function readBackupPutCount(
   db: D1Database,
   userId: number,
-): Promise<boolean> {
+): Promise<{ hourKey: string; count: number }> {
   const hourKey = new Date().toISOString().slice(0, 13);
   const rowKey = `zk_backup_put:${userId}`;
   const row = await db
@@ -50,10 +84,23 @@ async function checkBackupPutRateLimit(
   if (storedHour !== hourKey) {
     count = 0;
   }
-  if (count >= MAX_PUT_PER_HOUR) {
-    return false;
-  }
+  return { hourKey, count };
+}
 
+async function isBackupPutRateLimited(
+  db: D1Database,
+  userId: number,
+): Promise<boolean> {
+  const { count } = await readBackupPutCount(db, userId);
+  return count >= MAX_PUT_PER_HOUR;
+}
+
+async function recordBackupPutSuccess(
+  db: D1Database,
+  userId: number,
+): Promise<void> {
+  const { hourKey, count } = await readBackupPutCount(db, userId);
+  const rowKey = `zk_backup_put:${userId}`;
   await db
     .prepare(
       `INSERT INTO sync_control (tenant_id, key, value, updated_at)
@@ -64,8 +111,6 @@ async function checkBackupPutRateLimit(
     )
     .bind(rowKey, JSON.stringify({ hour: hourKey, count: count + 1 }))
     .run();
-
-  return true;
 }
 
 async function logBackupEvent(
@@ -90,6 +135,9 @@ export async function getZkKeyBackupRoute(
 ): Promise<Response> {
   const s = c.get("session");
   if (!s) return c.json({ error: "unauthorized" }, 401);
+  if (!zkAccountKeyEnabled(c.env)) {
+    return c.json({ error: "zk_account_key_disabled" }, 403);
+  }
 
   const row = await c.env.DB
     .prepare(
@@ -121,9 +169,8 @@ export async function putZkKeyBackupRoute(
 ): Promise<Response> {
   const s = c.get("session");
   if (!s) return c.json({ error: "unauthorized" }, 401);
-
-  if (!(await checkBackupPutRateLimit(c.env.DB, s.userId))) {
-    return c.json({ error: "rate_limited" }, 429);
+  if (!zkAccountKeyEnabled(c.env)) {
+    return c.json({ error: "zk_account_key_disabled" }, 403);
   }
 
   let body: unknown;
@@ -172,6 +219,13 @@ export async function putZkKeyBackupRoute(
   ) {
     return c.json({ error: "invalid wrapped_key" }, 400);
   }
+  if (!validateKdfParams(kdf_alg, kdf_params)) {
+    return c.json({ error: "invalid kdf_params" }, 400);
+  }
+
+  if (await isBackupPutRateLimited(c.env.DB, s.userId)) {
+    return c.json({ error: "rate_limited" }, 429);
+  }
 
   const existing = await c.env.DB
     .prepare(
@@ -192,6 +246,7 @@ export async function putZkKeyBackupRoute(
       )
       .bind(s.userId, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp)
       .run();
+    await recordBackupPutSuccess(c.env.DB, s.userId);
     await logBackupEvent(c.env, "zk.backup.enrolled", s.userId, key_fp, 1, false);
     return c.json({ backup_version: 1, key_fp });
   }
@@ -233,6 +288,7 @@ export async function putZkKeyBackupRoute(
         s.userId,
       )
       .run();
+    await recordBackupPutSuccess(c.env.DB, s.userId);
     await logBackupEvent(c.env, "zk.backup.rotated", s.userId, key_fp, nextVersion, true);
     return c.json({ backup_version: nextVersion, key_fp });
   }
@@ -269,6 +325,7 @@ export async function putZkKeyBackupRoute(
       s.userId,
     )
     .run();
+  await recordBackupPutSuccess(c.env.DB, s.userId);
   await logBackupEvent(c.env, "zk.backup.updated", s.userId, key_fp, nextVersion, false);
   return c.json({ backup_version: nextVersion, key_fp });
 }

--- a/worker/src/api/zk-key-backup.ts
+++ b/worker/src/api/zk-key-backup.ts
@@ -5,6 +5,7 @@
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { consumeReauthProof } from "../auth/zk-reauth";
+import { writeZkAudit } from "../observability/zk-events";
 
 const KEY_FP_RE = /^[0-9a-f]{8,64}$/;
 const MAX_WRAPPED_BYTES = 8 * 1024;
@@ -67,23 +68,21 @@ async function checkBackupPutRateLimit(
   return true;
 }
 
-function logBackupEvent(
+async function logBackupEvent(
+  env: Context<AuthEnv>["env"],
   event: string,
   userId: number,
   keyFp: string,
   backupVersion: number,
   rotation: boolean,
-): void {
-  console.log(
-    JSON.stringify({
-      prefix: "[zk]",
-      event,
-      user_id: userId,
-      key_fp: keyFp,
-      backup_version: backupVersion,
-      rotation,
-    }),
-  );
+): Promise<void> {
+  await writeZkAudit(env, {
+    event,
+    user_id: userId,
+    key_fp: keyFp,
+    backup_version: backupVersion,
+    rotation,
+  });
 }
 
 export async function getZkKeyBackupRoute(
@@ -193,7 +192,7 @@ export async function putZkKeyBackupRoute(
       )
       .bind(s.userId, kdf_alg, kdf_params, wrap_iv, wrapped_key, key_fp)
       .run();
-    logBackupEvent("zk.backup.enrolled", s.userId, key_fp, 1, false);
+    await logBackupEvent(c.env, "zk.backup.enrolled", s.userId, key_fp, 1, false);
     return c.json({ backup_version: 1, key_fp });
   }
 
@@ -234,7 +233,7 @@ export async function putZkKeyBackupRoute(
         s.userId,
       )
       .run();
-    logBackupEvent("zk.backup.rotated", s.userId, key_fp, nextVersion, true);
+    await logBackupEvent(c.env, "zk.backup.rotated", s.userId, key_fp, nextVersion, true);
     return c.json({ backup_version: nextVersion, key_fp });
   }
 
@@ -270,6 +269,6 @@ export async function putZkKeyBackupRoute(
       s.userId,
     )
     .run();
-  logBackupEvent("zk.backup.updated", s.userId, key_fp, nextVersion, false);
+  await logBackupEvent(c.env, "zk.backup.updated", s.userId, key_fp, nextVersion, false);
   return c.json({ backup_version: nextVersion, key_fp });
 }

--- a/worker/src/api/zk-payloads.test.ts
+++ b/worker/src/api/zk-payloads.test.ts
@@ -88,6 +88,30 @@ describe("putZkPayloadsRoute", () => {
     expect(upsert).toBeDefined();
     expect(upsert!.args[0]).toBe(7);
     expect(upsert!.args[1]).toBe("Roxabi/live#42");
+    expect(upsert!.sql).toContain("key_fp");
+  });
+
+  it("accepts key_fp alias and dual-writes pubkey_fp", async () => {
+    const { db, stmts } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/payloads",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          payloads: [{
+            issue_key: "Roxabi/live#7",
+            key_fp: "cafebabe12345678",
+            encrypted_payload: "v2-envelope",
+          }],
+        }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const upsert = stmts().find((s) => s.sql.includes("INSERT INTO zk_payloads"));
+    expect(upsert!.args[2]).toBe("cafebabe12345678");
+    expect(upsert!.args[3]).toBe("cafebabe12345678");
   });
 
   it("scrubs plaintext titles from issues.payload after upsert", async () => {

--- a/worker/src/api/zk-payloads.ts
+++ b/worker/src/api/zk-payloads.ts
@@ -16,6 +16,7 @@ const MAX_CIPHERTEXT_BYTES = 64 * 1024;
 interface PayloadRow {
   issue_key: string;
   pubkey_fp: string;
+  key_fp: string | null;
   encrypted_payload: string;
   updated_at: string;
 }
@@ -23,6 +24,7 @@ interface PayloadRow {
 interface PutEntry {
   issue_key: string;
   pubkey_fp: string;
+  key_fp: string;
   encrypted_payload: string;
 }
 
@@ -38,7 +40,7 @@ export async function listZkPayloadsRoute(
 
   const rows = await c.env.DB
     .prepare(
-      `SELECT issue_key, pubkey_fp, encrypted_payload, updated_at
+      `SELECT issue_key, pubkey_fp, key_fp, encrypted_payload, updated_at
        FROM zk_payloads WHERE user_id = ?`,
     )
     .bind(s.userId)
@@ -82,14 +84,25 @@ export async function putZkPayloadsRoute(
     }
     const e = raw as Record<string, unknown>;
     const issue_key = e.issue_key;
-    const pubkey_fp = e.pubkey_fp;
+    const key_fp_raw =
+      typeof e.key_fp === "string"
+        ? e.key_fp
+        : typeof e.pubkey_fp === "string"
+          ? e.pubkey_fp
+          : null;
     const encrypted_payload = e.encrypted_payload;
     if (typeof issue_key !== "string" || !ISSUE_KEY_RE.test(issue_key)) {
       return c.json({ error: "invalid issue_key" }, 400);
     }
-    if (typeof pubkey_fp !== "string" || pubkey_fp.length < 8 || pubkey_fp.length > 128) {
-      return c.json({ error: "invalid pubkey_fp" }, 400);
+    if (
+      typeof key_fp_raw !== "string" ||
+      key_fp_raw.length < 8 ||
+      key_fp_raw.length > 128
+    ) {
+      return c.json({ error: "invalid key_fp" }, 400);
     }
+    const key_fp = key_fp_raw;
+    const pubkey_fp = key_fp;
     if (
       typeof encrypted_payload !== "string" ||
       encrypted_payload.length === 0 ||
@@ -97,19 +110,20 @@ export async function putZkPayloadsRoute(
     ) {
       return c.json({ error: "invalid encrypted_payload" }, 400);
     }
-    entries.push({ issue_key, pubkey_fp, encrypted_payload });
+    entries.push({ issue_key, pubkey_fp, key_fp, encrypted_payload });
   }
 
   await c.env.DB.batch(
     entries.map((e) =>
       c.env.DB.prepare(
-        `INSERT INTO zk_payloads (user_id, issue_key, pubkey_fp, encrypted_payload, updated_at)
-         VALUES (?, ?, ?, ?, datetime('now'))
+        `INSERT INTO zk_payloads (user_id, issue_key, pubkey_fp, key_fp, encrypted_payload, updated_at)
+         VALUES (?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(user_id, issue_key) DO UPDATE SET
-           pubkey_fp = excluded.pubkey_fp,
+           pubkey_fp = excluded.key_fp,
+           key_fp = excluded.key_fp,
            encrypted_payload = excluded.encrypted_payload,
            updated_at = datetime('now')`,
-      ).bind(s.userId, e.issue_key, e.pubkey_fp, e.encrypted_payload),
+      ).bind(s.userId, e.issue_key, e.pubkey_fp, e.key_fp, e.encrypted_payload),
     ),
   );
 

--- a/worker/src/api/zk-reauth.test.ts
+++ b/worker/src/api/zk-reauth.test.ts
@@ -18,11 +18,13 @@ const STUB_SESSION: SessionContext = {
 
 const CODE = "0123456789abcdef0123456789abcdef";
 
-function makeEnv(db: D1Database): Env {
+function makeEnv(db: D1Database, overrides: Partial<Env> = {}): Env {
   return {
     DB: db,
     ASSETS: { fetch: async () => new Response("ok") } as unknown as Fetcher,
     GITHUB_WEBHOOK_SECRET: "",
+    ZK_ACCOUNT_KEY: "1",
+    ...overrides,
   } as unknown as Env;
 }
 
@@ -54,6 +56,20 @@ describe("consumeZkReauthRoute", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { reauth_proof: string };
     expect(body.reauth_proof).toBe(CODE);
+  });
+
+  it("returns 403 when ZK_ACCOUNT_KEY flag is off", async () => {
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/consume-reauth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: CODE }),
+      },
+      makeEnv(db, { ZK_ACCOUNT_KEY: "0" }),
+    );
+    expect(res.status).toBe(403);
   });
 
   it("returns 410 when code expired", async () => {

--- a/worker/src/api/zk-reauth.test.ts
+++ b/worker/src/api/zk-reauth.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { consumeZkReauthRoute } from "./zk-reauth";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { captureDb } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+const CODE = "0123456789abcdef0123456789abcdef";
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("ok") } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.post("/api/zk/consume-reauth", consumeZkReauthRoute);
+  return app;
+}
+
+describe("consumeZkReauthRoute", () => {
+  it("returns reauth_proof when code valid", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("zk_reauth_proofs")) return [{ ok: 1 }];
+      return [];
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/consume-reauth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: CODE }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { reauth_proof: string };
+    expect(body.reauth_proof).toBe(CODE);
+  });
+
+  it("returns 410 when code expired", async () => {
+    const { db } = captureDb(() => []);
+    const res = await makeApp(db).request(
+      "/api/zk/consume-reauth",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: CODE }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(410);
+  });
+});

--- a/worker/src/api/zk-reauth.ts
+++ b/worker/src/api/zk-reauth.ts
@@ -4,7 +4,12 @@
 
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
-import { issueReauthProof } from "../auth/zk-reauth";
+import { zkAccountKeyEnabled } from "../auth/zk-flags";
+import {
+  issueReauthProof,
+  isConsumeReauthRateLimited,
+  recordConsumeReauthSuccess,
+} from "../auth/zk-reauth";
 
 const CODE_RE = /^[0-9a-f]{32}$/;
 
@@ -13,6 +18,12 @@ export async function consumeZkReauthRoute(
 ): Promise<Response> {
   const s = c.get("session");
   if (!s) return c.json({ error: "unauthorized" }, 401);
+  if (!zkAccountKeyEnabled(c.env)) {
+    return c.json({ error: "zk_account_key_disabled" }, 403);
+  }
+  if (await isConsumeReauthRateLimited(c.env.DB, s.userId)) {
+    return c.json({ error: "rate_limited" }, 429);
+  }
 
   let body: unknown;
   try {
@@ -38,5 +49,6 @@ export async function consumeZkReauthRoute(
     return c.json({ error: "reauth_expired" }, 410);
   }
 
+  await recordConsumeReauthSuccess(c.env.DB, s.userId);
   return c.json({ reauth_proof: proof });
 }

--- a/worker/src/api/zk-reauth.ts
+++ b/worker/src/api/zk-reauth.ts
@@ -1,0 +1,42 @@
+/**
+ * POST /api/zk/consume-reauth — validate OAuth step-up code (#216 PR 2).
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/types";
+import { issueReauthProof } from "../auth/zk-reauth";
+
+const CODE_RE = /^[0-9a-f]{32}$/;
+
+export async function consumeZkReauthRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "code required" }, 400);
+  }
+
+  const code =
+    body !== null &&
+    typeof body === "object" &&
+    "code" in body &&
+    typeof (body as { code: unknown }).code === "string"
+      ? (body as { code: string }).code
+      : null;
+
+  if (!code || !CODE_RE.test(code)) {
+    return c.json({ error: "invalid code" }, 400);
+  }
+
+  const proof = await issueReauthProof(c.env, s.userId, code);
+  if (!proof) {
+    return c.json({ error: "reauth_expired" }, 410);
+  }
+
+  return c.json({ reauth_proof: proof });
+}

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -13,6 +13,7 @@ import type { Env } from "../types";
 import { mintSession } from "./session";
 import { sessionCookie } from "./cookies";
 import { createUserTokenHandoff } from "./userTokenHandoff";
+import { createZkReauthCode } from "./zk-reauth";
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -55,6 +56,7 @@ export async function loginRoute(
 ): Promise<Response> {
   const redirectAfter = sanitizeRedirect(c.req.query("redirect") ?? undefined);
   const zkTokenHandoff = c.req.query("zk") === "1" ? 1 : 0;
+  const reauth = c.req.query("reauth") === "1" ? 1 : 0;
 
   // 16 random bytes → 32 hex chars
   const stateBytes = new Uint8Array(16);
@@ -63,10 +65,10 @@ export async function loginRoute(
 
   // Store state in D1 — single-use, expires in 10 minutes
   await c.env.DB.prepare(
-    `INSERT INTO oauth_state (state, redirect_after, expires_at, zk_token_handoff)
-     VALUES (?, ?, datetime('now', '+10 minutes'), ?)`,
+    `INSERT INTO oauth_state (state, redirect_after, expires_at, zk_token_handoff, reauth)
+     VALUES (?, ?, datetime('now', '+10 minutes'), ?, ?)`,
   )
-    .bind(state, redirectAfter, zkTokenHandoff)
+    .bind(state, redirectAfter, zkTokenHandoff, reauth)
     .run();
 
   // Build GitHub authorize URL — redirect_uri derived from origin only (D-6)
@@ -114,10 +116,14 @@ export async function callbackRoute(
   // Consume state — single-use + expiry guard in one atomic statement (closes TOCTOU)
   const stateRow = await c.env.DB.prepare(
     `DELETE FROM oauth_state WHERE state = ? AND expires_at > datetime('now')
-     RETURNING redirect_after, zk_token_handoff`,
+     RETURNING redirect_after, zk_token_handoff, reauth`,
   )
     .bind(state)
-    .first<{ redirect_after: string | null; zk_token_handoff: number }>();
+    .first<{
+      redirect_after: string | null;
+      zk_token_handoff: number;
+      reauth: number;
+    }>();
 
   if (!stateRow) {
     return c.json({ error: "bad_request" }, 400);
@@ -125,6 +131,7 @@ export async function callbackRoute(
 
   let redirectAfter = stateRow.redirect_after ?? "/";
   const wantsZkHandoff = stateRow.zk_token_handoff === 1;
+  const wantsReauth = stateRow.reauth === 1;
 
   // Build redirect_uri from origin (D-6)
   const origin = new URL(c.req.url).origin;
@@ -251,7 +258,12 @@ export async function callbackRoute(
   // Mint session tied to the first installation's tenant
   const rawToken = await mintSession(c.env.DB, userId, firstTenantId);
 
-  if (wantsZkHandoff) {
+  if (wantsReauth) {
+    const reauthCode = await createZkReauthCode(c.env, userId);
+    const dest = new URL(redirectAfter, origin);
+    dest.searchParams.set("zk_reauth", reauthCode);
+    redirectAfter = `${dest.pathname}${dest.search}`;
+  } else if (wantsZkHandoff) {
     try {
       const handoffCode = await createUserTokenHandoff(
         c.env,

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -200,8 +200,8 @@ export async function callbackRoute(
 
   // Upsert user — get internal id
   const userRow = await c.env.DB.prepare(
-    `INSERT INTO users (github_id, github_login) VALUES (?, ?)
-     ON CONFLICT(github_id) DO UPDATE SET github_login=excluded.github_login, updated_at=datetime('now')
+    `INSERT INTO users (github_id, github_login, zk_opt_in) VALUES (?, ?, 1)
+     ON CONFLICT(github_id) DO UPDATE SET github_login=excluded.github_login, zk_opt_in=1, updated_at=datetime('now')
      RETURNING id`,
   )
     .bind(ghUser.id, ghUser.login)

--- a/worker/src/auth/zk-flags.test.ts
+++ b/worker/src/auth/zk-flags.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { zkAccountKeyEnabled, zkStructureOnlyEnabled } from "./zk-flags";
+import type { Env } from "../types";
+
+function env(flags: Partial<Env>): Env {
+  return flags as Env;
+}
+
+describe("zkAccountKeyEnabled", () => {
+  it("is false when unset", () => {
+    expect(zkAccountKeyEnabled(env({}))).toBe(false);
+  });
+
+  it("is true for 1 or true", () => {
+    expect(zkAccountKeyEnabled(env({ ZK_ACCOUNT_KEY: "1" }))).toBe(true);
+    expect(zkAccountKeyEnabled(env({ ZK_ACCOUNT_KEY: "true" }))).toBe(true);
+    expect(zkAccountKeyEnabled(env({ ZK_ACCOUNT_KEY: "TRUE" }))).toBe(true);
+  });
+
+  it("is false for 0", () => {
+    expect(zkAccountKeyEnabled(env({ ZK_ACCOUNT_KEY: "0" }))).toBe(false);
+  });
+});
+
+describe("zkStructureOnlyEnabled", () => {
+  it("is false when unset", () => {
+    expect(zkStructureOnlyEnabled(env({}))).toBe(false);
+  });
+
+  it("is true for 1", () => {
+    expect(zkStructureOnlyEnabled(env({ ZK_STRUCTURE_ONLY: "1" }))).toBe(true);
+  });
+});

--- a/worker/src/auth/zk-flags.ts
+++ b/worker/src/auth/zk-flags.ts
@@ -1,0 +1,13 @@
+import type { Env } from "../types";
+
+/** True when `ZK_ACCOUNT_KEY` env is `1` or `true` (case-insensitive). */
+export function zkAccountKeyEnabled(env: Env): boolean {
+  const v = env.ZK_ACCOUNT_KEY?.trim().toLowerCase();
+  return v === "1" || v === "true";
+}
+
+/** True when `ZK_STRUCTURE_ONLY` env is `1` or `true` (case-insensitive). */
+export function zkStructureOnlyEnabled(env: Env): boolean {
+  const v = env.ZK_STRUCTURE_ONLY?.trim().toLowerCase();
+  return v === "1" || v === "true";
+}

--- a/worker/src/auth/zk-reauth.ts
+++ b/worker/src/auth/zk-reauth.ts
@@ -5,7 +5,63 @@
 import type { Env } from "../types";
 
 const REAUTH_TTL_MINUTES = 5;
+const MAX_CONSUME_PER_HOUR = 10;
 const CODE_RE = /^[0-9a-f]{32}$/;
+
+async function readConsumeCount(
+  db: D1Database,
+  userId: number,
+): Promise<{ hourKey: string; count: number }> {
+  const hourKey = new Date().toISOString().slice(0, 13);
+  const rowKey = `zk_reauth_consume:${userId}`;
+  const row = await db
+    .prepare(
+      `SELECT value FROM sync_control WHERE tenant_id = 0 AND key = ?`,
+    )
+    .bind(rowKey)
+    .first<{ value: string }>();
+
+  let count = 0;
+  let storedHour = hourKey;
+  if (row?.value) {
+    try {
+      const parsed = JSON.parse(row.value) as { hour?: string; count?: number };
+      storedHour = parsed.hour ?? hourKey;
+      count = typeof parsed.count === "number" ? parsed.count : 0;
+    } catch {
+      count = 0;
+    }
+  }
+  if (storedHour !== hourKey) count = 0;
+  return { hourKey, count };
+}
+
+/** Rate limit POST /api/zk/consume-reauth (defense in depth). */
+export async function isConsumeReauthRateLimited(
+  db: D1Database,
+  userId: number,
+): Promise<boolean> {
+  const { count } = await readConsumeCount(db, userId);
+  return count >= MAX_CONSUME_PER_HOUR;
+}
+
+export async function recordConsumeReauthSuccess(
+  db: D1Database,
+  userId: number,
+): Promise<void> {
+  const { hourKey, count } = await readConsumeCount(db, userId);
+  const rowKey = `zk_reauth_consume:${userId}`;
+  await db
+    .prepare(
+      `INSERT INTO sync_control (tenant_id, key, value, updated_at)
+       VALUES (0, ?, ?, datetime('now'))
+       ON CONFLICT(tenant_id, key) DO UPDATE SET
+         value = excluded.value,
+         updated_at = datetime('now')`,
+    )
+    .bind(rowKey, JSON.stringify({ hour: hourKey, count: count + 1 }))
+    .run();
+}
 
 function reauthCode(): string {
   const bytes = new Uint8Array(16);

--- a/worker/src/auth/zk-reauth.ts
+++ b/worker/src/auth/zk-reauth.ts
@@ -1,0 +1,63 @@
+/**
+ * OAuth step-up re-auth for zk_key_backups UPDATE (#216 PR 2).
+ */
+
+import type { Env } from "../types";
+
+const REAUTH_TTL_MINUTES = 5;
+const CODE_RE = /^[0-9a-f]{32}$/;
+
+function reauthCode(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function createZkReauthCode(
+  env: Env,
+  userId: number,
+): Promise<string> {
+  const code = reauthCode();
+  await env.DB.prepare(
+    `INSERT INTO zk_reauth_proofs (code, user_id, expires_at)
+     VALUES (?, ?, datetime('now', '+${REAUTH_TTL_MINUTES} minutes'))`,
+  )
+    .bind(code, userId)
+    .run();
+  return code;
+}
+
+/** Validates code for session user; returns same code as opaque reauth_proof. */
+export async function issueReauthProof(
+  env: Env,
+  userId: number,
+  code: string,
+): Promise<string | null> {
+  if (!CODE_RE.test(code)) return null;
+  const row = await env.DB.prepare(
+    `SELECT 1 AS ok FROM zk_reauth_proofs
+     WHERE code = ? AND user_id = ? AND expires_at > datetime('now')`,
+  )
+    .bind(code, userId)
+    .first<{ ok: number }>();
+  return row ? code : null;
+}
+
+/** Single-use consume on backup PUT — deletes proof row. */
+export async function consumeReauthProof(
+  env: Env,
+  userId: number,
+  proof: string,
+): Promise<boolean> {
+  if (!CODE_RE.test(proof)) return false;
+  const row = await env.DB.prepare(
+    `DELETE FROM zk_reauth_proofs
+     WHERE code = ? AND user_id = ? AND expires_at > datetime('now')
+     RETURNING code`,
+  )
+    .bind(proof, userId)
+    .first<{ code: string }>();
+  return row != null;
+}

--- a/worker/src/auth/zk.test.ts
+++ b/worker/src/auth/zk.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   d1PayloadTitle,
+  redactIssueTitle,
   loadZkSealedIssueKeys,
   isIssueZkSealed,
   scrubIssuePayloads,
@@ -12,6 +13,12 @@ describe("zk D1 redaction helpers", () => {
     const sealed = new Set(["Roxabi/live#1"]);
     expect(d1PayloadTitle("Secret", "Roxabi/live#1", sealed)).toBeNull();
     expect(d1PayloadTitle("Visible", "Roxabi/live#2", sealed)).toBe("Visible");
+  });
+
+  it("redactIssueTitle mirrors d1PayloadTitle for API responses", () => {
+    const sealed = new Set(["Roxabi/live#1"]);
+    expect(redactIssueTitle("Secret", "Roxabi/live#1", sealed)).toBeNull();
+    expect(redactIssueTitle("Visible", "Roxabi/live#2", sealed)).toBe("Visible");
   });
 
   it("loadZkSealedIssueKeys returns distinct issue_key set", async () => {

--- a/worker/src/auth/zk.ts
+++ b/worker/src/auth/zk.ts
@@ -42,6 +42,16 @@ export function d1PayloadTitle(
   return title ?? null;
 }
 
+/** API title field — null once a zk_payloads row exists for the issue. */
+export function redactIssueTitle(
+  title: string | null | undefined,
+  issueKey: string,
+  sealedKeys: ReadonlySet<string>,
+): string | null {
+  if (sealedKeys.has(issueKey)) return null;
+  return title ?? null;
+}
+
 /** Wipe plaintext content from issues.payload after sealing. */
 export async function scrubIssuePayloads(
   db: D1Database,

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -269,6 +269,29 @@ describe("tenants table", () => {
 // Suite 8 — edges and indexes
 // ---------------------------------------------------------------------------
 
+describe("0013_zk_always_on", () => {
+  it("sets zk_opt_in = 1 for all users", () => {
+    const migDb = new Database(":memory:");
+    const pre = appliedFiles.filter((f) => !f.startsWith("0013_"));
+    for (const file of pre) {
+      migDb.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+    }
+    migDb.exec(`
+      INSERT INTO users (id, github_id, github_login, zk_opt_in)
+      VALUES (1, 1, 'off', 0), (2, 2, 'on', 1);
+    `);
+    migDb.exec(readFileSync(join(MIGRATIONS_DIR, "0013_zk_always_on.sql"), "utf8"));
+    const rows = migDb
+      .prepare(`SELECT github_login, zk_opt_in FROM users ORDER BY id`)
+      .all() as Array<{ github_login: string; zk_opt_in: number }>;
+    expect(rows).toEqual([
+      { github_login: "off", zk_opt_in: 1 },
+      { github_login: "on", zk_opt_in: 1 },
+    ]);
+    migDb.close();
+  });
+});
+
 describe("0012_scrub_zk_sealed_payloads", () => {
   it("clears issues.payload for keys present in zk_payloads", () => {
     const scrubDb = new Database(":memory:");

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -96,7 +96,7 @@ describe("migration chain", () => {
 
   it("loads all migration files in lexical order", () => {
     // Uses appliedFiles captured by beforeAll — verifies the actual apply order, not just FS state.
-    expect(appliedFiles.length).toBeGreaterThanOrEqual(14);
+    expect(appliedFiles.length).toBeGreaterThanOrEqual(15);
     expect(appliedFiles[0]).toMatch(/^0001_/);
     // Contiguity check: each file's 4-digit prefix must equal its 1-based position
     for (let i = 0; i < appliedFiles.length; i++) {
@@ -295,6 +295,16 @@ describe("user_token_handoffs table", () => {
 describe("oauth_state zk_token_handoff", () => {
   it("has zk_token_handoff column (0011)", () => {
     expect(getColumnNames(db, "oauth_state")).toContain("zk_token_handoff");
+  });
+
+  it("has reauth column (0015)", () => {
+    expect(getColumnNames(db, "oauth_state")).toContain("reauth");
+  });
+});
+
+describe("zk_reauth_proofs table", () => {
+  it("has code primary key (0015)", () => {
+    expect(getPkColumns(db, "zk_reauth_proofs")).toEqual(["code"]);
   });
 });
 

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -96,7 +96,7 @@ describe("migration chain", () => {
 
   it("loads all migration files in lexical order", () => {
     // Uses appliedFiles captured by beforeAll — verifies the actual apply order, not just FS state.
-    expect(appliedFiles.length).toBeGreaterThanOrEqual(9);
+    expect(appliedFiles.length).toBeGreaterThanOrEqual(14);
     expect(appliedFiles[0]).toMatch(/^0001_/);
     // Contiguity check: each file's 4-digit prefix must equal its 1-based position
     for (let i = 0; i < appliedFiles.length; i++) {
@@ -189,8 +189,66 @@ describe("zk_payloads table", () => {
     expect(cols).toContain("user_id");
     expect(cols).toContain("issue_key");
     expect(cols).toContain("pubkey_fp");
+    expect(cols).toContain("key_fp");
     expect(cols).toContain("encrypted_payload");
     expect(cols).toContain("updated_at");
+  });
+
+  it("key_fp is nullable (0014)", () => {
+    const col = getColumns(db, "zk_payloads").find((c) => c.name === "key_fp");
+    expect(col).toBeDefined();
+    expect(col?.notnull).toBe(0);
+  });
+});
+
+describe("zk_key_backups table", () => {
+  it("has user_id primary key (0014)", () => {
+    expect(getPkColumns(db, "zk_key_backups")).toEqual(["user_id"]);
+  });
+
+  it("has expected columns", () => {
+    const cols = getColumnNames(db, "zk_key_backups");
+    expect(cols).toContain("user_id");
+    expect(cols).toContain("backup_version");
+    expect(cols).toContain("kdf_alg");
+    expect(cols).toContain("kdf_params");
+    expect(cols).toContain("wrap_iv");
+    expect(cols).toContain("wrapped_key");
+    expect(cols).toContain("key_fp");
+    expect(cols).toContain("created_at");
+    expect(cols).toContain("updated_at");
+  });
+
+  it("backup_version defaults to 1", () => {
+    const col = getColumns(db, "zk_key_backups").find(
+      (c) => c.name === "backup_version",
+    );
+    expect(col).toBeDefined();
+    expect(col?.notnull).toBe(1);
+    expect(col?.dflt_value).toBe("1");
+  });
+});
+
+describe("0014_zk_key_backups", () => {
+  it("backfills key_fp from pubkey_fp on existing rows", () => {
+    const migDb = new Database(":memory:");
+    const pre = appliedFiles.filter((f) => !f.startsWith("0014_"));
+    for (const file of pre) {
+      migDb.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+    }
+    migDb.exec(`
+      INSERT INTO users (id, github_id, github_login)
+      VALUES (1, 1, 'tester');
+      INSERT INTO zk_payloads (user_id, issue_key, pubkey_fp, encrypted_payload, updated_at)
+      VALUES (1, 'Roxabi/live#1', 'abc12345', 'cipher', datetime('now'));
+    `);
+    migDb.exec(readFileSync(join(MIGRATIONS_DIR, "0014_zk_key_backups.sql"), "utf8"));
+    const row = migDb
+      .prepare(`SELECT pubkey_fp, key_fp FROM zk_payloads WHERE issue_key = ?`)
+      .get("Roxabi/live#1") as { pubkey_fp: string; key_fp: string | null };
+    expect(row.pubkey_fp).toBe("abc12345");
+    expect(row.key_fp).toBe("abc12345");
+    migDb.close();
   });
 });
 

--- a/worker/src/observability/zk-events.test.ts
+++ b/worker/src/observability/zk-events.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import type { Env } from "../types";
+import { writeZkAudit } from "./zk-events";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("writeZkAudit", () => {
+  it("logs JSON and no-ops when LOGS is unbound (never throws)", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const env = {} as unknown as Env;
+
+    await expect(
+      writeZkAudit(env, {
+        event: "zk.backup.enrolled",
+        user_id: 7,
+        key_fp: "deadbeef12345678",
+        backup_version: 1,
+        rotation: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const line = JSON.parse(log.mock.calls[0][0] as string);
+    expect(line).toMatchObject({
+      prefix: "[zk]",
+      event: "zk.backup.enrolled",
+      user_id: 7,
+      key_fp: "deadbeef12345678",
+      backup_version: 1,
+      rotation: false,
+    });
+    expect(line.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("puts audit JSON to R2 when LOGS is bound", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const put = vi.fn().mockResolvedValue(undefined);
+    const env = { LOGS: { put } } as unknown as Env;
+
+    await writeZkAudit(env, {
+      event: "zk.backup.updated",
+      user_id: 3,
+      key_fp: "cafebabe",
+      backup_version: 2,
+      rotation: false,
+    });
+
+    expect(put).toHaveBeenCalledTimes(1);
+    const [key, body, opts] = put.mock.calls[0];
+    expect(key).toMatch(/^zk\/events\/\d{4}-\d{2}-\d{2}\/.+-zk-backup-updated\.json$/);
+    expect(opts).toMatchObject({ httpMetadata: { contentType: "application/json" } });
+    const snap = JSON.parse(body as string);
+    expect(snap.event).toBe("zk.backup.updated");
+    expect(snap.user_id).toBe(3);
+  });
+
+  it("swallows R2 put failures (audit must not fail the route)", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const put = vi.fn().mockRejectedValue(new Error("R2 down"));
+    const env = { LOGS: { put } } as unknown as Env;
+
+    await expect(
+      writeZkAudit(env, {
+        event: "zk.backup.rotated",
+        user_id: 1,
+        key_fp: "abcd",
+        backup_version: 3,
+        rotation: true,
+      }),
+    ).resolves.toBeUndefined();
+    expect(put).toHaveBeenCalledTimes(1);
+  });
+});

--- a/worker/src/observability/zk-events.ts
+++ b/worker/src/observability/zk-events.ts
@@ -1,0 +1,39 @@
+/**
+ * ZK audit events → Workers Logs + R2 LOGS bucket (#216 PR 9).
+ * Reuses the writeRunAudit pattern from sync.ts — best-effort, never throws.
+ */
+
+import type { Env } from "../types";
+
+/** Fields safe to persist in audit logs (no passphrase, keys, or ciphertext). */
+export interface ZkAuditEvent {
+  event: string;
+  user_id: number;
+  key_fp?: string;
+  backup_version?: number;
+  rotation?: boolean;
+}
+
+export async function writeZkAudit(
+  env: Env,
+  event: ZkAuditEvent,
+): Promise<void> {
+  try {
+    const ts = new Date().toISOString();
+    const payload = { ts, prefix: "[zk]", ...event };
+
+    console.log(JSON.stringify(payload));
+
+    const bucket = env.LOGS;
+    if (!bucket) return;
+
+    const slug = event.event.replace(/\./g, "-");
+    const key = `zk/events/${ts.slice(0, 10)}/${ts}-${slug}.json`;
+    await bucket.put(key, JSON.stringify(payload), {
+      httpMetadata: { contentType: "application/json" },
+    });
+    console.log(`[zk] audit written → ${key}`);
+  } catch (err) {
+    console.error("[zk] audit write failed (non-fatal):", err);
+  }
+}

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -14,6 +14,11 @@ import { activeTenantRoute } from "./api/active-tenant";
 import { zkOptInRoute } from "./api/zk-opt-in";
 import { listZkPayloadsRoute, putZkPayloadsRoute } from "./api/zk-payloads";
 import { consumeZkHandoffRoute } from "./api/zk-handoff";
+import { consumeZkReauthRoute } from "./api/zk-reauth";
+import {
+  getZkKeyBackupRoute,
+  putZkKeyBackupRoute,
+} from "./api/zk-key-backup";
 import { zkGithubGraphqlRoute } from "./api/zk-github-proxy";
 
 const app = new Hono<AuthEnv>();
@@ -80,6 +85,10 @@ app.use("/api/zk/payloads", requireSession);
 app.get("/api/zk/payloads", listZkPayloadsRoute);
 app.put("/api/zk/payloads", putZkPayloadsRoute);
 app.post("/api/zk/consume-handoff", requireSession, consumeZkHandoffRoute);
+app.post("/api/zk/consume-reauth", requireSession, consumeZkReauthRoute);
+app.use("/api/zk/key-backup", requireSession);
+app.get("/api/zk/key-backup", getZkKeyBackupRoute);
+app.put("/api/zk/key-backup", putZkKeyBackupRoute);
 app.post("/api/zk/github/graphql", requireSession, zkGithubGraphqlRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.

--- a/worker/src/sync/queries.ts
+++ b/worker/src/sync/queries.ts
@@ -5,19 +5,8 @@
  * No logic lives here; callers import the constants they need.
  */
 
-export const ISSUES_QUERY = `
-query($owner: String!, $name: String!, $cursor: String, $since: DateTime) {
-  repository(owner: $owner, name: $name) {
-    issues(
-      first: 100
-      after: $cursor
-      filterBy: { since: $since }
-      orderBy: { field: UPDATED_AT, direction: ASC }
-    ) {
-      pageInfo { hasNextPage endCursor }
-      nodes {
+const ISSUES_QUERY_NODES = `
         number
-        title
         state
         url
         createdAt
@@ -29,12 +18,49 @@ query($owner: String!, $name: String!, $cursor: String, $since: DateTime) {
         parent { number repository { nameWithOwner } }
         blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
         blocking(first: 50) { nodes { number repository { nameWithOwner } } }
-      }
+`;
+
+export const ISSUES_QUERY = `
+query($owner: String!, $name: String!, $cursor: String, $since: DateTime) {
+  repository(owner: $owner, name: $name) {
+    issues(
+      first: 100
+      after: $cursor
+      filterBy: { since: $since }
+      orderBy: { field: UPDATED_AT, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        title
+${ISSUES_QUERY_NODES}      }
     }
   }
   rateLimit { cost remaining resetAt }
 }
 `;
+
+/** Structure-only variant — omits `title` on issue nodes (#216 PR 6). */
+export const ISSUES_QUERY_STRUCTURE_ONLY = `
+query($owner: String!, $name: String!, $cursor: String, $since: DateTime) {
+  repository(owner: $owner, name: $name) {
+    issues(
+      first: 100
+      after: $cursor
+      filterBy: { since: $since }
+      orderBy: { field: UPDATED_AT, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+${ISSUES_QUERY_NODES}      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export function pickIssuesQuery(structureOnly: boolean): string {
+  return structureOnly ? ISSUES_QUERY_STRUCTURE_ONLY : ISSUES_QUERY;
+}
 
 export const REPOS_QUERY = `
 query($org: String!, $cursor: String) {
@@ -109,6 +135,21 @@ query($owner: String!, $name: String!, $cursor: String) {
  * cursor).  Reduces subreq count from 3×N+1 to N+1, staying under the Workers
  * Free 50-subrequest cap for any org with ≤49 repos.
  */
+const REPO_BUNDLE_ISSUES_NODES = `
+        number
+        state
+        url
+        createdAt
+        updatedAt
+        closedAt
+        milestone { title }
+        labels(first: 30) { nodes { name } }
+        subIssues(first: 50) { nodes { number repository { nameWithOwner } } }
+        parent { number repository { nameWithOwner } }
+        blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
+        blocking(first: 50) { nodes { number repository { nameWithOwner } } }
+`;
+
 export const REPO_BUNDLE_QUERY = `
 query(
   $owner: String!
@@ -127,20 +168,8 @@ query(
     ) {
       pageInfo { hasNextPage endCursor }
       nodes {
-        number
         title
-        state
-        url
-        createdAt
-        updatedAt
-        closedAt
-        milestone { title }
-        labels(first: 30) { nodes { name } }
-        subIssues(first: 50) { nodes { number repository { nameWithOwner } } }
-        parent { number repository { nameWithOwner } }
-        blockedBy(first: 50) { nodes { number repository { nameWithOwner } } }
-        blocking(first: 50) { nodes { number repository { nameWithOwner } } }
-      }
+${REPO_BUNDLE_ISSUES_NODES}      }
     }
     refs(refPrefix: "refs/heads/", first: 100, after: $refsCursor) {
       pageInfo { hasNextPage endCursor }
@@ -164,6 +193,53 @@ query(
 }
 `;
 
+/** Structure-only variant — omits `title` on issue nodes (#216 PR 6). */
+export const REPO_BUNDLE_QUERY_STRUCTURE_ONLY = `
+query(
+  $owner: String!
+  $name: String!
+  $issuesCursor: String
+  $refsCursor: String
+  $prsCursor: String
+  $since: DateTime
+) {
+  repository(owner: $owner, name: $name) {
+    issues(
+      first: 100
+      after: $issuesCursor
+      filterBy: { since: $since }
+      orderBy: { field: UPDATED_AT, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+${REPO_BUNDLE_ISSUES_NODES}      }
+    }
+    refs(refPrefix: "refs/heads/", first: 100, after: $refsCursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes { name }
+    }
+    pullRequests(states: OPEN, first: 50, after: $prsCursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        state
+        # first: 25 — PRs closing more issues are out of scope for this tool
+        # (Roxabi convention: 1 PR ≈ 1 epic)
+        closingIssuesReferences(first: 25) {
+          nodes { number repository { nameWithOwner } }
+        }
+        labels(first: 20) { nodes { name } }
+      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export function pickRepoBundleQuery(structureOnly: boolean): string {
+  return structureOnly ? REPO_BUNDLE_QUERY_STRUCTURE_ONLY : REPO_BUNDLE_QUERY;
+}
+
 export const STUB_ISSUE_QUERY = `
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
@@ -174,6 +250,22 @@ query($owner: String!, $name: String!, $number: Int!) {
   rateLimit { cost remaining resetAt }
 }
 `;
+
+/** Structure-only variant — omits `title` on the stub issue node (#216 PR 6). */
+export const STUB_ISSUE_QUERY_STRUCTURE_ONLY = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number state url createdAt updatedAt closedAt
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+`;
+
+export function pickStubIssueQuery(structureOnly: boolean): string {
+  return structureOnly ? STUB_ISSUE_QUERY_STRUCTURE_ONLY : STUB_ISSUE_QUERY;
+}
 
 export const SINGLE_ISSUE_DEPS_QUERY = `
 query($owner: String!, $name: String!, $number: Int!) {

--- a/worker/src/sync/sync.test.ts
+++ b/worker/src/sync/sync.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BRANCH_ISSUE_RE,
   UPSERT_ISSUE_SQL,
+  UPSERT_ISSUE_SQL_STRUCTURE,
   batchChunked,
   canonicalKey,
   collectEdges,
@@ -398,6 +399,17 @@ describe("UPSERT_ISSUE_SQL", () => {
   });
 });
 
+describe("UPSERT_ISSUE_SQL_STRUCTURE", () => {
+  it("uses empty json_object() payload with no title bind arg", () => {
+    expect(UPSERT_ISSUE_SQL_STRUCTURE).toMatch(/json_object\(\)/);
+    expect(UPSERT_ISSUE_SQL_STRUCTURE).not.toMatch(/json_object\('title', \?\)/);
+  });
+
+  it("updates payload via excluded.payload on conflict", () => {
+    expect(UPSERT_ISSUE_SQL_STRUCTURE).toMatch(/payload\s*=\s*excluded\.payload/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // acquireSyncLock
 // ---------------------------------------------------------------------------
@@ -579,11 +591,20 @@ vi.mock("./graphql", () => ({
 vi.mock("./queries", () => ({
   ARCHIVED_REPOS_QUERY: "ARCHIVED_REPOS_QUERY",
   ISSUES_QUERY: "ISSUES_QUERY",
+  ISSUES_QUERY_STRUCTURE_ONLY: "ISSUES_QUERY_STRUCTURE_ONLY",
   PRS_QUERY: "PRS_QUERY",
   REFS_QUERY: "REFS_QUERY",
   REPO_BUNDLE_QUERY: "REPO_BUNDLE_QUERY",
+  REPO_BUNDLE_QUERY_STRUCTURE_ONLY: "REPO_BUNDLE_QUERY_STRUCTURE_ONLY",
   REPOS_QUERY: "REPOS_QUERY",
   STUB_ISSUE_QUERY: "STUB_ISSUE_QUERY",
+  STUB_ISSUE_QUERY_STRUCTURE_ONLY: "STUB_ISSUE_QUERY_STRUCTURE_ONLY",
+  pickIssuesQuery: (structureOnly: boolean) =>
+    structureOnly ? "ISSUES_QUERY_STRUCTURE_ONLY" : "ISSUES_QUERY",
+  pickRepoBundleQuery: (structureOnly: boolean) =>
+    structureOnly ? "REPO_BUNDLE_QUERY_STRUCTURE_ONLY" : "REPO_BUNDLE_QUERY",
+  pickStubIssueQuery: (structureOnly: boolean) =>
+    structureOnly ? "STUB_ISSUE_QUERY_STRUCTURE_ONLY" : "STUB_ISSUE_QUERY",
 }));
 
 vi.mock("../auth/installToken", () => ({
@@ -659,6 +680,72 @@ describe("syncRepoIssues", () => {
 
     // Edge collection
     expect(edges.has("Roxabi/lyra#42")).toBe(true);
+  });
+
+  it("structureOnly=true uses structure query and empty payload upsert", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        rateLimit: { cost: 1, remaining: 4999 },
+        repository: {
+          issues: {
+            nodes: [
+              {
+                number: 7,
+                state: "OPEN",
+                url: "https://github.com/Roxabi/lyra/issues/7",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+                closedAt: null,
+                milestone: null,
+                labels: { nodes: [] },
+                subIssues: { nodes: [] },
+                parent: null,
+                blockedBy: { nodes: [] },
+                blocking: { nodes: [] },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    });
+
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("SELECT last_synced_at")) {
+        return makeFakeStmt(sql, args, []);
+      }
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await syncRepoIssues(db, "fake-token", "Roxabi", "lyra", new Map(), false, new Set(), true);
+
+    expect(mockGhGraphql).toHaveBeenCalledWith(
+      "ISSUES_QUERY_STRUCTURE_ONLY",
+      { owner: "Roxabi", name: "lyra", cursor: null, since: null },
+      "fake-token",
+    );
+
+    const upsertStmt = capturedStmts.find((s) => s.sql.includes("INSERT INTO issues"));
+    expect(upsertStmt).toBeDefined();
+    expect(upsertStmt!.sql).toContain("json_object()");
+    expect(upsertStmt!.args).not.toContain("Test issue");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        prefix: "[zk]",
+        event: "structure_only.title_skipped",
+        key: "Roxabi/lyra#7",
+        repo: "Roxabi/lyra",
+      }),
+    );
+    logSpy.mockRestore();
   });
 });
 
@@ -848,6 +935,73 @@ describe("syncRepoBundle", () => {
     // Branch apply: batch called (reset+set for issue 10)
     const batchMock = (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch;
     expect(batchMock).toHaveBeenCalled();
+  });
+
+  it("structureOnly=true uses structure bundle query and empty payload upsert", async () => {
+    const { ghGraphql } = await import("./graphql");
+    const mockGhGraphql = vi.mocked(ghGraphql);
+
+    mockGhGraphql.mockResolvedValueOnce({
+      data: {
+        rateLimit: { cost: 3, remaining: 4997 },
+        repository: {
+          issues: {
+            nodes: [
+              {
+                number: 11,
+                state: "OPEN",
+                url: "https://github.com/Roxabi/lyra/issues/11",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-02T00:00:00Z",
+                closedAt: null,
+                milestone: null,
+                labels: { nodes: [] },
+                subIssues: { nodes: [] },
+                parent: null,
+                blockedBy: { nodes: [] },
+                blocking: { nodes: [] },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+          refs: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+          pullRequests: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+        },
+      },
+    });
+
+    const capturedStmts: FakeStmt[] = [];
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("SELECT last_synced_at")) {
+        return makeFakeStmt(sql, args, []);
+      }
+      const stmt = makeFakeStmt(sql, args, [], 1);
+      capturedStmts.push(stmt);
+      return stmt;
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await syncRepoBundle(db, "fake-token", "Roxabi", "lyra", new Map(), false, new Set(), true);
+
+    expect(mockGhGraphql).toHaveBeenCalledWith(
+      "REPO_BUNDLE_QUERY_STRUCTURE_ONLY",
+      expect.objectContaining({ owner: "Roxabi", name: "lyra", since: null }),
+      "fake-token",
+    );
+
+    const upsertStmt = capturedStmts.find((s) => s.sql.includes("INSERT INTO issues"));
+    expect(upsertStmt).toBeDefined();
+    expect(upsertStmt!.sql).toContain("json_object()");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        prefix: "[zk]",
+        event: "structure_only.title_skipped",
+        key: "Roxabi/lyra#11",
+        repo: "Roxabi/lyra",
+      }),
+    );
+    logSpy.mockRestore();
   });
 
   it("fullSync=true forces since=null without reading the watermark, and returns stale PRs closed (#80)", async () => {

--- a/worker/src/sync/sync.ts
+++ b/worker/src/sync/sync.ts
@@ -11,15 +11,16 @@
 
 import { ghGraphql, GraphQLError } from "./graphql";
 import {
-  ISSUES_QUERY,
   PRS_QUERY,
   REFS_QUERY,
-  REPO_BUNDLE_QUERY,
-  STUB_ISSUE_QUERY,
+  pickIssuesQuery,
+  pickRepoBundleQuery,
+  pickStubIssueQuery,
 } from "./queries";
 import type { Env } from "../types";
 import { getInstallationToken, listInstallationRepos } from "../auth/installToken";
 import { d1PayloadTitle, loadZkSealedIssueKeys } from "../auth/zk";
+import { zkStructureOnlyEnabled } from "../auth/zk-flags";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -66,6 +67,107 @@ export const UPSERT_ISSUE_SQL = `
       status            = excluded.status,
       has_active_branch = excluded.has_active_branch
 `;
+
+/** Structure-only upsert — empty payload, one fewer bind arg (#216 PR 6). */
+export const UPSERT_ISSUE_SQL_STRUCTURE = `
+  INSERT INTO issues
+      (key, repo, number, payload, state, url, created_at, updated_at,
+       closed_at, milestone, is_stub, lane, priority, size, status,
+       has_active_branch)
+  VALUES
+      (?, ?, ?, json_object(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(key) DO UPDATE SET
+      repo              = excluded.repo,
+      number            = excluded.number,
+      payload           = excluded.payload,
+      state             = excluded.state,
+      url               = excluded.url,
+      created_at        = excluded.created_at,
+      updated_at        = excluded.updated_at,
+      closed_at         = excluded.closed_at,
+      milestone         = excluded.milestone,
+      is_stub           = excluded.is_stub,
+      lane              = excluded.lane,
+      priority          = excluded.priority,
+      size              = excluded.size,
+      status            = excluded.status,
+      has_active_branch = excluded.has_active_branch
+`;
+
+function logStructureOnlyTitleSkipped(key: string, repo: string): void {
+  console.log(
+    JSON.stringify({
+      prefix: "[zk]",
+      event: "structure_only.title_skipped",
+      key,
+      repo,
+    }),
+  );
+}
+
+interface IssueUpsertFields {
+  key: string;
+  repo: string;
+  number: number;
+  title?: string | null;
+  state: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  milestone: string | null;
+  isStub: number;
+  lane: string | null;
+  priority: string | null;
+  size: string | null;
+}
+
+function prepareIssueUpsert(
+  db: D1Database,
+  structureOnly: boolean,
+  sealedKeys: ReadonlySet<string>,
+  fields: IssueUpsertFields,
+): D1PreparedStatement {
+  if (structureOnly) {
+    logStructureOnlyTitleSkipped(fields.key, fields.repo);
+    return db.prepare(UPSERT_ISSUE_SQL_STRUCTURE).bind(
+      fields.key,
+      fields.repo,
+      fields.number,
+      fields.state.toLowerCase(),
+      fields.url,
+      fields.createdAt,
+      fields.updatedAt,
+      fields.closedAt,
+      fields.milestone,
+      fields.isStub,
+      fields.lane,
+      fields.priority,
+      fields.size,
+      null, // status — managed by Project v2 board
+      0, // has_active_branch — set by branch pass
+    );
+  }
+
+  return db.prepare(UPSERT_ISSUE_SQL).bind(
+    fields.key,
+    fields.repo,
+    fields.number,
+    d1PayloadTitle(fields.title, fields.key, sealedKeys),
+    fields.state.toLowerCase(),
+    fields.url,
+    fields.createdAt,
+    fields.updatedAt,
+    fields.closedAt,
+    fields.milestone,
+    fields.isStub,
+    fields.lane,
+    fields.priority,
+    fields.size,
+    null, // status — managed by Project v2 board
+    0, // has_active_branch — set by branch pass
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Regex constants (verbatim from sync.py)
@@ -294,7 +396,7 @@ export async function resetAuthFailures(db: D1Database, tenantId: number = 0): P
 
 interface IssueNodeFull {
   number: number;
-  title: string;
+  title?: string;
   state: string;
   url: string;
   createdAt: string;
@@ -329,6 +431,7 @@ export async function syncRepoIssues(
   collectedEdges: Map<string, EdgeData>,
   fullSync = false,
   sealedKeys: ReadonlySet<string> = new Set(),
+  structureOnly = false,
 ): Promise<void> {
   const repo = `${owner}/${name}`;
   let cursor: string | null = null;
@@ -347,7 +450,7 @@ export async function syncRepoIssues(
 
   while (true) {
     const response: { data: IssuesData } & Record<string, unknown> = await ghGraphql<IssuesData>(
-      ISSUES_QUERY,
+      pickIssuesQuery(structureOnly),
       { owner, name, cursor, since },
       token,
     );
@@ -369,24 +472,22 @@ export async function syncRepoIssues(
       const derived = extractFromLabels(labels);
 
       pageStmts.push(
-        db.prepare(UPSERT_ISSUE_SQL).bind(
+        prepareIssueUpsert(db, structureOnly, sealedKeys, {
           key,
           repo,
-          node.number,
-          d1PayloadTitle(node.title, key, sealedKeys),
-          node.state.toLowerCase(),
-          node.url,
-          node.createdAt,
-          node.updatedAt,
-          node.closedAt ?? null,
-          node.milestone?.title ?? null,
-          0, // is_stub
-          derived.lane,
-          derived.priority,
-          derived.size,
-          null, // status — managed by Project v2 board
-          0, // has_active_branch — set by branch pass
-        ),
+          number: node.number,
+          title: node.title,
+          state: node.state,
+          url: node.url,
+          createdAt: node.createdAt,
+          updatedAt: node.updatedAt,
+          closedAt: node.closedAt ?? null,
+          milestone: node.milestone?.title ?? null,
+          isStub: 0,
+          lane: derived.lane,
+          priority: derived.priority,
+          size: derived.size,
+        }),
       );
 
       // Label wipe + rewrite
@@ -739,6 +840,7 @@ export async function syncRepoBundle(
   collectedEdges: Map<string, EdgeData>,
   fullSync = false,
   sealedKeys: ReadonlySet<string> = new Set(),
+  structureOnly = false,
 ): Promise<number> {
   const repo = `${owner}/${name}`;
 
@@ -776,7 +878,7 @@ export async function syncRepoBundle(
 
     const response: { data: BundleData } & Record<string, unknown> =
       await ghGraphql<BundleData>(
-        REPO_BUNDLE_QUERY,
+        pickRepoBundleQuery(structureOnly),
         {
           owner,
           name,
@@ -805,24 +907,22 @@ export async function syncRepoBundle(
         const derived = extractFromLabels(labels);
 
         pageStmts.push(
-          db.prepare(UPSERT_ISSUE_SQL).bind(
+          prepareIssueUpsert(db, structureOnly, sealedKeys, {
             key,
             repo,
-            node.number,
-            d1PayloadTitle(node.title, key, sealedKeys),
-            node.state.toLowerCase(),
-            node.url,
-            node.createdAt,
-            node.updatedAt,
-            node.closedAt ?? null,
-            node.milestone?.title ?? null,
-            0, // is_stub
-            derived.lane,
-            derived.priority,
-            derived.size,
-            null, // status
-            0, // has_active_branch — set by applyActiveBranches after loop
-          ),
+            number: node.number,
+            title: node.title,
+            state: node.state,
+            url: node.url,
+            createdAt: node.createdAt,
+            updatedAt: node.updatedAt,
+            closedAt: node.closedAt ?? null,
+            milestone: node.milestone?.title ?? null,
+            isStub: 0,
+            lane: derived.lane,
+            priority: derived.priority,
+            size: derived.size,
+          }),
         );
         pageStmts.push(db.prepare("DELETE FROM labels WHERE issue_key=?").bind(key));
         for (const lbl of labels) {
@@ -909,7 +1009,7 @@ interface StubIssueData {
   repository: {
     issue: {
       number: number;
-      title: string;
+      title?: string;
       state: string;
       url: string;
       createdAt: string;
@@ -928,6 +1028,7 @@ export async function closedHopPass(
   db: D1Database,
   resolveToken: (owner: string, name: string) => Promise<string>,
   sealedKeys: ReadonlySet<string> = new Set(),
+  structureOnly = false,
 ): Promise<number> {
   const missingRows = await db
     .prepare(
@@ -965,7 +1066,7 @@ export async function closedHopPass(
     let response: { data: StubIssueData } & Record<string, unknown>;
     try {
       response = await ghGraphql<StubIssueData>(
-        STUB_ISSUE_QUERY,
+        pickStubIssueQuery(structureOnly),
         { owner, name, number: parseInt(numberStr, 10) },
         token,
       );
@@ -988,24 +1089,22 @@ export async function closedHopPass(
     }
 
     stubStmts.push(
-      db.prepare(UPSERT_ISSUE_SQL).bind(
+      prepareIssueUpsert(db, structureOnly, sealedKeys, {
         key,
-        ownerRepo,
-        node.number,
-        d1PayloadTitle(node.title, key, sealedKeys),
-        node.state.toLowerCase(),
-        node.url,
-        node.createdAt,
-        node.updatedAt,
-        node.closedAt ?? null,
-        null, // milestone
-        1, // is_stub
-        null, // lane
-        null, // priority
-        null, // size
-        null, // status
-        0, // has_active_branch
-      ),
+        repo: ownerRepo,
+        number: node.number,
+        title: node.title,
+        state: node.state,
+        url: node.url,
+        createdAt: node.createdAt,
+        updatedAt: node.updatedAt,
+        closedAt: node.closedAt ?? null,
+        milestone: null,
+        isStub: 1,
+        lane: null,
+        priority: null,
+        size: null,
+      }),
     );
     inserted++;
   }
@@ -1439,6 +1538,7 @@ export async function runSync(env: Env): Promise<void> {
       };
 
     // Pass 1: bundled issues + refs + PRs per repo in window.
+    const structureOnly = zkStructureOnlyEnabled(env);
     const sealedKeys = await loadZkSealedIssueKeys(db);
     const collectedEdges = new Map<string, EdgeData>();
     let skippedCount = 0;
@@ -1460,6 +1560,7 @@ export async function runSync(env: Env): Promise<void> {
           collectedEdges,
           true,
           sealedKeys,
+          structureOnly,
         );
       } catch (err) {
         console.error(`[sync] skipping ${repo}:`, err);
@@ -1484,6 +1585,7 @@ export async function runSync(env: Env): Promise<void> {
         return makeRepoResolver(repoTenants)();
       },
       sealedKeys,
+      structureOnly,
     );
     console.log(`[sync] completed — stubs=${stubsCount}`);
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -42,4 +42,8 @@ export interface Env {
   // Consumed by auth/tokenCrypto + auth/installToken. Set via `wrangler secret put INSTALL_TOKEN_KEY`.
   // Optional at type-level (provisioned at deploy-time via CI); runtime guard in auth/installToken.ts getInstallTokenKey().
   INSTALL_TOKEN_KEY?: string;
+  /** Feature flag: passphrase account-key enrollment (#216 PR 1b). Default off. */
+  ZK_ACCOUNT_KEY?: string;
+  /** Feature flag: structure-only server sync (#216 PR 6). Default off. */
+  ZK_STRUCTURE_ONLY?: string;
 }

--- a/worker/src/webhook/handlers.test.ts
+++ b/worker/src/webhook/handlers.test.ts
@@ -173,6 +173,8 @@ function makeIssuePayload(action: string, issueOverrides: Record<string, unknown
 // ---------------------------------------------------------------------------
 
 describe("handleIssues", () => {
+  const baseEnv = makeEnv();
+
   afterEach(() => vi.clearAllMocks());
 
   describe("opened / edited (upsert path)", () => {
@@ -182,7 +184,7 @@ describe("handleIssues", () => {
       const payload = makeIssuePayload("opened");
 
       // Act
-      await handleIssues(payload, db);
+      await handleIssues(payload, db, baseEnv);
 
       // Assert — batch was called (SC9 atomic requirement)
       expect(vi.mocked(db.batch)).toHaveBeenCalledOnce();
@@ -202,7 +204,18 @@ describe("handleIssues", () => {
       });
       const payload = makeIssuePayload("edited", { title: "Plaintext from GitHub" });
 
-      await handleIssues(payload, db);
+      await handleIssues(payload, db, baseEnv);
+
+      const batchArgs = vi.mocked(db.batch).mock.calls[0][0] as unknown as FakeStmt[];
+      expect(batchArgs[0].args[3]).toBeNull();
+    });
+
+    it("binds null title when ZK_STRUCTURE_ONLY is enabled", async () => {
+      const { db } = captureDb();
+      const payload = makeIssuePayload("edited", { title: "Plaintext from GitHub" });
+      const env = makeEnv({ ZK_STRUCTURE_ONLY: "1" });
+
+      await handleIssues(payload, db, env);
 
       const batchArgs = vi.mocked(db.batch).mock.calls[0][0] as unknown as FakeStmt[];
       expect(batchArgs[0].args[3]).toBeNull();
@@ -216,7 +229,7 @@ describe("handleIssues", () => {
       });
 
       // Act
-      await handleIssues(payload, db);
+      await handleIssues(payload, db, baseEnv);
 
       // Assert
       const batchArgs = vi.mocked(db.batch).mock.calls[0][0] as unknown as FakeStmt[];
@@ -233,7 +246,7 @@ describe("handleIssues", () => {
       const payload = makeIssuePayload("deleted");
 
       // Act
-      await handleIssues(payload, db);
+      await handleIssues(payload, db, baseEnv);
 
       // Assert
       expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
@@ -247,7 +260,7 @@ describe("handleIssues", () => {
       const payload = makeIssuePayload("deleted");
 
       // Act
-      await handleIssues(payload, db);
+      await handleIssues(payload, db, baseEnv);
 
       // Assert — a stmt with DELETE FROM issues was run
       const deletedStmt = stmts().find((s) => s.sql.includes("DELETE FROM issues"));
@@ -262,7 +275,7 @@ describe("handleIssues", () => {
       const payload = makeIssuePayload("transferred");
 
       // Act
-      await handleIssues(payload, db);
+      await handleIssues(payload, db, baseEnv);
 
       // Assert
       const deletedStmt = stmts().find((s) => s.sql.includes("DELETE FROM issues"));
@@ -273,7 +286,7 @@ describe("handleIssues", () => {
     it("guard: deleting the deleted/transferred check would break test — no batch called", async () => {
       // Negative: batch must NOT be called on deleted action
       const { db } = captureDb();
-      await handleIssues(makeIssuePayload("deleted"), db);
+      await handleIssues(makeIssuePayload("deleted"), db, baseEnv);
       expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
     });
   });

--- a/worker/src/webhook/handlers.ts
+++ b/worker/src/webhook/handlers.ts
@@ -27,6 +27,7 @@ import {
   type WebhookIssue,
 } from "./mutations";
 import { isIssueZkSealed } from "../auth/zk";
+import { zkStructureOnlyEnabled } from "../auth/zk-flags";
 import { BRANCH_ISSUE_RE, canonicalKey, extractFromLabels, syncBranches } from "../sync/sync";
 import { fetchIssueDeps, GraphQLError } from "../sync/graphql";
 import { resolveInstallToken } from "../auth/installToken";
@@ -85,7 +86,11 @@ function issueKey(
  * deleted, transferred.
  * Issue upsert + label replacement are committed atomically via db.batch (SC9).
  */
-export async function handleIssues(payload: Record<string, unknown>, db: D1Database): Promise<void> {
+export async function handleIssues(
+  payload: Record<string, unknown>,
+  db: D1Database,
+  env: Env,
+): Promise<void> {
   const action = payload["action"] as string | undefined;
   const issue = payload["issue"] as Record<string, unknown>;
   const repo = ((payload["repository"] as Record<string, unknown> | undefined) ?? {})["full_name"] as string | undefined ?? "";
@@ -113,8 +118,10 @@ export async function handleIssues(payload: Record<string, unknown>, db: D1Datab
 
   const derived = extractFromLabels(names);
 
+  const structureOnly = zkStructureOnlyEnabled(env);
   const sealed = await isIssueZkSealed(db, key);
-  const title = sealed ? null : ((issue["title"] as string | undefined) ?? null);
+  const title =
+    structureOnly || sealed ? null : ((issue["title"] as string | undefined) ?? null);
 
   const issuePartial: WebhookIssue = {
     key,
@@ -584,7 +591,7 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
 
   try {
     if (event === "issues") {
-      await handleIssues(payload, db);
+      await handleIssues(payload, db, c.env);
       mutated = true;
     } else if (event === "issue_dependencies") {
       const changed = await handleDeps(payload, db, c.env);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,6 +22,10 @@ routes = [
   { pattern = "live.roxabi.dev", custom_domain = true },
 ]
 
+[vars]
+ZK_ACCOUNT_KEY = "0"
+ZK_STRUCTURE_ONLY = "0"
+
 [assets]
 directory = "./frontend"
 binding   = "ASSETS"
@@ -57,6 +61,10 @@ bucket_name = "roxabi-live-logs"
 [env.staging]
 name = "roxabi-live-staging"
 workers_dev = true
+
+[env.staging.vars]
+ZK_ACCOUNT_KEY = "0"
+ZK_STRUCTURE_ONLY = "0"
 # `routes` is inheritable — without this explicit empty override a staging
 # deploy would inherit the top-level live.roxabi.dev custom domain (#101) and
 # bind it to the staging Worker. Keep this even though staging has no routes.


### PR DESCRIPTION
## Summary

Implements [#216](https://github.com/Roxabi/roxabi-live/issues/216) — passphrase-backed multi-device encryption, structure-only server sync (flag-gated), and hybrid multi-user model.

Design: [`docs/zk-account-key-design.md`](docs/zk-account-key-design.md)

## PR stack (single branch)

| Slice | Description |
|-------|-------------|
| PR 1 | D1 `zk_key_backups` + `key_fp` column |
| PR 1b | `ZK_ACCOUNT_KEY` / `ZK_STRUCTURE_ONLY` flags on `/api/me` |
| PR 2 | `GET/PUT /api/zk/key-backup` + OAuth re-auth for UPDATE |
| PR 3 | hash-wasm Argon2id + `accountKey` v2 crypto |
| PR 7 | `key_fp` dual-accept on payloads API |
| PR 4–5 | Enrollment/unlock UI + ECDH→accountKey migration |
| PR 6 | Structure-only sync (flag-gated) |
| PR 8 | Docs (`ZK_ENCRYPTION.md`) + integration tests |
| PR 9 | R2 zk audit events |

**Not included:** PR 11 (`0016` global title scrub) — merge only after enrollment ≥ 95%.

## Rollout

1. Deploy with flags off (`ZK_ACCOUNT_KEY=0`, `ZK_STRUCTURE_ONLY=0`)
2. Enable `ZK_ACCOUNT_KEY` in staging → enroll test users
3. Enable `ZK_STRUCTURE_ONLY` in staging after client sealing verified
4. Prod flip after metrics green; PR 11 scrub as separate gated merge

## Tests

- Worker: 610 tests pass
- Frontend: 30 tests pass

Closes #216