### PR TITLE
chore: promote staging to main (v0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.19.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.19.0...roxabi-live/v0.19.1) (2026-06-19)
+
+
+### Bug Fixes
+
+* **auth:** verify `setSessionTenant` row count before returning `linked` from install-refresh
+* **auth:** exclude suspended tenants from install-refresh and `/api/me` installations
+* **auth:** stop `mustReOAuth` when webhook already linked `user_installations` (install intent short-circuit)
+* **auth:** harden post-OAuth HTML against XSS (`sanitizeAuthRedirect`, `authNavigateHtml`)
+* **auth:** revoke other active sessions on OAuth success
+* **auth:** same-origin CSRF guard on POST mutations
+* **frontend:** use server `oauth_fallback`, surface consent errors, strict `onboarding_step` gate
+
+
+## [0.19.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.18.1...roxabi-live/v0.19.0) (2026-06-19)
+
+
+### Features
+
+* **auth:** server-owned onboarding (`onboarding_step` in `/api/me`) — install → consent → ready
+* **auth:** `POST /api/install/refresh` links installs via webhook without full re-OAuth
+* **auth:** `POST /api/consent` persists operator acknowledgement in D1
+* **auth:** OAuth completes with 200 + Set-Cookie + inline dashboard (drops `/auth/exchange` hop)
+* **auth:** login intents `?intent=signin|install|reauth|zk`
+* **webhook:** `installation.created` links sender → `user_installations`
+
+
+### Changed
+
+* **auth:** remove `/auth/continue`, `sessionRedirectHtml`, and `frontend/github-install.js` (−264 LOC net)
+
+
 ## [0.18.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.18.0...roxabi-live/v0.18.1) (2026-06-19)
 
 

