### PR TITLE
feat(zk): reset encryption after lost passphrase

### DIFF
--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -232,6 +232,24 @@ body.gated #error-msg {
   display: flex;
   gap: 10px;
   justify-content: flex-end;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.consent-btn-link {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  margin-right: auto;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.consent-btn-link:hover {
+  color: var(--text);
 }
 
 /* ─── Consent warning (beta / secrets notice) ────────────────────────────── */

--- a/frontend/zk-crypto.js
+++ b/frontend/zk-crypto.js
@@ -133,6 +133,16 @@ async function metaIdbPut(login, record) {
   });
 }
 
+async function metaIdbDelete(login) {
+  const db = await openMetaDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(META_STORE_NAME, 'readwrite');
+    tx.objectStore(META_STORE_NAME).delete(login);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
 /** True when a per-device ECDH key pair exists in IndexedDB. */
 export async function hasZkKeyPair(githubLogin) {
   const existing = await idbGet(githubLogin);
@@ -155,6 +165,11 @@ export async function saveAccountMeta(githubLogin, meta) {
 /** @returns {Promise<{ key_fp: string, enrolled_at: string }|null>} */
 export async function getAccountMeta(githubLogin) {
   return metaIdbGet(githubLogin);
+}
+
+/** Remove enrollment metadata after server-side ZK reset (#216). */
+export async function deleteAccountMeta(githubLogin) {
+  await metaIdbDelete(githubLogin);
 }
 
 async function generateKeyPair() {

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -24,6 +24,10 @@ import {
   getZkReauthProof,
   clearZkReauthProof,
 } from './zk-github.js';
+import {
+  wireZkResetUi,
+  showLostPassphraseWarning,
+} from './zk-reset.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -277,8 +281,16 @@ export function showEnrollGate(githubLogin) {
   });
 }
 
-export function showUnlockGate() {
+export function showUnlockGate(githubLogin = gateGithubLogin) {
   return new Promise((resolve) => {
+    const resetCtx = { $, escHtml, renderZkDialog };
+    const reopenUnlock = () => {
+      showUnlockGate(githubLogin).then(resolve);
+    };
+    if (wireZkResetUi(resetCtx, githubLogin, reopenUnlock)) {
+      return;
+    }
+
     renderZkDialog(
       'Unlock encryption',
       `
@@ -290,12 +302,17 @@ export function showUnlockGate() {
           </label>
           <p class="zk-error" id="zk-unlock-error" hidden></p>
           <div class="zk-actions">
+            <button type="button" class="consent-btn-link" id="zk-lost-pass">Lost passphrase?</button>
             <button type="button" class="consent-btn-secondary" id="zk-unlock-logout">Sign out</button>
             <button type="submit" class="consent-btn-primary" id="zk-unlock-submit">Unlock</button>
           </div>
         </form>
       `,
     );
+
+    $('zk-lost-pass')?.addEventListener('click', () => {
+      showLostPassphraseWarning(resetCtx, reopenUnlock);
+    });
 
     const form = $('zk-unlock-form');
     const passInput = $('zk-unlock-pass');

--- a/frontend/zk-reset.js
+++ b/frontend/zk-reset.js
@@ -1,0 +1,160 @@
+// zk-reset.js — lost-passphrase recovery: wipe server + local ZK state (#216)
+
+import { api } from './auth.js';
+import { deleteAccountMeta, deleteZkKeyPair } from './zk-crypto.js';
+import { clearZkSession } from './zk-session.js';
+import {
+  getZkReauthProof,
+  clearZkReauthProof,
+  zkReauthLoginUrl,
+} from './zk-github.js';
+const RESET_PENDING_KEY = 'roxabi:zk-reset-pending';
+
+export function isZkResetPending() {
+  return sessionStorage.getItem(RESET_PENDING_KEY) === '1';
+}
+
+export function setZkResetPending() {
+  sessionStorage.setItem(RESET_PENDING_KEY, '1');
+}
+
+export function clearZkResetPending() {
+  sessionStorage.removeItem(RESET_PENDING_KEY);
+}
+
+/** Wipe browser key material after server reset. */
+export async function clearLocalZkState(githubLogin) {
+  clearZkSession();
+  clearZkReauthProof();
+  clearZkResetPending();
+  try {
+    await deleteZkKeyPair(githubLogin);
+  } catch {
+    /* IndexedDB unavailable */
+  }
+  try {
+    await deleteAccountMeta(githubLogin);
+  } catch {
+    /* IndexedDB unavailable */
+  }
+}
+
+async function postZkReset() {
+  const reauth_proof = getZkReauthProof();
+  if (!reauth_proof) throw new Error('reauth_required');
+  const resp = await api('/api/zk/reset', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reauth_proof }),
+  });
+  const data = await resp.json();
+  if (!resp.ok) {
+    const err = new Error(data?.error ?? 'reset_failed');
+    err.code = data?.error;
+    throw err;
+  }
+  clearZkReauthProof();
+  return data;
+}
+
+/**
+ * Full reset: server purge + local wipe, then enroll gate for new passphrase.
+ * @param {string} githubLogin
+ */
+export async function resetZkAccountAndReenroll(githubLogin) {
+  await postZkReset();
+  await clearLocalZkState(githubLogin);
+  window.location.reload();
+}
+
+function renderResetWarning($, escHtml, renderZkDialog, onCancelled) {
+  renderZkDialog(
+    'Reset encryption?',
+    `
+      <p class="consent-warning">
+        <strong>This cannot be undone.</strong>
+        All encrypted issue titles stored for your account on the server will be
+        deleted. You will choose a new passphrase and re-seal content from GitHub.
+      </p>
+      <p>GitHub sign-in is required to confirm this action.</p>
+      <div class="zk-actions">
+        <button type="button" class="consent-btn-secondary" id="zk-reset-cancel">Cancel</button>
+        <button type="button" class="consent-btn-primary" id="zk-reset-verify">Verify with GitHub</button>
+      </div>
+    `,
+  );
+  $('zk-reset-cancel')?.addEventListener('click', () => {
+    clearZkResetPending();
+    onCancelled?.();
+  });
+  $('zk-reset-verify')?.addEventListener('click', () => {
+    setZkResetPending();
+    const redirect = `${window.location.pathname}${window.location.search}`;
+    window.location.href = zkReauthLoginUrl(redirect);
+  });
+}
+
+function renderResetExecute($, escHtml, renderZkDialog, githubLogin, onCancelled) {
+  renderZkDialog(
+    'Confirm reset',
+    `
+      <p>GitHub verified. Delete all your encrypted data and set a new passphrase?</p>
+      <p class="zk-error" id="zk-reset-error" hidden></p>
+      <div class="zk-actions">
+        <button type="button" class="consent-btn-secondary" id="zk-reset-abort">Cancel</button>
+        <button type="button" class="consent-btn-primary" id="zk-reset-confirm">Reset and start over</button>
+      </div>
+    `,
+  );
+
+  const errorEl = $('zk-reset-error');
+  const confirmBtn = $('zk-reset-confirm');
+
+  $('zk-reset-abort')?.addEventListener('click', () => {
+    clearZkResetPending();
+    clearZkReauthProof();
+    onCancelled?.();
+  });
+
+  confirmBtn?.addEventListener('click', async () => {
+    errorEl.hidden = true;
+    confirmBtn.disabled = true;
+    confirmBtn.textContent = 'Resetting…';
+    try {
+      await resetZkAccountAndReenroll(githubLogin);
+    } catch (err) {
+      if (err?.code === 'reauth_required') {
+        errorEl.textContent = 'Verification expired — try again.';
+        clearZkReauthProof();
+      } else if (err?.code === 'rate_limited') {
+        errorEl.textContent = 'Too many resets — try again later.';
+      } else {
+        errorEl.textContent = err?.message ?? 'Reset failed. Try again.';
+      }
+      errorEl.hidden = false;
+      confirmBtn.disabled = false;
+      confirmBtn.textContent = 'Reset and start over';
+    }
+  });
+}
+
+/**
+ * Wire lost-passphrase UI into unlock gate helpers.
+ * @param {{ $: (id: string) => HTMLElement|null, escHtml: (s: string) => string, renderZkDialog: Function }} ctx
+ * @param {string} githubLogin
+ */
+export function wireZkResetUi(ctx, githubLogin, onCancelled) {
+  const { $, escHtml, renderZkDialog } = ctx;
+
+  if (isZkResetPending() && getZkReauthProof()) {
+    renderResetExecute($, escHtml, renderZkDialog, githubLogin, onCancelled);
+    return true;
+  }
+
+  return false;
+}
+
+export function showLostPassphraseWarning(ctx, onCancelled) {
+  const { $, escHtml, renderZkDialog } = ctx;
+  renderResetWarning($, escHtml, renderZkDialog, onCancelled);
+}

--- a/frontend/zk-reset.test.js
+++ b/frontend/zk-reset.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const apiMock = vi.fn();
+const deleteZkKeyPairMock = vi.fn();
+const deleteAccountMetaMock = vi.fn();
+const clearZkSessionMock = vi.fn();
+const getZkReauthProofMock = vi.fn();
+const clearZkReauthProofMock = vi.fn();
+
+vi.mock('./auth.js', () => ({ api: (...args) => apiMock(...args) }));
+vi.mock('./zk-crypto.js', () => ({
+  deleteZkKeyPair: (...args) => deleteZkKeyPairMock(...args),
+  deleteAccountMeta: (...args) => deleteAccountMetaMock(...args),
+}));
+vi.mock('./zk-session.js', () => ({
+  clearZkSession: () => clearZkSessionMock(),
+}));
+vi.mock('./zk-github.js', () => ({
+  getZkReauthProof: () => getZkReauthProofMock(),
+  clearZkReauthProof: () => clearZkReauthProofMock(),
+  zkReauthLoginUrl: (r) => `/login?reauth=1&redirect=${encodeURIComponent(r)}`,
+}));
+
+const {
+  isZkResetPending,
+  setZkResetPending,
+  clearZkResetPending,
+  clearLocalZkState,
+  resetZkAccountAndReenroll,
+} = await import('./zk-reset.js');
+
+describe('zk-reset', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    apiMock.mockReset();
+    deleteZkKeyPairMock.mockReset();
+    deleteAccountMetaMock.mockReset();
+    clearZkSessionMock.mockReset();
+    getZkReauthProofMock.mockReset();
+    clearZkReauthProofMock.mockReset();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('tracks reset pending flag in sessionStorage', () => {
+    expect(isZkResetPending()).toBe(false);
+    setZkResetPending();
+    expect(isZkResetPending()).toBe(true);
+    clearZkResetPending();
+    expect(isZkResetPending()).toBe(false);
+  });
+
+  it('clearLocalZkState wipes session and IndexedDB helpers', async () => {
+    await clearLocalZkState('alice');
+    expect(clearZkSessionMock).toHaveBeenCalled();
+    expect(deleteZkKeyPairMock).toHaveBeenCalledWith('alice');
+    expect(deleteAccountMetaMock).toHaveBeenCalledWith('alice');
+    expect(clearZkReauthProofMock).toHaveBeenCalled();
+  });
+
+  it('resetZkAccountAndReenroll posts reset then reloads', async () => {
+    const reload = vi.fn();
+    vi.stubGlobal('location', { reload });
+
+    getZkReauthProofMock.mockReturnValue('a'.repeat(32));
+    apiMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+
+    await resetZkAccountAndReenroll('alice');
+
+    expect(apiMock).toHaveBeenCalledWith('/api/zk/reset', expect.objectContaining({ method: 'POST' }));
+    expect(deleteAccountMetaMock).toHaveBeenCalledWith('alice');
+    expect(reload).toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/worker/src/api/zk-reset.test.ts
+++ b/worker/src/api/zk-reset.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { postZkResetRoute, purgeUserZkData } from "./zk-reset";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { makeFakeDb, makeFakeStmt } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const STUB_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: 9,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+const VALID_PROOF = "0123456789abcdef0123456789abcdef";
+
+function makeEnv(db: D1Database, overrides: Partial<Env> = {}): Env {
+  return {
+    DB: db,
+    ASSETS: { fetch: async () => new Response("ok") } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+    ZK_ACCOUNT_KEY: "1",
+    ...overrides,
+  } as unknown as Env;
+}
+
+function makeApp(db: D1Database): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("session", STUB_SESSION);
+    await next();
+  });
+  app.post("/api/zk/reset", postZkResetRoute);
+  return app;
+}
+
+describe("postZkResetRoute", () => {
+  it("returns 403 when ZK_ACCOUNT_KEY flag is off", async () => {
+    const db = makeFakeDb(() => makeFakeStmt("", [], []));
+    const res = await makeApp(db).request(
+      "/api/zk/reset",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reauth_proof: VALID_PROOF }),
+      },
+      makeEnv(db, { ZK_ACCOUNT_KEY: "0" }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 without reauth_proof", async () => {
+    const db = makeFakeDb(() => makeFakeStmt("", [], []));
+    const res = await makeApp(db).request(
+      "/api/zk/reset",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("reauth_required");
+  });
+
+  it("returns 403 when reauth proof is invalid", async () => {
+    const db = makeFakeDb((sql) => {
+      if (sql.includes("zk_reauth_proofs") && sql.includes("SELECT")) {
+        return makeFakeStmt(sql, [], []);
+      }
+      return makeFakeStmt(sql, [], []);
+    });
+    const res = await makeApp(db).request(
+      "/api/zk/reset",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reauth_proof: VALID_PROOF }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("purges user ZK data on valid reauth", async () => {
+    const captured: ReturnType<typeof makeFakeStmt>[] = [];
+    const db = makeFakeDb((sql, args) => {
+      let rows: Record<string, unknown>[] = [];
+      let changes = 0;
+      if (sql.includes("SELECT DISTINCT issue_key FROM zk_payloads WHERE user_id")) {
+        rows = [{ issue_key: "Roxabi/live#1" }];
+      } else if (sql.includes("SELECT COUNT(*)")) {
+        rows = [{ n: 2 }];
+      } else if (sql.includes("SELECT DISTINCT issue_key FROM zk_payloads")) {
+        rows = [];
+      } else if (sql.includes("zk_reauth_proofs") && sql.includes("SELECT")) {
+        rows = [{ ok: 1 }];
+      } else if (sql.includes("zk_reauth_proofs") && sql.includes("DELETE")) {
+        rows = [{ code: VALID_PROOF }];
+        changes = 1;
+      } else if (sql.includes("sync_control") && sql.includes("zk_reset")) {
+        changes = 1;
+      } else if (sql.startsWith("DELETE") || sql.includes("UPDATE issues")) {
+        changes = 1;
+      }
+      const stmt = makeFakeStmt(sql, args, rows, changes);
+      captured.push(stmt);
+      return stmt;
+    });
+
+    const res = await makeApp(db).request(
+      "/api/zk/reset",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reauth_proof: VALID_PROOF }),
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; payloads_deleted: number };
+    expect(body.ok).toBe(true);
+    expect(body.payloads_deleted).toBe(2);
+
+    expect(
+      captured.some((s) => s.sql.includes("DELETE FROM zk_payloads")),
+    ).toBe(true);
+    expect(
+      captured.some((s) => s.sql.includes("DELETE FROM zk_key_backups")),
+    ).toBe(true);
+  });
+});
+
+describe("purgeUserZkData", () => {
+  it("scrubs issues only when no other user still seals them", async () => {
+    const captured: ReturnType<typeof makeFakeStmt>[] = [];
+    const db = makeFakeDb((sql, args) => {
+      let rows: Record<string, unknown>[] = [];
+      let changes = 0;
+      if (sql.includes("SELECT DISTINCT issue_key FROM zk_payloads WHERE user_id")) {
+        rows = [{ issue_key: "Roxabi/live#9" }];
+      } else if (sql.includes("SELECT COUNT(*)")) {
+        rows = [{ n: 1 }];
+      } else if (sql.includes("SELECT DISTINCT issue_key FROM zk_payloads")) {
+        rows = [];
+      } else if (sql.startsWith("DELETE") || sql.includes("UPDATE issues")) {
+        changes = 1;
+      }
+      const stmt = makeFakeStmt(sql, args, rows, changes);
+      captured.push(stmt);
+      return stmt;
+    });
+
+    const stats = await purgeUserZkData(db, 7);
+    expect(stats.payloads_deleted).toBe(1);
+    expect(stats.issues_scrubbed).toBe(1);
+    expect(
+      captured.some((s) => s.sql.includes("UPDATE issues SET payload")),
+    ).toBe(true);
+  });
+});

--- a/worker/src/api/zk-reset.ts
+++ b/worker/src/api/zk-reset.ts
@@ -1,0 +1,147 @@
+/**
+ * POST /api/zk/reset — wipe user ZK state after lost passphrase (#216).
+ * Requires OAuth step-up reauth_proof. Irreversible; user must re-enroll.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "../auth/types";
+import { zkAccountKeyEnabled } from "../auth/zk-flags";
+import { consumeReauthProof, issueReauthProof } from "../auth/zk-reauth";
+import { loadZkSealedIssueKeys, scrubIssuePayloads } from "../auth/zk";
+import { writeZkAudit } from "../observability/zk-events";
+
+const REAUTH_PROOF_RE = /^[0-9a-f]{32}$/;
+const MAX_RESET_PER_HOUR = 3;
+
+async function readResetCount(
+  db: D1Database,
+  userId: number,
+): Promise<{ hourKey: string; count: number }> {
+  const hourKey = new Date().toISOString().slice(0, 13);
+  const rowKey = `zk_reset:${userId}`;
+  const row = await db
+    .prepare(`SELECT value FROM sync_control WHERE tenant_id = 0 AND key = ?`)
+    .bind(rowKey)
+    .first<{ value: string }>();
+
+  let count = 0;
+  let storedHour = hourKey;
+  if (row?.value) {
+    try {
+      const parsed = JSON.parse(row.value) as { hour?: string; count?: number };
+      storedHour = parsed.hour ?? hourKey;
+      count = typeof parsed.count === "number" ? parsed.count : 0;
+    } catch {
+      count = 0;
+    }
+  }
+  if (storedHour !== hourKey) count = 0;
+  return { hourKey, count };
+}
+
+async function isResetRateLimited(
+  db: D1Database,
+  userId: number,
+): Promise<boolean> {
+  const { count } = await readResetCount(db, userId);
+  return count >= MAX_RESET_PER_HOUR;
+}
+
+async function recordResetSuccess(
+  db: D1Database,
+  userId: number,
+): Promise<void> {
+  const { hourKey, count } = await readResetCount(db, userId);
+  const rowKey = `zk_reset:${userId}`;
+  await db
+    .prepare(
+      `INSERT INTO sync_control (tenant_id, key, value, updated_at)
+       VALUES (0, ?, ?, datetime('now'))
+       ON CONFLICT(tenant_id, key) DO UPDATE SET
+         value = excluded.value,
+         updated_at = datetime('now')`,
+    )
+    .bind(rowKey, JSON.stringify({ hour: hourKey, count: count + 1 }))
+    .run();
+}
+
+/** Delete all ZK rows for user; scrub issues no longer sealed by anyone. */
+export async function purgeUserZkData(
+  db: D1Database,
+  userId: number,
+): Promise<{ payloads_deleted: number; issues_scrubbed: number }> {
+  const keyRows = await db
+    .prepare(`SELECT DISTINCT issue_key FROM zk_payloads WHERE user_id = ?`)
+    .bind(userId)
+    .all<{ issue_key: string }>();
+  const affectedKeys = (keyRows.results ?? []).map((r) => r.issue_key);
+
+  const payloadCount = await db
+    .prepare(`SELECT COUNT(*) AS n FROM zk_payloads WHERE user_id = ?`)
+    .bind(userId)
+    .first<{ n: number }>();
+
+  await db.batch([
+    db.prepare(`DELETE FROM zk_payloads WHERE user_id = ?`).bind(userId),
+    db.prepare(`DELETE FROM zk_key_backups WHERE user_id = ?`).bind(userId),
+    db.prepare(`DELETE FROM zk_reauth_proofs WHERE user_id = ?`).bind(userId),
+    db.prepare(`DELETE FROM user_token_handoffs WHERE user_id = ?`).bind(userId),
+  ]);
+
+  const stillSealed = await loadZkSealedIssueKeys(db);
+  const toScrub = affectedKeys.filter((k) => !stillSealed.has(k));
+  await scrubIssuePayloads(db, toScrub);
+
+  return {
+    payloads_deleted: payloadCount?.n ?? 0,
+    issues_scrubbed: toScrub.length,
+  };
+}
+
+export async function postZkResetRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const s = c.get("session");
+  if (!s) return c.json({ error: "unauthorized" }, 401);
+  if (!zkAccountKeyEnabled(c.env)) {
+    return c.json({ error: "zk_account_key_disabled" }, 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid body" }, 400);
+  }
+
+  if (body === null || typeof body !== "object") {
+    return c.json({ error: "invalid body" }, 400);
+  }
+
+  const reauth_proof = (body as Record<string, unknown>).reauth_proof;
+  if (typeof reauth_proof !== "string" || !REAUTH_PROOF_RE.test(reauth_proof)) {
+    return c.json({ error: "reauth_required" }, 403);
+  }
+
+  if (await isResetRateLimited(c.env.DB, s.userId)) {
+    return c.json({ error: "rate_limited" }, 429);
+  }
+
+  if (!(await issueReauthProof(c.env, s.userId, reauth_proof))) {
+    return c.json({ error: "reauth_required" }, 403);
+  }
+
+  const stats = await purgeUserZkData(c.env.DB, s.userId);
+
+  if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
+    return c.json({ error: "reauth_required" }, 403);
+  }
+
+  await recordResetSuccess(c.env.DB, s.userId);
+  await writeZkAudit(c.env, {
+    event: "zk.account.reset",
+    user_id: s.userId,
+  });
+
+  return c.json({ ok: true, ...stats });
+}

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -19,6 +19,7 @@ import {
   getZkKeyBackupRoute,
   putZkKeyBackupRoute,
 } from "./api/zk-key-backup";
+import { postZkResetRoute } from "./api/zk-reset";
 import { zkGithubGraphqlRoute } from "./api/zk-github-proxy";
 
 const app = new Hono<AuthEnv>();
@@ -89,6 +90,8 @@ app.post("/api/zk/consume-reauth", requireSession, consumeZkReauthRoute);
 app.use("/api/zk/key-backup", requireSession);
 app.get("/api/zk/key-backup", getZkKeyBackupRoute);
 app.put("/api/zk/key-backup", putZkKeyBackupRoute);
+app.use("/api/zk/reset", requireSession);
+app.post("/api/zk/reset", postZkResetRoute);
 app.post("/api/zk/github/graphql", requireSession, zkGithubGraphqlRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.


### PR DESCRIPTION
## Summary

When a user loses their encryption passphrase, they can wipe all **their** ZK data and start over.

- **`POST /api/zk/reset`** — session + OAuth step-up `reauth_proof`; deletes `zk_key_backups`, `zk_payloads`, handoffs; scrubs `issues.payload` for issues no longer sealed by anyone
- **Unlock gate** — "Lost passphrase?" → GitHub verify → confirm → reload → enroll gate
- Clears local IndexedDB (`roxabi-zk-v1` / `roxabi-zk-v2`) on reset

## Security

Same reauth discipline as backup UPDATE (5 min proof, single-use). Rate limit: 3 resets/hour/user.

## Test plan

- [x] worker 625/625
- [x] frontend 45/45