### PR TITLE
fix(auth): serve /dashboard/ not index.html — break post-login redirect loop

### DIFF
--- a/worker/src/auth/dashboard-route.test.ts
+++ b/worker/src/auth/dashboard-route.test.ts
@@ -44,9 +44,16 @@ function makeEnv(db: D1Database, assetsBody = "dashboard-html"): Env {
   return {
     DB: db,
     ASSETS: {
+      // Emulate Cloudflare Assets default html_handling ("auto-trailing-slash"):
+      // "/dashboard/index.html" → 307 redirect to the canonical "/dashboard/".
+      // serveDashboardShell must request "/dashboard/" so it never propagates a
+      // 307 back to the browser (which caused ERR_TOO_MANY_REDIRECTS in prod).
       fetch: vi.fn(async (req: Request) => {
         const url = new URL(req.url);
-        expect(url.pathname).toBe("/dashboard/index.html");
+        if (url.pathname === "/dashboard/index.html") {
+          return new Response(null, { status: 307, headers: { Location: "/dashboard/" } });
+        }
+        expect(url.pathname).toBe("/dashboard/");
         return new Response(assetsBody, { status: 200 });
       }),
     } as unknown as Fetcher,
@@ -115,6 +122,22 @@ describe("GET /dashboard", () => {
     expect(await res.text()).toBe("dashboard-html");
     expect(res.headers.get("Cache-Control")).toContain("no-store");
     expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("never propagates Cloudflare's index.html→dir 307 (no redirect loop)", async () => {
+    const db = makeSessionDb(STUB_SESSION);
+    const env = makeEnv(db);
+
+    const res = await app.request(
+      "/dashboard/",
+      { headers: { Cookie: `roxabi_session=${VALID_RAW_TOKEN}` } },
+      env,
+    );
+
+    // Must serve the shell (200), NOT bounce a 307 back to /dashboard/ → loop.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Location")).toBeNull();
+    expect(await res.text()).toBe("dashboard-html");
   });
 
   it("allows install-pending sessions (null tenantId)", async () => {

--- a/worker/src/auth/dashboard-route.ts
+++ b/worker/src/auth/dashboard-route.ts
@@ -71,7 +71,14 @@ export async function serveDashboardShell(
   extraSetCookies: string[] = [],
 ): Promise<Response> {
   const assetUrl = new URL(reqUrl);
-  assetUrl.pathname = "/dashboard/index.html";
+  // Request the canonical directory form, NOT "/dashboard/index.html".
+  // Cloudflare Assets (default html_handling: "auto-trailing-slash") answers
+  // "/dashboard/index.html" with a 307 → "/dashboard/". serveDashboardShell
+  // propagates the asset status verbatim, so fetching the .html form turns this
+  // into a redirect that bounces back through dashboardRoute → 307 → … →
+  // ERR_TOO_MANY_REDIRECTS for any authenticated user. "/dashboard/" is the
+  // canonical 200 form and never redirects.
+  assetUrl.pathname = "/dashboard/";
   const assetRes = await env.ASSETS.fetch(new Request(assetUrl.toString(), raw));
   const headers = new Headers(assetRes.headers);
   for (const [key, value] of Object.entries(AUTH_NO_CACHE)) {


### PR DESCRIPTION
## Prod-down hotfix — login redirect loop

**Symptom:** after authenticating with GitHub, every user hits `ERR_TOO_MANY_REDIRECTS` on `/dashboard/` (reproduced in a private window → not a cache issue).

### Root cause
`serveDashboardShell` fetched `/dashboard/index.html` via the `ASSETS` binding and propagated the asset status verbatim. Cloudflare Assets (default `html_handling: "auto-trailing-slash"`) answers `/dashboard/index.html` with a **307 → `/dashboard/`**. So:

```
valid session → GET /dashboard/ → dashboardRoute → serveDashboardShell
   → ASSETS.fetch(/dashboard/index.html) → 307 Location: /dashboard/
   → Worker returns that 307 → browser follows → /dashboard/ → … ∞
```

Unauthenticated users never reach the shell (they're redirected to `/login` first), which is why the loop only appears **after login**.

Verified on prod:
```
GET /dashboard/index.html → 307 Location: /dashboard/
GET /index.html           → 307 Location: /           (same CF pattern)
```

### Fix
Fetch the canonical directory form `/dashboard/` (200, never redirects) instead of `/dashboard/index.html`.

### Why CI was green
The `dashboard-route` test mocked `ASSETS.fetch` to return `200` in-process for `/dashboard/index.html`, so it never saw CF's real 307. The mock is now hardened to emulate CF (307 on `*/index.html`, 200 on the canonical dir) + a dedicated regression test asserts no 3xx is ever propagated — a revert now fails CI.

### Testing
- `npm run typecheck` ✓
- `npx vitest run` → **730/730** ✓
- biome (pre-commit) ✓

### Deploy
Merge to `main` → CI `wrangler deploy` → `live.roxabi.dev`. Restores public login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)