--- a/artifacts/reviews/auth-refactor-v0.19.0-code-review.md
+++ b/artifacts/reviews/auth-refactor-v0.19.0-code-review.md
@@ -1,0 +1,130 @@
+# Code Review — Auth refactor v0.19.0
+
+**Scope:** `git diff 374421c6..HEAD` (31 files, −264 LOC net)  
+**Release:** `0.19.0`  
+**Date:** 2026-06-19  
+**Agents:** security-auditor, backend-dev, frontend-dev, tester
+
+---
+
+## Verdict: **Request changes**
+
+Direction is correct (server-owned onboarding, drop exchange hop, webhook install link). Ship fixes for **session-upgrade correctness**, **suspended-tenant filter**, **`mustReOAuth` over-trigger**, and **test gaps** on new routes before treating v0.19.0 as done.
+
+---
+
+## Blockers
+
+### issue: `setSessionTenant` success not verified before returning `status: "linked"`
+`worker/src/api/install-refresh.ts:49-60` — backend-dev — **Confidence: 90%**
+
+Handler mutates in-memory `s.tenantId` and returns `linked` even if D1 `UPDATE` affected 0 rows (expired session between middleware and handler).
+
+**Fix:** Check update row count or re-`validateSession`; return `401` on failure.
+
+---
+
+### issue: Suspended tenants not excluded from install-refresh auto-link
+`worker/src/api/install-refresh.ts:26-30` — backend-dev — **Confidence: 88%**
+
+Query filters `deleted_at` but not `suspended_at`. User can get `200 linked` then immediate `401` on next gated request.
+
+**Fix:** Add `AND t.suspended_at IS NULL`; mirror `active-tenant.ts` guards.
+
+---
+
+### issue: `mustReOAuth` forces full OAuth when webhook linked user but `tenantId` still null
+`worker/src/auth/oauth.ts:56-76` — backend-dev — **Confidence: 85%**
+
+`intent=install` + `tenantId === null` → OAuth even when `user_installations` already populated. Undermines `oauth_fallback` and install-refresh path.
+
+**Fix:** If `user_installations` count > 0, short-circuit to dashboard redirect (no GitHub).
+
+---
+
+### issue: XSS in `authNavigateHtml` slow-session fallback
+`worker/src/auth/post-oauth.ts:51` — security-auditor — **Confidence: 88%**
+
+`sanitizeAuthRedirect` allows `"`, `<`, `>` in paths; `innerHTML` concatenation with `next` enables XSS on ZK/reauth flows.
+
+**Fix:** HTML-encode `safeDest` in template or tighten redirect allowlist.
+
+---
+
+### issue: No route tests for `POST /api/install/refresh` or `POST /api/consent`
+— tester — **Confidence: 95%**
+
+New primary APIs untested; webhook sender link in `handlers-app.ts` also untested.
+
+**Fix:** Add `install-refresh.test.ts`, `consent.test.ts`, extend `handlers-app.test.ts` + `me.test.ts`.
+
+---
+
+## Warnings
+
+### suggestion: `oauth_fallback` returned by server but ignored by client
+`worker/src/api/install-refresh.ts:41` / `frontend/auth.js:167` — backend-dev, frontend-dev — **Confidence: 90%**
+
+Client hardcodes reconnect URL; server field is dead.
+
+**Fix:** Use `body.oauth_fallback` in install-timeout hint.
+
+---
+
+### suggestion: `ORDER BY tenant_id` picks wrong org for multi-install users
+`worker/src/api/install-refresh.ts:48` — backend-dev — **Confidence: 75%**
+
+Lowest PK ≠ installation just completed.
+
+**Fix:** Optional `installation_id` in POST body or skip auto-switch when count > 1.
+
+---
+
+### issue: Silent consent POST / auto-migration failures
+`frontend/auth.js:234-242`, `39-48` — frontend-dev — **Confidence: 85%**
+
+User gets no feedback on failure.
+
+**Fix:** Surface error in consent dialog / `#error-msg`.
+
+---
+
+### suggestion: CSRF defense-in-depth missing on POST mutations
+`worker/src/router.ts:102-106` — security-auditor — **Confidence: 75%**
+
+Relies on `SameSite=Lax` only; router comment incorrectly says `Strict` for logout.
+
+**Fix:** Origin/Referer host check on POST; fix comment.
+
+---
+
+### suggestion: Concurrent sessions not revoked on OAuth success
+`worker/src/auth/oauth.ts:353` — security-auditor — **Confidence: 80%**
+
+Each login mints new session without revoking prior tokens.
+
+**Fix:** Revoke other active sessions for `userId` on OAuth success.
+
+---
+
+### issue: Frontend gate tests removed without replacement
+`frontend/auth.test.js` — frontend-dev, tester — **Confidence: 90%**
+
+`requireAuthGate`, `pollInstallRefresh`, `migrateLegacyConsent` untested.
+
+**Fix:** Vitest mocks for step routing and install poll.
+
+---
+
+## Praise
+
+- **Post-OAuth 200 + Set-Cookie** eliminates exchange hop and redirect-loop class (`post-oauth.ts`, `oauth.ts`).
+- **Server-owned `onboarding_step`** centralizes install/consent/ready (`onboarding.ts`, `me.ts`).
+- **Webhook batching** for sender → `user_installations` is atomic and idempotent (`handlers-app.ts`).
+- **702 worker + 48 frontend tests green**; oauth callback paths updated for inline dashboard serve.
+
+---
+
+## Recommended next step
+
+**/fix** — address blockers 1–3 + XSS + minimal route tests, then re-review.

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -87,22 +87,32 @@ function renderInstallOption(opt) {
     </a>`;
 }
 
-async function pollInstallRefresh(maxAttempts = 15) {
+/** @returns {{ linked: object|null, oauthFallback: string }} */
+export async function pollInstallRefresh(maxAttempts = 20) {
+  let oauthFallback = '/login?intent=install&redirect=%2Fdashboard';
   for (let i = 0; i < maxAttempts; i++) {
     const resp = await fetch('/api/install/refresh', {
       method: 'POST',
       credentials: 'same-origin',
       cache: 'no-store',
     });
-    if (resp.status === 200) return resp.json();
+    if (resp.status === 401) throw new AuthError();
+    if (resp.status === 200) return { linked: await resp.json(), oauthFallback };
     if (resp.status === 202) {
       const body = await resp.json().catch(() => ({}));
+      if (body.oauth_fallback) oauthFallback = body.oauth_fallback;
       await new Promise(r => setTimeout(r, body.retry_after_ms ?? 2000));
       continue;
     }
     throw new Error(`/api/install/refresh ${resp.status}`);
   }
-  return null;
+  return { linked: null, oauthFallback };
+}
+
+export function onboardingStepFromMe(me) {
+  const step = me?.onboarding_step;
+  if (step === 'install' || step === 'consent' || step === 'ready') return step;
+  throw new Error('invalid onboarding_step');
 }
 
 function renderInstallCta(me) {
@@ -157,21 +167,25 @@ function renderInstallCta(me) {
     btn.disabled = true;
     btn.textContent = 'Vérification…';
     try {
-      const refreshed = await pollInstallRefresh();
-      if (refreshed?.onboarding_step) {
+      const { linked, oauthFallback } = await pollInstallRefresh();
+      if (linked?.onboarding_step) {
         location.reload();
         return;
       }
       if (hint) {
         hint.hidden = false;
+        const fallback = escHtml(oauthFallback);
         hint.innerHTML =
-          'Installation pas encore détectée. Attendez quelques secondes et réessayez, ou ' +
-          '<a href="/login?intent=install&amp;redirect=%2Fdashboard">reconnectez-vous via GitHub</a>.';
+          'Installation pas encore détectée après plusieurs tentatives. Réessayez ou ' +
+          `<a href="${fallback}">reconnectez-vous via GitHub</a>.`;
       }
-    } catch {
+    } catch (e) {
       if (hint) {
         hint.hidden = false;
-        hint.textContent = 'Erreur réseau — réessayez dans un instant.';
+        hint.textContent =
+          e instanceof AuthError
+            ? 'Session expirée — rechargez la page ou reconnectez-vous.'
+            : 'Erreur réseau — réessayez dans un instant.';
       }
     } finally {
       btn.disabled = false;
@@ -206,6 +220,7 @@ function renderConsentGate(me) {
           <strong>Les titres et corps d'issues sont chiffrés côté client avant stockage.</strong>
           La structure du graphe (état, blockers, labels) reste lisible par l'opérateur.
         </p>
+        <p class="consent-error" id="consent-error" hidden role="alert"></p>
         <div class="consent-actions">
           <button class="consent-btn-secondary" id="consent-logout">Se déconnecter</button>
           <button class="consent-btn-primary" id="consent-ack">J'ai compris — lancer la synchronisation</button>
@@ -233,12 +248,20 @@ function renderConsentGate(me) {
 
     ackBtn.addEventListener('click', async () => {
       ackBtn.disabled = true;
+      const errEl = $('consent-error');
+      if (errEl) errEl.hidden = true;
       try {
         await api('/api/consent', { method: 'POST' });
+        clearLegacyConsent(me.user.github_login);
         el.setAttribute('hidden', '');
         resolve();
       } catch {
         ackBtn.disabled = false;
+        if (errEl) {
+          errEl.hidden = false;
+          errEl.textContent =
+            'Enregistrement impossible — vérifiez votre connexion et réessayez.';
+        }
       }
     });
 
@@ -312,7 +335,13 @@ export async function requireAuthGate() {
   }
 
   me = await migrateLegacyConsent(me);
-  const step = me.onboarding_step ?? 'install';
+  let step;
+  try {
+    step = onboardingStepFromMe(me);
+  } catch {
+    showSessionLost();
+    return 'landing';
+  }
 
   if (step === 'install') {
     renderInstallCta(me);

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AuthError, api, escHtml, loginUrl, DASHBOARD_PATH } from './auth.js';
+import {
+  AuthError,
+  api,
+  escHtml,
+  loginUrl,
+  DASHBOARD_PATH,
+  pollInstallRefresh,
+  onboardingStepFromMe,
+} from './auth.js';
 
 describe('loginUrl', () => {
   it('defaults redirect to dashboard', () => {
@@ -24,5 +32,61 @@ describe('api', () => {
   it('throws AuthError on 401', async () => {
     fetch.mockResolvedValue({ status: 401, ok: false });
     await expect(api('/api/me')).rejects.toBeInstanceOf(AuthError);
+  });
+});
+
+describe('onboardingStepFromMe', () => {
+  it('returns valid onboarding steps', () => {
+    expect(onboardingStepFromMe({ onboarding_step: 'install' })).toBe('install');
+    expect(onboardingStepFromMe({ onboarding_step: 'consent' })).toBe('consent');
+    expect(onboardingStepFromMe({ onboarding_step: 'ready' })).toBe('ready');
+  });
+
+  it('throws when onboarding_step is missing or invalid', () => {
+    expect(() => onboardingStepFromMe({})).toThrow('invalid onboarding_step');
+    expect(() => onboardingStepFromMe({ onboarding_step: 'bogus' })).toThrow();
+  });
+});
+
+describe('pollInstallRefresh', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns linked payload on 200', async () => {
+    fetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ status: 'linked', onboarding_step: 'consent' }),
+    });
+    const { linked } = await pollInstallRefresh(1);
+    expect(linked.onboarding_step).toBe('consent');
+  });
+
+  it('captures oauth_fallback from 202 responses', async () => {
+    fetch
+      .mockResolvedValueOnce({
+        status: 202,
+        ok: false,
+        json: async () => ({
+          retry_after_ms: 1,
+          oauth_fallback: '/login?intent=install&redirect=%2Ffoo',
+        }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({ status: 'linked' }),
+      });
+    const { oauthFallback } = await pollInstallRefresh(2);
+    expect(oauthFallback).toBe('/login?intent=install&redirect=%2Ffoo');
+  });
+
+  it('throws AuthError on 401', async () => {
+    fetch.mockResolvedValueOnce({ status: 401, ok: false });
+    await expect(pollInstallRefresh(1)).rejects.toBeInstanceOf(AuthError);
   });
 });

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -42,9 +42,11 @@ export function openSettings(me) {
   const displayName = getDisplayName(login);
   const themePref = getThemePref();
   const installations = me.installations ?? [];
-  const personalOpt = (me.install_options ?? []).find(o => o.kind === 'personal');
-  const pickerOpt = (me.install_options ?? []).find(o => o.kind === 'picker');
-  const installUrl = personalOpt?.url ?? pickerOpt?.url ?? 'https://github.com/apps/roxabi-live/installations/new';
+  const installUrl =
+    (me.install_options ?? []).find(o => o.kind === 'personal')?.url ??
+    (me.install_options ?? []).find(o => o.kind === 'picker')?.url ??
+    (me.install_options ?? [])[0]?.url ??
+    null;
 
   gate.innerHTML = `
     <div class="settings-dialog" role="dialog" aria-modal="true" aria-labelledby="settings-title">

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,11 +14,12 @@ worker/src/webhook/mutations.ts  # 339 lines — #180 D1 write helpers for webho
 worker/src/sync/sync.test.ts  # 1729 lines — #180 integration harness for runSync; #216 structure-only
 worker/src/api/zk-key-backup.test.ts  # 506 lines — #216 backup API security + CAS/reauth tests; fp enforcement + atomic UPSERT tests
 worker/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-worker/src/auth/oauth.test.ts  # 1112 lines — #180 OAuth + install-pending; login prompt step-1 + redirect-loop guards
+worker/src/auth/oauth.test.ts  # 1145 lines — #180 OAuth + install-pending; mustReOAuth webhook-link short-circuit
 worker/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 worker/src/api/graph.test.ts  # 745 lines — #180 tenant-scoped graph + #142 S2 zk + closed_under_open_epic
 worker/src/migrations.test.ts  # 323 lines — schema tests incl. users.consent_at (0020)
 worker/src/webhook/mutations.test.ts  # 587 lines — #180 webhook mutation tests
-worker/src/webhook/handlers-app.test.ts  # 498 lines — #180 app lifecycle handler tests
+worker/src/webhook/handlers-app.test.ts  # 516 lines — #180 app lifecycle + sender→user_installations tests
 worker/src/auth/installToken.test.ts  # 470 lines — #180 install token + pagination tests
-worker/src/auth/session.test.ts  # 343 lines — #180 session + install-pending SQL guard; sessionRedirectHtml cookie tests
+worker/src/auth/session.test.ts  # 357 lines — #180 session + authNavigateHtml XSS guard tests
+worker/src/api/me.test.ts  # 335 lines — onboarding_step + install_options + suspended tenant filter tests

--- a/worker/src/api/consent.test.ts
+++ b/worker/src/api/consent.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import { consentRoute } from "./consent";
+import { captureDb, dispatchByTable, makeEnv, STUB_SESSION } from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const SESSION: SessionContext = {
+  ...STUB_SESSION,
+  tenantId: 9,
+};
+
+function makeApp(session?: SessionContext): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  if (session) {
+    app.use("*", async (c, next) => {
+      c.set("session", session);
+      await next();
+    });
+  }
+  app.post("/api/consent", consentRoute);
+  return app;
+}
+
+async function postConsent(app: Hono<AuthEnv>, db: D1Database): Promise<Response> {
+  return await app.request("/api/consent", { method: "POST" }, makeEnv(db));
+}
+
+describe("consentRoute", () => {
+  it("returns 401 when session is missing", async () => {
+    const { db } = captureDb();
+    const res = await postConsent(makeApp(), db);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when user row is missing", async () => {
+    const { db } = captureDb(() => []);
+    const res = await postConsent(makeApp(SESSION), db);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns consent_at and full me payload on success", async () => {
+    const consentAt = "2026-06-19T12:00:00Z";
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        consent_at: [{ consent_at: consentAt }],
+        users: [
+          {
+            zk_opt_in: 0,
+            install_targets_json: null,
+            consent_at: consentAt,
+          },
+        ],
+        user_installations: [
+          { tenant_id: 9, account_login: "Roxabi", account_type: "Organization" },
+        ],
+      }),
+    );
+    const res = await postConsent(makeApp(SESSION), db);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      consent_at: string;
+      onboarding_step: string;
+      user: { github_login: string };
+    };
+    expect(body.consent_at).toBe(consentAt);
+    expect(body.onboarding_step).toBe("ready");
+    expect(body.user.github_login).toBe(SESSION.githubLogin);
+  });
+
+  it("UPDATE uses COALESCE to keep existing consent_at", async () => {
+    const { db, stmts } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        consent_at: [{ consent_at: "2026-01-01T00:00:00Z" }],
+        users: [
+          {
+            zk_opt_in: 0,
+            install_targets_json: null,
+            consent_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        user_installations: [
+          { tenant_id: 9, account_login: "Roxabi", account_type: "Organization" },
+        ],
+      }),
+    );
+    await postConsent(makeApp(SESSION), db);
+    const updateStmt = stmts().find((s) => s.sql.includes("consent_at"));
+    expect(updateStmt).toBeDefined();
+    expect(updateStmt!.sql).toContain("COALESCE(consent_at");
+  });
+});

