### PR TITLE
chore: promote staging to main (v0.17.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.17.8](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.17.7...roxabi-live/v0.17.8) (2026-06-19)
+
+
+### Bug Fixes
+
+* **auth:** `/auth/exchange` serves dashboard HTML (200 + Set-Cookie) — no post-cookie redirect hop
+* **auth:** strip `install=1` after linked OAuth; re-OAuth when install=1 but zero linked installations
+* **auth:** `/auth/status` reports `tenant_id` + `installations` for loop diagnosis
+
+
 ## [0.17.7](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.17.6...roxabi-live/v0.17.7) (2026-06-19)
 
 

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,7 +14,7 @@ worker/src/webhook/mutations.ts  # 339 lines — #180 D1 write helpers for webho
 worker/src/sync/sync.test.ts  # 1729 lines — #180 integration harness for runSync; #216 structure-only
 worker/src/api/zk-key-backup.test.ts  # 506 lines — #216 backup API security + CAS/reauth tests; fp enforcement + atomic UPSERT tests
 worker/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-worker/src/auth/oauth.test.ts  # 1065 lines — #180 OAuth + install-pending; auth/exchange cookie hop + install=1 short-circuit
+worker/src/auth/oauth.test.ts  # 1067 lines — #180 OAuth + install-pending; exchange inline dashboard + install linked-count gate
 worker/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 worker/src/api/graph.test.ts  # 745 lines — #180 tenant-scoped graph + #142 S2 zk + closed_under_open_epic
 worker/src/migrations.test.ts  # 317 lines — #216 zk_key_backups + zk_reauth_proofs + oauth_exchange schema tests

--- a/worker/src/api/install-complete.ts
+++ b/worker/src/api/install-complete.ts
@@ -14,5 +14,5 @@ import { authRedirect } from "../auth/cookies";
 export async function installCompleteRoute(
   c: Context<{ Bindings: Env }>,
 ): Promise<Response> {
-  return authRedirect("/login?redirect=/dashboard");
+  return authRedirect("/login?redirect=/dashboard?install=1");
 }

--- a/worker/src/auth/cookies.ts
+++ b/worker/src/auth/cookies.ts
@@ -24,6 +24,21 @@ export function sanitizeAuthRedirect(raw: string | undefined): string {
   return "/dashboard";
 }
 
+/** True when a relative path targets the dashboard shell. */
+export function isDashboardDest(path: string): boolean {
+  const url = new URL(path, "https://_/");
+  return url.pathname === "/dashboard" || url.pathname === "/dashboard/";
+}
+
+/** Remove ?install=1 — only needed to trigger server-side re-OAuth, not for rendering. */
+export function stripInstallParam(path: string): string {
+  const url = new URL(path, "https://_/");
+  if (!url.searchParams.has("install")) return path;
+  url.searchParams.delete("install");
+  const pathname = url.pathname.replace(/\/$/, "") || "/dashboard";
+  return `${pathname}${url.search}`;
+}
+
 /** 302 redirect that must not be stored by the browser or CDN. */
 export function authRedirect(
   location: string,

--- a/worker/src/auth/dashboard-route.ts
+++ b/worker/src/auth/dashboard-route.ts
@@ -6,10 +6,10 @@
 import type { Context } from "hono";
 import type { AuthEnv } from "./types";
 import {
+  AUTH_NO_CACHE,
   authRedirect,
   clearSessionCookieHeaders,
   readSessionToken,
-  withAuthNoCache,
 } from "./cookies";
 import { validateSession } from "./session";
 
@@ -38,10 +38,25 @@ export async function dashboardRoute(
     return authRedirect(loginDest, clearSessionCookieHeaders());
   }
 
+  return serveDashboardShell(c);
+}
+
+/** Serve dashboard/index.html with auth no-cache headers (optional Set-Cookie). */
+export async function serveDashboardShell(
+  c: Context<AuthEnv>,
+  extraSetCookies: string[] = [],
+): Promise<Response> {
   const assetUrl = new URL(c.req.url);
   assetUrl.pathname = "/dashboard/index.html";
   const assetRes = await c.env.ASSETS.fetch(
     new Request(assetUrl.toString(), c.req.raw),
   );
-  return withAuthNoCache(assetRes);
+  const headers = new Headers(assetRes.headers);
+  for (const [key, value] of Object.entries(AUTH_NO_CACHE)) {
+    headers.set(key, value);
+  }
+  for (const cookie of extraSetCookies) {
+    headers.append("Set-Cookie", cookie);
+  }
+  return new Response(assetRes.body, { status: assetRes.status, headers });
 }

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -342,29 +342,31 @@ describe("loginRoute", () => {
       expect(res.headers.get("Location")).not.toMatch(/^https:\/\/github\.com/);
     });
 
