### PR TITLE
chore: promote staging to main (v0.17.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.17.9](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.17.8...roxabi-live/v0.17.9) (2026-06-19)
+
+
+### Bug Fixes
+
+* **auth:** `install=1` is a `/login` query flag only — strip from `redirect=` to stop OAuth loops for valid install-pending sessions
+* **frontend:** « I've installed — continue » → `/login?install=1&redirect=/dashboard`
+
+
 ## [0.17.8](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.17.7...roxabi-live/v0.17.8) (2026-06-19)
 
 

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -12,6 +12,11 @@ export function loginUrl(redirect = DASHBOARD_PATH) {
   return `/login?redirect=${encodeURIComponent(redirect)}`;
 }
 
+/** Re-OAuth after GitHub App install — install=1 is a /login flag, not redirect=. */
+export function refreshInstallLoginUrl(redirect = DASHBOARD_PATH) {
+  return `/login?install=1&redirect=${encodeURIComponent(redirect)}`;
+}
+
 /** @deprecated Server gates /dashboard; client redirect causes OAuth loops. */
 function showSessionLost() {
   const el = document.getElementById('error-msg');
@@ -159,7 +164,7 @@ function renderInstallCta(me) {
       </p>
       <div class="install-actions">
         <button type="button" class="consent-btn-secondary" id="install-logout">Sign out</button>
-        <a href="${escHtml(loginUrl(`${DASHBOARD_PATH}?install=1`))}" class="auth-login-btn" id="install-continue">I've installed — continue</a>
+        <a href="${escHtml(refreshInstallLoginUrl(DASHBOARD_PATH))}" class="auth-login-btn" id="install-continue">I've installed — continue</a>
       </div>
     </div>
   `;

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AuthError, api, hasConsent, setConsent, resolveView, escHtml, loginUrl, DASHBOARD_PATH } from './auth.js';
+import { AuthError, api, hasConsent, setConsent, resolveView, escHtml, loginUrl, refreshInstallLoginUrl, DASHBOARD_PATH } from './auth.js';
 
 // ─── loginUrl ─────────────────────────────────────────────────────────────────
 
@@ -15,6 +15,12 @@ describe('loginUrl', () => {
 
   it('encodes install query on dashboard', () => {
     expect(loginUrl('/dashboard?install=1')).toBe('/login?redirect=%2Fdashboard%3Finstall%3D1');
+  });
+});
+
+describe('refreshInstallLoginUrl', () => {
+  it('uses top-level install=1 flag', () => {
+    expect(refreshInstallLoginUrl()).toBe('/login?install=1&redirect=%2Fdashboard');
   });
 });
 

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,7 +14,7 @@ worker/src/webhook/mutations.ts  # 339 lines — #180 D1 write helpers for webho
 worker/src/sync/sync.test.ts  # 1729 lines — #180 integration harness for runSync; #216 structure-only
 worker/src/api/zk-key-backup.test.ts  # 506 lines — #216 backup API security + CAS/reauth tests; fp enforcement + atomic UPSERT tests
 worker/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-worker/src/auth/oauth.test.ts  # 1067 lines — #180 OAuth + install-pending; exchange inline dashboard + install linked-count gate
+worker/src/auth/oauth.test.ts  # 1094 lines — #180 OAuth + install-pending; install=1 login flag + exchange inline dashboard
 worker/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 worker/src/api/graph.test.ts  # 745 lines — #180 tenant-scoped graph + #142 S2 zk + closed_under_open_epic
 worker/src/migrations.test.ts  # 317 lines — #216 zk_key_backups + zk_reauth_proofs + oauth_exchange schema tests

--- a/worker/src/api/install-complete.ts
+++ b/worker/src/api/install-complete.ts
@@ -14,5 +14,5 @@ import { authRedirect } from "../auth/cookies";
 export async function installCompleteRoute(
   c: Context<{ Bindings: Env }>,
 ): Promise<Response> {
-  return authRedirect("/login?redirect=/dashboard?install=1");
+  return authRedirect("/login?install=1&redirect=/dashboard");
 }

--- a/worker/src/auth/dashboard-route.test.ts
+++ b/worker/src/auth/dashboard-route.test.ts
@@ -61,16 +61,14 @@ const STUB_SESSION: SessionContext = {
 };
 
 describe("GET /dashboard", () => {
-  it("redirects to /login preserving ?install=1 when no cookie", async () => {
+  it("redirects to /login without install=1 in redirect when no cookie", async () => {
     const db = makeSessionDb(null);
     const env = makeEnv(db);
 
     const res = await app.request("/dashboard/?install=1", {}, env);
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe(
-      "/login?redirect=%2Fdashboard%2F%3Finstall%3D1",
-    );
+    expect(res.headers.get("Location")).toBe("/login?redirect=%2Fdashboard");
     expect(res.headers.get("Cache-Control")).toContain("no-store");
     expect(env.ASSETS.fetch).not.toHaveBeenCalled();
   });

--- a/worker/src/auth/dashboard-route.ts
+++ b/worker/src/auth/dashboard-route.ts
@@ -15,9 +15,12 @@ import { validateSession } from "./session";
 
 export const DASHBOARD_PATH = "/dashboard";
 
-/** Build /login?redirect=… preserving dashboard query (e.g. ?install=1). */
+/** Build /login?redirect=… — never embed install=1 (use /login?install=1 instead). */
 export function dashboardLoginUrl(reqUrl: URL): string {
-  const redirectPath = reqUrl.pathname + reqUrl.search;
+  const pathUrl = new URL(reqUrl.pathname + reqUrl.search, "https://_/");
+  pathUrl.searchParams.delete("install");
+  const pathname = pathUrl.pathname.replace(/\/$/, "") || "/dashboard";
+  const redirectPath = `${pathname}${pathUrl.search}`;
   return `/login?redirect=${encodeURIComponent(redirectPath)}`;
 }
 

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -388,29 +388,23 @@ describe("loginRoute", () => {
       expect(res.headers.get("Location")).not.toMatch(/^https:\/\/github\.com/);
     });
 
-    it("still starts OAuth when redirect includes install=1 and session is install-pending", async () => {
+    it("short-circuits install-pending session when install=1 is only in redirect=", async () => {
       const validRow = {
         userId: 1,
         tenantId: null,
         githubId: 42,
         githubLogin: "alice",
       };
-      const bindStmt = {
-        first: vi.fn().mockResolvedValue(validRow),
-        run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
-        all: vi.fn().mockResolvedValue({ results: [] }),
-        bind: vi.fn(function (this: unknown) {
-          return this;
-        }),
-      };
-      const stmt = {
-        first: vi.fn().mockResolvedValue(validRow),
-        run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
-        all: vi.fn().mockResolvedValue({ results: [] }),
-        bind: vi.fn(() => bindStmt),
-      };
       const db = {
-        prepare: vi.fn(() => stmt),
+        prepare: vi.fn((sql: string) => ({
+          sql,
+          first: vi.fn().mockResolvedValue(validRow),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+          all: vi.fn().mockResolvedValue({ results: [] }),
+          bind: vi.fn(function (this: unknown) {
+            return this;
+          }),
+        })),
         batch: vi.fn().mockResolvedValue([]),
         dump: vi.fn(),
         exec: vi.fn(),
@@ -422,7 +416,43 @@ describe("loginRoute", () => {
           encodeURIComponent("/dashboard?install=1"),
         {
           method: "GET",
-          headers: { Cookie: `__Host-session=${"a".repeat(64)}` },
+          headers: { Cookie: `roxabi_session=${"a".repeat(64)}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard");
+      expect(res.headers.get("Location")).not.toMatch(/^https:\/\/github\.com/);
+    });
+
+    it("starts OAuth when /login?install=1 and session is install-pending", async () => {
+      const validRow = {
+        userId: 1,
+        tenantId: null,
+        githubId: 42,
+        githubLogin: "alice",
+      };
+      const db = {
+        prepare: vi.fn(() => ({
+          first: vi.fn().mockResolvedValue(validRow),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+          all: vi.fn().mockResolvedValue({ results: [] }),
+          bind: vi.fn(function (this: unknown) {
+            return this;
+          }),
+        })),
+        batch: vi.fn().mockResolvedValue([]),
+        dump: vi.fn(),
+        exec: vi.fn(),
+      } as unknown as D1Database;
+
+      const { app, env } = makeApp(db);
+      const res = await app.request(
+        "http://localhost/login?install=1&redirect=%2Fdashboard",
+        {
+          method: "GET",
+          headers: { Cookie: `roxabi_session=${"a".repeat(64)}` },
         },
         env,
       );

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -46,15 +46,16 @@ function bytesToHex(bytes: Uint8Array): string {
  * endpoint.  The redirect_uri is derived from the request origin — never from
  * a query parameter — to prevent redirect-uri injection (D-6).
  */
-/** OAuth must run again (install handoff, ZK flows, explicit reauth). */
-async function mustReOAuth(
-  c: Context<{ Bindings: Env }>,
-  redirectAfter: string,
-): Promise<boolean> {
+/**
+ * OAuth must run again (install refresh, ZK flows, explicit reauth).
+ * install=1 must be a top-level /login query flag — NOT embedded in redirect=,
+ * otherwise every post-OAuth hop back to /login?redirect=/dashboard?install=1
+ * re-triggers GitHub while the session cookie is already valid (redirect loop).
+ */
+async function mustReOAuth(c: Context<{ Bindings: Env }>): Promise<boolean> {
   if (c.req.query("reauth") === "1") return true;
   if (c.req.query("zk") === "1") return true;
-
-  if (!redirectAfter.includes("install=1")) return false;
+  if (c.req.query("install") !== "1") return false;
 
   const token = readSessionToken(c);
   if (!token) return true;
@@ -80,16 +81,14 @@ export async function loginRoute(
   const zkTokenHandoff = c.req.query("zk") === "1" ? 1 : 0;
   const reauth = c.req.query("reauth") === "1" ? 1 : 0;
 
-  if (!(await mustReOAuth(c, redirectAfter))) {
+  const cleanRedirect = stripInstallParam(redirectAfter);
+
+  if (!(await mustReOAuth(c))) {
     const token = readSessionToken(c);
     if (token) {
       const session = await validateSession(c.env.DB, token);
       if (session) {
-        let dest = redirectAfter;
-        if (session.tenantId != null && dest.includes("install=1")) {
-          dest = stripInstallParam(dest);
-        }
-        return authRedirect(dest);
+        return authRedirect(cleanRedirect);
       }
     }
   }
@@ -104,7 +103,7 @@ export async function loginRoute(
     `INSERT INTO oauth_state (state, redirect_after, expires_at, zk_token_handoff, reauth)
      VALUES (?, ?, datetime('now', '+10 minutes'), ?, ?)`,
   )
-    .bind(state, redirectAfter, zkTokenHandoff, reauth)
+    .bind(state, cleanRedirect, zkTokenHandoff, reauth)
     .run();
 
   // Build GitHub authorize URL — redirect_uri derived from origin only (D-6)

--- a/worker/src/router.test.ts
+++ b/worker/src/router.test.ts
@@ -216,7 +216,7 @@ describe("requireSession auth gate", () => {
       const res = await app.request("/install/complete", {}, env);
       expect(res.status).toBe(302);
       expect(res.headers.get("Location")).toBe(
-        "/login?redirect=/dashboard?install=1",
+        "/login?install=1&redirect=/dashboard",
       );
       expect(res.headers.get("Cache-Control")).toContain("no-store");
       expect(db.prepare).not.toHaveBeenCalled();

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.17.8"
+APP_RELEASE = "0.17.9"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -69,7 +69,7 @@ name = "roxabi-live-staging"
 workers_dev = true
 
 [env.staging.vars]
-APP_RELEASE = "0.17.8"
+APP_RELEASE = "0.17.9"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"
 # `routes` is inheritable — without this explicit empty override a staging


### PR DESCRIPTION
v0.17.9 — install=1 as /login flag only; fixes OAuth redirect loop for install-pending sessions.