### PR TITLE
chore: promote staging to main (0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.21.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.20.0...roxabi-live/v0.21.0) (2026-06-22)
+
+
+### Features
+
+* **auth:** show signing-out overlay during logout
+* **dashboard:** default table columns to priority; public/private badges on repo filter
+* **security:** gate staging workers.dev behind CF Access; anti-indexing (`robots.txt`, `X-Robots-Tag`)
+
+
+### Bug Fixes
+
+* **security:** staging Access setup script supports Bitwarden global API key; webhook path in domain
+
+
 ## [0.20.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.19.2...roxabi-live/v0.20.0) (2026-06-22)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Roxabi Live pulls GitHub issues from the entire org into a [Cloudflare D1](https://developers.cloudflare.com/d1/) database and serves a multi-view dashboard at **[live.roxabi.dev](https://live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via a GitHub org webhook, and re-syncs daily via a Cron Trigger — all on a single Cloudflare Worker.
 
-**Multi-user:** any GitHub user with access to the installed GitHub App can sign in via OAuth (`GET /login`). The app is session-gated — `/api/*` requires an active session cookie. `/admin/*` additionally sits behind Cloudflare Access (Email-OTP) as a defense-in-depth layer.
+**Multi-user:** any GitHub user with access to the installed GitHub App can sign in via OAuth (`GET /login`). The app is session-gated — `/api/*` requires an active session cookie. `/admin/*` additionally sits behind Cloudflare Access (Email-OTP) as a defense-in-depth layer. The **staging** workers.dev URL is fully gated by CF Access (see `docs/s10-staging-access.md`).
 
 ## Why
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -509,6 +509,7 @@ Bypass (if Access is configured) so that GitHub can reach it; the Worker validat
 every webhook request via HMAC-SHA256 (`X-Hub-Signature-256`, `GITHUB_WEBHOOK_SECRET`).
 
 For CF Access setup on `/admin/*` see [docs/s7-access-cutover.md](s7-access-cutover.md).
+For the staging workers.dev gate see [docs/s10-staging-access.md](s10-staging-access.md).
 
 ---
 

--- a/docs/s10-staging-access.md
+++ b/docs/s10-staging-access.md
@@ -1,0 +1,109 @@
+# S10 — Staging edge gate (CF Access + anti-indexing)
+
+Staging (`roxabi-live-staging.mickael-b5e.workers.dev`) must not be publicly reachable or
+indexable. Two layers:
+
+1. **Cloudflare Access (edge)** — Email OTP before any Worker handler runs.
+2. **Worker anti-indexing** — `robots.txt` + `X-Robots-Tag: noindex` on every staging response.
+
+Prod (`live.roxabi.dev`) keeps the S7 model: GitHub OAuth at the Worker for `/dashboard` and
+`/api/*`; CF Access only on `/admin/*` (+ webhook bypass).
+
+---
+
+## Prerequisites
+
+- Cloudflare account `b5e90be971920ce406f7b679c4f1cd33` (`mickael@bouly.io`)
+- Zero Trust → Settings → Authentication → **One-time PIN** enabled
+- API token with **Access: Apps and Policies Write**
+
+---
+
+## Automated setup (preferred)
+
+```bash
+export CLOUDFLARE_API_TOKEN='<token>'
+# Optional: comma-separated operators
+export STAGING_ACCESS_EMAILS='mickael@bouly.io'
+
+./scripts/setup-staging-access.sh
+```
+
+Creates two Access apps (order matters):
+
+| App | Domain | Path | Policy |
+|-----|--------|------|--------|
+| Roxabi Live Staging — webhook bypass | `roxabi-live-staging.mickael-b5e.workers.dev` | `/webhook` | **Bypass** (Everyone) |
+| Roxabi Live Staging | same | `/` (all paths) | **Allow** emails in `STAGING_ACCESS_EMAILS` |
+
+Default allowlist: `mickael@bouly.io`. Add emails:
+
+```bash
+STAGING_ACCESS_EMAILS='mickael@bouly.io,teammate@example.com' ./scripts/setup-staging-access.sh
+```
+
+To update an existing app's policy, edit it in **Zero Trust → Access → Applications** (the
+script is idempotent on create only).
+
+---
+
+## Manual setup (dashboard)
+
+### 1 — Webhook bypass (create first)
+
+Zero Trust → Access → Applications → Add → **Self-hosted**
+
+- Name: `Roxabi Live Staging — webhook bypass`
+- Domain: `roxabi-live-staging.mickael-b5e.workers.dev`
+- Path: `/webhook`
+- Policy: **Bypass**, include **Everyone**
+
+### 2 — Staging gate
+
+Add → **Self-hosted**
+
+- Name: `Roxabi Live Staging`
+- Domain: `roxabi-live-staging.mickael-b5e.workers.dev` (no path → all paths)
+- Policy: **Allow**, include emails `mickael@bouly.io`
+- Auth: One-time PIN, session **24 h**
+
+### Alternative: one-click workers.dev Access
+
+Workers & Pages → `roxabi-live-staging` → Settings → Domains & Routes →
+**Enable Cloudflare Access** → **Manage Cloudflare Access** to add emails.
+
+Still add the `/webhook` bypass app manually — the one-click toggle does not split paths.
+
+---
+
+## Verification
+
+```bash
+# Dashboard — must hit CF Access, NOT Worker /login:
+curl -sI "https://roxabi-live-staging.mickael-b5e.workers.dev/dashboard/" \
+  | grep -iE 'HTTP/|^location'
+# expect: HTTP/2 302  |  Location: https://*.cloudflareaccess.com/...
+
+# Webhook — must reach Worker (4xx without HMAC), no Access redirect:
+curl -sI -X POST "https://roxabi-live-staging.mickael-b5e.workers.dev/webhook/github" \
+  | grep -iE 'HTTP/|^location|cf-access'
+# expect: HTTP 401/403/405  |  no Location: *.cloudflareaccess.com
+
+# Anti-indexing (deployed Worker):
+curl -s "https://roxabi-live-staging.mickael-b5e.workers.dev/robots.txt"
+# expect: User-agent: *\nDisallow: /
+```
+
+After CF Access OTP, users still complete **GitHub OAuth** (`/login`) for app sessions.
+Access and OAuth are stacked: edge identity first, then GitHub App membership.
+
+---
+
+## Worker anti-indexing
+
+When `GITHUB_APP_SLUG=roxabi-live-staging` (see `wrangler.toml` `[env.staging.vars]`):
+
+- `GET /robots.txt` → `Disallow: /`
+- Every response gets `X-Robots-Tag: noindex, nofollow, noarchive`
+
+This is defense-in-depth if the URL is shared or crawled before Access is enabled.