--- a/worker/src/api/consent.ts
+++ b/worker/src/api/consent.ts
@@ -4,6 +4,7 @@
 
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
+import { buildMePayload } from "./me";
 
 export async function consentRoute(c: Context<AuthEnv>): Promise<Response> {
   const s = c.get("session");
@@ -23,5 +24,6 @@ export async function consentRoute(c: Context<AuthEnv>): Promise<Response> {
     return c.json({ error: "not_found" }, 404);
   }
 
-  return c.json({ consent_at: row.consent_at, onboarding_step: "ready" });
+  const payload = await buildMePayload(c.env, s);
+  return c.json({ ...payload, consent_at: row.consent_at });
 }

--- a/worker/src/api/install-refresh.test.ts
+++ b/worker/src/api/install-refresh.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv, SessionContext } from "../auth/types";
+import {
+  installRefreshRoute,
+  OAUTH_FALLBACK,
+} from "./install-refresh";
+import {
+  captureDb,
+  dispatchByTable,
+  makeEnv,
+  makeFakeStmt,
+  makeFakeDb,
+  type FakeResult,
+} from "../test-utils";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const RAW_TOKEN = "a".repeat(64);
+const COOKIE = `roxabi_session=${RAW_TOKEN}`;
+
+const PENDING_SESSION: SessionContext = {
+  userId: 7,
+  tenantId: null,
+  githubId: 42,
+  githubLogin: "alice",
+};
+
+function makeApp(
+  session: SessionContext | undefined,
+): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  if (session) {
+    app.use("*", async (c, next) => {
+      c.set("session", session);
+      await next();
+    });
+  }
+  app.post("/api/install/refresh", installRefreshRoute);
+  return app;
+}
+
+function meRows(): FakeResult[] {
+  return [{ zk_opt_in: 0, install_targets_json: null, consent_at: null }];
+}
+
+async function postRefresh(
+  app: Hono<AuthEnv>,
+  db: D1Database,
+  cookie?: string,
+): Promise<Response> {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.Cookie = cookie;
+  return await app.request(
+    "/api/install/refresh",
+    { method: "POST", headers },
+    makeEnv(db),
+  );
+}
+
+describe("installRefreshRoute", () => {
+  it("returns 401 when session is missing", async () => {
+    const { db } = captureDb();
+    const res = await postRefresh(makeApp(undefined), db);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 202 pending when user has no linked installations", async () => {
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_installations: [],
+        users: meRows(),
+      }),
+    );
+    const res = await postRefresh(makeApp(PENDING_SESSION), db, COOKIE);
+    expect(res.status).toBe(202);
+    const body = await res.json() as {
+      status: string;
+      retry_after_ms: number;
+      oauth_fallback: string;
+    };
+    expect(body.status).toBe("pending");
+    expect(body.retry_after_ms).toBe(2000);
+    expect(body.oauth_fallback).toBe(OAUTH_FALLBACK);
+  });
+
+  it("installations query excludes suspended tenants", async () => {
+    const { db, stmts } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_installations: [],
+        users: meRows(),
+      }),
+    );
+    await postRefresh(makeApp(PENDING_SESSION), db, COOKIE);
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt!.sql).toContain("suspended_at IS NULL");
+  });
+
+  it("returns 200 linked with me payload when installations exist", async () => {
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_installations: [
+          { tenant_id: 9, account_login: "Roxabi", account_type: "Organization" },
+        ],
+        users: meRows(),
+      }),
+    );
+    const linkedSession: SessionContext = { ...PENDING_SESSION, tenantId: 9 };
+    const res = await postRefresh(makeApp(linkedSession), db, COOKIE);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      status: string;
+      onboarding_step: string;
+      installations: unknown[];
+    };
+    expect(body.status).toBe("linked");
+    expect(body.onboarding_step).toBe("consent");
+    expect(body.installations).toHaveLength(1);
+  });
+
+  it("auto-switches tenant only when exactly one installation", async () => {
+    const captured: ReturnType<typeof makeFakeStmt>[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const rows: FakeResult[] = [];
+      if (sql.includes("user_installations") && sql.includes("SELECT")) {
+        rows.push({
+          tenant_id: 5,
+          account_login: "solo",
+          account_type: "User",
+        });
+      } else if (sql.includes("zk_opt_in") || sql.includes("install_targets_json")) {
+        rows.push(...meRows());
+      }
+      const changes = sql.includes("UPDATE sessions SET tenant_id") ? 1 : 0;
+      const stmt = makeFakeStmt(sql, args, rows, changes);
+      captured.push(stmt);
+      return stmt;
+    });
+
+    const res = await postRefresh(makeApp(PENDING_SESSION), db, COOKIE);
+    expect(res.status).toBe(200);
+    const updateStmt = captured.find((s) =>
+      s.sql.includes("UPDATE sessions SET tenant_id"),
+    );
+    expect(updateStmt).toBeDefined();
+    expect(updateStmt!.args[0]).toBe(5);
+  });
+
+  it("skips auto-switch when multiple installations exist", async () => {
+    const captured: ReturnType<typeof makeFakeStmt>[] = [];
+    const db = makeFakeDb((sql, args) => {
+      const rows: FakeResult[] = [];
+      if (sql.includes("user_installations") && sql.includes("SELECT")) {
+        rows.push(
+          { tenant_id: 5, account_login: "a", account_type: "User" },
+          { tenant_id: 6, account_login: "b", account_type: "Organization" },
+        );
+      } else if (sql.includes("zk_opt_in") || sql.includes("install_targets_json")) {
+        rows.push(...meRows());
+      }
+      const stmt = makeFakeStmt(sql, args, rows, 0);
+      captured.push(stmt);
+      return stmt;
+    });
+
+    const res = await postRefresh(makeApp(PENDING_SESSION), db, COOKIE);
+    expect(res.status).toBe(200);
+    const updateStmt = captured.find((s) =>
+      s.sql.includes("UPDATE sessions SET tenant_id"),
+    );
+    expect(updateStmt).toBeUndefined();
+  });
+
+  it("returns 401 when setSessionTenant affects zero rows", async () => {
+    const { db } = captureDb((sql) =>
+      dispatchByTable(sql, {
+        user_installations: [
+          { tenant_id: 5, account_login: "solo", account_type: "User" },
+        ],
+        users: meRows(),
+      }),
+    );
+    const res = await postRefresh(makeApp(PENDING_SESSION), db, COOKIE);
+    expect(res.status).toBe(401);
+  });
+});