-    it("short-circuits to dashboard when redirect includes install=1 and session has a linked tenant", async () => {
+    it("short-circuits to dashboard without install=1 when session has a linked tenant", async () => {
       const validRow = {
         userId: 1,
         tenantId: 10,
         githubId: 42,
         githubLogin: "alice",
       };
-      const bindStmt = {
-        first: vi.fn().mockResolvedValue(validRow),
-        run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
-        all: vi.fn().mockResolvedValue({ results: [] }),
-        bind: vi.fn(function (this: unknown) {
-          return this;
-        }),
-      };
-      const stmt = {
-        first: vi.fn().mockResolvedValue(validRow),
-        run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
-        all: vi.fn().mockResolvedValue({ results: [] }),
-        bind: vi.fn(() => bindStmt),
-      };
       const db = {
-        prepare: vi.fn(() => stmt),
+        prepare: vi.fn((sql: string) => {
+          const stmt = {
+            sql,
+            first: vi.fn().mockImplementation(function (this: { sql: string }) {
+              if (this.sql.toLowerCase().includes("count")) {
+                return Promise.resolve({ n: 1 });
+              }
+              return Promise.resolve(validRow);
+            }),
+            run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+            all: vi.fn().mockResolvedValue({ results: [] }),
+            bind: vi.fn(function (this: unknown) {
+              return this;
+            }),
+          };
+          return stmt;
+        }),
         batch: vi.fn().mockResolvedValue([]),
         dump: vi.fn(),
         exec: vi.fn(),
@@ -382,7 +384,7 @@ describe("loginRoute", () => {
       );
 
       expect(res.status).toBe(302);
-      expect(res.headers.get("Location")).toBe("/dashboard?install=1");
+      expect(res.headers.get("Location")).toBe("/dashboard");
       expect(res.headers.get("Location")).not.toMatch(/^https:\/\/github\.com/);
     });
 

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -15,6 +15,7 @@ import {
   authRedirect,
   readSessionToken,
   sanitizeAuthRedirect,
+  stripInstallParam,
 } from "./cookies";
 import { validateSession } from "./session";
 import { createUserTokenHandoff } from "./userTokenHandoff";
@@ -59,8 +60,17 @@ async function mustReOAuth(
   if (!token) return true;
   const session = await validateSession(c.env.DB, token);
   if (!session) return true;
-  // Post-install refresh only while session is still install-pending (no tenant).
-  return session.tenantId === null;
+  if (session.tenantId === null) return true;
+
+  const linked = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS n FROM user_installations ui
+     JOIN tenants t ON t.id = ui.tenant_id AND t.deleted_at IS NULL
+     WHERE ui.user_id = ?`,
+  )
+    .bind(session.userId)
+    .first<{ n: number }>();
+
+  return (linked?.n ?? 0) === 0;
 }
 
 export async function loginRoute(
@@ -75,7 +85,11 @@ export async function loginRoute(
     if (token) {
       const session = await validateSession(c.env.DB, token);
       if (session) {
-        return authRedirect(redirectAfter);
+        let dest = redirectAfter;
+        if (session.tenantId != null && dest.includes("install=1")) {
+          dest = stripInstallParam(dest);
+        }
+        return authRedirect(dest);
       }
     }
   }
@@ -343,7 +357,7 @@ export async function callbackRoute(
   const exchangeCode = await createOAuthExchange(
     c.env.DB,
     rawToken,
-    redirectAfter,
+    stripInstallParam(redirectAfter),
   );
   return authRedirect(`/auth/exchange?code=${exchangeCode}`);
 }

--- a/worker/src/auth/oauthExchange.test.ts
+++ b/worker/src/auth/oauthExchange.test.ts
@@ -9,12 +9,17 @@ function makeApp(db: D1Database) {
   app.get("/auth/exchange", authExchangeRoute);
   return {
     app,
-    env: { DB: db, ASSETS: {} as Fetcher } as AuthEnv["Bindings"],
+    env: {
+      DB: db,
+      ASSETS: {
+        fetch: vi.fn(async () => new Response("<html>dashboard</html>", { status: 200 })),
+      } as unknown as Fetcher,
+    } as AuthEnv["Bindings"],
   };
 }
 
 describe("authExchangeRoute", () => {
-  it("sets session cookie and redirects to stored destination", async () => {
+  it("serves dashboard HTML with session cookie for dashboard destinations", async () => {
     const row = {
       session_token: "a".repeat(64),
       redirect_after: "/dashboard?install=1",
@@ -34,14 +39,42 @@ describe("authExchangeRoute", () => {
       env,
     );
 
-    expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/dashboard?install=1");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("dashboard");
+    expect(res.headers.get("Location")).toBeNull();
     const cookie = res.headers.get("Set-Cookie") ?? "";
     expect(cookie).toContain("roxabi_session=");
     expect(cookie).toContain("HttpOnly");
     expect(cookie).toContain("Secure");
     expect(cookie).toContain("SameSite=Lax");
     expect(res.headers.get("Cache-Control")).toContain("no-store");
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("redirects non-dashboard destinations with Set-Cookie", async () => {
+    const row = {
+      session_token: "a".repeat(64),
+      redirect_after: "/settings",
+    };
+    const db = makeFakeDb((sql, args) => {
+      const stmt = makeFakeStmt(sql, args, [row], 1);
+      (stmt as { first: <T>() => Promise<T | null> }).first = vi
+        .fn()
+        .mockResolvedValue(row);
+      return stmt;
+    });
+    const { app, env } = makeApp(db);
+
+    const res = await app.request(
+      "/auth/exchange?code=abc123",
+      { method: "GET" },
+      env,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/settings");
+    expect(res.headers.get("Set-Cookie")).toContain("roxabi_session=");
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
   });
 
   it("returns 400 when code is missing", async () => {

--- a/worker/src/auth/oauthExchange.ts
+++ b/worker/src/auth/oauthExchange.ts
@@ -2,14 +2,17 @@
  * One-time OAuth session exchange (#145).
  *
  * Callback mints a session then 302s to GET /auth/exchange?code=…
- * Exchange consumes the code, sets roxabi_session via 302 Set-Cookie, redirects.
- * Avoids HTML+JS cookie races in browsers that drop Set-Cookie on 200 shells.
+ * Exchange sets roxabi_session and either serves dashboard HTML (200) or 302s.
+ * Serving dashboard inline avoids a follow-up navigation that drops Set-Cookie
+ * in some browsers (Opera/normal profile redirect loops).
  */
 
 import type { Context } from "hono";
 import type { AuthEnv } from "./types";
+import { serveDashboardShell } from "./dashboard-route";
 import {
   authRedirect,
+  isDashboardDest,
   sanitizeAuthRedirect,
   sessionCookieHeaders,
 } from "./cookies";
@@ -63,5 +66,10 @@ export async function authExchangeRoute(
     return c.json({ error: "expired" }, 400);
   }
 
-  return authRedirect(row.redirect_after, sessionCookieHeaders(row.session_token));
+  const cookies = sessionCookieHeaders(row.session_token);
+  if (isDashboardDest(row.redirect_after)) {
+    return serveDashboardShell(c, cookies);
+  }
+
+  return authRedirect(row.redirect_after, cookies);
 }

--- a/worker/src/auth/status.ts
+++ b/worker/src/auth/status.ts
@@ -16,8 +16,22 @@ export async function authStatusRoute(
   const legacy = readNamedCookie(cookieHeader, LEGACY_SESSION_COOKIE);
   const token = readSessionToken(c);
   let sessionValid = false;
+  let tenantId: number | null = null;
+  let installations = 0;
   if (token) {
-    sessionValid = !!(await validateSession(c.env.DB, token));
+    const session = await validateSession(c.env.DB, token);
+    sessionValid = session != null;
+    if (session) {
+      tenantId = session.tenantId;
+      const row = await c.env.DB.prepare(
+        `SELECT COUNT(*) AS n FROM user_installations ui
+         JOIN tenants t ON t.id = ui.tenant_id AND t.deleted_at IS NULL
+         WHERE ui.user_id = ?`,
+      )
+        .bind(session.userId)
+        .first<{ n: number }>();
+      installations = row?.n ?? 0;
+    }
   }
 
   return c.json(
@@ -28,6 +42,8 @@ export async function authStatusRoute(
         [LEGACY_SESSION_COOKIE]: legacy != null,
       },
       session_valid: sessionValid,
+      tenant_id: tenantId,
+      installations,
     },
     200,
     AUTH_NO_CACHE,

--- a/worker/src/router.test.ts
+++ b/worker/src/router.test.ts
@@ -215,7 +215,9 @@ describe("requireSession auth gate", () => {
       const env = makeEnv(db);
       const res = await app.request("/install/complete", {}, env);
       expect(res.status).toBe(302);
-      expect(res.headers.get("Location")).toBe("/login?redirect=/dashboard");
+      expect(res.headers.get("Location")).toBe(
+        "/login?redirect=/dashboard?install=1",
+      );
       expect(res.headers.get("Cache-Control")).toContain("no-store");
       expect(db.prepare).not.toHaveBeenCalled();
     });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.17.7"
+APP_RELEASE = "0.17.8"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -69,7 +69,7 @@ name = "roxabi-live-staging"
 workers_dev = true
 
 [env.staging.vars]
-APP_RELEASE = "0.17.7"
+APP_RELEASE = "0.17.8"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"
 # `routes` is inheritable — without this explicit empty override a staging


### PR DESCRIPTION
## Summary

v0.17.8 — fixes persistent OAuth redirect loop when session is valid but browser drops cookie on post-exchange redirect.

- `/auth/exchange` serves dashboard HTML (200 + Set-Cookie) instead of 302 → `/dashboard`
- Strip `install=1` after linked OAuth; re-OAuth when install=1 but zero installations
- `/auth/status` adds `tenant_id` + `installations`

## Test plan

- [ ] `GET /api/release` → `0.17.8`
- [ ] `https://live.roxabi.dev/auth/reset`
- [ ] OAuth flow on `/dashboard/?install=1` lands on dashboard (no loop)