### PR TITLE
fix(auth): stop onboarding redirect loop (v0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.18.0...roxabi-live/v0.18.1) (2026-06-19)
+
+
+### Bug Fixes
+
+* **auth:** fix login prompt double-encoded `redirect` (`%252F`) — OAuth link now uses single `%2F`
+* **auth:** `/dashboard/?code=` forwards to `/auth/exchange` (or `/oauth/callback` with `state`) instead of looping through `/login`
+* **auth:** strip `code`/`state` from `/login?redirect=` targets; decode once-encoded `%2F` paths in `sanitizeAuthRedirect`
+
+
 ## [0.18.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.17.9...roxabi-live/v0.18.0) (2026-06-19)
 
 

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,7 +14,7 @@ worker/src/webhook/mutations.ts  # 339 lines — #180 D1 write helpers for webho
 worker/src/sync/sync.test.ts  # 1729 lines — #180 integration harness for runSync; #216 structure-only
 worker/src/api/zk-key-backup.test.ts  # 506 lines — #216 backup API security + CAS/reauth tests; fp enforcement + atomic UPSERT tests
 worker/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-worker/src/auth/oauth.test.ts  # 1110 lines — #180 OAuth + install-pending; login prompt step-1 + onboarding flow
+worker/src/auth/oauth.test.ts  # 1112 lines — #180 OAuth + install-pending; login prompt step-1 + redirect-loop guards
 worker/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 worker/src/api/graph.test.ts  # 745 lines — #180 tenant-scoped graph + #142 S2 zk + closed_under_open_epic
 worker/src/migrations.test.ts  # 317 lines — #216 zk_key_backups + zk_reauth_proofs + oauth_exchange schema tests

--- a/worker/src/auth/cookies.test.ts
+++ b/worker/src/auth/cookies.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeAuthRedirect } from "./cookies";
+
+describe("sanitizeAuthRedirect", () => {
+  it("returns /dashboard for missing input", () => {
+    expect(sanitizeAuthRedirect(undefined)).toBe("/dashboard");
+  });
+
+  it("accepts normal relative paths", () => {
+    expect(sanitizeAuthRedirect("/dashboard")).toBe("/dashboard");
+    expect(sanitizeAuthRedirect("/dash")).toBe("/dash");
+  });
+
+  it("decodes once-encoded paths (%2Fdashboard → /dashboard)", () => {
+    expect(sanitizeAuthRedirect("%2Fdashboard")).toBe("/dashboard");
+  });
+
+  it("rejects open redirects", () => {
+    expect(sanitizeAuthRedirect("//evil")).toBe("/dashboard");
+    expect(sanitizeAuthRedirect("https://evil")).toBe("/dashboard");
+  });
+});