--- a/docs/s10-staging-access.md
+++ b/docs/s10-staging-access.md
@@ -22,7 +22,10 @@ Prod (`live.roxabi.dev`) keeps the S7 model: GitHub OAuth at the Worker for `/da
 ## Automated setup (preferred)
 
 ```bash
-export CLOUDFLARE_API_TOKEN='<token>'
+# Global API key from Bitwarden (same as setup:workers-builds)
+source scripts/bw-cloudflare-global-env.sh
+
+# Or: export CLOUDFLARE_API_TOKEN='<token>'
 # Optional: comma-separated operators
 export STAGING_ACCESS_EMAILS='mickael@bouly.io'
 
@@ -33,7 +36,7 @@ Creates two Access apps (order matters):
 
 | App | Domain | Path | Policy |
 |-----|--------|------|--------|
-| Roxabi Live Staging — webhook bypass | `roxabi-live-staging.mickael-b5e.workers.dev` | `/webhook` | **Bypass** (Everyone) |
+| Roxabi Live Staging — webhook bypass | `roxabi-live-staging.mickael-b5e.workers.dev/webhook` | — | **Bypass** (Everyone) |
 | Roxabi Live Staging | same | `/` (all paths) | **Allow** emails in `STAGING_ACCESS_EMAILS` |
 
 Default allowlist: `mickael@bouly.io`. Add emails:

--- a/docs/s7-access-cutover.md
+++ b/docs/s7-access-cutover.md
@@ -124,9 +124,9 @@ the recovery block is here for completeness.
 
 ## Phase 2 — Staging smoke gate
 
