### PR TITLE
feat(auth): guided GitHub App install UX

### DIFF
--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -71,6 +71,103 @@
   outline-offset: 3px;
 }
 
+/* ─── Install guide (post-OAuth, pre-installation) ─────────────────────────── */
+
+.install-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 20px;
+  max-width: 560px;
+  text-align: left;
+}
+
+.install-panel h2 {
+  text-align: center;
+}
+
+.install-lead {
+  max-width: none;
+}
+
+.install-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.install-option {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  text-align: left;
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.install-option:hover {
+  background: var(--bg-panel);
+  border-color: var(--border-hi);
+}
+
+.install-option:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.install-option-info {
+  cursor: default;
+}
+
+.install-option-info:hover {
+  background: var(--bg-card);
+  border-color: var(--border);
+}
+
+.install-option-title {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.install-option-name {
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.install-option-hint {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.install-note {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: none;
+  text-align: center;
+}
+
+.install-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
 /* ─── Org picker (select in header-actions) ──────────────────────────────── */
 
 .org-picker {

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,6 +1,8 @@
 // auth.js — Auth gate state machine, consent persistence, API wrapper
 // Exports: AuthError, api, hasConsent, setConsent, resolveView, requireAuthGate, getSessionProfile
 
+import { githubInstallUrl, partitionInstallTargets } from './github-install.js';
+
 const $ = id => document.getElementById(id);
 
 // ─── AuthError ────────────────────────────────────────────────────────────────
@@ -85,22 +87,94 @@ function renderLanding() {
 
 // ─── Internal: render install CTA ────────────────────────────────────────────
 
-function renderInstallCta() {
+/**
+ * @param {{ user: { github_id: number, github_login: string }, install_targets?: Array<{ id: number, login: string, type: string }> }} me
+ */
+function renderInstallCta(me) {
   document.body.classList.add('gated');
   const el = $('auth-install');
+  const targets = me.install_targets ?? [];
+  const { personal, orgs } = partitionInstallTargets(targets);
+  const login = escHtml(me.user.github_login);
+
+  const personalUrl = personal ? githubInstallUrl(personal) : githubInstallUrl();
+  const orgCards = orgs.length
+    ? orgs.map(org => `
+        <a
+          class="install-option"
+          href="${escHtml(githubInstallUrl(org))}"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span class="install-option-title">Organisation</span>
+          <span class="install-option-name">${escHtml(org.login)}</span>
+          <span class="install-option-hint">Install on this org — choose all repos or selected repos on GitHub</span>
+        </a>
+      `).join('')
+    : `
+        <a
+          class="install-option"
+          href="${escHtml(githubInstallUrl())}"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span class="install-option-title">Organisation</span>
+          <span class="install-option-name">Pick on GitHub</span>
+          <span class="install-option-hint">GitHub will show every org where you can install or request access</span>
+        </a>
+      `;
+
   el.innerHTML = `
-    <h2>Install the GitHub App</h2>
-    <p>No GitHub App installation found for your account. Install the Roxabi Live app on your organisation to get started.</p>
-    <a
-      href="https://github.com/apps/roxabi-live/installations/new"
-      class="auth-login-btn"
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label="Install GitHub App"
-    >Install GitHub App</a>
-    <p><small>After installing, reload this page.</small></p>
+    <div class="install-panel">
+      <h2>Install Roxabi Live on GitHub</h2>
+      <p class="install-lead">
+        Signed in as <strong>${login}</strong>. Choose where to install the app.
+        GitHub handles permissions and repository access — you can install on your
+        personal account, an organisation, or limit access to specific repositories.
+      </p>
+      <div class="install-options" role="list">
+        <a
+          class="install-option"
+          href="${escHtml(personalUrl)}"
+          target="_blank"
+          rel="noopener noreferrer"
+          role="listitem"
+        >
+          <span class="install-option-title">Personal account</span>
+          <span class="install-option-name">${login}</span>
+          <span class="install-option-hint">Your repos only — good for solo projects</span>
+        </a>
+        ${orgCards}
+        <div class="install-option install-option-info" role="listitem">
+          <span class="install-option-title">Specific repositories only</span>
+          <span class="install-option-hint">
+            Pick an account above, then on GitHub choose <strong>Only select repositories</strong>
+            and select the repos you want Roxabi Live to read.
+          </span>
+        </div>
+      </div>
+      <p class="install-note">
+        Installation opens on GitHub in a new tab. When you are done, return here and continue —
+        we will pick up the new installation automatically.
+      </p>
+      <div class="install-actions">
+        <button type="button" class="consent-btn-secondary" id="install-logout">Sign out</button>
+        <a href="/login?redirect=/" class="auth-login-btn" id="install-continue">I've installed — continue</a>
+      </div>
+    </div>
   `;
   el.removeAttribute('hidden');
+
+  $('install-logout')?.addEventListener('click', async () => {
+    await api('/logout', { method: 'POST' }).catch(() => {});
+    location.href = '/';
+  });
+
+  if (location.search.includes('install=1')) {
+    const clean = new URL(location.href);
+    clean.searchParams.delete('install');
+    history.replaceState(null, '', clean.pathname + clean.search + clean.hash);
+  }
 }
 
 // ─── Internal: render consent gate ───────────────────────────────────────────
@@ -286,7 +360,7 @@ export async function requireAuthGate() {
   const view = resolveView(me, consented);
 
   if (view === 'install') {
-    renderInstallCta();
+    renderInstallCta(me);
     return 'install';
   }
 

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -49,7 +49,7 @@ export function setConsent(login) {
  * @returns {'install'|'consent'|'dashboard'}
  */
 export function resolveView(me, consented) {
-  if (me.installations.length === 0) return 'install';
+  if (me.install_pending || me.installations.length === 0) return 'install';
   if (!consented) return 'consent';
   return 'dashboard';
 }
@@ -105,6 +105,7 @@ function renderInstallCta(me) {
           href="${escHtml(githubInstallUrl(org))}"
           target="_blank"
           rel="noopener noreferrer"
+          role="listitem"
         >
           <span class="install-option-title">Organisation</span>
           <span class="install-option-name">${escHtml(org.login)}</span>
@@ -117,6 +118,7 @@ function renderInstallCta(me) {
           href="${escHtml(githubInstallUrl())}"
           target="_blank"
           rel="noopener noreferrer"
+          role="listitem"
         >
           <span class="install-option-title">Organisation</span>
           <span class="install-option-name">Pick on GitHub</span>
@@ -154,8 +156,8 @@ function renderInstallCta(me) {
         </div>
       </div>
       <p class="install-note">
-        Installation opens on GitHub in a new tab. When you are done, return here and continue —
-        we will pick up the new installation automatically.
+        Installation opens on GitHub in a new tab. When you are done, return here and
+        <strong>Continue</strong> to sign in again — GitHub will expose the new installation.
       </p>
       <div class="install-actions">
         <button type="button" class="consent-btn-secondary" id="install-logout">Sign out</button>
@@ -165,15 +167,18 @@ function renderInstallCta(me) {
   `;
   el.removeAttribute('hidden');
 
+  const firstInstallLink = el.querySelector('.install-option[href]');
+  firstInstallLink?.focus();
+
   $('install-logout')?.addEventListener('click', async () => {
     await api('/logout', { method: 'POST' }).catch(() => {});
     location.href = '/';
   });
 
-  if (location.search.includes('install=1')) {
-    const clean = new URL(location.href);
-    clean.searchParams.delete('install');
-    history.replaceState(null, '', clean.pathname + clean.search + clean.hash);
+  const pageUrl = new URL(location.href);
+  if (pageUrl.searchParams.has('install')) {
+    pageUrl.searchParams.delete('install');
+    history.replaceState(null, '', pageUrl.pathname + pageUrl.search + pageUrl.hash);
   }
 }
 

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -10,6 +10,18 @@ describe('resolveView', () => {
     account_type: 'Organization',
   };
 
+  describe('when install_pending is true', () => {
+    it("returns 'install' even if installations is non-empty", () => {
+      const me = {
+        user: { github_id: 42, github_login: 'alice' },
+        active_tenant_id: null,
+        install_pending: true,
+        installations: [installationFixture],
+      };
+      expect(resolveView(me, true)).toBe('install');
+    });
+  });
+
   describe('when installations is empty', () => {
     it("returns 'install' regardless of consent", () => {
       // Arrange

--- a/frontend/github-install.js
+++ b/frontend/github-install.js
@@ -1,0 +1,26 @@
+// github-install.js — GitHub App installation deep links (mirrors worker/src/auth/github-install.ts)
+
+export const GITHUB_APP_SLUG = 'roxabi-live';
+
+const INSTALL_BASE = `https://github.com/apps/${GITHUB_APP_SLUG}/installations/new`;
+
+/**
+ * @param {{ id: number, login: string, type: 'User'|'Organization' }|undefined} target
+ */
+export function githubInstallUrl(target) {
+  const url = new URL(INSTALL_BASE);
+  if (target) {
+    url.searchParams.set('target_id', String(target.id));
+    url.searchParams.set('target_type', target.type);
+  }
+  return url.toString();
+}
+
+/**
+ * @param {Array<{ id: number, login: string, type: string }>} targets
+ */
+export function partitionInstallTargets(targets) {
+  const personal = targets.find(t => t.type === 'User') ?? null;
+  const orgs = targets.filter(t => t.type === 'Organization');
+  return { personal, orgs };
+}

--- a/frontend/github-install.test.js
+++ b/frontend/github-install.test.js
@@ -2,6 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { githubInstallUrl, partitionInstallTargets } from './github-install.js';
 
 describe('githubInstallUrl', () => {
+  it('returns base install URL without target', () => {
+    expect(githubInstallUrl()).toBe('https://github.com/apps/roxabi-live/installations/new');
+  });
+
+  it('builds personal account deep link', () => {
+    const url = new URL(githubInstallUrl({ id: 42, login: 'alice', type: 'User' }));
+    expect(url.searchParams.get('target_id')).toBe('42');
+    expect(url.searchParams.get('target_type')).toBe('User');
+  });
+
   it('builds org deep link', () => {
     const url = new URL(githubInstallUrl({ id: 9, login: 'Roxabi', type: 'Organization' }));
     expect(url.searchParams.get('target_id')).toBe('9');

--- a/frontend/github-install.test.js
+++ b/frontend/github-install.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { githubInstallUrl, partitionInstallTargets } from './github-install.js';
+
+describe('githubInstallUrl', () => {
+  it('builds org deep link', () => {
+    const url = new URL(githubInstallUrl({ id: 9, login: 'Roxabi', type: 'Organization' }));
+    expect(url.searchParams.get('target_id')).toBe('9');
+    expect(url.searchParams.get('target_type')).toBe('Organization');
+  });
+});
+
+describe('partitionInstallTargets', () => {
+  it('splits personal account and orgs', () => {
+    const targets = [
+      { id: 1, login: 'alice', type: 'User' },
+      { id: 2, login: 'Roxabi', type: 'Organization' },
+      { id: 3, login: 'Other', type: 'Organization' },
+    ];
+    const { personal, orgs } = partitionInstallTargets(targets);
+    expect(personal?.login).toBe('alice');
+    expect(orgs.map(o => o.login)).toEqual(['Roxabi', 'Other']);
+  });
+});

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,11 +14,11 @@ worker/src/webhook/mutations.ts  # 339 lines — #180 D1 write helpers for webho
 worker/src/sync/sync.test.ts  # 1715 lines — #180 integration harness for runSync; #216 structure-only
 worker/src/api/zk-key-backup.test.ts  # 385 lines — #216 backup API security + CAS/reauth tests
 worker/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-worker/src/auth/oauth.test.ts  # 864 lines — #180 OAuth callback + batch tests
+worker/src/auth/oauth.test.ts  # 931 lines — #180 OAuth + install-pending flow tests
 worker/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 worker/src/api/graph.test.ts  # 745 lines — #180 tenant-scoped graph + #142 S2 zk + closed_under_open_epic
 worker/src/migrations.test.ts  # 310 lines — #216 zk_key_backups + zk_reauth_proofs schema tests
 worker/src/webhook/mutations.test.ts  # 587 lines — #180 webhook mutation tests
 worker/src/webhook/handlers-app.test.ts  # 498 lines — #180 app lifecycle handler tests
 worker/src/auth/installToken.test.ts  # 470 lines — #180 install token + pagination tests
-worker/src/auth/session.test.ts  # 318 lines — #180 session middleware contract tests
+worker/src/auth/session.test.ts  # 323 lines — #180 session + install-pending SQL guard tests

--- a/worker/migrations/0017_install_pending_session.sql
+++ b/worker/migrations/0017_install_pending_session.sql
@@ -1,0 +1,27 @@
+-- migration: 0017_install_pending_session.sql
+-- Install-pending OAuth sessions (nullable tenant_id) + cached install targets on users.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE sessions_new (
+  id          INTEGER PRIMARY KEY,
+  user_id     INTEGER NOT NULL REFERENCES users(id),
+  tenant_id   INTEGER REFERENCES tenants(id),
+  token_hash  TEXT NOT NULL UNIQUE,
+  expires_at  TEXT NOT NULL,
+  revoked_at  TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO sessions_new (id, user_id, tenant_id, token_hash, expires_at, revoked_at, created_at)
+  SELECT id, user_id, tenant_id, token_hash, expires_at, revoked_at, created_at FROM sessions;
+
+DROP TABLE sessions;
+ALTER TABLE sessions_new RENAME TO sessions;
+
+CREATE INDEX IF NOT EXISTS ix_sessions_user_id ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS ix_sessions_expires_at ON sessions(expires_at);
+
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE users ADD COLUMN install_targets_json TEXT;

--- a/worker/src/api/install-complete.ts
+++ b/worker/src/api/install-complete.ts
@@ -1,0 +1,20 @@
+/**
+ * GET /install/complete — post-install return URL (GitHub App Setup URL).
+ *
+ * Operator config (GitHub App settings → Setup URL):
+ *   https://live.roxabi.dev/install/complete
+ *
+ * Re-OAuth is required so we can fetch /user/installations and link tenants.
+ */
+
+import type { Context } from "hono";
+import type { Env } from "../types";
+
+export async function installCompleteRoute(
+  c: Context<{ Bindings: Env }>,
+): Promise<Response> {
+  return new Response(null, {
+    status: 302,
+    headers: { Location: "/login?redirect=/" },
+  });
+}

--- a/worker/src/api/issues.test.ts
+++ b/worker/src/api/issues.test.ts
@@ -15,17 +15,19 @@ vi.mock("../auth/repoAccess", () => ({
 
 vi.mock("../auth/session", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../auth/session")>();
+  const injectSession = (async (c, next) => {
+    c.set("session", {
+      userId: 1,
+      tenantId: 1,
+      githubId: 1001,
+      githubLogin: "octocat",
+    });
+    await next();
+  }) as typeof actual.requireSession;
   return {
     ...actual,
-    requireSession: (async (c, next) => {
-      c.set("session", {
-        userId: 1,
-        tenantId: 1,
-        githubId: 1001,
-        githubLogin: "octocat",
-      });
-      await next();
-    }) as typeof actual.requireSession,
+    requireSession: injectSession,
+    requireLinkedTenant: injectSession,
   };
 });
 

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -36,12 +36,15 @@ function makeEnv(db: D1Database): Env {
  * then mounts meRoute + logoutRoute.
  * This tests the route handlers in isolation — independent of requireSession.
  */
-function makeApp(db: D1Database): Hono<AuthEnv> {
+function makeApp(
+  db: D1Database,
+  session: SessionContext = STUB_SESSION,
+): Hono<AuthEnv> {
   const app = new Hono<AuthEnv>();
 
   // Stub middleware: injects session without any cookie/DB check
   app.use("*", async (c, next) => {
-    c.set("session", STUB_SESSION);
+    c.set("session", session);
     await next();
   });
 
@@ -210,6 +213,61 @@ describe("meRoute", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { active_tenant_id: number };
     expect(body.active_tenant_id).toBe(STUB_SESSION.tenantId);
+  });
+
+  it("returns install_pending and install_targets when session has no tenant", async () => {
+    const targetsJson = JSON.stringify([
+      { id: 42, login: "alice", type: "User" },
+      { id: 77, login: "Roxabi", type: "Organization" },
+    ]);
+    const { db } = captureDb((sql) => {
+      if (sql.includes("install_targets_json")) {
+        return [{ zk_opt_in: 1, install_targets_json: targetsJson }];
+      }
+      if (sql.includes("user_installations")) return [];
+      return [];
+    });
+    const pendingSession: SessionContext = {
+      ...STUB_SESSION,
+      tenantId: null,
+    };
+    const res = await makeApp(db, pendingSession).request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as {
+      install_pending: boolean;
+      install_targets: Array<{ login: string }>;
+      active_tenant_id: number | null;
+      installations: unknown[];
+    };
+    expect(body.install_pending).toBe(true);
+    expect(body.active_tenant_id).toBeNull();
+    expect(body.installations).toEqual([]);
+    expect(body.install_targets.map((t) => t.login)).toEqual(["alice", "Roxabi"]);
+  });
+
+  it("suppresses install_targets once a tenant is linked", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("install_targets_json")) {
+        return [{ zk_opt_in: 1, install_targets_json: "[]" }];
+      }
+      if (sql.includes("user_installations")) {
+        return [{ tenant_id: 9, account_login: "Roxabi", account_type: "Organization" }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as {
+      install_pending: boolean;
+      install_targets: unknown[];
+    };
+    expect(body.install_pending).toBe(false);
+    expect(body.install_targets).toEqual([]);
+  });
+
+  it("installations SELECT filters soft-deleted tenants", async () => {
+    const { db, stmts } = captureDb();
+    await makeApp(db).request("/api/me", {}, makeEnv(db));
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt!.sql).toContain("deleted_at IS NULL");
   });
 
   it("installations SELECT projects account_type (#148 SC7)", async () => {

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -39,16 +39,18 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
   const rows = await c.env.DB
     .prepare(
       `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
-       FROM user_installations ui JOIN tenants t ON t.id = ui.tenant_id WHERE ui.user_id = ?`,
+       FROM user_installations ui
+       JOIN tenants t ON t.id = ui.tenant_id
+       WHERE ui.user_id = ? AND t.deleted_at IS NULL`,
     )
     .bind(s.userId)
     .all<{ tenant_id: number; account_login: string; account_type: string }>();
 
   const installations = rows.results;
-  const installTargets =
-    installations.length === 0
-      ? parseInstallTargets(userRow?.install_targets_json)
-      : [];
+  const installPending = s.tenantId == null;
+  const installTargets = installPending
+    ? parseInstallTargets(userRow?.install_targets_json)
+    : [];
 
   return c.json({
     user: {
@@ -59,7 +61,7 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
       zk_account_key_enabled: zkAccountKeyEnabled(c.env),
     },
     active_tenant_id: s.tenantId,
-    install_pending: s.tenantId == null,
+    install_pending: installPending,
     install_targets: installTargets,
     installations,
   });

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -8,6 +8,7 @@ import type { AuthEnv } from "../auth/types";
 import { readSessionToken, clearSessionCookie } from "../auth/cookies";
 import { deleteSession } from "../auth/session";
 import { zkAccountKeyEnabled } from "../auth/zk-flags";
+import { parseInstallTargets } from "../auth/github-install";
 
 // ---------------------------------------------------------------------------
 // GET /api/me
@@ -24,9 +25,9 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
   }
 
   const userRow = await c.env.DB
-    .prepare(`SELECT zk_opt_in FROM users WHERE id = ?`)
+    .prepare(`SELECT zk_opt_in, install_targets_json FROM users WHERE id = ?`)
     .bind(s.userId)
-    .first<{ zk_opt_in: number }>();
+    .first<{ zk_opt_in: number; install_targets_json: string | null }>();
 
   const enrolledRow = await c.env.DB
     .prepare(
@@ -43,6 +44,12 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
     .bind(s.userId)
     .all<{ tenant_id: number; account_login: string; account_type: string }>();
 
+  const installations = rows.results;
+  const installTargets =
+    installations.length === 0
+      ? parseInstallTargets(userRow?.install_targets_json)
+      : [];
+
   return c.json({
     user: {
       github_id: s.githubId,
@@ -52,7 +59,9 @@ export async function meRoute(c: Context<AuthEnv>): Promise<Response> {
       zk_account_key_enabled: zkAccountKeyEnabled(c.env),
     },
     active_tenant_id: s.tenantId,
-    installations: rows.results,
+    install_pending: s.tenantId == null,
+    install_targets: installTargets,
+    installations,
   });
 }
 

--- a/worker/src/auth/github-install.test.ts
+++ b/worker/src/auth/github-install.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  GITHUB_APP_SLUG,
+  githubInstallUrl,
+  parseInstallTargets,
+} from "./github-install";
+
+describe("githubInstallUrl", () => {
+  it("returns base install URL without target", () => {
+    expect(githubInstallUrl()).toBe(
+      `https://github.com/apps/${GITHUB_APP_SLUG}/installations/new`,
+    );
+  });
+
+  it("pre-selects user account via target_id and target_type", () => {
+    const url = new URL(
+      githubInstallUrl({ id: 42, login: "alice", type: "User" }),
+    );
+    expect(url.searchParams.get("target_id")).toBe("42");
+    expect(url.searchParams.get("target_type")).toBe("User");
+  });
+
+  it("pre-selects organisation via target_id and target_type", () => {
+    const url = new URL(
+      githubInstallUrl({ id: 99, login: "Roxabi", type: "Organization" }),
+    );
+    expect(url.searchParams.get("target_id")).toBe("99");
+    expect(url.searchParams.get("target_type")).toBe("Organization");
+  });
+});
+
+describe("parseInstallTargets", () => {
+  it("returns [] for null/empty/invalid JSON", () => {
+    expect(parseInstallTargets(null)).toEqual([]);
+    expect(parseInstallTargets("")).toEqual([]);
+    expect(parseInstallTargets("{")).toEqual([]);
+    expect(parseInstallTargets("[]")).toEqual([]);
+  });
+
+  it("filters malformed entries", () => {
+    const raw = JSON.stringify([
+      { id: 1, login: "alice", type: "User" },
+      { id: "bad", login: "x", type: "User" },
+      { login: "no-id", type: "Organization" },
+    ]);
+    expect(parseInstallTargets(raw)).toEqual([
+      { id: 1, login: "alice", type: "User" },
+    ]);
+  });
+});

--- a/worker/src/auth/github-install.ts
+++ b/worker/src/auth/github-install.ts
@@ -1,0 +1,52 @@
+/**
+ * GitHub App installation URL helpers.
+ *
+ * Installation always completes on github.com — these helpers build deep links
+ * that pre-select account/org when possible. Repository scope is chosen on
+ * GitHub during install ("Only select repositories").
+ */
+
+export const GITHUB_APP_SLUG = "roxabi-live";
+
+export type InstallTargetType = "User" | "Organization";
+
+export interface InstallTarget {
+  id: number;
+  login: string;
+  type: InstallTargetType;
+}
+
+const INSTALL_BASE = `https://github.com/apps/${GITHUB_APP_SLUG}/installations/new`;
+
+/**
+ * Build the GitHub App installation URL.
+ * When target is omitted, GitHub shows the account/org picker.
+ */
+export function githubInstallUrl(target?: InstallTarget): string {
+  const url = new URL(INSTALL_BASE);
+  if (target) {
+    url.searchParams.set("target_id", String(target.id));
+    url.searchParams.set("target_type", target.type);
+  }
+  return url.toString();
+}
+
+/** Parse install_targets_json from users — invalid JSON yields []. */
+export function parseInstallTargets(raw: string | null | undefined): InstallTarget[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (t): t is InstallTarget =>
+        t != null &&
+        typeof t === "object" &&
+        typeof (t as InstallTarget).id === "number" &&
+        typeof (t as InstallTarget).login === "string" &&
+        ((t as InstallTarget).type === "User" ||
+          (t as InstallTarget).type === "Organization"),
+    );
+  } catch {
+    return [];
+  }
+}

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -1046,9 +1046,17 @@ describe("callbackRoute", () => {
                 headers: { "Content-Type": "application/json" },
               },
             );
-          } else {
+          } else if (fetchCallCount === 3) {
             return new Response(
               JSON.stringify({ installations: [] }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          } else {
+            return new Response(
+              JSON.stringify([{ id: 77, login: "Roxabi" }]),
               {
                 status: 200,
                 headers: { "Content-Type": "application/json" },
@@ -1059,7 +1067,7 @@ describe("callbackRoute", () => {
       );
     }
 
-    it("returns 302 to GitHub app install page when installations is empty", async () => {
+    it("returns 302 to install guide with ?install=1 when installations is empty", async () => {
       // Arrange
       const stateValue = "f".repeat(32);
       const captured: FakeStmt[] = [];
@@ -1077,11 +1085,11 @@ describe("callbackRoute", () => {
       // Assert
       expect(res.status).toBe(302);
       const location = res.headers.get("Location") ?? "";
-      expect(location).toContain("github.com/apps/");
-      expect(location).toContain("installations/new");
+      expect(location).toContain("install=1");
+      expect(location).not.toContain("github.com");
     });
 
-    it("does NOT set a session cookie when installations is empty", async () => {
+    it("sets install-pending session cookie when installations is empty", async () => {
       // Arrange
       const stateValue = "0".repeat(32);
       const captured: FakeStmt[] = [];
@@ -1096,11 +1104,11 @@ describe("callbackRoute", () => {
         env,
       );
 
-      // Assert — no Set-Cookie header when no installations
-      expect(res.headers.get("Set-Cookie")).toBeNull();
+      // Assert
+      expect(res.headers.get("Set-Cookie")).toContain("__Host-session=");
     });
 
-    it("does NOT insert a session row when installations is empty", async () => {
+    it("inserts install-pending session (tenant_id null) when installations is empty", async () => {
       // Arrange
       const stateValue = "1".repeat(32);
       const captured: FakeStmt[] = [];
@@ -1115,18 +1123,18 @@ describe("callbackRoute", () => {
         env,
       );
 
-      // Assert — no INSERT INTO sessions statement
+      // Assert
       const sessionsInsert = captured.find(
         (s) =>
           s.sql.toLowerCase().includes("sessions") &&
           s.sql.toLowerCase().includes("insert"),
       );
-      expect(sessionsInsert).toBeUndefined();
+      expect(sessionsInsert).toBeDefined();
+      expect(sessionsInsert!.args[1]).toBeNull();
     });
 
-    it("F4 — does NOT insert a user row when installations is empty (no ghost users)", async () => {
-      // Arrange — F4: user upsert must happen AFTER the install check, so zero
-      // installations must never produce an INSERT INTO users.
+    it("upserts user with install_targets_json when installations is empty", async () => {
+      // Arrange
       const stateValue = "2".repeat(32);
       const captured: FakeStmt[] = [];
       const db = makeZeroInstallDb(captured);
@@ -1140,13 +1148,24 @@ describe("callbackRoute", () => {
         env,
       );
 
-      // Assert — no INSERT INTO users statement was executed
+      // Assert
       const usersInsert = captured.find(
         (s) =>
           s.sql.toLowerCase().includes("insert") &&
           s.sql.toLowerCase().includes("users"),
       );
-      expect(usersInsert).toBeUndefined();
+      expect(usersInsert).toBeDefined();
+      expect(usersInsert!.sql).toContain("install_targets_json");
+      const targets = JSON.parse(String(usersInsert!.args[2])) as Array<{
+        login: string;
+        type: string;
+      }>;
+      expect(targets.some((t) => t.login === "alice" && t.type === "User")).toBe(
+        true,
+      );
+      expect(targets.some((t) => t.login === "Roxabi" && t.type === "Organization")).toBe(
+        true,
+      );
     });
   });
 });

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -1133,6 +1133,54 @@ describe("callbackRoute", () => {
       expect(sessionsInsert!.args[1]).toBeNull();
     });
 
+    it("still mints install-pending session when /user/orgs fails (User target only)", async () => {
+      const stateValue = "3".repeat(32);
+      const captured: FakeStmt[] = [];
+      const db = makeZeroInstallDb(captured);
+      let fetchCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          fetchCallCount++;
+          if (fetchCallCount === 1) {
+            return new Response(JSON.stringify({ access_token: "tok" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          } else if (fetchCallCount === 2) {
+            return new Response(JSON.stringify({ id: 42, login: "alice" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          } else if (fetchCallCount === 3) {
+            return new Response(JSON.stringify({ installations: [] }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          return new Response("error", { status: 500 });
+        }),
+      );
+      const { app, env } = makeApp(db);
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Set-Cookie")).toContain("__Host-session=");
+      const usersInsert = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("insert") &&
+          s.sql.toLowerCase().includes("users"),
+      );
+      const targets = JSON.parse(String(usersInsert!.args[2])) as Array<{
+        type: string;
+      }>;
+      expect(targets).toHaveLength(1);
+      expect(targets[0].type).toBe("User");
+    });
+
     it("upserts user with install_targets_json when installations is empty", async () => {
       // Arrange
       const stateValue = "2".repeat(32);

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -99,7 +99,7 @@ export async function loginRoute(
  *   2. Consume state — atomic single-use DELETE ... RETURNING (closes TOCTOU).
  *   3. Exchange code for access_token.
  *   4. Fetch /user and /user/installations.
- *   5. If no installations → redirect to app install page (no DB write, no session).
+ *   5. If no installations → upsert user, cache install targets, mint install-pending session.
  *   6. Upsert user → tenants → user_installations.
  *   7. Mint session tied to first installation, set __Host-session cookie.
  */
@@ -195,20 +195,64 @@ export async function callbackRoute(
     }>;
   };
 
-  // No installations — redirect to app install page, no session, no DB write
+  // No installations — mint install-pending session and show our install guide
   if (installations.length === 0) {
+    const orgsRes = await fetch(
+      "https://api.github.com/user/orgs?per_page=100",
+      { headers: ghHeaders },
+    );
+    const orgs = orgsRes.ok
+      ? ((await orgsRes.json()) as Array<{ id: number; login: string }>)
+      : [];
+
+    const installTargets = [
+      { id: ghUser.id, login: ghUser.login, type: "User" as const },
+      ...orgs.map((o) => ({
+        id: o.id,
+        login: o.login,
+        type: "Organization" as const,
+      })),
+    ];
+
+    const userRow = await c.env.DB.prepare(
+      `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
+       VALUES (?, ?, 1, ?)
+       ON CONFLICT(github_id) DO UPDATE SET
+         github_login=excluded.github_login,
+         zk_opt_in=1,
+         install_targets_json=excluded.install_targets_json,
+         updated_at=datetime('now')
+       RETURNING id`,
+    )
+      .bind(ghUser.id, ghUser.login, JSON.stringify(installTargets))
+      .first<{ id: number }>();
+
+    if (!userRow) {
+      return c.json({ error: "db_error" }, 500);
+    }
+
+    const rawToken = await mintSession(c.env.DB, userRow.id, null);
+    const installDest = new URL(redirectAfter, origin);
+    installDest.searchParams.set("install", "1");
+
     return new Response(null, {
       status: 302,
       headers: {
-        Location: "https://github.com/apps/roxabi-live/installations/new",
+        Location: `${installDest.pathname}${installDest.search}`,
+        "Set-Cookie": sessionCookie(rawToken),
       },
     });
   }
 
   // Upsert user — get internal id
   const userRow = await c.env.DB.prepare(
-    `INSERT INTO users (github_id, github_login, zk_opt_in) VALUES (?, ?, 1)
-     ON CONFLICT(github_id) DO UPDATE SET github_login=excluded.github_login, zk_opt_in=1, updated_at=datetime('now')
+    `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
+     VALUES (?, ?, 1, NULL)
+     ON CONFLICT(github_id) DO UPDATE SET
+       github_login=excluded.github_login,
+       zk_opt_in=1,
+       install_targets_json=NULL,
+       updated_at=datetime('now')
      RETURNING id`,
   )
     .bind(ghUser.id, ghUser.login)

--- a/worker/src/auth/repoAccess.ts
+++ b/worker/src/auth/repoAccess.ts
@@ -51,7 +51,7 @@ export async function resolveVisibleRepos(
 ): Promise<string[]> {
   const s = c.get("session");
   // Middleware guarantees session; guard defensively — fail-closed.
-  if (!s) {
+  if (!s || s.tenantId == null) {
     return [];
   }
 

--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -154,6 +154,12 @@ describe("validateSession — SQL guard clauses", () => {
     expect(stmts()[0].sql).toContain("ui.tenant_id = s.tenant_id");
   });
 
+  it("SQL allows install-pending sessions when tenant_id IS NULL", async () => {
+    const { db, stmts } = captureDb();
+    await validateSession(db, "h".repeat(64));
+    expect(stmts()[0].sql).toContain("s.tenant_id IS NULL");
+  });
+
   it("passes the hash of rawToken as the bound arg (¬raw token itself)", async () => {
     // Arrange
     const { db, stmts } = captureDb();

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -36,7 +36,7 @@ async function sha256hex(s: string): Promise<string> {
 export async function mintSession(
   db: D1Database,
   userId: number,
-  tenantId: number,
+  tenantId: number | null,
 ): Promise<string> {
   const randomBytes = new Uint8Array(32);
   crypto.getRandomValues(randomBytes);
@@ -75,10 +75,15 @@ export async function validateSession(
        WHERE s.token_hash = ?
          AND s.expires_at > datetime('now')
          AND s.revoked_at IS NULL
-         AND NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL)
-         AND EXISTS (
-           SELECT 1 FROM user_installations ui
-           WHERE ui.user_id = s.user_id AND ui.tenant_id = s.tenant_id
+         AND (
+           s.tenant_id IS NULL
+           OR (
+             NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id = s.tenant_id AND t.suspended_at IS NOT NULL)
+             AND EXISTS (
+               SELECT 1 FROM user_installations ui
+               WHERE ui.user_id = s.user_id AND ui.tenant_id = s.tenant_id
+             )
+           )
          )`,
     )
     .bind(hash)
@@ -143,6 +148,25 @@ export const requireSession: MiddlewareHandler<AuthEnv> = async (c, next) => {
 
   const ctx = await validateSession(c.env.DB, token);
   if (!ctx) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  c.set("session", ctx);
+  await next();
+};
+
+/**
+ * Session middleware for data routes — requires a linked GitHub App installation.
+ * Install-pending sessions (tenant_id IS NULL) receive 401.
+ */
+export const requireLinkedTenant: MiddlewareHandler<AuthEnv> = async (c, next) => {
+  const token = readSessionToken(c);
+  if (!token) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const ctx = await validateSession(c.env.DB, token);
+  if (!ctx || ctx.tenantId == null) {
     return c.json({ error: "unauthorized" }, 401);
   }
 

--- a/worker/src/auth/types.ts
+++ b/worker/src/auth/types.ts
@@ -6,7 +6,8 @@ import type { Env } from "../types";
 
 export interface SessionContext {
   userId: number;
-  tenantId: number;
+  /** null while the user is signed in but has not linked a GitHub App installation yet */
+  tenantId: number | null;
   githubId: number;
   githubLogin: string;
 }

--- a/worker/src/router.test.ts
+++ b/worker/src/router.test.ts
@@ -209,6 +209,17 @@ describe("requireSession auth gate", () => {
   // Positive control — valid session cookie must NOT produce 401
   // -------------------------------------------------------------------------
 
+  describe("GET /install/complete — post-install return", () => {
+    it("returns 302 to /login?redirect=/ without touching DB", async () => {
+      const db = makeDbThatMustNotBeCalled();
+      const env = makeEnv(db);
+      const res = await app.request("/install/complete", {}, env);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/login?redirect=/");
+      expect(db.prepare).not.toHaveBeenCalled();
+    });
+  });
+
   describe("install-pending session — linked tenant required", () => {
     it("GET /api/graph returns 401 when session has null tenantId", async () => {
       const db = makeSessionDb({
@@ -219,6 +230,27 @@ describe("requireSession auth gate", () => {
       const res = await app.request(
         "/api/graph",
         { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("POST /api/zk-opt-in returns 401 when session has null tenantId", async () => {
+      const db = makeSessionDb({
+        ...STUB_SESSION,
+        tenantId: null,
+      });
+      const env = makeEnv(db);
+      const res = await app.request(
+        "/api/zk-opt-in",
+        {
+          method: "POST",
+          headers: {
+            Cookie: `__Host-session=${VALID_RAW_TOKEN}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ opt_in: true }),
+        },
         env,
       );
       expect(res.status).toBe(401);

--- a/worker/src/router.test.ts
+++ b/worker/src/router.test.ts
@@ -209,6 +209,22 @@ describe("requireSession auth gate", () => {
   // Positive control — valid session cookie must NOT produce 401
   // -------------------------------------------------------------------------
 
+  describe("install-pending session — linked tenant required", () => {
+    it("GET /api/graph returns 401 when session has null tenantId", async () => {
+      const db = makeSessionDb({
+        ...STUB_SESSION,
+        tenantId: null,
+      });
+      const env = makeEnv(db);
+      const res = await app.request(
+        "/api/graph",
+        { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+        env,
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
   describe("positive control — valid session cookie", () => {
     it("GET /api/issues with valid session does not return 401", async () => {
       // Arrange — DB answers validateSession's query with a valid row

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -9,7 +9,8 @@ import { checkAdminAuth } from "./api/auth";
 import { loginRoute, callbackRoute } from "./auth/oauth";
 import { meRoute, logoutRoute } from "./api/me";
 import type { AuthEnv } from "./auth/types";
-import { requireSession } from "./auth/session";
+import { requireSession, requireLinkedTenant } from "./auth/session";
+import { installCompleteRoute } from "./api/install-complete";
 import { activeTenantRoute } from "./api/active-tenant";
 import { zkOptInRoute } from "./api/zk-opt-in";
 import { listZkPayloadsRoute, putZkPayloadsRoute } from "./api/zk-payloads";
@@ -33,15 +34,15 @@ app.get("/api/version", versionRoute);
 app.post("/webhook/github", webhookRoute);
 
 // GET /api/graph — v6 graph payload: nodes + edges (S6, #98). Session-gated (#148).
-app.use("/api/graph", requireSession);
+app.use("/api/graph", requireLinkedTenant);
 app.get("/api/graph", graphRoute);
 
 // GET /api/issues — list with optional repo/state/label/limit/offset filters (S6, #98).
 // GET /api/issues/* — single issue by key (key contains owner/repo#N slash) (S6, #98).
 // List route MUST be registered before the wildcard so Hono's first-match wins.
 // Both paths need their own use() — /api/issues/* does NOT match bare /api/issues (#148).
-app.use("/api/issues", requireSession);
-app.use("/api/issues/*", requireSession);
+app.use("/api/issues", requireLinkedTenant);
+app.use("/api/issues/*", requireLinkedTenant);
 app.get("/api/issues", listIssuesRoute);
 app.get("/api/issues/*", getIssueRoute);
 
@@ -78,21 +79,22 @@ app.get("/health", async (c) => {
 // ── Auth routes (#145, S2) ───────────────────────────────────────────────────
 app.get("/login", loginRoute);
 app.get("/oauth/callback", callbackRoute);
+app.get("/install/complete", installCompleteRoute);
 app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
-app.post("/api/active-tenant", requireSession, activeTenantRoute);
-app.post("/api/zk-opt-in", requireSession, zkOptInRoute);
-app.use("/api/zk/payloads", requireSession);
+app.post("/api/active-tenant", requireLinkedTenant, activeTenantRoute);
+app.post("/api/zk-opt-in", requireLinkedTenant, zkOptInRoute);
+app.use("/api/zk/payloads", requireLinkedTenant);
 app.get("/api/zk/payloads", listZkPayloadsRoute);
 app.put("/api/zk/payloads", putZkPayloadsRoute);
-app.post("/api/zk/consume-handoff", requireSession, consumeZkHandoffRoute);
-app.post("/api/zk/consume-reauth", requireSession, consumeZkReauthRoute);
-app.use("/api/zk/key-backup", requireSession);
+app.post("/api/zk/consume-handoff", requireLinkedTenant, consumeZkHandoffRoute);
+app.post("/api/zk/consume-reauth", requireLinkedTenant, consumeZkReauthRoute);
+app.use("/api/zk/key-backup", requireLinkedTenant);
 app.get("/api/zk/key-backup", getZkKeyBackupRoute);
 app.put("/api/zk/key-backup", putZkKeyBackupRoute);
-app.use("/api/zk/reset", requireSession);
+app.use("/api/zk/reset", requireLinkedTenant);
 app.post("/api/zk/reset", postZkResetRoute);
-app.post("/api/zk/github/graphql", requireSession, zkGithubGraphqlRoute);
+app.post("/api/zk/github/graphql", requireLinkedTenant, zkGithubGraphqlRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);


### PR DESCRIPTION
## Summary
- Keep first-time users on Roxabi Live after OAuth when no GitHub App installation exists: install-pending session, guided install screen, and post-install return via `/install/complete`.
- Pre-select personal account or each org the user belongs to (`target_id` / `target_type` deep links); explain how to limit to specific repositories on GitHub.
- Add migration `0017` (nullable `sessions.tenant_id`, `users.install_targets_json`) and `requireLinkedTenant` so data routes stay gated until an installation is linked.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Implementation | 2 commits on `feat/github-install-ux` | Complete |
| Verification | Typecheck ✅ Tests ✅ (632 worker + 47 frontend) | Passed |

## Test Plan
- [ ] OAuth with zero installations → lands on install guide (`?install=1`), session cookie set, `/api/me` returns `install_pending: true` and org targets
- [ ] Install on GitHub → Setup URL `/install/complete` → re-login → consent → dashboard
- [ ] `GET /api/graph` with install-pending session → 401

## Operator follow-up
- [ ] Set GitHub App **Setup URL** to `https://live.roxabi.dev/install/complete` (staging: adjust host if needed)

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`