### PR TITLE
chore(zk): nuclear reset + enable ZK_ACCOUNT_KEY in prod

### DIFF
--- a/worker/migrations/0016_zk_nuclear_reset.sql
+++ b/worker/migrations/0016_zk_nuclear_reset.sql
@@ -1,0 +1,9 @@
+-- migration: 0016_zk_nuclear_reset.sql
+-- Full ZK reset: purge all ciphertext, backups, handoffs; scrub issue titles from D1.
+-- Operator rollout (#216): skip v1→v2 migration, re-enroll from scratch.
+
+DELETE FROM zk_reauth_proofs;
+DELETE FROM zk_key_backups;
+DELETE FROM zk_payloads;
+DELETE FROM user_token_handoffs;
+UPDATE issues SET payload = json_object();

--- a/worker/src/migrations.test.ts
+++ b/worker/src/migrations.test.ts
@@ -232,7 +232,12 @@ describe("zk_key_backups table", () => {
 describe("0014_zk_key_backups", () => {
   it("backfills key_fp from pubkey_fp on existing rows", () => {
     const migDb = new Database(":memory:");
-    const pre = appliedFiles.filter((f) => !f.startsWith("0014_"));
+    const pre = appliedFiles.filter(
+      (f) =>
+        !f.startsWith("0014_") &&
+        !f.startsWith("0015_") &&
+        !f.startsWith("0016_"),
+    );
     for (const file of pre) {
       migDb.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
     }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-ZK_ACCOUNT_KEY = "0"
+ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "0"
 
 [assets]


### PR DESCRIPTION
## Summary

Operator-requested rollout: skip v1→v2 migration, wipe all ZK state, enable passphrase gate in production.

- **Migration `0016`**: `DELETE` all `zk_payloads`, `zk_key_backups`, `zk_reauth_proofs`, `user_token_handoffs`; `UPDATE issues SET payload = json_object()` (global title scrub)
- **`ZK_ACCOUNT_KEY = "1"`** on production (`wrangler.toml` top-level vars)
- Staging unchanged (`ZK_ACCOUNT_KEY` stays `"0"`)

## Post-merge

Users must enroll with a new passphrase on next visit. Local browser ECDH keys (v1) are ignored server-side after wipe — client should clear `roxabi-zk-*` localStorage if enroll gate misbehaves.

`ZK_STRUCTURE_ONLY` remains off — GitHub sync will repopulate issue titles in D1 until users re-seal or we flip that flag.

## Test plan

- [x] worker tests 620/620