-Staging (`roxabi-live-staging.mickael-b5e.workers.dev`) has no CF Access in front —
-requests go directly to the Worker. This isolates the Worker's own `requireSession` gate,
-proving the exact behavior prod must show once the edge Access wall is removed.
+Staging (`roxabi-live-staging.mickael-b5e.workers.dev`) is gated at the edge by CF Access
+(Email OTP — see `docs/s10-staging-access.md`). After OTP, requests hit the Worker; the
+smoke checks below still validate `requireSession` behind the edge gate.
 
 ```bash
 # unauthenticated graph request — Worker requireSession must reject:

--- a/frontend/app.css
+++ b/frontend/app.css
@@ -892,11 +892,33 @@ main {
   pointer-events: none;
   user-select: none;
 }
-.ms-sub {
+.ms-meta {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.ms-sub {
   font-size: 10px;
   color: var(--text-dim);
   font-style: italic;
+}
+.ms-badge {
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  padding: 1px 6px;
+  border-radius: 4px;
+  text-transform: lowercase;
+  font-style: normal;
+}
+.ms-badge-public {
+  color: var(--teal);
+  background: rgba(20, 184, 166, 0.12);
+}
+.ms-badge-private {
+  color: var(--accent);
+  background: var(--accent-dim);
 }
 .ms-item-archived {
   opacity: 0.7;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -391,6 +391,10 @@ function sortReposByActivity(repos, nodes) {
   return [...repos].sort((a, b) => compareReposByActivity(a, b, nodes));
 }
 
+function repoVisibilityBadge(isPrivate) {
+  return isPrivate ? "private" : "public";
+}
+
 function populateFilters(repoData) {
   const nodes = state.nodes;
 
@@ -406,11 +410,13 @@ function populateFilters(repoData) {
     value: r.repo,
     label: r.repo.split("/")[1] || r.repo,
     tone: repoTone(r.repo),
+    badge: repoVisibilityBadge(Boolean(r.is_private)),
   }));
   const archItems = archived.map((r) => ({
     value: r.repo,
     label: r.repo.split("/")[1] || r.repo,
     tone: repoTone(r.repo),
+    badge: repoVisibilityBadge(Boolean(r.is_private)),
     archived: true,
   }));
   const repoItems = archItems.length
@@ -524,7 +530,7 @@ async function loadAndRender(zkOptIn, githubLogin, zkAccountKeyEnabled = false) 
     repoData = data.repos;
   } else {
     const derived = [...new Set(nodes.map((n) => n.repo))].sort();
-    repoData = derived.map((repo) => ({ repo, archived: false }));
+    repoData = derived.map((repo) => ({ repo, archived: false, is_private: true }));
   }
   populateFilters(repoData);
   render();

--- a/frontend/auth.css
+++ b/frontend/auth.css
@@ -11,7 +11,8 @@
 .auth-view[hidden],
 .consent-gate[hidden],
 .zk-gate[hidden],
-.initial-sync-gate[hidden] {
+.initial-sync-gate[hidden],
+.signout-gate[hidden] {
   display: none;
 }
 
@@ -723,6 +724,62 @@ body.gated #view-list,
 body.gated #graph-panel,
 body.gated #error-msg {
   display: none;
+}
+
+/* ─── Sign-out in progress ────────────────────────────────────────────────── */
+
+.signout-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 700;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+[data-theme="light"] .signout-gate {
+  background: rgba(0, 0, 0, 0.48);
+}
+
+.signout-dialog {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 12px;
+  box-shadow: var(--panel-shadow);
+  max-width: 360px;
+  width: 100%;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.signout-message {
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.signout-spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  animation: signout-spin 0.9s linear infinite;
+}
+
+@keyframes signout-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ─── Initial corpus sync overlay ─────────────────────────────────────────── */

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,5 +1,6 @@
 // auth.js — Server-owned onboarding gate (install → consent → ready)
 
+import { detectLocale, t } from "./i18n.js";
 import { renderOnboardingSteps } from "./onboarding.js";
 
 const $ = (id) => document.getElementById(id);
@@ -47,11 +48,40 @@ export async function api(path, opts) {
   return resp;
 }
 
+/** Full-screen feedback while POST /logout completes. */
+function showSignOutOverlay() {
+  if (document.getElementById("signout-gate")) return;
+
+  const gate = document.createElement("div");
+  gate.id = "signout-gate";
+  gate.className = "signout-gate";
+  gate.setAttribute("role", "alertdialog");
+  gate.setAttribute("aria-modal", "true");
+  gate.setAttribute("aria-busy", "true");
+  gate.setAttribute("aria-live", "polite");
+
+  const dialog = document.createElement("div");
+  dialog.className = "signout-dialog";
+
+  const spinner = document.createElement("div");
+  spinner.className = "signout-spinner";
+  spinner.setAttribute("aria-hidden", "true");
+
+  const message = document.createElement("p");
+  message.className = "signout-message";
+  message.textContent = t(detectLocale(), "auth.signingOut");
+
+  dialog.append(spinner, message);
+  gate.appendChild(dialog);
+  document.body.appendChild(gate);
+}
+
 /**
  * End session and navigate away.
  * @param {{ after?: "redirect" | "reload", to?: string }} [opts]
  */
 export async function signOut(opts = {}) {
+  showSignOutOverlay();
   const { after = "redirect", to = "/" } = opts;
   await api("/logout", { method: "POST" }).catch(() => {});
   if (after === "reload") location.reload();

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -65,6 +65,18 @@ describe("signOut", () => {
     expect(location.href).toBe("/");
   });
 
+  it("shows a signing-out overlay while logout runs", async () => {
+    fetch.mockResolvedValue({ status: 200, ok: true });
+    const pending = signOut();
+    const gate = document.getElementById("signout-gate");
+    expect(gate).toBeTruthy();
+    expect(gate?.querySelector(".signout-spinner")).toBeTruthy();
+    expect(gate?.querySelector(".signout-message")?.textContent).toMatch(
+      /Déconnexion|Signing out/i,
+    );
+    await pending;
+  });
+
   it("reloads when requested", async () => {
     fetch.mockResolvedValue({ status: 200, ok: true });
     await signOut({ after: "reload" });

--- a/frontend/i18n/locales/en.js
+++ b/frontend/i18n/locales/en.js
@@ -8,6 +8,7 @@ export default {
   "nav.signUp": "Sign up",
   "nav.myDashboard": "My dashboard",
   "nav.signOut": "Sign out",
+  "auth.signingOut": "Signing out…",
   "nav.myProfile": "My profile",
   "nav.features": "Features",
   "nav.howItWorks": "How it works",

--- a/frontend/i18n/locales/fr.js
+++ b/frontend/i18n/locales/fr.js
@@ -8,6 +8,7 @@ export default {
   "nav.signUp": "Créer un compte",
   "nav.myDashboard": "Mon dashboard",
   "nav.signOut": "Se déconnecter",
+  "auth.signingOut": "Déconnexion en cours…",
   "nav.myProfile": "Mon profil",
   "nav.features": "Fonctionnalités",
   "nav.howItWorks": "Comment ça marche",

--- a/frontend/multi_select.js
+++ b/frontend/multi_select.js
@@ -156,21 +156,35 @@ export class MultiSelect {
       const span = document.createElement("span");
       span.textContent = item.label;
 
-      if (item.sublabel) {
+      lbl.append(cb, span);
+
+      const meta = document.createElement("span");
+      meta.className = "ms-meta";
+      let hasMeta = false;
+
+      if (item.badge) {
+        const badge = document.createElement("span");
+        badge.className = `ms-badge ms-badge-${item.badge}`;
+        badge.textContent = item.badge;
+        meta.appendChild(badge);
+        hasMeta = true;
+      } else if (item.sublabel) {
         const sub = document.createElement("span");
         sub.className = "ms-sub";
         sub.textContent = item.sublabel;
-        lbl.append(cb, span, sub);
-      } else {
-        lbl.append(cb, span);
+        meta.appendChild(sub);
+        hasMeta = true;
       }
 
       if (item.archived) {
         const sub = document.createElement("span");
         sub.className = "ms-sub";
         sub.textContent = "archived";
-        lbl.appendChild(sub);
+        meta.appendChild(sub);
+        hasMeta = true;
       }
+
+      if (hasMeta) lbl.appendChild(meta);
 
       li.appendChild(lbl);
       ul.appendChild(li);

--- a/frontend/multi_select.test.js
+++ b/frontend/multi_select.test.js
@@ -34,6 +34,17 @@ describe("MultiSelect pill collapse", () => {
     expect(trigger.querySelector("[data-ms-expand]")).not.toBeNull();
   });
 
+  it("renders public/private badges in the panel", () => {
+    const ms = new MultiSelect(trigger, panel);
+    ms.setItems([
+      { value: "org/pub", label: "pub", badge: "public" },
+      { value: "org/sec", label: "sec", badge: "private" },
+    ]);
+
+    expect(panel.querySelector(".ms-badge-public")?.textContent).toBe("public");
+    expect(panel.querySelector(".ms-badge-private")?.textContent).toBe("private");
+  });
+
   it("expands all pills when the ellipsis is clicked", () => {
     const ms = new MultiSelect(trigger, panel, { maxVisiblePills: 2 });
     ms.setItems(

--- a/frontend/site.css
+++ b/frontend/site.css
@@ -369,3 +369,60 @@ body::before {
     padding: 12px 16px;
   }
 }
+
+/* ─── Sign-out in progress (shared with auth.js signOut) ───────────────────── */
+
+.signout-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 700;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+[data-theme="light"] .signout-gate {
+  background: rgba(0, 0, 0, 0.48);
+}
+
+.signout-dialog {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-hi);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--panel-shadow);
+  max-width: 360px;
+  width: 100%;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.signout-message {
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.signout-spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  animation: signout-spin 0.9s linear infinite;
+}
+
+@keyframes signout-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -54,7 +54,7 @@ export const state = {
   label: SS.getJSON("v6:label", []),
   search: SS.get("v6:search", ""),
   pivotRow: SS.get("v6:pivotRow", "milestone"),
-  pivotCol: SS.get("v6:pivotCol", "lane"),
+  pivotCol: SS.get("v6:pivotCol", "priority"),
   graphRow: SS.get("v6:graphRow", "milestone"),
   graphCol: SS.get("v6:graphCol", "lane"),
   listGroup: SS.get("v7:listGroup", "none"),

--- a/scripts/setup-staging-access.sh
+++ b/scripts/setup-staging-access.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Provision Cloudflare Access on the staging workers.dev URL.
+# Requires CLOUDFLARE_API_TOKEN with Access: Apps and Policies Write.
+set -euo pipefail
+
+: "${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN (Access: Apps and Policies Write)}"
+: "${CLOUDFLARE_ACCOUNT_ID:=b5e90be971920ce406f7b679c4f1cd33}"
+
+STAGING_HOST="${STAGING_HOST:-roxabi-live-staging.mickael-b5e.workers.dev}"
+# Comma-separated allowlist — extend when onboarding more operators.
+STAGING_ACCESS_EMAILS="${STAGING_ACCESS_EMAILS:-mickael@bouly.io}"
+
+API="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/access/apps"
+AUTH=(-H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json")
+
+cf_json() {
+  curl -fsS "${AUTH[@]}" "$@"
+}
+
+list_apps() {
+  cf_json "${API}?per_page=50"
+}
+
+app_exists() {
+  local name="$1"
+  list_apps | jq -e --arg n "$name" '.result[] | select(.name == $n) | .id' >/dev/null
+}
+
+email_includes_json() {
+  local emails_csv="$1"
+  local arr="["
+  local first=1
+  IFS=',' read -ra parts <<< "$emails_csv"
+  for raw in "${parts[@]}"; do
+    local email
+    email="$(echo "$raw" | xargs)"
+    [[ -z "$email" ]] && continue
+    [[ $first -eq 0 ]] && arr+=","
+    first=0
+    arr+="$(jq -nc --arg e "$email" '{email:{email:$e}}')"
+  done
+  arr+="]"
+  echo "$arr"
+}
+
+create_webhook_bypass_app() {
+  local name="Roxabi Live Staging — webhook bypass"
+  if app_exists "$name"; then
+    echo "✓ Access app already exists: ${name}"
+    return 0
+  fi
+  echo "→ Creating Access app: ${name}"
+  cf_json --request POST "$API" --data @- <<EOF
+{
+  "name": "${name}",
+  "type": "self_hosted",
+  "domain": "${STAGING_HOST}",
+  "path": "/webhook",
+  "session_duration": "24h",
+  "policies": [
+    {
+      "name": "GitHub webhook bypass",
+      "decision": "bypass",
+      "include": [{ "everyone": {} }],
+      "precedence": 1
+    }
+  ]
+}
+EOF
+  echo "✓ ${name}"
+}
+
+create_staging_gate_app() {
+  local name="Roxabi Live Staging"
+  if app_exists "$name"; then
+    echo "✓ Access app already exists: ${name}"
+    return 0
+  fi
+  local includes
+  includes="$(email_includes_json "$STAGING_ACCESS_EMAILS")"
+  echo "→ Creating Access app: ${name} (emails: ${STAGING_ACCESS_EMAILS})"
+  cf_json --request POST "$API" --data "$(jq -nc \
+    --arg name "$name" \
+    --arg domain "$STAGING_HOST" \
+    --argjson includes "$includes" \
+    '{
+      name: $name,
+      type: "self_hosted",
+      domain: $domain,
+      session_duration: "24h",
+      policies: [
+        {
+          name: "Allow staging operators",
+          decision: "allow",
+          include: $includes,
+          precedence: 1
+        }
+      ]
+    }')"
+  echo "✓ ${name}"
+}
+
+verify_gate() {
+  echo "→ Verifying edge gate"
+  local code location
+  code="$(curl -s -o /dev/null -w '%{http_code}' "https://${STAGING_HOST}/dashboard/")"
+  location="$(curl -sI "https://${STAGING_HOST}/dashboard/" | awk 'tolower($1)=="location:" {print $2}' | tr -d '\r')"
+  if [[ "$code" == "302" && "$location" == *"cloudflareaccess.com"* ]]; then
+    echo "✓ Dashboard redirects to Cloudflare Access (${code})"
+  else
+    echo "⚠ Expected CF Access redirect; got HTTP ${code} location=${location:-none}" >&2
+    return 1
+  fi
+
+  local webhook_code
+  webhook_code="$(curl -s -o /dev/null -w '%{http_code}' -X POST "https://${STAGING_HOST}/webhook/github")"
+  if [[ "$webhook_code" != "302" ]]; then
+    echo "✓ /webhook/github bypasses Access (HTTP ${webhook_code}, Worker HMAC gate)"
+  else
+    echo "⚠ /webhook/github still redirects to Access — check bypass app path precedence" >&2
+    return 1
+  fi
+}
+
+echo "Account: ${CLOUDFLARE_ACCOUNT_ID}"
+echo "Host:    ${STAGING_HOST}"
+
+# More-specific /webhook app must exist before the catch-all OTP app (prod runbook pattern).
+create_webhook_bypass_app
+create_staging_gate_app
+verify_gate
+
+echo "✓ Staging CF Access configured"

--- a/scripts/setup-staging-access.sh
+++ b/scripts/setup-staging-access.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Provision Cloudflare Access on the staging workers.dev URL.
-# Requires CLOUDFLARE_API_TOKEN with Access: Apps and Policies Write.
+#
+# Auth (either):
+#   export CLOUDFLARE_API_TOKEN=…   # Access: Apps and Policies Write
+#   source scripts/bw-cloudflare-global-env.sh   # global API key via Bitwarden
 set -euo pipefail
 
-: "${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN (Access: Apps and Policies Write)}"
 : "${CLOUDFLARE_ACCOUNT_ID:=b5e90be971920ce406f7b679c4f1cd33}"
 
 STAGING_HOST="${STAGING_HOST:-roxabi-live-staging.mickael-b5e.workers.dev}"
@@ -11,10 +13,24 @@ STAGING_HOST="${STAGING_HOST:-roxabi-live-staging.mickael-b5e.workers.dev}"
 STAGING_ACCESS_EMAILS="${STAGING_ACCESS_EMAILS:-mickael@bouly.io}"
 
 API="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/access/apps"
-AUTH=(-H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json")
+
+cf_auth_args() {
+  if [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+    printf '%s\n' "-H" "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
+    return 0
+  fi
+  if [[ -n "${CLOUDFLARE_EMAIL:-}" && -n "${CLOUDFLARE_API_KEY:-}" ]]; then
+    printf '%s\n' "-H" "X-Auth-Email: ${CLOUDFLARE_EMAIL}" "-H" "X-Auth-Key: ${CLOUDFLARE_API_KEY}"
+    return 0
+  fi
+  echo "Set CLOUDFLARE_API_TOKEN or source scripts/bw-cloudflare-global-env.sh" >&2
+  return 1
+}
 
 cf_json() {
-  curl -fsS "${AUTH[@]}" "$@"
+  local -a auth
+  mapfile -t auth < <(cf_auth_args)
+  curl -fsS "${auth[@]}" -H "Content-Type: application/json" "$@"
 }
 
 list_apps() {
@@ -43,30 +59,48 @@ email_includes_json() {
   echo "$arr"
 }
 
+webhook_bypass_payload() {
+  local name="Roxabi Live Staging — webhook bypass"
+  # Path is embedded in domain (same shape as prod live.roxabi.dev/webhook).
+  jq -nc \
+    --arg name "$name" \
+    --arg domain "${STAGING_HOST}/webhook" \
+    '{
+      name: $name,
+      type: "self_hosted",
+      domain: $domain,
+      session_duration: "24h",
+      app_launcher_visible: false,
+      policies: [
+        {
+          name: "GitHub webhook bypass",
+          decision: "bypass",
+          include: [{ everyone: {} }],
+          precedence: 1
+        }
+      ]
+    }'
+}
+
 create_webhook_bypass_app() {
   local name="Roxabi Live Staging — webhook bypass"
-  if app_exists "$name"; then
-    echo "✓ Access app already exists: ${name}"
+  local app_id domain
+  app_id="$(list_apps | jq -r --arg n "$name" '.result[] | select(.name == $n) | .id' | head -1)"
+  domain="${STAGING_HOST}/webhook"
+  if [[ -n "$app_id" ]]; then
+    local current
+    current="$(cf_json "${API}/${app_id}" | jq -r '.result.domain')"
+    if [[ "$current" == "$domain" ]]; then
+      echo "✓ Access app already exists: ${name}"
+      return 0
+    fi
+    echo "→ Updating Access app domain: ${name} (${current} → ${domain})"
+    cf_json --request PUT "${API}/${app_id}" --data "$(webhook_bypass_payload)" >/dev/null
+    echo "✓ ${name} (updated)"
     return 0
   fi
   echo "→ Creating Access app: ${name}"
-  cf_json --request POST "$API" --data @- <<EOF
-{
-  "name": "${name}",
-  "type": "self_hosted",
-  "domain": "${STAGING_HOST}",
-  "path": "/webhook",
-  "session_duration": "24h",
-  "policies": [
-    {
-      "name": "GitHub webhook bypass",
-      "decision": "bypass",
-      "include": [{ "everyone": {} }],
-      "precedence": 1
-    }
-  ]
-}
-EOF
+  cf_json --request POST "$API" --data "$(webhook_bypass_payload)" >/dev/null
   echo "✓ ${name}"
 }
 
@@ -88,6 +122,7 @@ create_staging_gate_app() {
       type: "self_hosted",
       domain: $domain,
       session_duration: "24h",
+      app_launcher_visible: false,
       policies: [
         {
           name: "Allow staging operators",

--- a/worker/src/api/graph-test-helpers.ts
+++ b/worker/src/api/graph-test-helpers.ts
@@ -85,6 +85,8 @@ export function makeGraphTestApp() {
   return a;
 }
 
+type RepoAccessRow = { repo: string; is_private: number };
+
 function graphDbRows(
   sql: string,
   labels: unknown[],
@@ -92,25 +94,33 @@ function graphDbRows(
   issues: unknown[],
   edges: unknown[],
   repos: unknown[],
-  visibleRepos: string[],
+  _visibleRepos: string[],
+  repoAccess: RepoAccessRow[],
   zkOptIn: boolean,
   sealedIssueKeys: string[],
 ): FakeResult[] {
+  const lower = sql.toLowerCase();
   const issueRows = issues as Array<{ repo: string; updated_at?: string | null }>;
-  if (sql.toLowerCase().includes("group by repo")) {
+  if (lower.includes("group by repo")) {
     return aggregateRepoActivity(issueRows);
+  }
+  const privacyByRepo = new Map(repoAccess.map((row) => [row.repo, row.is_private]));
+  const repoRows = (repos as Array<{ repo: string; archived: number }>).map((row) => ({
+    repo: row.repo,
+    archived: row.archived,
+    is_private: privacyByRepo.get(row.repo) ?? 1,
+  }));
+  if (lower.includes("from repos")) {
+    return repoRows;
   }
   return dispatchByTable(sql, {
     zk_opt_in: [{ zk_opt_in: zkOptIn ? 1 : 0 }],
     "from zk_payloads": sealedIssueKeys.map((issue_key) => ({ issue_key })),
-    tenant_repo_access: visibleRepos.map((repo) => ({
-      repo,
-      is_private: 0,
-    })),
+    tenant_repo_access: repoAccess,
     "from labels": labels as FakeResult[],
     "from pr_state": prState as FakeResult[],
     "from edges": edges as FakeResult[],
-    "from repos": repos as FakeResult[],
+    "from repos": repoRows as FakeResult[],
     "from issues": issues as FakeResult[],
   });
 }
@@ -124,10 +134,17 @@ export function makeGraphEnv(
   overrideVisible?: string[],
   zkOptIn = false,
   sealedIssueKeys: string[] = [],
+  repoAccess?: RepoAccessRow[],
 ): Env {
   const visibleRepos = overrideVisible ?? [
     ...new Set((issues as Array<{ repo: string }>).map((i) => i.repo)),
   ];
+  const accessRows =
+    repoAccess ??
+    visibleRepos.map((repo) => ({
+      repo,
+      is_private: 0,
+    }));
   const db = makeFakeDb((sql, args) =>
     makeFakeStmt(
       sql,
@@ -140,6 +157,7 @@ export function makeGraphEnv(
         edges,
         repos,
         visibleRepos,
+        accessRows,
         zkOptIn,
         sealedIssueKeys,
       ),
@@ -158,9 +176,21 @@ export function makeGraphEnvWithCapture(
 ): { env: Env; capturedSqls: string[] } {
   const capturedSqls: string[] = [];
   const visibleRepos = [...new Set((issues as Array<{ repo: string }>).map((i) => i.repo))];
+  const accessRows = visibleRepos.map((repo) => ({ repo, is_private: 0 }));
   const { db } = captureDb((sql, _args) => {
     capturedSqls.push(sql);
-    return graphDbRows(sql, labels, prState, issues, edges, repos, visibleRepos, false, []);
+    return graphDbRows(
+      sql,
+      labels,
+      prState,
+      issues,
+      edges,
+      repos,
+      visibleRepos,
+      accessRows,
+      false,
+      [],
+    );
   });
   return { env: makeEnv(db), capturedSqls };
 }

--- a/worker/src/api/graph.test.ts
+++ b/worker/src/api/graph.test.ts
@@ -285,6 +285,7 @@ describe("GET /api/graph", () => {
         repos: {
           repo: string;
           archived: boolean;
+          is_private: boolean;
           issue_count: number;
           last_updated_at: string | null;
         }[];
@@ -294,18 +295,67 @@ describe("GET /api/graph", () => {
           {
             repo: GRAPH_REPO,
             archived: false,
+            is_private: false,
             issue_count: 2,
             last_updated_at: "2026-06-21T08:00:00Z",
           },
           {
             repo: "Roxabi/roxabi-factory",
             archived: false,
+            is_private: false,
             issue_count: 0,
             last_updated_at: null,
           },
           {
             repo: "Roxabi/roxabi-vault",
             archived: true,
+            is_private: false,
+            issue_count: 0,
+            last_updated_at: null,
+          },
+        ]),
+      );
+    });
+
+    it("returns is_private from tenant_repo_access", async () => {
+      const repoRows = [
+        { repo: GRAPH_REPO, archived: 0 },
+        { repo: "Roxabi/secret", archived: 0 },
+      ];
+      const issues = [graphIssue(1)];
+      const visibleList = repoRows.map((r) => r.repo);
+      const res = await testApp.request(
+        "/api/graph",
+        {},
+        makeGraphEnv(
+          [],
+          [],
+          issues,
+          [],
+          repoRows,
+          visibleList,
+          false,
+          [],
+          [
+            { repo: GRAPH_REPO, is_private: 0 },
+            { repo: "Roxabi/secret", is_private: 1 },
+          ],
+        ),
+      );
+      const body = await res.json<{ repos: { repo: string; is_private: boolean }[] }>();
+      expect(body.repos).toEqual(
+        expect.arrayContaining([
+          {
+            repo: GRAPH_REPO,
+            archived: false,
+            is_private: false,
+            issue_count: 1,
+            last_updated_at: null,
+          },
+          {
+            repo: "Roxabi/secret",
+            archived: false,
+            is_private: true,
             issue_count: 0,
             last_updated_at: null,
           },

--- a/worker/src/api/graph.ts
+++ b/worker/src/api/graph.ts
@@ -10,7 +10,7 @@
  *   (b) open pr_state — build Map<issueKey, {has_reviewed_label:number}[]>
  *   (c) issues — one row per issue
  *   (d) edges — all src_key/dst_key/kind rows
- *   (e) repos — registry rows + per-repo issue_count / last_updated_at (sort in UI)
+ *   (e) repos — registry rows + is_private + per-repo issue_count / last_updated_at
  */
 
 import type { Context } from "hono";
@@ -248,19 +248,27 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
     edges = edges.filter((e) => keys.has(e.src) && keys.has(e.dst));
   }
 
-  // (e) repos — registry + activity stats for filter dropdown ordering
+  // (e) repos — registry + visibility + activity stats for filter dropdown ordering
   interface RepoRow {
     repo: string;
     archived: number;
+    is_private: number;
   }
   interface RepoActivityRow {
     repo: string;
     issue_count: number;
     last_updated_at: string | null;
   }
+  const tenantId = session?.tenantId ?? null;
   const [repoRows, activityRows] = await Promise.all([
-    c.env.DB.prepare(`SELECT repo, archived FROM repos WHERE repo IN (${ph})`)
-      .bind(...visible)
+    c.env.DB.prepare(
+      `SELECT r.repo, r.archived, COALESCE(tra.is_private, 1) AS is_private
+       FROM repos r
+       LEFT JOIN tenant_repo_access tra
+         ON tra.tenant_id = ? AND tra.repo = r.repo
+       WHERE r.repo IN (${ph})`,
+    )
+      .bind(tenantId, ...visible)
       .all<RepoRow>(),
     c.env.DB.prepare(
       `SELECT repo, COUNT(*) AS issue_count, MAX(updated_at) AS last_updated_at
