### PR TITLE
fix(zk): consume reauth proof before purge on reset

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -354,6 +354,8 @@ async function init() {
   try {
     await consumeZkHandoffFromUrl();
     await consumeZkReauthFromUrl();
+    const { reconcileZkResetPendingAfterReauth } = await import('./zk-reset.js');
+    reconcileZkResetPendingAfterReauth();
     const me = await getSessionProfile();
     sessionGithubLogin = me.user?.github_login ?? '';
     const zkAccountKeyEnabled = isZkAccountKeyEnabled(me);

--- a/frontend/zk-reset.js
+++ b/frontend/zk-reset.js
@@ -22,6 +22,13 @@ export function clearZkResetPending() {
   sessionStorage.removeItem(RESET_PENDING_KEY);
 }
 
+/** Drop stale reset intent when OAuth step-up did not yield a proof. */
+export function reconcileZkResetPendingAfterReauth() {
+  if (isZkResetPending() && !getZkReauthProof()) {
+    clearZkResetPending();
+  }
+}
+
 /** Wipe browser key material after server reset. */
 export async function clearLocalZkState(githubLogin) {
   clearZkSession();
@@ -47,7 +54,12 @@ async function postZkReset() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ reauth_proof }),
   });
-  const data = await resp.json();
+  let data = {};
+  try {
+    data = await resp.json();
+  } catch {
+    data = {};
+  }
   if (!resp.ok) {
     const err = new Error(data?.error ?? 'reset_failed');
     err.code = data?.error;
@@ -57,12 +69,33 @@ async function postZkReset() {
   return data;
 }
 
+/** If server already wiped enrollment, treat reset as complete locally. */
+export async function recoverFromPartialZkReset(githubLogin) {
+  try {
+    const meResp = await api('/api/me');
+    const me = await meResp.json();
+    if (me?.user?.zk_enrolled === false) {
+      await clearLocalZkState(githubLogin);
+      window.location.reload();
+      return true;
+    }
+  } catch {
+    /* ignore */
+  }
+  return false;
+}
+
 /**
  * Full reset: server purge + local wipe, then enroll gate for new passphrase.
  * @param {string} githubLogin
  */
 export async function resetZkAccountAndReenroll(githubLogin) {
-  await postZkReset();
+  try {
+    await postZkReset();
+  } catch (err) {
+    if (await recoverFromPartialZkReset(githubLogin)) return;
+    throw err;
+  }
   await clearLocalZkState(githubLogin);
   window.location.reload();
 }
@@ -124,6 +157,7 @@ function renderResetExecute($, escHtml, renderZkDialog, githubLogin, onCancelled
       await resetZkAccountAndReenroll(githubLogin);
     } catch (err) {
       if (err?.code === 'reauth_required') {
+        if (await recoverFromPartialZkReset(githubLogin)) return;
         errorEl.textContent = 'Verification expired — try again.';
         clearZkReauthProof();
       } else if (err?.code === 'rate_limited') {
@@ -149,6 +183,10 @@ export function wireZkResetUi(ctx, githubLogin, onCancelled) {
   if (isZkResetPending() && getZkReauthProof()) {
     renderResetExecute($, escHtml, renderZkDialog, githubLogin, onCancelled);
     return true;
+  }
+
+  if (isZkResetPending() && !getZkReauthProof()) {
+    clearZkResetPending();
   }
 
   return false;

--- a/worker/src/api/zk-reset.test.ts
+++ b/worker/src/api/zk-reset.test.ts
@@ -134,6 +134,18 @@ describe("postZkResetRoute", () => {
     expect(
       captured.some((s) => s.sql.includes("DELETE FROM zk_key_backups")),
     ).toBe(true);
+
+    const consumeIdx = captured.findIndex(
+      (s) =>
+        s.sql.includes("zk_reauth_proofs") &&
+        s.sql.includes("DELETE") &&
+        s.sql.includes("RETURNING"),
+    );
+    const purgeIdx = captured.findIndex((s) =>
+      s.sql.includes("DELETE FROM zk_payloads"),
+    );
+    expect(consumeIdx).toBeGreaterThanOrEqual(0);
+    expect(purgeIdx).toBeGreaterThan(consumeIdx);
   });
 });
 

--- a/worker/src/api/zk-reset.ts
+++ b/worker/src/api/zk-reset.ts
@@ -84,7 +84,6 @@ export async function purgeUserZkData(
   await db.batch([
     db.prepare(`DELETE FROM zk_payloads WHERE user_id = ?`).bind(userId),
     db.prepare(`DELETE FROM zk_key_backups WHERE user_id = ?`).bind(userId),
-    db.prepare(`DELETE FROM zk_reauth_proofs WHERE user_id = ?`).bind(userId),
     db.prepare(`DELETE FROM user_token_handoffs WHERE user_id = ?`).bind(userId),
   ]);
 
@@ -127,15 +126,16 @@ export async function postZkResetRoute(
     return c.json({ error: "rate_limited" }, 429);
   }
 
-  if (!(await issueReauthProof(c.env, s.userId, reauth_proof))) {
+  const proof = await issueReauthProof(c.env, s.userId, reauth_proof);
+  if (!proof) {
     return c.json({ error: "reauth_required" }, 403);
   }
-
-  const stats = await purgeUserZkData(c.env.DB, s.userId);
 
   if (!(await consumeReauthProof(c.env, s.userId, reauth_proof))) {
     return c.json({ error: "reauth_required" }, 403);
   }
+
+  const stats = await purgeUserZkData(c.env.DB, s.userId);
 
   await recordResetSuccess(c.env.DB, s.userId);
   await writeZkAudit(c.env, {


### PR DESCRIPTION
## Review Fixes Applied

Addresses **Request changes** from code review on PR #220.

### Blockers fixed
- **consume before purge** — `consumeReauthProof` now runs before `purgeUserZkData`; removed bulk `zk_reauth_proofs` delete from purge batch
- **Test ordering assertion** — happy path asserts consume DELETE precedes payload purge
- **Frontend partial-wipe recovery** — on reset failure, check `/api/me`; if `zk_enrolled === false`, clear local state + reload
- **Stale reset-pending** — clear when OAuth reauth did not produce a proof

## Test plan
- [x] worker 625/625
- [x] frontend 45/45