### PR TITLE
feat(zk): show dismissible banner when migration is incomplete

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -15,6 +15,8 @@ import {
   ensureAccountKeySealing,
   syncZkContentFromGitHub,
   SEALED_TITLE_LABEL,
+  isZkMigrationIncomplete,
+  clearZkMigrationIncomplete,
 } from './zk-sync.js';
 import { requireZkEnrollmentGate } from './zk-enroll.js';
 import { waitForInitialSync } from './initial-sync.js';
@@ -34,10 +36,31 @@ const listControls  = $('list-controls');
 const graphControls = $('graph-controls');
 const subtitle      = $('subtitle');
 const errorMsg      = $('error-msg');
+const zkMigrationNotice = $('zk-migration-notice');
 
 const PIVOT_DIMS = ['milestone', 'priority', 'repo', 'lane', 'size', 'none'];
 const LIST_DIMS  = ['milestone', 'priority', 'repo', 'lane', 'size', 'status', 'parent', 'none'];
 const TABLE_GROUP_DIMS = ['lane', 'parent', 'none'];
+
+// ─── ZK migration incomplete notice ─────────────────────────────────────────
+function showZkMigrationNotice() {
+  if (!isZkMigrationIncomplete()) return;
+  zkMigrationNotice.textContent = '';
+  const msg = document.createElement('span');
+  msg.textContent =
+    ‘Encryption upgrade incomplete — open Roxabi on your original device to finish, or some older items can’t be decrypted.’;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'zk-migration-notice-dismiss';
+  btn.title = 'Dismiss';
+  btn.textContent = '×';
+  btn.addEventListener('click', () => {
+    clearZkMigrationIncomplete();
+    zkMigrationNotice.hidden = true;
+  });
+  zkMigrationNotice.append(msg, btn);
+  zkMigrationNotice.hidden = false;
+}
 
 // ─── Seg group builder (click active to deactivate → 'none') ────────────────
 function buildSegs(container, values, current, onPick, opts = {}) {
@@ -379,6 +402,7 @@ async function init() {
       await applyZkDecryption(state.nodes, sessionGithubLogin, { accountKeyMode: true });
       state.nodesByKey = new Map(state.nodes.map((n) => [n.key, n]));
       render();
+      showZkMigrationNotice();
     }
     if (getGithubUserToken()) {
       try {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -48,7 +48,7 @@ function showZkMigrationNotice() {
   zkMigrationNotice.textContent = '';
   const msg = document.createElement('span');
   msg.textContent =
-    ‘Encryption upgrade incomplete — open Roxabi on your original device to finish, or some older items can’t be decrypted.’;
+    'Encryption upgrade incomplete — open Roxabi on your original device to finish, or some older items can\'t be decrypted.';
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'zk-migration-notice-dismiss';

--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -214,6 +214,39 @@
   color: var(--text);
 }
 
+/* ─── ZK migration incomplete notice ─────────────────────────────────────── */
+
+.zk-migration-notice {
+  align-items: center;
+  background: rgba(234, 179, 8, 0.08);
+  border-bottom: 1px solid rgba(234, 179, 8, 0.35);
+  color: var(--text-muted);
+  display: flex;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  gap: 8px;
+  justify-content: center;
+  padding: 6px 16px;
+  text-align: center;
+}
+
+.zk-migration-notice[hidden] { display: none; }
+
+.zk-migration-notice-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.zk-migration-notice-dismiss:hover {
+  color: var(--text);
+}
+
 .zk-opt-in-panel {
   border-top: 1px solid var(--border);
   margin-top: 6px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -100,6 +100,7 @@
     </span>
   </div>
   <div id="operator-notice" class="operator-notice" hidden></div>
+  <div id="zk-migration-notice" class="zk-migration-notice" hidden></div>
 </div>
 
 <main>


### PR DESCRIPTION
## Summary

- Adds `isZkMigrationIncomplete()` + `clearZkMigrationIncomplete()` exports to `zk-sync.js`, backed by a `sessionStorage` flag set/cleared inside `migrateV1PayloadsToAccountKey()` (partial migration → set; full success → clear)
- Adds a dismissible yellow banner (`#zk-migration-notice`) in `index.html` + `auth.css`, wired in `app.js` via `showZkMigrationNotice()` called after the `zkAccountKeyEnabled` decrypt/render block
- 5 new tests in `zk-sync.test.js` (flag set on partial migration, flag cleared on full success, `isZkMigrationIncomplete` / `clearZkMigrationIncomplete` behaviour); all 55 tests pass

Follow-up from PR #225 review.

## Test plan

- [ ] All 55 frontend tests pass (`cd frontend && npm test`)
- [ ] Pre-commit lint + typecheck + trufflehog pass (verified on commit)
- [ ] Manual: unlock ZK on a non-original device where some v1 rows can't be decrypted → yellow banner appears; dismiss → banner hides and flag cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)