@@ -275,6 +283,7 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
     return {
       repo: r.repo,
       archived: Boolean(r.archived),
+      is_private: Number(r.is_private) !== 0,
       issue_count: activity?.issue_count ?? 0,
       last_updated_at: activity?.last_updated_at ?? null,
     };

--- a/worker/src/observability/staging-privacy.test.ts
+++ b/worker/src/observability/staging-privacy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { Env } from "../types";
+import { applyStagingPrivacyHeaders, isStagingEnv, stagingRobotsResponse } from "./staging-privacy";
+
+function env(slug?: string): Env {
+  return {
+    DB: {} as D1Database,
+    ASSETS: {} as Fetcher,
+    GITHUB_WEBHOOK_SECRET: "x",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_CLIENT_ID: "c",
+    GITHUB_APP_CLIENT_SECRET: "s",
+    GITHUB_APP_PRIVATE_KEY: "k",
+    GITHUB_APP_WEBHOOK_SECRET: "w",
+    GITHUB_APP_SLUG: slug,
+  };
+}
+
+describe("isStagingEnv", () => {
+  it("is true only for the staging app slug", () => {
+    expect(isStagingEnv(env("roxabi-live-staging"))).toBe(true);
+    expect(isStagingEnv(env("roxabi-live"))).toBe(false);
+    expect(isStagingEnv(env())).toBe(false);
+  });
+});
+
+describe("stagingRobotsResponse", () => {
+  it("blocks all crawlers and sets noindex headers", async () => {
+    const res = stagingRobotsResponse();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("User-agent: *\nDisallow: /\n");
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex, nofollow, noarchive");
+  });
+});
+
+describe("applyStagingPrivacyHeaders", () => {
+  it("adds X-Robots-Tag without dropping existing headers", () => {
+    const original = new Response("ok", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    });
+    const wrapped = applyStagingPrivacyHeaders(original);
+    expect(wrapped.headers.get("Content-Type")).toBe("text/plain");
+    expect(wrapped.headers.get("X-Robots-Tag")).toBe("noindex, nofollow, noarchive");
+  });
+});