--- a/worker/src/api/install-refresh.ts
+++ b/worker/src/api/install-refresh.ts
@@ -11,7 +11,13 @@ import { readSessionToken } from "../auth/cookies";
 import { setSessionTenant } from "../auth/session";
 import { buildMePayload } from "./me";
 
-const OAUTH_FALLBACK = "/login?intent=install&redirect=%2Fdashboard";
+export const OAUTH_FALLBACK = "/login?intent=install&redirect=%2Fdashboard";
+
+const INSTALLATIONS_SQL = `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
+       FROM user_installations ui
+       JOIN tenants t ON t.id = ui.tenant_id
+       WHERE ui.user_id = ? AND t.deleted_at IS NULL AND t.suspended_at IS NULL
+       ORDER BY ui.tenant_id`;
 
 export async function installRefreshRoute(
   c: Context<AuthEnv>,
@@ -21,14 +27,7 @@ export async function installRefreshRoute(
     return c.json({ error: "unauthorized" }, 401);
   }
 
-  const rows = await c.env.DB
-    .prepare(
-      `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
-       FROM user_installations ui
-       JOIN tenants t ON t.id = ui.tenant_id
-       WHERE ui.user_id = ? AND t.deleted_at IS NULL
-       ORDER BY ui.tenant_id`,
-    )
+  const rows = await c.env.DB.prepare(INSTALLATIONS_SQL)
     .bind(s.userId)
     .all<{ tenant_id: number; account_login: string; account_type: string }>();
 
@@ -44,18 +43,29 @@ export async function installRefreshRoute(
     );
   }
 