--- a/worker/src/auth/cookies.ts
+++ b/worker/src/auth/cookies.ts
@@ -20,7 +20,24 @@ export const AUTH_NO_CACHE: Record<string, string> = {
 
 /** Safe relative redirect target (open-redirect guards). */
 export function sanitizeAuthRedirect(raw: string | undefined): string {
-  if (raw && /^\/(?![/\\])/.test(raw) && !/[\r\n\0]/.test(raw)) return raw;
+  let candidate = raw?.trim();
+  if (!candidate) return "/dashboard";
+
+  // Recover once-encoded paths from double-encoded login links (%252F → %2F → /).
+  if (!/^\/(?![/\\])/.test(candidate) && /^%2[fF]/.test(candidate)) {
+    try {
+      const decoded = decodeURIComponent(candidate);
+      if (/^\/(?![/\\])/.test(decoded) && !/[\r\n\0]/.test(decoded)) {
+        candidate = decoded;
+      }
+    } catch {
+      /* keep candidate */
+    }
+  }
+
+  if (/^\/(?![/\\])/.test(candidate) && !/[\r\n\0]/.test(candidate)) {
+    return candidate;
+  }
   return "/dashboard";
 }
 

--- a/worker/src/auth/dashboard-route.test.ts
+++ b/worker/src/auth/dashboard-route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { Env } from "../types";
 import type { SessionContext } from "./types";
 import { app } from "../router";
+import { dashboardLoginUrl } from "./dashboard-route";
 
 const VALID_RAW_TOKEN = "b".repeat(64);
 
@@ -128,5 +129,51 @@ describe("GET /dashboard", () => {
 
     expect(res.status).toBe(200);
     expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("forwards ?code&state to /oauth/callback (GitHub handoff)", async () => {
+    const db = makeSessionDb(null);
+    const env = makeEnv(db);
+
+    const res = await app.request(
+      "/dashboard/?code=ghcode&state=ghstate",
+      {},
+      env,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/oauth/callback?code=ghcode&state=ghstate",
+    );
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards lone ?code to /auth/exchange (session handoff)", async () => {
+    const db = makeSessionDb(null);
+    const env = makeEnv(db);
+
+    const res = await app.request(
+      "/dashboard/?code=3021f76392ee418d8b6a9d70a5e8cd99",
+      {},
+      env,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/auth/exchange?code=3021f76392ee418d8b6a9d70a5e8cd99",
+    );
+    expect(env.ASSETS.fetch).not.toHaveBeenCalled();
+  });
+
+});
+
+describe("dashboardLoginUrl", () => {
+  it("strips code, state, and install from redirect target", () => {
+    const url = new URL(
+      "https://live.roxabi.dev/dashboard/?code=abc&state=xyz&install=1&view=graph",
+    );
+    expect(dashboardLoginUrl(url)).toBe(
+      "/login?redirect=%2Fdashboard%3Fview%3Dgraph",
+    );
   });
 });

--- a/worker/src/auth/dashboard-route.ts
+++ b/worker/src/auth/dashboard-route.ts
@@ -15,10 +15,15 @@ import { validateSession } from "./session";
 
 export const DASHBOARD_PATH = "/dashboard";
 
+/** Query params that must not round-trip through /login?redirect= (auth handoff / loops). */
+const DASHBOARD_LOGIN_STRIP = ["install", "code", "state"] as const;
+
 /** Build /login?redirect=… — never embed install=1 (use /login?install=1 instead). */
 export function dashboardLoginUrl(reqUrl: URL): string {
   const pathUrl = new URL(reqUrl.pathname + reqUrl.search, "https://_/");
-  pathUrl.searchParams.delete("install");
+  for (const key of DASHBOARD_LOGIN_STRIP) {
+    pathUrl.searchParams.delete(key);
+  }
   const pathname = pathUrl.pathname.replace(/\/$/, "") || "/dashboard";
   const redirectPath = `${pathname}${pathUrl.search}`;
   return `/login?redirect=${encodeURIComponent(redirectPath)}`;
@@ -28,6 +33,21 @@ export async function dashboardRoute(
   c: Context<AuthEnv>,
 ): Promise<Response> {
   const reqUrl = new URL(c.req.url);
+
+  // OAuth callback or one-shot exchange must not hit the session gate (redirect loop).
+  const handoffCode = reqUrl.searchParams.get("code");
+  if (handoffCode) {
+    const handoffState = reqUrl.searchParams.get("state");
+    if (handoffState) {
+      const callback = new URL("/oauth/callback", reqUrl.origin);
+      callback.search = reqUrl.search;
+      return authRedirect(`${callback.pathname}${callback.search}`);
+    }
+    return authRedirect(
+      `/auth/exchange?code=${encodeURIComponent(handoffCode)}`,
+    );
+  }
+
   const loginDest = dashboardLoginUrl(reqUrl);
 
   const token = readSessionToken(c);

--- a/worker/src/auth/login-prompt.ts
+++ b/worker/src/auth/login-prompt.ts
@@ -56,7 +56,7 @@ export function serveLoginPrompt(
       La connexion est la première étape — l'installation de l'app et la
       synchronisation suivront ensuite.
     </p>
-    <a class="auth-login-btn login-prompt-github" href="${encodeURI(continueUrl)}">
+    <a class="auth-login-btn login-prompt-github" href="${continueUrl}">
       Continuer avec GitHub
     </a>
     <p class="login-prompt-foot"><a href="/">Retour à l'accueil</a></p>

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -70,6 +70,8 @@ describe("loginRoute", () => {
       expect(body).toContain("Continuer avec GitHub");
       expect(body).toContain("Connexion GitHub");
       expect(body).toContain("/login?go=1");
+      expect(body).not.toContain("%252F");
+      expect(body).toContain('href="/login?go=1&redirect=%2Fdashboard"');
       expect(res.headers.get("Location")).toBeNull();
       expect(stmts()).toHaveLength(0);
     });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.18.0"
+APP_RELEASE = "0.18.1"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -69,7 +69,7 @@ name = "roxabi-live-staging"
 workers_dev = true
 
 [env.staging.vars]
-APP_RELEASE = "0.18.0"
+APP_RELEASE = "0.18.1"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"
 # `routes` is inheritable — without this explicit empty override a staging


### PR DESCRIPTION
## Summary
- Fix double-encoded `redirect` in login prompt OAuth link (`%252F` → `%2F`)
- Forward `/dashboard/?code=` to `/auth/exchange` (session handoff) or `/oauth/callback` (with `state`)
- Strip `code`/`state` from `/login?redirect=` to break infinite redirect loops
- Decode once-encoded `%2F` paths in `sanitizeAuthRedirect`

## Test plan
- [x] Worker tests (701 pass)
- [ ] Prod: `/auth/reset` → « Se connecter » → GitHub OAuth (no `ERR_TOO_MANY_REDIRECTS`)