### PR TITLE
chore: promote staging to main (0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.21.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.0...roxabi-live/v0.21.1) (2026-06-22)
+
+
+### Bug Fixes
+
+* **zk:** avoid double passphrase prompt on unlock (migration + parallel auto-unlock races)
+* **zk:** dedupe unlock bootstrap across init, BFCache restore, and idle lock; tolerate IndexedDB persistence errors after successful crypto unlock
+
+
 ## [0.21.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.20.0...roxabi-live/v0.21.0) (2026-06-22)
 
 

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -46,6 +46,10 @@ let keyBackupCache = null;
 let zkRestoreInFlight = false;
 let zkRestoreLastAt = 0;
 const ZK_RESTORE_DEBOUNCE_MS = 2000;
+/** @type {Promise<boolean>|null} */
+let zkUnlockInFlight = null;
+/** @type {Promise<void>|null} */
+let unlockGatePromise = null;
 
 function invalidateKeyBackupCache() {
   keyBackupCache = null;
@@ -133,10 +137,23 @@ async function putKeyBackup(body) {
   return result;
 }
 
+/** v1→v2 migration must never block unlock — a network error used to surface as "wrong passphrase". */
+async function runBestEffortV1Migration(githubLogin, accountKey, key_fp) {
+  if (!githubLogin) return;
+  try {
+    const payloads = await fetchPayloadRows();
+    if (payloadsHaveV1(payloads) && (await hasZkKeyPair(githubLogin))) {
+      await migrateV1PayloadsToAccountKey(githubLogin, accountKey, key_fp);
+    }
+  } catch (err) {
+    zkLog("zk.migrate.v1_to_v2.deferred", { error: String(err?.message ?? err) });
+  }
+}
+
 /**
  * Restore from device session or remembered passphrase — at most one GET key-backup.
  */
-async function tryAutoUnlockZk(githubLogin) {
+async function tryAutoUnlockZkInner(githubLogin) {
   if (isZkUnlocked()) return true;
 
   let backup;
@@ -169,10 +186,7 @@ async function tryAutoUnlockZk(githubLogin) {
     setZkSession(session, backup.key_fp);
     if (githubLogin) {
       await saveDeviceSession(githubLogin, accountKey, backup.key_fp);
-      const payloads = await fetchPayloadRows();
-      if (payloadsHaveV1(payloads) && (await hasZkKeyPair(githubLogin))) {
-        await migrateV1PayloadsToAccountKey(githubLogin, accountKey, backup.key_fp);
-      }
+      await runBestEffortV1Migration(githubLogin, accountKey, backup.key_fp);
     }
     setZkRememberMode(true);
     zkLog("zk.unlock.success", {
@@ -183,11 +197,21 @@ async function tryAutoUnlockZk(githubLogin) {
     updateLockButton();
     return true;
   } catch {
+    clearZkSession();
     await clearRememberPassphrase(githubLogin);
     setZkRememberMode(false);
     zkLog("zk.unlock.failure");
     return false;
   }
+}
+
+async function tryAutoUnlockZk(githubLogin) {
+  if (isZkUnlocked()) return true;
+  if (zkUnlockInFlight) return zkUnlockInFlight;
+  zkUnlockInFlight = tryAutoUnlockZkInner(githubLogin).finally(() => {
+    zkUnlockInFlight = null;
+  });
+  return zkUnlockInFlight;
 }
 
 async function tryAutoUnlockZkDebounced(githubLogin) {
@@ -272,26 +296,25 @@ export async function enrollAccountKey(passphrase, githubLogin) {
 export async function unlockAccountKey(passphrase) {
   const t0 = performance.now();
   const backup = await fetchKeyBackup();
+  let accountKey;
   try {
-    const accountKey = await unwrapAccountKey(passphrase, backup);
-    const session = await sessionAccountKey(accountKey);
-    setZkSession(session, backup.key_fp);
-    if (gateGithubLogin) {
-      await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
-      const payloads = await fetchPayloadRows();
-      if (payloadsHaveV1(payloads) && (await hasZkKeyPair(gateGithubLogin))) {
-        await migrateV1PayloadsToAccountKey(gateGithubLogin, accountKey, backup.key_fp);
-      }
-    }
-    zkLog("zk.unlock.success", {
-      key_fp: backup.key_fp,
-      kdf_duration_ms: Math.round(performance.now() - t0),
-    });
-    return { key_fp: backup.key_fp };
+    accountKey = await unwrapAccountKey(passphrase, backup);
   } catch (err) {
+    clearZkSession();
     zkLog("zk.unlock.failure");
     throw err;
   }
+  const session = await sessionAccountKey(accountKey);
+  setZkSession(session, backup.key_fp);
+  if (gateGithubLogin) {
+    await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
+    await runBestEffortV1Migration(gateGithubLogin, accountKey, backup.key_fp);
+  }
+  zkLog("zk.unlock.success", {
+    key_fp: backup.key_fp,
+    kdf_duration_ms: Math.round(performance.now() - t0),
+  });
+  return { key_fp: backup.key_fp };
 }
 
 function showZkGate() {
@@ -427,12 +450,20 @@ export function showEnrollGate(githubLogin) {
 }
 
 export function showUnlockGate(githubLogin = gateGithubLogin) {
-  return new Promise((resolve) => {
+  if (unlockGatePromise) return unlockGatePromise;
+
+  unlockGatePromise = new Promise((resolve) => {
+    const finish = () => {
+      unlockGatePromise = null;
+      resolve();
+    };
     const resetCtx = { $, escHtml, renderZkDialog };
     const reopenUnlock = () => {
-      showUnlockGate(githubLogin).then(resolve);
+      showUnlockGate(githubLogin).then(finish);
     };
     if (wireZkResetUi(resetCtx, githubLogin, reopenUnlock)) {
+      unlockGatePromise = null;
+      resolve();
       return;
     }
 
@@ -475,6 +506,7 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
 
     form?.addEventListener("submit", async (e) => {
       e.preventDefault();
+      if (submitBtn.disabled) return;
       errorEl.hidden = true;
       submitBtn.disabled = true;
       submitBtn.textContent = "Unlocking…";
@@ -483,7 +515,7 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
         await unlockAccountKey(pass);
         await applyZkRememberChoice(githubLogin, pass, zkRememberChecked());
         hideZkGate();
-        resolve();
+        finish();
       } catch {
         errorEl.textContent = "Incorrect passphrase. Try again.";
         errorEl.hidden = false;
@@ -493,6 +525,7 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
       }
     });
   });
+  return unlockGatePromise;
 }
 
 function updateLockButton() {
@@ -535,7 +568,7 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
   setZkAutoLockHandler(async () => {
     updateLockButton();
     if (gateGithubLogin && (await tryAutoUnlockZkDebounced(gateGithubLogin))) return;
-    showUnlockGate().catch(() => {});
+    await showUnlockGate().catch(() => {});
   });
   setZkPageRestoreHandler(() => {
     if (me.user?.zk_enrolled === true && !isZkUnlocked()) {
@@ -546,7 +579,7 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
           return;
         }
         updateLockButton();
-        showUnlockGate().catch(() => {});
+        await showUnlockGate().catch(() => {});
       })();
     }
   });

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -43,13 +43,12 @@ let gateGithubLogin = "";
 let keyBackupInflight = null;
 /** @type {object|null} */
 let keyBackupCache = null;
-let zkRestoreInFlight = false;
-let zkRestoreLastAt = 0;
-const ZK_RESTORE_DEBOUNCE_MS = 2000;
 /** @type {Promise<boolean>|null} */
 let zkUnlockInFlight = null;
 /** @type {Promise<void>|null} */
 let unlockGatePromise = null;
+/** @type {Promise<boolean>|null} */
+let zkBootstrapPromise = null;
 
 function invalidateKeyBackupCache() {
   keyBackupCache = null;
@@ -72,7 +71,7 @@ export function lockZkSession() {
   }
   zkLog("zk.lock.explicit");
   updateLockButton();
-  showUnlockGate().catch(() => {});
+  ensureZkUnlocked(gateGithubLogin).catch(() => {});
 }
 
 function zkRememberChecked() {
@@ -214,20 +213,24 @@ async function tryAutoUnlockZk(githubLogin) {
   return zkUnlockInFlight;
 }
 
-async function tryAutoUnlockZkDebounced(githubLogin) {
+/** Single-flight bootstrap: auto-unlock then at most one unlock gate (init + BFCache + idle lock). */
+async function ensureZkUnlocked(githubLogin) {
   if (isZkUnlocked()) return true;
-  const now = Date.now();
-  if (zkRestoreInFlight || now - zkRestoreLastAt < ZK_RESTORE_DEBOUNCE_MS) {
-    return false;
-  }
-  zkRestoreInFlight = true;
-  try {
-    const ok = await tryAutoUnlockZk(githubLogin);
-    zkRestoreLastAt = Date.now();
-    return ok;
-  } finally {
-    zkRestoreInFlight = false;
-  }
+  if (zkBootstrapPromise) return zkBootstrapPromise;
+  zkBootstrapPromise = (async () => {
+    try {
+      if (await tryAutoUnlockZk(githubLogin)) {
+        await syncZkRememberMode(githubLogin);
+        updateLockButton();
+        return true;
+      }
+      await showUnlockGate(githubLogin);
+      return isZkUnlocked();
+    } finally {
+      zkBootstrapPromise = null;
+    }
+  })();
+  return zkBootstrapPromise;
 }
 
 /** @deprecated Use tryAutoUnlockZk — kept for external importers. */
@@ -307,7 +310,11 @@ export async function unlockAccountKey(passphrase) {
   const session = await sessionAccountKey(accountKey);
   setZkSession(session, backup.key_fp);
   if (gateGithubLogin) {
-    await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
+    try {
+      await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
+    } catch (err) {
+      zkLog("zk.device.save.deferred", { error: String(err?.message ?? err) });
+    }
     await runBestEffortV1Migration(gateGithubLogin, accountKey, backup.key_fp);
   }
   zkLog("zk.unlock.success", {
@@ -513,10 +520,19 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
       try {
         const pass = passInput.value;
         await unlockAccountKey(pass);
-        await applyZkRememberChoice(githubLogin, pass, zkRememberChecked());
+        try {
+          await applyZkRememberChoice(githubLogin, pass, zkRememberChecked());
+        } catch (err) {
+          zkLog("zk.remember.save.deferred", { error: String(err?.message ?? err) });
+        }
         hideZkGate();
         finish();
       } catch {
+        if (isZkUnlocked()) {
+          hideZkGate();
+          finish();
+          return;
+        }
         errorEl.textContent = "Incorrect passphrase. Try again.";
         errorEl.hidden = false;
         submitBtn.disabled = false;
@@ -565,22 +581,14 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
   wireIdleLock();
   wirePageHideLock();
   wireZkLockButton();
-  setZkAutoLockHandler(async () => {
+  setZkAutoLockHandler(() => {
     updateLockButton();
-    if (gateGithubLogin && (await tryAutoUnlockZkDebounced(gateGithubLogin))) return;
-    await showUnlockGate().catch(() => {});
+    ensureZkUnlocked(gateGithubLogin).catch(() => {});
   });
   setZkPageRestoreHandler(() => {
     if (me.user?.zk_enrolled === true && !isZkUnlocked()) {
-      (async () => {
-        if (await tryAutoUnlockZkDebounced(githubLogin)) {
-          await syncZkRememberMode(githubLogin);
-          updateLockButton();
-          return;
-        }
-        updateLockButton();
-        await showUnlockGate().catch(() => {});
-      })();
+      updateLockButton();
+      ensureZkUnlocked(githubLogin).catch(() => {});
     }
   });
 
@@ -599,12 +607,7 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
   }
 
   if (!isZkUnlocked()) {
-    if (await tryAutoUnlockZk(githubLogin)) {
-      await syncZkRememberMode(githubLogin);
-      updateLockButton();
-    } else {
-      await showUnlockGate();
-    }
+    await ensureZkUnlocked(githubLogin);
     return true;
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.21.0"
+APP_RELEASE = "0.21.1"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -72,7 +72,7 @@ workers_dev = true
 # Worker also serves robots.txt + X-Robots-Tag when GITHUB_APP_SLUG is staging.
 
 [env.staging.vars]
-APP_RELEASE = "0.21.0"
+APP_RELEASE = "0.21.1"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"


### PR DESCRIPTION
## Promotion: staging → main (0.21.1)

### Bug Fixes

* **zk:** avoid double passphrase prompt on unlock (migration + parallel auto-unlock races)
* **zk:** dedupe unlock bootstrap across init, BFCache restore, and idle lock; tolerate IndexedDB persistence errors after successful crypto unlock

## Pre-flight

- [x] CI passing on staging (7/7 success)
- [x] Open PRs on staging acknowledged (dependabot #259, #260 — unrelated)
- [x] Deploy preview skipped (no `deploy-preview.yml` workflow in repo; ZK fix verified on staging)
- [x] Release notes committed to staging

---
Generated with `/promote`