--- a/worker/src/observability/staging-privacy.ts
+++ b/worker/src/observability/staging-privacy.ts
@@ -1,0 +1,30 @@
+import type { Env } from "../types";
+
+/** Staging Worker — identified by the staging GitHub App slug in wrangler.toml. */
+export function isStagingEnv(env: Env): boolean {
+  return env.GITHUB_APP_SLUG === "roxabi-live-staging";
+}
+
+const STAGING_ROBOTS_TAG = "noindex, nofollow, noarchive";
+
+/** Crawlers must not index staging even if the URL leaks past the edge gate. */
+export function stagingRobotsResponse(): Response {
+  return new Response("User-agent: *\nDisallow: /\n", {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Robots-Tag": STAGING_ROBOTS_TAG,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}
+
+export function applyStagingPrivacyHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("X-Robots-Tag", STAGING_ROBOTS_TAG);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/worker/src/router.ts
+++ b/worker/src/router.ts
@@ -34,9 +34,27 @@ import { authResetRoute } from "./auth/reset";
 import { requireLinkedTenant, requireSession } from "./auth/session";
 import { authStatusRoute } from "./auth/status";
 import type { AuthEnv } from "./auth/types";
+import {
+  applyStagingPrivacyHeaders,
+  isStagingEnv,
+  stagingRobotsResponse,
+} from "./observability/staging-privacy";
 import { webhookRoute } from "./webhook/handlers";
 
 const app = new Hono<AuthEnv>();
+
+// Staging: block crawlers even if the workers.dev URL leaks (CF Access is the primary gate).
+app.use("*", async (c, next) => {
+  if (!isStagingEnv(c.env)) {
+    await next();
+    return;
+  }
+  if (c.req.path === "/robots.txt") {
+    return stagingRobotsResponse();
+  }
+  await next();
+  c.res = applyStagingPrivacyHeaders(c.res);
+});
 
 // ── API routes — evaluated BEFORE the ASSETS fallback ───────────────────────
 // S1 scaffold wires /health + /api/version. S5 (#97) adds POST /webhook/github.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -68,6 +68,8 @@ bucket_name = "roxabi-live-logs"
 [env.staging]
 name = "roxabi-live-staging"
 workers_dev = true
+# Edge gate: CF Access Email OTP on the workers.dev URL (scripts/setup-staging-access.sh).
+# Worker also serves robots.txt + X-Robots-Tag when GITHUB_APP_SLUG is staging.
 
 [env.staging.vars]
 APP_RELEASE = "0.19.13"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.19.13"
+APP_RELEASE = "0.21.0"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -72,7 +72,7 @@ workers_dev = true
 # Worker also serves robots.txt + X-Robots-Tag when GITHUB_APP_SLUG is staging.
 
 [env.staging.vars]
-APP_RELEASE = "0.19.13"
+APP_RELEASE = "0.21.0"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"


### PR DESCRIPTION
## Promotion: staging → main (0.21.0)

### Features
- **auth:** show signing-out overlay during logout
- **dashboard:** default table columns to priority; public/private badges on repo filter
- **security:** gate staging workers.dev behind CF Access; anti-indexing (`robots.txt`, `X-Robots-Tag`)

### Bug Fixes
- **security:** staging Access setup script supports Bitwarden global API key; webhook path in domain

## Pre-flight
- [x] CI passing on staging
- [x] Open PRs on staging acknowledged (dependabot only)
- [x] Deploy preview skipped (no workflow)
- [x] Release notes committed to staging

---
Generated via `/promote`