+  let activeTenantId = s.tenantId;
   const rawToken = readSessionToken(c);
-  const firstTenantId = installations[0].tenant_id;
-  if (rawToken && s.tenantId == null) {
-    await setSessionTenant(c.env.DB, rawToken, firstTenantId);
+
+  if (rawToken && activeTenantId == null && installations.length === 1) {
+    const upgraded = await setSessionTenant(
+      c.env.DB,
+      rawToken,
+      installations[0].tenant_id,
+    );
+    if (!upgraded) {
+      return c.json({ error: "unauthorized" }, 401);
+    }
     await c.env.DB.prepare(
       `UPDATE users SET install_targets_json = NULL, updated_at = datetime('now') WHERE id = ?`,
     )
       .bind(s.userId)
       .run();
-    s.tenantId = firstTenantId;
+    activeTenantId = installations[0].tenant_id;
   }
 
-  const payload = await buildMePayload(c.env, { ...s, tenantId: s.tenantId ?? firstTenantId });
+  const payload = await buildMePayload(c.env, {
+    ...s,
+    tenantId: activeTenantId,
+  });
   return c.json({ status: "linked", ...payload });
 }

--- a/worker/src/api/me.test.ts
+++ b/worker/src/api/me.test.ts
@@ -270,6 +270,63 @@ describe("meRoute", () => {
     expect(installStmt!.sql).toContain("deleted_at IS NULL");
   });
 
