### PR TITLE
chore: promote staging to main (v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.17.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.16.0...roxabi-live/v0.17.0) (2026-06-19)
+
+
+### Features
+
+* **frontend:** public landing page at `/` with Se connecter CTA; dep-graph app moved to `/dashboard`
+* **auth:** server-side session gate on `/dashboard` — unauthenticated users redirect to `/login` before HTML loads
+
+
 ## [0.16.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.15.0...roxabi-live/v0.16.0) (2026-06-19)
 
 

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -5,6 +5,17 @@ import { githubInstallUrl, partitionInstallTargets } from './github-install.js';
 
 const $ = id => document.getElementById(id);
 
+export const DASHBOARD_PATH = '/dashboard';
+
+/** Safe login URL with post-auth return path (defaults to dashboard). */
+export function loginUrl(redirect = DASHBOARD_PATH) {
+  return `/login?redirect=${encodeURIComponent(redirect)}`;
+}
+
+function redirectToLogin() {
+  location.replace(loginUrl());
+}
+
 // ─── AuthError ────────────────────────────────────────────────────────────────
 
 export class AuthError extends Error {
@@ -70,19 +81,6 @@ export async function getSessionProfile() {
 /** True when server exposes ZK_ACCOUNT_KEY feature (#216 PR 1b). */
 export function isZkAccountKeyEnabled(me) {
   return me?.user?.zk_account_key_enabled === true;
-}
-
-// ─── Internal: render landing ─────────────────────────────────────────────────
-
-function renderLanding() {
-  document.body.classList.add('gated');
-  const el = $('auth-landing');
-  el.innerHTML = `
-    <h2>Welcome to Roxabi Live</h2>
-    <p>Sign in with GitHub to view your organisation's dependency graph.</p>
-    <a href="/login" class="auth-login-btn" aria-label="Sign in with GitHub">Sign in with GitHub</a>
-  `;
-  el.removeAttribute('hidden');
 }
 
 // ─── Internal: render install CTA ────────────────────────────────────────────
@@ -156,7 +154,7 @@ function renderInstallCta(me) {
       </p>
       <div class="install-actions">
         <button type="button" class="consent-btn-secondary" id="install-logout">Sign out</button>
-        <a href="/login?redirect=/" class="auth-login-btn" id="install-continue">I've installed — continue</a>
+        <a href="${escHtml(loginUrl())}" class="auth-login-btn" id="install-continue">I've installed — continue</a>
       </div>
     </div>
   `;
@@ -322,7 +320,7 @@ export async function requireAuthGate() {
     me = await fetchMe();
   } catch (e) {
     if (e instanceof AuthError) {
-      renderLanding();
+      redirectToLogin();
       return 'landing';
     }
     throw e;

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -1,5 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AuthError, api, hasConsent, setConsent, resolveView, escHtml } from './auth.js';
+import { AuthError, api, hasConsent, setConsent, resolveView, escHtml, loginUrl, DASHBOARD_PATH } from './auth.js';
+
+// ─── loginUrl ─────────────────────────────────────────────────────────────────
+
+describe('loginUrl', () => {
+  it('defaults to dashboard redirect', () => {
+    expect(loginUrl()).toBe('/login?redirect=%2Fdashboard');
+    expect(DASHBOARD_PATH).toBe('/dashboard');
+  });
+
+  it('encodes custom redirect paths', () => {
+    expect(loginUrl('/foo/bar')).toBe('/login?redirect=%2Ffoo%2Fbar');
+  });
+});
 
 // ─── resolveView (pure) ───────────────────────────────────────────────────────
 

--- a/frontend/dashboard/index.html
+++ b/frontend/dashboard/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dep-Graph v6 · Roxabi Live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@500;600;700&display=swap">
+<link rel="stylesheet" href="/app.css">
+<link rel="stylesheet" href="/auth.css">
+<link rel="stylesheet" href="/graph.css">
+</head>
+<body>
+<div class="sticky-head">
+  <header class="page-header">
+    <div>
+      <h1>Dep-Graph <span class="accent">v6</span> · Roxabi Live</h1>
+      <div class="subtitle" id="subtitle">Loading…</div>
+    </div>
+    <div class="header-actions">
+      <div class="segs view-segs" role="group" aria-label="View">
+        <button id="btn-table" class="seg on" data-v="table" aria-pressed="true"  title="Table"><span class="ico">⊞</span> Table</button>
+        <button id="btn-list"  class="seg"    data-v="list"  aria-pressed="false" title="List"><span class="ico">≡</span> List</button>
+        <button id="btn-graph" class="seg"    data-v="graph" aria-pressed="false" title="Graph"><span class="ico">⋈</span> Graph</button>
+      </div>
+      <select id="org-picker" class="org-picker" aria-label="Active organisation" hidden></select>
+      <button id="zk-lock-btn" class="theme-btn" type="button" hidden title="Lock encryption">Lock</button>
+      <div id="user-menu-wrap" class="user-menu-wrap" hidden>
+        <button id="user-menu-btn" class="user-avatar-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Account menu">
+          <img id="user-menu-avatar" class="user-avatar-img" alt="" width="28" height="28" />
+        </button>
+        <div id="user-menu-panel" class="user-menu-panel" role="menu" hidden>
+          <button type="button" class="user-menu-item" id="user-menu-settings" role="menuitem">Settings</button>
+          <button type="button" class="user-menu-item user-menu-item-danger" id="user-menu-signout" role="menuitem">Sign out</button>
+        </div>
+      </div>
+      <button id="theme-btn" class="theme-btn" type="button" title="Toggle theme" aria-label="Toggle theme">🌙</button>
+    </div>
+  </header>
+
+  <div class="toolbar">
+    <div class="ms-wrap">
+      <button id="ms-repo-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by repo">
+        <span class="ms-placeholder">All repos</span>
+      </button>
+      <button id="ms-repo-clear" class="ms-clear-inline" aria-label="Clear repo filter" hidden>×</button>
+      <div id="ms-repo-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
+      <button id="ms-milestone-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by milestone">
+        <span class="ms-placeholder">All milestones</span>
+      </button>
+      <button id="ms-milestone-clear" class="ms-clear-inline" aria-label="Clear milestone filter" hidden>×</button>
+      <div id="ms-milestone-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
+      <button id="ms-priority-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by priority">
+        <span class="ms-placeholder">All priorities</span>
+      </button>
+      <button id="ms-priority-clear" class="ms-clear-inline" aria-label="Clear priority filter" hidden>×</button>
+      <div id="ms-priority-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
+      <button id="ms-label-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by label">
+        <span class="ms-placeholder">All labels</span>
+      </button>
+      <button id="ms-label-clear" class="ms-clear-inline" aria-label="Clear label filter" hidden>×</button>
+      <div id="ms-label-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="ms-wrap">
+      <button id="ms-status-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by status">
+        <span class="ms-placeholder">All statuses</span>
+      </button>
+      <button id="ms-status-clear" class="ms-clear-inline" aria-label="Clear status filter" hidden>×</button>
+      <div id="ms-status-panel" class="ms-panel" hidden></div>
+    </div>
+
+    <div class="search-wrap">
+      <input type="search" id="search-input" placeholder="Search issues…" autocomplete="off" aria-label="Search issues">
+      <button id="search-clear" class="clear-btn" aria-label="Clear search" hidden>×</button>
+    </div>
+
+    <span class="pivot-controls" id="pivot-controls">
+      <span class="toolbar-label">Row</span>
+      <div class="segs" id="pivot-row-segs" role="group" aria-label="Pivot row dimension"></div>
+      <span class="toolbar-label">Col</span>
+      <div class="segs" id="pivot-col-segs" role="group" aria-label="Pivot column dimension"></div>
+      <span class="toolbar-label">Group</span>
+      <div class="segs" id="table-group-segs" role="group" aria-label="Group cells by"></div>
+    </span>
+
+    <span class="list-controls" id="list-controls" style="display:none">
+      <span class="toolbar-label">Group</span>
+      <div class="segs" id="list-group-segs" role="group" aria-label="Primary grouping"></div>
+      <span class="toolbar-label">Then</span>
+      <div class="segs" id="list-group2-segs" role="group" aria-label="Secondary grouping"></div>
+    </span>
+
+    <span class="graph-controls" id="graph-controls">
+      <div class="segs" id="graph-edge-segs" role="group" aria-label="Parent visibility"></div>
+    </span>
+  </div>
+  <div id="zk-migration-notice" class="zk-migration-notice" hidden></div>
+</div>
+
+<main>
+  <div id="view-table" class="view view-active" role="region" aria-label="Table view"></div>
+  <div id="view-list"  class="view"             role="region" aria-label="List view"></div>
+  <section id="graph-panel" class="view"        role="region" aria-label="Graph view" hidden></section>
+  <div id="error-msg" class="error-msg" hidden></div>
+  <div id="auth-install" class="auth-view" hidden></div>
+</main>
+
+<footer class="page-footer">
+  <span>v6</span>
+</footer>
+
+<div id="consent-gate" class="consent-gate" hidden></div>
+<div id="zk-gate" class="zk-gate" hidden></div>
+<div id="initial-sync-gate" class="initial-sync-gate" hidden></div>
+<div id="settings-gate" class="settings-gate" hidden></div>
+
+<script type="module" src="/state.js"></script>
+<script type="module" src="/pivot.js"></script>
+<script type="module" src="/auth.js"></script>
+<script type="module" src="/app.js"></script>
+<script type="module" src="/graph.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,137 +1,80 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="fr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Dep-Graph v6 · Roxabi Live</title>
+<title>Roxabi Live — Graphe de dépendances GitHub</title>
+<meta name="description" content="Cockpit opérationnel pour visualiser issues, blockers et dépendances de votre organisation GitHub.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@500;600;700&display=swap">
-<link rel="stylesheet" href="app.css">
-<link rel="stylesheet" href="auth.css">
-<link rel="stylesheet" href="graph.css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@500;600;700&display=swap">
+<link rel="stylesheet" href="landing.css">
 </head>
 <body>
-<div class="sticky-head">
-  <header class="page-header">
+<header class="landing-header">
+  <a class="landing-brand" href="/">
+    <span class="landing-brand-mark">v6</span>
+    <span class="landing-brand-name">Roxabi Live</span>
+  </a>
+  <a id="landing-cta" class="landing-cta" href="/login?redirect=%2Fdashboard">Se connecter</a>
+</header>
+
+<main class="landing-main">
+  <section class="landing-hero">
     <div>
-      <h1>Dep-Graph <span class="accent">v6</span> · Roxabi Live</h1>
-      <div class="subtitle" id="subtitle">Loading…</div>
-    </div>
-    <div class="header-actions">
-      <div class="segs view-segs" role="group" aria-label="View">
-        <button id="btn-table" class="seg on" data-v="table" aria-pressed="true"  title="Table"><span class="ico">⊞</span> Table</button>
-        <button id="btn-list"  class="seg"    data-v="list"  aria-pressed="false" title="List"><span class="ico">≡</span> List</button>
-        <button id="btn-graph" class="seg"    data-v="graph" aria-pressed="false" title="Graph"><span class="ico">⋈</span> Graph</button>
+      <p class="landing-eyebrow">Operations cockpit</p>
+      <h1>Votre graphe de dépendances <span>GitHub</span>, en temps réel</h1>
+      <p class="landing-lead">
+        Roxabi Live synchronise issues, blockers et relations parent/enfant
+        pour donner une vue claire de ce qui est prêt, bloqué ou terminé —
+        en tableau, liste ou graphe interactif.
+      </p>
+      <div class="landing-hero-actions">
+        <a id="landing-hero-cta" class="landing-cta" href="/login?redirect=%2Fdashboard">Se connecter</a>
+        <a class="landing-hero-secondary" href="#features">Découvrir</a>
       </div>
-      <select id="org-picker" class="org-picker" aria-label="Active organisation" hidden></select>
-      <button id="zk-lock-btn" class="theme-btn" type="button" hidden title="Lock encryption">Lock</button>
-      <div id="user-menu-wrap" class="user-menu-wrap" hidden>
-        <button id="user-menu-btn" class="user-avatar-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Account menu">
-          <img id="user-menu-avatar" class="user-avatar-img" alt="" width="28" height="28" />
-        </button>
-        <div id="user-menu-panel" class="user-menu-panel" role="menu" hidden>
-          <button type="button" class="user-menu-item" id="user-menu-settings" role="menuitem">Settings</button>
-          <button type="button" class="user-menu-item user-menu-item-danger" id="user-menu-signout" role="menuitem">Sign out</button>
-        </div>
+    </div>
+
+    <div class="landing-preview" aria-hidden="true">
+      <div class="landing-preview-bar">
+        <span class="landing-preview-dot"></span>
+        <span class="landing-preview-dot"></span>
+        <span class="landing-preview-dot"></span>
+        <span class="landing-preview-title">dep-graph · ready / blocked / done</span>
       </div>
-      <button id="theme-btn" class="theme-btn" type="button" title="Toggle theme" aria-label="Toggle theme">🌙</button>
+      <div class="landing-preview-grid">
+        <div class="landing-preview-cell accent"></div>
+        <div class="landing-preview-cell"></div>
+        <div class="landing-preview-cell accent"></div>
+        <div class="landing-preview-cell"></div>
+        <div class="landing-preview-cell accent"></div>
+        <div class="landing-preview-cell"></div>
+        <div class="landing-preview-cell"></div>
+        <div class="landing-preview-cell accent"></div>
+        <div class="landing-preview-cell"></div>
+      </div>
     </div>
-  </header>
+  </section>
 
-  <div class="toolbar">
-    <div class="ms-wrap">
-      <button id="ms-repo-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by repo">
-        <span class="ms-placeholder">All repos</span>
-      </button>
-      <button id="ms-repo-clear" class="ms-clear-inline" aria-label="Clear repo filter" hidden>×</button>
-      <div id="ms-repo-panel" class="ms-panel" hidden></div>
-    </div>
-
-    <div class="ms-wrap">
-      <button id="ms-milestone-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by milestone">
-        <span class="ms-placeholder">All milestones</span>
-      </button>
-      <button id="ms-milestone-clear" class="ms-clear-inline" aria-label="Clear milestone filter" hidden>×</button>
-      <div id="ms-milestone-panel" class="ms-panel" hidden></div>
-    </div>
-
-    <div class="ms-wrap">
-      <button id="ms-priority-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by priority">
-        <span class="ms-placeholder">All priorities</span>
-      </button>
-      <button id="ms-priority-clear" class="ms-clear-inline" aria-label="Clear priority filter" hidden>×</button>
-      <div id="ms-priority-panel" class="ms-panel" hidden></div>
-    </div>
-
-    <div class="ms-wrap">
-      <button id="ms-label-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by label">
-        <span class="ms-placeholder">All labels</span>
-      </button>
-      <button id="ms-label-clear" class="ms-clear-inline" aria-label="Clear label filter" hidden>×</button>
-      <div id="ms-label-panel" class="ms-panel" hidden></div>
-    </div>
-
-    <div class="ms-wrap">
-      <button id="ms-status-btn" class="ms-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by status">
-        <span class="ms-placeholder">All statuses</span>
-      </button>
-      <button id="ms-status-clear" class="ms-clear-inline" aria-label="Clear status filter" hidden>×</button>
-      <div id="ms-status-panel" class="ms-panel" hidden></div>
-    </div>
-
-    <div class="search-wrap">
-      <input type="search" id="search-input" placeholder="Search issues…" autocomplete="off" aria-label="Search issues">
-      <button id="search-clear" class="clear-btn" aria-label="Clear search" hidden>×</button>
-    </div>
-
-    <!-- Table-only: Pivot seg controls -->
-    <span class="pivot-controls" id="pivot-controls">
-      <span class="toolbar-label">Row</span>
-      <div class="segs" id="pivot-row-segs" role="group" aria-label="Pivot row dimension"></div>
-      <span class="toolbar-label">Col</span>
-      <div class="segs" id="pivot-col-segs" role="group" aria-label="Pivot column dimension"></div>
-      <span class="toolbar-label">Group</span>
-      <div class="segs" id="table-group-segs" role="group" aria-label="Group cells by"></div>
-    </span>
-
-    <!-- List-only: Group-by segs (2 levels) -->
-    <span class="list-controls" id="list-controls" style="display:none">
-      <span class="toolbar-label">Group</span>
-      <div class="segs" id="list-group-segs" role="group" aria-label="Primary grouping"></div>
-      <span class="toolbar-label">Then</span>
-      <div class="segs" id="list-group2-segs" role="group" aria-label="Secondary grouping"></div>
-    </span>
-
-    <!-- Shared: hide parent issues in all views (+ parent edges in graph) -->
-    <span class="graph-controls" id="graph-controls">
-      <div class="segs" id="graph-edge-segs" role="group" aria-label="Parent visibility"></div>
-    </span>
-  </div>
-  <div id="zk-migration-notice" class="zk-migration-notice" hidden></div>
-</div>
-
-<main>
-  <div id="view-table" class="view view-active" role="region" aria-label="Table view"></div>
-  <div id="view-list"  class="view"             role="region" aria-label="List view"></div>
-  <section id="graph-panel" class="view"        role="region" aria-label="Graph view" hidden></section>
-  <div id="error-msg" class="error-msg" hidden></div>
-  <div id="auth-landing" class="auth-view" hidden></div>
-  <div id="auth-install" class="auth-view" hidden></div>
+  <section id="features" class="landing-features">
+    <article class="landing-feature">
+      <h3>Vue multi-format</h3>
+      <p>Tableau pivot, liste groupée et graphe de dépendances — même corpus, trois angles de lecture.</p>
+    </article>
+    <article class="landing-feature">
+      <h3>Sync continue</h3>
+      <p>Webhook GitHub + réconciliation quotidienne. L'état du board reflète votre org sans export manuel.</p>
+    </article>
+    <article class="landing-feature">
+      <h3>Chiffrement côté client</h3>
+      <p>Titres et corps d'issues chiffrés avant stockage. La structure du graphe reste exploitable pour le pilotage.</p>
+    </article>
+  </section>
 </main>
 
-<footer class="page-footer">
-  <span>v6</span>
+<footer class="landing-footer">
+  <span>Roxabi Live · Dep-Graph v6</span>
 </footer>
 
-<div id="consent-gate" class="consent-gate" hidden></div>
-<div id="zk-gate" class="zk-gate" hidden></div>
-<div id="initial-sync-gate" class="initial-sync-gate" hidden></div>
-<div id="settings-gate" class="settings-gate" hidden></div>
-
-<script type="module" src="state.js"></script>
-<script type="module" src="pivot.js"></script>
-<script type="module" src="auth.js"></script>
-<script type="module" src="app.js"></script>
-<script type="module" src="graph.js"></script>
+<script type="module" src="landing.js"></script>
 </body>
 </html>

--- a/frontend/landing.css
+++ b/frontend/landing.css
@@ -1,0 +1,306 @@
+:root,
+[data-theme="dark"] {
+  --bg: #0d1117;
+  --bg-panel: #13191f;
+  --bg-card: #161b22;
+  --border: #21262d;
+  --border-hi: #30363d;
+  --text: #fafafa;
+  --text-muted: #8b93a1;
+  --accent: #e85d04;
+  --accent-dim: rgba(232, 93, 4, 0.14);
+  --accent-glow: rgba(232, 93, 4, 0.35);
+  --panel-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="light"] {
+  --bg: #f5f2ec;
+  --bg-panel: #ede9e0;
+  --bg-card: #faf8f4;
+  --border: rgba(0, 0, 0, 0.09);
+  --border-hi: rgba(0, 0, 0, 0.18);
+  --text: #1a1d2b;
+  --text-muted: #5a6070;
+  --accent: #b8760a;
+  --accent-dim: rgba(184, 118, 10, 0.12);
+  --accent-glow: rgba(184, 118, 10, 0.28);
+  --panel-shadow: 0 12px 40px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+  min-height: 100vh;
+}
+
+body::before {
+  background:
+    radial-gradient(ellipse 80% 50% at 50% -10%, var(--accent-glow), transparent 55%),
+    radial-gradient(ellipse 40% 30% at 100% 0%, rgba(20, 184, 166, 0.08), transparent 50%);
+  content: '';
+  inset: 0;
+  pointer-events: none;
+  position: fixed;
+  z-index: 0;
+}
+
+.landing-header,
+.landing-main,
+.landing-footer {
+  position: relative;
+  z-index: 1;
+}
+
+.landing-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: 1080px;
+  padding: 20px 24px;
+}
+
+.landing-brand {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.landing-brand-mark {
+  background: var(--accent-dim);
+  border: 1px solid var(--border-hi);
+  border-radius: 10px;
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 8px 10px;
+}
+
+.landing-brand-name {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.landing-cta {
+  background: var(--accent);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 18px;
+  text-decoration: none;
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.landing-cta:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.landing-cta:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.landing-main {
+  margin: 0 auto;
+  max-width: 1080px;
+  padding: 48px 24px 72px;
+}
+
+.landing-hero {
+  display: grid;
+  gap: 40px;
+  grid-template-columns: 1.1fr 0.9fr;
+  margin-bottom: 72px;
+}
+
+.landing-eyebrow {
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  margin-bottom: 16px;
+  text-transform: uppercase;
+}
+
+.landing-hero h1 {
+  font-family: 'Outfit', sans-serif;
+  font-size: clamp(2rem, 4.5vw, 3.25rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.08;
+  margin-bottom: 18px;
+}
+
+.landing-hero h1 span {
+  color: var(--accent);
+}
+
+.landing-lead {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  max-width: 52ch;
+}
+
+.landing-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.landing-hero-secondary {
+  align-items: center;
+  background: transparent;
+  border: 1px solid var(--border-hi);
+  border-radius: 8px;
+  color: var(--text);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 10px 18px;
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.landing-hero-secondary:hover {
+  background: var(--bg-card);
+  border-color: var(--accent);
+}
+
+.landing-preview {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 14px;
+  box-shadow: var(--panel-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 280px;
+  padding: 20px;
+}
+
+.landing-preview-bar {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.landing-preview-dot {
+  border-radius: 50%;
+  height: 8px;
+  width: 8px;
+}
+
+.landing-preview-dot:nth-child(1) { background: #ef4444; }
+.landing-preview-dot:nth-child(2) { background: #f59e0b; }
+.landing-preview-dot:nth-child(3) { background: #22c55e; }
+
+.landing-preview-title {
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  margin-left: 8px;
+}
+
+.landing-preview-grid {
+  display: grid;
+  flex: 1;
+  gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+}
+
+.landing-preview-cell {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  min-height: 48px;
+  position: relative;
+}
+
+.landing-preview-cell.accent {
+  border-color: rgba(232, 93, 4, 0.45);
+  box-shadow: inset 0 0 0 1px var(--accent-dim);
+}
+
+.landing-preview-cell.accent::after {
+  background: var(--accent);
+  border-radius: 50%;
+  content: '';
+  height: 6px;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  width: 6px;
+}
+
+.landing-features {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.landing-feature {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 22px;
+}
+
+.landing-feature h3 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.landing-feature p {
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.landing-footer {
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 13px;
+  margin: 0 auto;
+  max-width: 1080px;
+  padding: 24px;
+  text-align: center;
+}
+
+@media (max-width: 860px) {
+  .landing-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-features {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/landing.js
+++ b/frontend/landing.js
@@ -1,0 +1,31 @@
+// landing.js — public homepage CTA (session-aware)
+
+const DASHBOARD_PATH = '/dashboard';
+const LOGIN_URL = `/login?redirect=${encodeURIComponent(DASHBOARD_PATH)}`;
+
+async function wireCta() {
+  const headerCta = document.getElementById('landing-cta');
+  const heroCta = document.getElementById('landing-hero-cta');
+  const targets = [headerCta, heroCta].filter(Boolean);
+  if (!targets.length) return;
+
+  let href = LOGIN_URL;
+  let label = 'Se connecter';
+
+  try {
+    const resp = await fetch('/api/me');
+    if (resp.ok) {
+      href = DASHBOARD_PATH;
+      label = 'Ouvrir le dashboard';
+    }
+  } catch {
+    // offline / transient — keep login CTA
+  }
+
+  for (const el of targets) {
+    el.href = href;
+    el.textContent = label;
+  }
+}
+
+wireCta();

--- a/frontend/landing.test.js
+++ b/frontend/landing.test.js
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('landing module', () => {
+  it('loads without import errors', async () => {
+    await expect(import('./landing.js')).resolves.toBeDefined();
+  });
+});

--- a/frontend/user-menu.js
+++ b/frontend/user-menu.js
@@ -54,7 +54,7 @@ export function wireUserMenu(me) {
   $('user-menu-signout')?.addEventListener('click', async () => {
     close();
     await api('/logout', { method: 'POST' }).catch(() => {});
-    location.reload();
+    location.href = '/';
   });
 
   document.addEventListener('click', (e) => {

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -1,6 +1,7 @@
 // zk-enroll.js — passphrase enrollment, unlock, lock UI (#216 PR 4)
 
 import { api, escHtml } from './auth.js';
+import { zkLoginUrl } from './zk-github.js';
 import {
   generateAccountKey,
   wrapAccountKey,
@@ -216,7 +217,7 @@ function renderDevice2Block() {
       </p>
       <p>
         Alternatively, after setup on the original device, you can
-        <a href="/login?zk=1">Link GitHub</a> here to re-seal content from GitHub.
+        <a href="${escHtml(zkLoginUrl())}">Link GitHub</a> here to re-seal content from GitHub.
       </p>
       <div class="zk-actions">
         <button type="button" class="consent-btn-secondary" id="zk-block-reload">Reload</button>

--- a/frontend/zk-github.js
+++ b/frontend/zk-github.js
@@ -53,7 +53,7 @@ export async function consumeZkReauthFromUrl() {
   }
 }
 
-export function zkReauthLoginUrl(redirect = '/') {
+export function zkReauthLoginUrl(redirect = '/dashboard') {
   const dest = encodeURIComponent(redirect);
   return `/login?reauth=1&redirect=${dest}`;
 }
@@ -79,7 +79,7 @@ export async function consumeZkHandoffFromUrl() {
   return true;
 }
 
-export function zkLoginUrl(redirect = '/') {
+export function zkLoginUrl(redirect = '/dashboard') {
   const dest = encodeURIComponent(redirect);
   return `/login?zk=1&redirect=${dest}`;
 }

--- a/worker/src/api/install-complete.ts
+++ b/worker/src/api/install-complete.ts
@@ -15,6 +15,6 @@ export async function installCompleteRoute(
 ): Promise<Response> {
   return new Response(null, {
     status: 302,
-    headers: { Location: "/login?redirect=/" },
+    headers: { Location: "/login?redirect=/dashboard" },
   });
 }

--- a/worker/src/auth/dashboard-route.test.ts
+++ b/worker/src/auth/dashboard-route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Env } from "../types";
+import type { SessionContext } from "./types";
+import { app } from "../router";
+
+const VALID_RAW_TOKEN = "b".repeat(64);
+
+function makeSessionDb(session: SessionContext | null): D1Database {
+  const validRow = session
+    ? {
+        userId: session.userId,
+        tenantId: session.tenantId,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      }
+    : null;
+
+  const bindStmt = {
+    first: vi.fn().mockResolvedValue(validRow),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+    bind: vi.fn(function (this: unknown) {
+      return this;
+    }),
+  };
+
+  const stmt = {
+    first: vi.fn().mockResolvedValue(validRow),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+    bind: vi.fn(() => bindStmt),
+  };
+
+  return {
+    prepare: vi.fn(() => stmt),
+    batch: vi.fn().mockResolvedValue([]),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+function makeEnv(db: D1Database, assetsBody = "dashboard-html"): Env {
+  return {
+    DB: db,
+    ASSETS: {
+      fetch: vi.fn(async (req: Request) => {
+        const url = new URL(req.url);
+        expect(url.pathname).toBe("/dashboard/index.html");
+        return new Response(assetsBody, { status: 200 });
+      }),
+    } as unknown as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "",
+  } as unknown as Env;
+}
+
+const STUB_SESSION: SessionContext = {
+  userId: 1,
+  tenantId: 1,
+  githubId: 1001,
+  githubLogin: "octocat",
+};
+
+describe("GET /dashboard", () => {
+  it("redirects to /login?redirect=/dashboard when no cookie", async () => {
+    const db = makeSessionDb(null);
+    const env = makeEnv(db);
+
+    const res = await app.request("/dashboard", {}, env);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/login?redirect=%2Fdashboard");
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+  });
+
+  it("redirects to login when session is invalid", async () => {
+    const db = makeSessionDb(null);
+    const env = makeEnv(db);
+
+    const res = await app.request(
+      "/dashboard",
+      { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+      env,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/login?redirect=%2Fdashboard");
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+  });
+
+  it("serves dashboard HTML when session is valid", async () => {
+    const db = makeSessionDb(STUB_SESSION);
+    const env = makeEnv(db);
+
+    const res = await app.request(
+      "/dashboard",
+      { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("dashboard-html");
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("allows install-pending sessions (null tenantId)", async () => {
+    const db = makeSessionDb({ ...STUB_SESSION, tenantId: null });
+    const env = makeEnv(db);
+
+    const res = await app.request(
+      "/dashboard/",
+      { headers: { Cookie: `__Host-session=${VALID_RAW_TOKEN}` } },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+  });
+});

--- a/worker/src/auth/dashboard-route.ts
+++ b/worker/src/auth/dashboard-route.ts
@@ -1,0 +1,30 @@
+/**
+ * GET /dashboard — session-gated shell for the dep-graph app.
+ * Unauthenticated requests redirect to /login before any dashboard HTML is served.
+ */
+
+import type { Context } from "hono";
+import type { AuthEnv } from "./types";
+import { readSessionToken } from "./cookies";
+import { validateSession } from "./session";
+
+export const DASHBOARD_PATH = "/dashboard";
+export const DASHBOARD_LOGIN = `/login?redirect=${encodeURIComponent(DASHBOARD_PATH)}`;
+
+export async function dashboardRoute(
+  c: Context<AuthEnv>,
+): Promise<Response> {
+  const token = readSessionToken(c);
+  if (!token) {
+    return c.redirect(DASHBOARD_LOGIN, 302);
+  }
+
+  const session = await validateSession(c.env.DB, token);
+  if (!session) {
+    return c.redirect(DASHBOARD_LOGIN, 302);
+  }
+
+  const assetUrl = new URL(c.req.url);
+  assetUrl.pathname = "/dashboard/index.html";
+  return c.env.ASSETS.fetch(new Request(assetUrl.toString(), c.req.raw));
+}

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -176,7 +176,7 @@ describe("loginRoute", () => {
       expect(insertStmt).toBeDefined();
       // args[0] = state (32 hex), args[1] = redirectAfter
       expect(insertStmt!.args[0]).toMatch(/^[0-9a-f]{32}$/);
-      expect(insertStmt!.args[1]).toBe("/"); // default when no ?redirect param
+      expect(insertStmt!.args[1]).toBe("/dashboard"); // default when no ?redirect param
     });
 
     it("?redirect=/dash stores '/dash' as redirect_after", async () => {
@@ -199,7 +199,7 @@ describe("loginRoute", () => {
       expect(insertStmt!.args[1]).toBe("/dash");
     });
 
-    it("?redirect=//evil stores '/' (open-redirect guard)", async () => {
+    it("?redirect=//evil stores '/dashboard' (open-redirect guard)", async () => {
       // Arrange
       const { db, stmts } = captureDb();
       const { app, env } = makeApp(db);
@@ -216,10 +216,10 @@ describe("loginRoute", () => {
         s.sql.toLowerCase().includes("oauth_state"),
       );
       expect(insertStmt).toBeDefined();
-      expect(insertStmt!.args[1]).toBe("/");
+      expect(insertStmt!.args[1]).toBe("/dashboard");
     });
 
-    it("?redirect=https://evil stores '/' (absolute URL guard)", async () => {
+    it("?redirect=https://evil stores '/dashboard' (absolute URL guard)", async () => {
       // Arrange
       const { db, stmts } = captureDb();
       const { app, env } = makeApp(db);
@@ -236,10 +236,10 @@ describe("loginRoute", () => {
         s.sql.toLowerCase().includes("oauth_state"),
       );
       expect(insertStmt).toBeDefined();
-      expect(insertStmt!.args[1]).toBe("/");
+      expect(insertStmt!.args[1]).toBe("/dashboard");
     });
 
-    it("?redirect=/\\evil stores '/' (backslash bypass guard)", async () => {
+    it("?redirect=/\\evil stores '/dashboard' (backslash bypass guard)", async () => {
       // Arrange — backslash-prefixed path; sanitizeRedirect regex (?![/\\]) rejects it
       const { db, stmts } = captureDb();
       const { app, env } = makeApp(db);
@@ -256,10 +256,10 @@ describe("loginRoute", () => {
         s.sql.toLowerCase().includes("oauth_state"),
       );
       expect(insertStmt).toBeDefined();
-      expect(insertStmt!.args[1]).toBe("/");
+      expect(insertStmt!.args[1]).toBe("/dashboard");
     });
 
-    it("?redirect=/ok\\r\\nX-Injected:x stores '/' (CRLF injection guard)", async () => {
+    it("?redirect=/ok\\r\\nX-Injected:x stores '/dashboard' (CRLF injection guard)", async () => {
       // Arrange — CRLF chars smuggled in the redirect param; sanitizeRedirect rejects via /[\r\n\0]/
       const { db, stmts } = captureDb();
       const { app, env } = makeApp(db);
@@ -276,10 +276,10 @@ describe("loginRoute", () => {
         s.sql.toLowerCase().includes("oauth_state"),
       );
       expect(insertStmt).toBeDefined();
-      expect(insertStmt!.args[1]).toBe("/");
+      expect(insertStmt!.args[1]).toBe("/dashboard");
     });
 
-    it("?redirect=/ok\\0null stores '/' (NUL injection guard)", async () => {
+    it("?redirect=/ok\\0null stores '/dashboard' (NUL injection guard)", async () => {
       // Arrange — NUL byte smuggled in the redirect param; sanitizeRedirect rejects via /[\r\n\0]/
       const { db, stmts } = captureDb();
       const { app, env } = makeApp(db);
@@ -296,7 +296,7 @@ describe("loginRoute", () => {
         s.sql.toLowerCase().includes("oauth_state"),
       );
       expect(insertStmt).toBeDefined();
-      expect(insertStmt!.args[1]).toBe("/");
+      expect(insertStmt!.args[1]).toBe("/dashboard");
     });
   });
 });

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -26,7 +26,7 @@ import { createZkReauthCode } from "./zk-reauth";
  */
 function sanitizeRedirect(raw: string | undefined): string {
   if (raw && /^\/(?![/\\])/.test(raw) && !/[\r\n\0]/.test(raw)) return raw;
-  return "/";
+  return "/dashboard";
 }
 
 /**
@@ -128,7 +128,7 @@ export async function callbackRoute(
     return c.json({ error: "bad_request" }, 400);
   }
 
-  let redirectAfter = stateRow.redirect_after ?? "/";
+  let redirectAfter = stateRow.redirect_after ?? "/dashboard";
   const wantsZkHandoff = stateRow.zk_token_handoff === 1;
   const wantsReauth = stateRow.reauth === 1;
 

--- a/worker/src/router.test.ts
+++ b/worker/src/router.test.ts
@@ -210,12 +210,12 @@ describe("requireSession auth gate", () => {
   // -------------------------------------------------------------------------
 
   describe("GET /install/complete — post-install return", () => {
-    it("returns 302 to /login?redirect=/ without touching DB", async () => {
+    it("returns 302 to /login?redirect=/dashboard without touching DB", async () => {
       const db = makeDbThatMustNotBeCalled();
       const env = makeEnv(db);
       const res = await app.request("/install/complete", {}, env);
       expect(res.status).toBe(302);
-      expect(res.headers.get("Location")).toBe("/login?redirect=/");
+      expect(res.headers.get("Location")).toBe("/login?redirect=/dashboard");
       expect(db.prepare).not.toHaveBeenCalled();
     });
   });

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -7,6 +7,7 @@ import { adminSyncRoute } from "./api/admin";
 import { webhookRoute } from "./webhook/handlers";
 import { checkAdminAuth } from "./api/auth";
 import { loginRoute, callbackRoute } from "./auth/oauth";
+import { dashboardRoute } from "./auth/dashboard-route";
 import { meRoute, logoutRoute } from "./api/me";
 import type { AuthEnv } from "./auth/types";
 import { requireSession, requireLinkedTenant } from "./auth/session";
@@ -101,6 +102,10 @@ app.post("/api/zk/github/graphql", requireLinkedTenant, zkGithubGraphqlRoute);
 // /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
 // blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
 app.post("/logout", logoutRoute);
+
+// GET /dashboard — session-gated app shell (HTML only; JS/CSS served from ASSETS root).
+app.get("/dashboard", dashboardRoute);
+app.get("/dashboard/", dashboardRoute);
 
 // ── Static-assets fallback — last resort (frontend populated in S7, #99) ────
 app.all("*", (c) => c.env.ASSETS.fetch(c.req.raw));


### PR DESCRIPTION
## Promotion: staging → main (v0.17.0)

### Features
- **frontend:** public landing page at `/` with Se connecter CTA; dep-graph app moved to `/dashboard`
- **auth:** server-side session gate on `/dashboard` — unauthenticated users redirect to `/login` before HTML loads

## Pre-flight
- [x] CI passing on staging
- [x] No open PRs targeting staging
- [x] Deploy preview skipped (CF Workers CI deploy)
- [x] Release notes committed to staging

---
Generated via `/promote`