+  it("installations SELECT filters suspended tenants", async () => {
+    const { db, stmts } = captureDb();
+    await makeApp(db).request("/api/me", {}, makeEnv(db));
+    const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
+    expect(installStmt!.sql).toContain("suspended_at IS NULL");
+  });
+
+  it("returns onboarding_step install when session has no tenant", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("install_targets_json")) {
+        return [{ zk_opt_in: 0, install_targets_json: "[]", consent_at: null }];
+      }
+      if (sql.includes("user_installations")) return [];
+      return [];
+    });
+    const pendingSession: SessionContext = { ...STUB_SESSION, tenantId: null };
+    const res = await makeApp(db, pendingSession).request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as { onboarding_step: string };
+    expect(body.onboarding_step).toBe("install");
+  });
+
+  it("returns onboarding_step consent when linked but not consented", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("install_targets_json")) {
+        return [{ zk_opt_in: 0, install_targets_json: null, consent_at: null }];
+      }
+      if (sql.includes("user_installations")) {
+        return [{ tenant_id: 9, account_login: "Roxabi", account_type: "Organization" }];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as { onboarding_step: string; consent_at: null };
+    expect(body.onboarding_step).toBe("consent");
+    expect(body.consent_at).toBeNull();
+  });
+
+  it("returns install_options when install is pending", async () => {
+    const targetsJson = JSON.stringify([
+      { id: 42, login: "alice", type: "User" },
+    ]);
+    const { db } = captureDb((sql) => {
+      if (sql.includes("install_targets_json")) {
+        return [{ zk_opt_in: 0, install_targets_json: targetsJson, consent_at: null }];
+      }
+      if (sql.includes("user_installations")) return [];
+      return [];
+    });
+    const pendingSession: SessionContext = { ...STUB_SESSION, tenantId: null };
+    const res = await makeApp(db, pendingSession).request("/api/me", {}, makeEnv(db));
+    const body = await res.json() as {
+      install_options: Array<{ kind: string; login?: string }>;
+    };
+    expect(body.install_options[0]?.kind).toBe("personal");
+    expect(body.install_options[0]?.login).toBe("alice");
+  });
+
   it("installations SELECT projects account_type (#148 SC7)", async () => {
     // Arrange
     const { db, stmts } = captureDb();

--- a/worker/src/api/me.ts
+++ b/worker/src/api/me.ts
@@ -67,7 +67,7 @@ export async function buildMePayload(
       `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
        FROM user_installations ui
        JOIN tenants t ON t.id = ui.tenant_id
-       WHERE ui.user_id = ? AND t.deleted_at IS NULL`,
+       WHERE ui.user_id = ? AND t.deleted_at IS NULL AND t.suspended_at IS NULL`,
     )
     .bind(session.userId)
     .all<{ tenant_id: number; account_login: string; account_type: string }>();

--- a/worker/src/auth/cookies.test.ts
+++ b/worker/src/auth/cookies.test.ts
@@ -19,4 +19,10 @@ describe("sanitizeAuthRedirect", () => {
     expect(sanitizeAuthRedirect("//evil")).toBe("/dashboard");
     expect(sanitizeAuthRedirect("https://evil")).toBe("/dashboard");
   });
+
+  it("rejects paths containing quotes or angle brackets", () => {
+    expect(sanitizeAuthRedirect('/x" onclick')).toBe("/dashboard");
+    expect(sanitizeAuthRedirect("/x<script>")).toBe("/dashboard");
+    expect(sanitizeAuthRedirect("/x'y")).toBe("/dashboard");
+  });
 });

--- a/worker/src/auth/cookies.ts
+++ b/worker/src/auth/cookies.ts
@@ -35,7 +35,11 @@ export function sanitizeAuthRedirect(raw: string | undefined): string {
     }
   }
 
-  if (/^\/(?![/\\])/.test(candidate) && !/[\r\n\0]/.test(candidate)) {
+  if (
+    /^\/(?![/\\])/.test(candidate) &&
+    !/[\r\n\0]/.test(candidate) &&
+    !/["'<>]/.test(candidate)
+  ) {
     return candidate;
   }
   return "/dashboard";

--- a/worker/src/auth/csrf.test.ts
+++ b/worker/src/auth/csrf.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv } from "./types";
+import { requireSameOriginPost } from "./csrf";
+import { makeEnv, captureDb } from "../test-utils";
+
+function makeApp(): Hono<AuthEnv> {
+  const app = new Hono<AuthEnv>();
+  app.post("/api/mutate", requireSameOriginPost, (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("requireSameOriginPost", () => {
+  it("allows POST with matching Origin", async () => {
+    const { db } = captureDb();
+    const res = await makeApp().request(
+      "https://live.roxabi.dev/api/mutate",
+      {
+        method: "POST",
+        headers: { Origin: "https://live.roxabi.dev" },
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects POST with mismatched Origin", async () => {
+    const { db } = captureDb();
+    const res = await makeApp().request(
+      "https://live.roxabi.dev/api/mutate",
+      {
+        method: "POST",
+        headers: { Origin: "https://evil.example" },
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("allows POST with matching Referer when Origin is absent", async () => {
+    const { db } = captureDb();
+    const res = await makeApp().request(
+      "https://live.roxabi.dev/api/mutate",
+      {
+        method: "POST",
+        headers: { Referer: "https://live.roxabi.dev/dashboard" },
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects POST with mismatched Referer", async () => {
+    const { db } = captureDb();
+    const res = await makeApp().request(
+      "https://live.roxabi.dev/api/mutate",
+      {
+        method: "POST",
+        headers: { Referer: "https://evil.example/phish" },
+      },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("allows POST when neither Origin nor Referer is present", async () => {
+    const { db } = captureDb();
+    const res = await makeApp().request(
+      "https://live.roxabi.dev/api/mutate",
+      { method: "POST" },
+      makeEnv(db),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/worker/src/auth/csrf.ts
+++ b/worker/src/auth/csrf.ts
@@ -1,0 +1,45 @@
+/**
+ * Same-origin guard for cookie-authenticated POST mutations.
+ */
+
+import type { MiddlewareHandler } from "hono";
+import type { AuthEnv } from "./types";
+
+function requestHost(c: { req: { url: string; header: (n: string) => string | undefined } }): string {
+  return new URL(c.req.url).host;
+}
+
+function originHost(origin: string): string | null {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return null;
+  }
+}
+
+/** Reject cross-site POST when Origin/Referer is present and mismatched. */
+export const requireSameOriginPost: MiddlewareHandler<AuthEnv> = async (c, next) => {
+  const expected = requestHost(c);
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const host = originHost(origin);
+    if (host && host !== expected) {
+      return c.json({ error: "forbidden" }, 403);
+    }
+    await next();
+    return;
+  }
+
+  const referer = c.req.header("Referer");
+  if (referer) {
+    try {
+      if (new URL(referer).host !== expected) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+    } catch {
+      return c.json({ error: "forbidden" }, 403);
+    }
+  }
+
+  await next();
+};

--- a/worker/src/auth/oauth.test.ts
+++ b/worker/src/auth/oauth.test.ts
@@ -443,14 +443,23 @@ describe("loginRoute", () => {
         githubLogin: "alice",
       };
       const db = {
-        prepare: vi.fn(() => ({
-          first: vi.fn().mockResolvedValue(validRow),
-          run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
-          all: vi.fn().mockResolvedValue({ results: [] }),
-          bind: vi.fn(function (this: unknown) {
-            return this;
-          }),
-        })),
+        prepare: vi.fn((sql: string) => {
+          const stmt = {
+            sql,
+            first: vi.fn().mockImplementation(function (this: { sql: string }) {
+              if (this.sql.toLowerCase().includes("count")) {
+                return Promise.resolve({ n: 0 });
+              }
+              return Promise.resolve(validRow);
+            }),
+            run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+            all: vi.fn().mockResolvedValue({ results: [] }),
+            bind: vi.fn(function (this: unknown) {
+              return this;
+            }),
+          };
+          return stmt;
+        }),
         batch: vi.fn().mockResolvedValue([]),
         dump: vi.fn(),
         exec: vi.fn(),
@@ -470,6 +479,51 @@ describe("loginRoute", () => {
       expect(res.headers.get("Location")).toMatch(
         /^https:\/\/github\.com\/login\/oauth\/authorize/,
       );
+    });
+
+    it("short-circuits install intent when webhook already linked user_installations", async () => {
+      const validRow = {
+        userId: 1,
+        tenantId: null,
+        githubId: 42,
+        githubLogin: "alice",
+      };
+      const db = {
+        prepare: vi.fn((sql: string) => {
+          const stmt = {
+            sql,
+            first: vi.fn().mockImplementation(function (this: { sql: string }) {
+              if (this.sql.toLowerCase().includes("count")) {
+                return Promise.resolve({ n: 1 });
+              }
+              return Promise.resolve(validRow);
+            }),
+            run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+            all: vi.fn().mockResolvedValue({ results: [] }),
+            bind: vi.fn(function (this: unknown) {
+              return this;
+            }),
+          };
+          return stmt;
+        }),
+        batch: vi.fn().mockResolvedValue([]),
+        dump: vi.fn(),
+        exec: vi.fn(),
+      } as unknown as D1Database;
+
+      const { app, env } = makeApp(db);
+      const res = await app.request(
+        "http://localhost/login?install=1&redirect=%2Fdashboard",
+        {
+          method: "GET",
+          headers: { Cookie: `roxabi_session=${"a".repeat(64)}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard");
+      expect(res.headers.get("Location")).not.toMatch(/^https:\/\/github\.com/);
     });
   });
 });

--- a/worker/src/auth/oauth.ts
+++ b/worker/src/auth/oauth.ts
@@ -10,7 +10,7 @@
 
 import type { Context } from "hono";
 import type { Env } from "../types";
-import { mintSession } from "./session";
+import { mintSession, revokeOtherSessions } from "./session";
 import {
   authRedirect,
   readSessionToken,
@@ -83,17 +83,18 @@ async function mustReOAuth(c: Context<{ Bindings: Env }>): Promise<boolean> {
   if (!token) return true;
   const session = await validateSession(c.env.DB, token);
   if (!session) return true;
-  if (session.tenantId === null) return true;
 
   const linked = await c.env.DB.prepare(
     `SELECT COUNT(*) AS n FROM user_installations ui
-     JOIN tenants t ON t.id = ui.tenant_id AND t.deleted_at IS NULL
+     JOIN tenants t ON t.id = ui.tenant_id AND t.deleted_at IS NULL AND t.suspended_at IS NULL
      WHERE ui.user_id = ?`,
   )
     .bind(session.userId)
     .first<{ n: number }>();
 
-  return (linked?.n ?? 0) === 0;
+  if ((linked?.n ?? 0) > 0) return false;
+  if (session.tenantId !== null) return false;
+  return true;
 }
 
 export async function loginRoute(
@@ -291,6 +292,7 @@ export async function callbackRoute(
     }
 
     const rawToken = await mintSession(c.env.DB, userRow.id, null);
+    await revokeOtherSessions(c.env.DB, userRow.id, rawToken);
     return completeOAuthSession(c, rawToken, redirectAfter);
   }
 
@@ -351,6 +353,7 @@ export async function callbackRoute(
 
   // Mint session tied to the first installation's tenant
   const rawToken = await mintSession(c.env.DB, userId, firstTenantId);
+  await revokeOtherSessions(c.env.DB, userId, rawToken);
 
   if (wantsReauth) {
     const reauthCode = await createZkReauthCode(c.env, userId);

--- a/worker/src/auth/post-oauth.ts
+++ b/worker/src/auth/post-oauth.ts
@@ -24,6 +24,15 @@ function destHasZkParams(path: string): boolean {
   );
 }
 
+function htmlAttrEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/'/g, "&#x27;");
+}
+
 /** 200 HTML: poll /api/me until cookie is live, then location.replace(dest). */
 export function authNavigateHtml(
   dest: string,
@@ -43,30 +52,31 @@ export function authNavigateHtml(
   var tries = 0;
   var max = 40;
   function go() { location.replace(next); }
+  function showSlowLink() {
+    var msg = document.getElementById("msg");
+    msg.textContent = "";
+    var a = document.createElement("a");
+    a.href = next;
+    a.textContent = "continuer";
+    msg.appendChild(document.createTextNode("Session lente — "));
+    msg.appendChild(a);
+  }
   function poll() {
     fetch("/api/me", { credentials: "same-origin", cache: "no-store" })
       .then(function (r) {
         if (r.ok) return go();
-        if (++tries >= max) {
-          document.getElementById("msg").innerHTML =
-            'Session lente — <a href="' + next + '">continuer</a>';
-          return;
-        }
+        if (++tries >= max) return showSlowLink();
         setTimeout(poll, 150);
       })
       .catch(function () {
-        if (++tries >= max) {
-          document.getElementById("msg").innerHTML =
-            'Session lente — <a href="' + next + '">continuer</a>';
-          return;
-        }
+        if (++tries >= max) return showSlowLink();
         setTimeout(poll, 150);
       });
   }
   setTimeout(poll, 50);
 })(${JSON.stringify(safeDest)});
 </script>
-<noscript><p><a href="${encodeURI(safeDest)}">Continuer</a></p></noscript>
+<noscript><p><a href="${htmlAttrEscape(safeDest)}">Continuer</a></p></noscript>
 </body>
 </html>`;
   const headers = new Headers({

--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -444,6 +444,22 @@ describe("authNavigateHtml", () => {
     expect(body).toContain("/dashboard");
     expect(body).not.toContain("//evil");
   });
+
+  it("rejects XSS payloads in redirect paths", async () => {
+    const res = authNavigateHtml('/dashboard" onclick="alert(1)');
+    const body = await res.text();
+    expect(body).not.toContain("onclick");
+    expect(body).toContain("/dashboard");
+  });
+
+  it("renders safe noscript fallback link for ZK destinations", async () => {
+    const res = authNavigateHtml("/dashboard?zk_handoff=abc");
+    const body = await res.text();
+    expect(body).toMatch(
+      /<noscript><p><a href="\/dashboard\?zk_handoff=abc">Continuer<\/a><\/p><\/noscript>/,
+    );
+    expect(body).not.toContain("<script>alert");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/worker/src/auth/session.ts
+++ b/worker/src/auth/session.ts
@@ -102,10 +102,10 @@ export async function setSessionTenant(
   db: D1Database,
   rawToken: string,
   tenantId: number,
-): Promise<void> {
+): Promise<boolean> {
   const hash = await sha256hex(rawToken);
 
-  await db
+  const result = await db
     .prepare(
       `UPDATE sessions SET tenant_id = ?
        WHERE token_hash = ?
@@ -113,6 +113,24 @@ export async function setSessionTenant(
          AND expires_at > datetime('now')`,
     )
     .bind(tenantId, hash)
+    .run();
+
+  return (result.meta?.changes ?? 0) > 0;
+}
+
+/** Revoke all other active sessions for a user (keep current token). */
+export async function revokeOtherSessions(
+  db: D1Database,
+  userId: number,
+  keepRawToken: string,
+): Promise<void> {
+  const hash = await sha256hex(keepRawToken);
+  await db
+    .prepare(
+      `UPDATE sessions SET revoked_at = datetime('now')
+       WHERE user_id = ? AND token_hash != ? AND revoked_at IS NULL`,
+    )
+    .bind(userId, hash)
     .run();
 }
 

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -17,6 +17,7 @@ import { dashboardRoute } from "./auth/dashboard-route";
 import { meRoute, logoutRoute } from "./api/me";
 import type { AuthEnv } from "./auth/types";
 import { requireSession, requireLinkedTenant } from "./auth/session";
+import { requireSameOriginPost } from "./auth/csrf";
 import { installCompleteRoute } from "./api/install-complete";
 import { activeTenantRoute } from "./api/active-tenant";
 import { zkOptInRoute } from "./api/zk-opt-in";
@@ -99,26 +100,26 @@ app.get("/auth/status", authStatusRoute);
 app.get("/install/complete", installCompleteRoute);
 app.use("/api/me", requireSession);
 app.get("/api/me", meRoute);
-app.post("/api/consent", requireLinkedTenant, consentRoute);
-app.post("/api/install/refresh", requireSession, installRefreshRoute);
+app.post("/api/consent", requireSameOriginPost, requireLinkedTenant, consentRoute);
+app.post("/api/install/refresh", requireSameOriginPost, requireSession, installRefreshRoute);
 app.use("/api/sync/status", requireLinkedTenant);
 app.get("/api/sync/status", syncStatusRoute);
-app.post("/api/active-tenant", requireLinkedTenant, activeTenantRoute);
-app.post("/api/zk-opt-in", requireLinkedTenant, zkOptInRoute);
+app.post("/api/active-tenant", requireSameOriginPost, requireLinkedTenant, activeTenantRoute);
+app.post("/api/zk-opt-in", requireSameOriginPost, requireLinkedTenant, zkOptInRoute);
 app.use("/api/zk/payloads", requireLinkedTenant);
 app.get("/api/zk/payloads", listZkPayloadsRoute);
 app.put("/api/zk/payloads", putZkPayloadsRoute);
-app.post("/api/zk/consume-handoff", requireLinkedTenant, consumeZkHandoffRoute);
-app.post("/api/zk/consume-reauth", requireLinkedTenant, consumeZkReauthRoute);
+app.post("/api/zk/consume-handoff", requireSameOriginPost, requireLinkedTenant, consumeZkHandoffRoute);
+app.post("/api/zk/consume-reauth", requireSameOriginPost, requireLinkedTenant, consumeZkReauthRoute);
 app.use("/api/zk/key-backup", requireLinkedTenant);
 app.get("/api/zk/key-backup", getZkKeyBackupRoute);
 app.put("/api/zk/key-backup", putZkKeyBackupRoute);
 app.use("/api/zk/reset", requireLinkedTenant);
-app.post("/api/zk/reset", postZkResetRoute);
-app.post("/api/zk/github/graphql", requireLinkedTenant, zkGithubGraphqlRoute);
-// /logout is intentionally ungated: logoutRoute is null-safe + idempotent, and SameSite=Strict
-// blocks cross-site cookie submission — gating it would make a stale/expired cookie impossible to clear.
-app.post("/logout", logoutRoute);
+app.post("/api/zk/reset", requireSameOriginPost, postZkResetRoute);
+app.post("/api/zk/github/graphql", requireSameOriginPost, requireLinkedTenant, zkGithubGraphqlRoute);
+// /logout is ungated by session middleware (idempotent + null-safe). SameSite=Lax on session cookie
+// blocks most cross-site POSTs; requireSameOriginPost adds defense-in-depth.
+app.post("/logout", requireSameOriginPost, logoutRoute);
 
 // GET /dashboard — session-gated app shell (HTML only; JS/CSS served from ASSETS root).
 app.get("/dashboard", dashboardRoute);

--- a/worker/src/webhook/handlers-app.test.ts
+++ b/worker/src/webhook/handlers-app.test.ts
@@ -137,6 +137,27 @@ describe("handleInstallation", () => {
       expect(batchedSql(batched()).some((sql) => /INSERT INTO sync_control/.test(sql))).toBe(true);
     });
 
+    it("links sender to user_installations when sender has a local account", async () => {
+      const { db, batched } = seededDb({
+        tenant: activeTenant,
+        user: { id: 42, github_id: 99901 },
+      });
+      const payload = {
+        action: "created",
+        installation: { id: 555, account: { login: "Roxabi", type: "Organization" } },
+        repositories: [],
+        sender: { id: 99901, login: "alice" },
+      };
+
+      await handleInstallation(payload, db, fakeEnv());
+
+      const linkStmt = allBatchedStmts(batched()).find((s) =>
+        /user_installations/.test(s.sql),
+      );
+      expect(linkStmt).toBeDefined();
+      expect(linkStmt!.args).toEqual([42, activeTenant.id]);
+    });
+
     it("created with no repositories still bumps data_version (tenant row created)", async () => {
       // Arrange
       const { db, recorded, batched, batchFn } = seededDb({ tenant: activeTenant });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.19.0"
+APP_RELEASE = "0.19.1"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -69,7 +69,7 @@ name = "roxabi-live-staging"
 workers_dev = true
 
 [env.staging.vars]
-APP_RELEASE = "0.19.0"
+APP_RELEASE = "0.19.1"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"
 # `routes` is inheritable — without this explicit empty override a staging


### PR DESCRIPTION
## Promotion: staging → main (v0.19.1)

## [0.19.1] — 2026-06-19

### Bug Fixes

* **auth:** verify `setSessionTenant` row count before returning `linked` from install-refresh
* **auth:** exclude suspended tenants from install-refresh and `/api/me` installations
* **auth:** stop `mustReOAuth` when webhook already linked `user_installations` (install intent short-circuit)
* **auth:** harden post-OAuth HTML against XSS (`sanitizeAuthRedirect`, `authNavigateHtml`)
* **auth:** revoke other active sessions on OAuth success
* **auth:** same-origin CSRF guard on POST mutations
* **frontend:** use server `oauth_fallback`, surface consent errors, strict `onboarding_step` gate

## [0.19.0] — changelog backfill (already on main)

### Features

* **auth:** server-owned onboarding (`onboarding_step` in `/api/me`) — install → consent → ready
* **auth:** `POST /api/install/refresh` links installs via webhook without full re-OAuth
* **auth:** `POST /api/consent` persists operator acknowledgement in D1
* **auth:** OAuth completes with 200 + Set-Cookie + inline dashboard (drops `/auth/exchange` hop)
* **auth:** login intents `?intent=signin|install|reauth|zk`
* **webhook:** `installation.created` links sender → `user_installations`

### Changed

* **auth:** remove `/auth/continue`, `sessionRedirectHtml`, and `frontend/github-install.js` (−264 LOC net)

## Pre-flight

- [x] CI passing on staging
- [x] No open PRs targeting staging
- [x] Deploy preview skipped (no `deploy-preview.yml`; staging deploy verified via CI)
- [x] Release notes committed to staging

---
Generated with Claude Code via `/promote`