### PR TITLE
chore: promote staging to main (0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.21.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.0...roxabi-live/v0.21.1) (2026-06-22)
+
+
+### Bug Fixes
+
+* **zk:** fix double passphrase prompt (migration races, parallel unlock paths, IndexedDB persistence errors)
+* **zk:** refresh decrypted titles immediately after unlock (BFCache / poll race showed `(locked)` until reload)
+* **zk:** cache `GET /api/zk/payloads` — stop sync-progress poll from spamming the endpoint every 2s
+* **auth:** branded post-OAuth interstitial (Roxabi card + spinner instead of blank white page)
+
+
 ## [0.21.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.20.0...roxabi-live/v0.21.0) (2026-06-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.21.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.0...roxabi-live/v0.21.1) (2026-06-22)
+
+
+### Bug Fixes
+
+* **zk:** avoid double passphrase prompt on unlock (migration + parallel auto-unlock races)
+* **zk:** dedupe unlock bootstrap across init, BFCache restore, and idle lock; tolerate IndexedDB persistence errors after successful crypto unlock
+
+
 ## [0.21.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.20.0...roxabi-live/v0.21.0) (2026-06-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## [0.21.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.0...roxabi-live/v0.21.1) (2026-06-22)
-
-
-### Bug Fixes
-
-* **zk:** avoid double passphrase prompt on unlock (migration + parallel auto-unlock races)
-* **zk:** dedupe unlock bootstrap across init, BFCache restore, and idle lock; tolerate IndexedDB persistence errors after successful crypto unlock
-
-
 ## [0.21.0](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.20.0...roxabi-live/v0.21.0) (2026-06-22)
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -25,6 +25,7 @@ import {
   getGithubUserToken,
   zkLoginUrl,
 } from "./zk-github.js";
+import { setZkSessionReadyHandler } from "./zk-session.js";
 import {
   applyZkDecryption,
   clearZkMigrationIncomplete,
@@ -513,6 +514,20 @@ async function loadGraphData() {
 let sessionZkOptIn = false;
 let sessionZkAccountKeyEnabled = false;
 let sessionGithubLogin = "";
+
+/** Re-decrypt titles when ZK unlock completes after a locked render (BFCache, poll race). */
+async function refreshZkTitles() {
+  if (!sessionZkOptIn || !sessionGithubLogin || !state.nodes?.length) return;
+  await applyZkDecryption(state.nodes, sessionGithubLogin, {
+    accountKeyMode: sessionZkAccountKeyEnabled,
+  });
+  state.nodesByKey = new Map(state.nodes.map((n) => [n.key, n]));
+  render();
+}
+
+setZkSessionReadyHandler(() => {
+  void refreshZkTitles();
+});
 
 async function loadAndRender(zkOptIn, githubLogin, zkAccountKeyEnabled = false) {
   const data = await loadGraphData();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -629,9 +629,12 @@ async function init() {
 
     if (zkAccountKeyEnabled) {
       const sealResult = await ensureAccountKeySealing(sessionGithubLogin, state.nodes);
-      await applyZkDecryption(state.nodes, sessionGithubLogin, { accountKeyMode: true });
-      state.nodesByKey = new Map(state.nodes.map((n) => [n.key, n]));
-      render();
+      // loadAndRender already decrypted; re-run only if sealing added new ciphertext rows.
+      if (sealResult?.sealed > 0) {
+        await applyZkDecryption(state.nodes, sessionGithubLogin, { accountKeyMode: true });
+        state.nodesByKey = new Map(state.nodes.map((n) => [n.key, n]));
+        render();
+      }
       showZkMigrationNotice();
       if (sealResult?.needsGithubLink) showZkGithubLinkNotice();
     }

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -32,7 +32,7 @@ import {
   wireIdleLock,
   wirePageHideLock,
 } from "./zk-session.js";
-import { migrateV1PayloadsToAccountKey } from "./zk-sync.js";
+import { fetchZkPayloadRows, migrateV1PayloadsToAccountKey } from "./zk-sync.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -261,9 +261,7 @@ function payloadsHaveV1(payloads) {
 
 async function fetchPayloadRows() {
   try {
-    const resp = await api("/api/zk/payloads");
-    const data = await resp.json();
-    return data.payloads ?? [];
+    return await fetchZkPayloadRows();
   } catch {
     return [];
   }

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -46,6 +46,10 @@ let keyBackupCache = null;
 let zkRestoreInFlight = false;
 let zkRestoreLastAt = 0;
 const ZK_RESTORE_DEBOUNCE_MS = 2000;
+/** @type {Promise<boolean>|null} */
+let zkUnlockInFlight = null;
+/** @type {Promise<void>|null} */
+let unlockGatePromise = null;
 
 function invalidateKeyBackupCache() {
   keyBackupCache = null;
@@ -133,10 +137,23 @@ async function putKeyBackup(body) {
   return result;
 }
 
+/** v1→v2 migration must never block unlock — a network error used to surface as "wrong passphrase". */
+async function runBestEffortV1Migration(githubLogin, accountKey, key_fp) {
+  if (!githubLogin) return;
+  try {
+    const payloads = await fetchPayloadRows();
+    if (payloadsHaveV1(payloads) && (await hasZkKeyPair(githubLogin))) {
+      await migrateV1PayloadsToAccountKey(githubLogin, accountKey, key_fp);
+    }
+  } catch (err) {
+    zkLog("zk.migrate.v1_to_v2.deferred", { error: String(err?.message ?? err) });
+  }
+}
+
 /**
  * Restore from device session or remembered passphrase — at most one GET key-backup.
  */
-async function tryAutoUnlockZk(githubLogin) {
+async function tryAutoUnlockZkInner(githubLogin) {
   if (isZkUnlocked()) return true;
 
   let backup;
@@ -169,10 +186,7 @@ async function tryAutoUnlockZk(githubLogin) {
     setZkSession(session, backup.key_fp);
     if (githubLogin) {
       await saveDeviceSession(githubLogin, accountKey, backup.key_fp);
-      const payloads = await fetchPayloadRows();
-      if (payloadsHaveV1(payloads) && (await hasZkKeyPair(githubLogin))) {
-        await migrateV1PayloadsToAccountKey(githubLogin, accountKey, backup.key_fp);
-      }
+      await runBestEffortV1Migration(githubLogin, accountKey, backup.key_fp);
     }
     setZkRememberMode(true);
     zkLog("zk.unlock.success", {
@@ -183,11 +197,21 @@ async function tryAutoUnlockZk(githubLogin) {
     updateLockButton();
     return true;
   } catch {
+    clearZkSession();
     await clearRememberPassphrase(githubLogin);
     setZkRememberMode(false);
     zkLog("zk.unlock.failure");
     return false;
   }
+}
+
+async function tryAutoUnlockZk(githubLogin) {
+  if (isZkUnlocked()) return true;
+  if (zkUnlockInFlight) return zkUnlockInFlight;
+  zkUnlockInFlight = tryAutoUnlockZkInner(githubLogin).finally(() => {
+    zkUnlockInFlight = null;
+  });
+  return zkUnlockInFlight;
 }
 
 async function tryAutoUnlockZkDebounced(githubLogin) {
@@ -272,26 +296,25 @@ export async function enrollAccountKey(passphrase, githubLogin) {
 export async function unlockAccountKey(passphrase) {
   const t0 = performance.now();
   const backup = await fetchKeyBackup();
+  let accountKey;
   try {
-    const accountKey = await unwrapAccountKey(passphrase, backup);
-    const session = await sessionAccountKey(accountKey);
-    setZkSession(session, backup.key_fp);
-    if (gateGithubLogin) {
-      await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
-      const payloads = await fetchPayloadRows();
-      if (payloadsHaveV1(payloads) && (await hasZkKeyPair(gateGithubLogin))) {
-        await migrateV1PayloadsToAccountKey(gateGithubLogin, accountKey, backup.key_fp);
-      }
-    }
-    zkLog("zk.unlock.success", {
-      key_fp: backup.key_fp,
-      kdf_duration_ms: Math.round(performance.now() - t0),
-    });
-    return { key_fp: backup.key_fp };
+    accountKey = await unwrapAccountKey(passphrase, backup);
   } catch (err) {
+    clearZkSession();
     zkLog("zk.unlock.failure");
     throw err;
   }
+  const session = await sessionAccountKey(accountKey);
+  setZkSession(session, backup.key_fp);
+  if (gateGithubLogin) {
+    await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
+    await runBestEffortV1Migration(gateGithubLogin, accountKey, backup.key_fp);
+  }
+  zkLog("zk.unlock.success", {
+    key_fp: backup.key_fp,
+    kdf_duration_ms: Math.round(performance.now() - t0),
+  });
+  return { key_fp: backup.key_fp };
 }
 
 function showZkGate() {
@@ -427,12 +450,20 @@ export function showEnrollGate(githubLogin) {
 }
 
 export function showUnlockGate(githubLogin = gateGithubLogin) {
-  return new Promise((resolve) => {
+  if (unlockGatePromise) return unlockGatePromise;
+
+  unlockGatePromise = new Promise((resolve) => {
+    const finish = () => {
+      unlockGatePromise = null;
+      resolve();
+    };
     const resetCtx = { $, escHtml, renderZkDialog };
     const reopenUnlock = () => {
-      showUnlockGate(githubLogin).then(resolve);
+      showUnlockGate(githubLogin).then(finish);
     };
     if (wireZkResetUi(resetCtx, githubLogin, reopenUnlock)) {
+      unlockGatePromise = null;
+      resolve();
       return;
     }
 
@@ -475,6 +506,7 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
 
     form?.addEventListener("submit", async (e) => {
       e.preventDefault();
+      if (submitBtn.disabled) return;
       errorEl.hidden = true;
       submitBtn.disabled = true;
       submitBtn.textContent = "Unlocking…";
@@ -483,7 +515,7 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
         await unlockAccountKey(pass);
         await applyZkRememberChoice(githubLogin, pass, zkRememberChecked());
         hideZkGate();
-        resolve();
+        finish();
       } catch {
         errorEl.textContent = "Incorrect passphrase. Try again.";
         errorEl.hidden = false;
@@ -493,6 +525,7 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
       }
     });
   });
+  return unlockGatePromise;
 }
 
 function updateLockButton() {
@@ -535,7 +568,7 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
   setZkAutoLockHandler(async () => {
     updateLockButton();
     if (gateGithubLogin && (await tryAutoUnlockZkDebounced(gateGithubLogin))) return;
-    showUnlockGate().catch(() => {});
+    await showUnlockGate().catch(() => {});
   });
   setZkPageRestoreHandler(() => {
     if (me.user?.zk_enrolled === true && !isZkUnlocked()) {
@@ -546,7 +579,7 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
           return;
         }
         updateLockButton();
-        showUnlockGate().catch(() => {});
+        await showUnlockGate().catch(() => {});
       })();
     }
   });

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -608,6 +608,7 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
 
   if (!isZkUnlocked()) {
     await ensureZkUnlocked(githubLogin);
+    if (!isZkUnlocked()) return false;
     return true;
   }
 

--- a/frontend/zk-enroll.js
+++ b/frontend/zk-enroll.js
@@ -43,13 +43,12 @@ let gateGithubLogin = "";
 let keyBackupInflight = null;
 /** @type {object|null} */
 let keyBackupCache = null;
-let zkRestoreInFlight = false;
-let zkRestoreLastAt = 0;
-const ZK_RESTORE_DEBOUNCE_MS = 2000;
 /** @type {Promise<boolean>|null} */
 let zkUnlockInFlight = null;
 /** @type {Promise<void>|null} */
 let unlockGatePromise = null;
+/** @type {Promise<boolean>|null} */
+let zkBootstrapPromise = null;
 
 function invalidateKeyBackupCache() {
   keyBackupCache = null;
@@ -72,7 +71,7 @@ export function lockZkSession() {
   }
   zkLog("zk.lock.explicit");
   updateLockButton();
-  showUnlockGate().catch(() => {});
+  ensureZkUnlocked(gateGithubLogin).catch(() => {});
 }
 
 function zkRememberChecked() {
@@ -214,20 +213,24 @@ async function tryAutoUnlockZk(githubLogin) {
   return zkUnlockInFlight;
 }
 
-async function tryAutoUnlockZkDebounced(githubLogin) {
+/** Single-flight bootstrap: auto-unlock then at most one unlock gate (init + BFCache + idle lock). */
+async function ensureZkUnlocked(githubLogin) {
   if (isZkUnlocked()) return true;
-  const now = Date.now();
-  if (zkRestoreInFlight || now - zkRestoreLastAt < ZK_RESTORE_DEBOUNCE_MS) {
-    return false;
-  }
-  zkRestoreInFlight = true;
-  try {
-    const ok = await tryAutoUnlockZk(githubLogin);
-    zkRestoreLastAt = Date.now();
-    return ok;
-  } finally {
-    zkRestoreInFlight = false;
-  }
+  if (zkBootstrapPromise) return zkBootstrapPromise;
+  zkBootstrapPromise = (async () => {
+    try {
+      if (await tryAutoUnlockZk(githubLogin)) {
+        await syncZkRememberMode(githubLogin);
+        updateLockButton();
+        return true;
+      }
+      await showUnlockGate(githubLogin);
+      return isZkUnlocked();
+    } finally {
+      zkBootstrapPromise = null;
+    }
+  })();
+  return zkBootstrapPromise;
 }
 
 /** @deprecated Use tryAutoUnlockZk — kept for external importers. */
@@ -307,7 +310,11 @@ export async function unlockAccountKey(passphrase) {
   const session = await sessionAccountKey(accountKey);
   setZkSession(session, backup.key_fp);
   if (gateGithubLogin) {
-    await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
+    try {
+      await saveDeviceSession(gateGithubLogin, accountKey, backup.key_fp);
+    } catch (err) {
+      zkLog("zk.device.save.deferred", { error: String(err?.message ?? err) });
+    }
     await runBestEffortV1Migration(gateGithubLogin, accountKey, backup.key_fp);
   }
   zkLog("zk.unlock.success", {
@@ -513,10 +520,19 @@ export function showUnlockGate(githubLogin = gateGithubLogin) {
       try {
         const pass = passInput.value;
         await unlockAccountKey(pass);
-        await applyZkRememberChoice(githubLogin, pass, zkRememberChecked());
+        try {
+          await applyZkRememberChoice(githubLogin, pass, zkRememberChecked());
+        } catch (err) {
+          zkLog("zk.remember.save.deferred", { error: String(err?.message ?? err) });
+        }
         hideZkGate();
         finish();
       } catch {
+        if (isZkUnlocked()) {
+          hideZkGate();
+          finish();
+          return;
+        }
         errorEl.textContent = "Incorrect passphrase. Try again.";
         errorEl.hidden = false;
         submitBtn.disabled = false;
@@ -565,22 +581,14 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
   wireIdleLock();
   wirePageHideLock();
   wireZkLockButton();
-  setZkAutoLockHandler(async () => {
+  setZkAutoLockHandler(() => {
     updateLockButton();
-    if (gateGithubLogin && (await tryAutoUnlockZkDebounced(gateGithubLogin))) return;
-    await showUnlockGate().catch(() => {});
+    ensureZkUnlocked(gateGithubLogin).catch(() => {});
   });
   setZkPageRestoreHandler(() => {
     if (me.user?.zk_enrolled === true && !isZkUnlocked()) {
-      (async () => {
-        if (await tryAutoUnlockZkDebounced(githubLogin)) {
-          await syncZkRememberMode(githubLogin);
-          updateLockButton();
-          return;
-        }
-        updateLockButton();
-        await showUnlockGate().catch(() => {});
-      })();
+      updateLockButton();
+      ensureZkUnlocked(githubLogin).catch(() => {});
     }
   });
 
@@ -599,12 +607,7 @@ export async function requireZkEnrollmentGate(me, githubLogin) {
   }
 
   if (!isZkUnlocked()) {
-    if (await tryAutoUnlockZk(githubLogin)) {
-      await syncZkRememberMode(githubLogin);
-      updateLockButton();
-    } else {
-      await showUnlockGate();
-    }
+    await ensureZkUnlocked(githubLogin);
     return true;
   }
 

--- a/frontend/zk-session.js
+++ b/frontend/zk-session.js
@@ -17,6 +17,8 @@ let rememberMode = false;
 let onAutoLock = null;
 /** @type {(() => void)|null} */
 let onPageRestore = null;
+/** @type {(() => void)|null} */
+let onSessionReady = null;
 
 export function isZkUnlocked() {
   return sessionKey !== null;
@@ -45,10 +47,16 @@ function currentIdleMs() {
   return rememberMode ? REMEMBER_IDLE_MS : IDLE_MS;
 }
 
+/** Fires after accountKey is loaded into memory (unlock, device restore, enroll). */
+export function setZkSessionReadyHandler(fn) {
+  onSessionReady = fn;
+}
+
 export function setZkSession(accountKey, keyFp) {
   sessionKey = accountKey;
   sessionKeyFp = keyFp;
   resetIdleTimer();
+  onSessionReady?.();
 }
 
 export function clearZkSession() {

--- a/frontend/zk-session.test.js
+++ b/frontend/zk-session.test.js
@@ -6,6 +6,7 @@ const {
   isZkUnlocked,
   setZkPageRestoreHandler,
   setZkAutoLockHandler,
+  setZkSessionReadyHandler,
   wirePageHideLock,
   wireIdleLock,
 } = await import("./zk-session.js");
@@ -41,6 +42,29 @@ describe("wirePageHideLock BFCache restore", () => {
     window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true }));
 
     expect(restoreHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("setZkSessionReadyHandler", () => {
+  afterEach(() => {
+    clearZkSession();
+    setZkSessionReadyHandler(null);
+  });
+
+  it("invokes handler when session is established", () => {
+    const onReady = vi.fn();
+    setZkSessionReadyHandler(onReady);
+    setZkSession({}, "fp12345678");
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke handler on clearZkSession", () => {
+    const onReady = vi.fn();
+    setZkSessionReadyHandler(onReady);
+    setZkSession({}, "fp12345678");
+    onReady.mockClear();
+    clearZkSession();
+    expect(onReady).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/zk-sync.js
+++ b/frontend/zk-sync.js
@@ -16,6 +16,36 @@ import { getSessionAccountKey, getSessionKeyFp, isZkUnlocked } from "./zk-sessio
 
 const BULK = 200;
 
+/** @type {Array<object>|null} */
+let payloadRowsCache = null;
+/** @type {Promise<Array<object>>|null} */
+let payloadRowsInflight = null;
+
+/** Drop cached ciphertext rows after local PUT (seal / migration). */
+export function invalidateZkPayloadCache() {
+  payloadRowsCache = null;
+  payloadRowsInflight = null;
+}
+
+/** GET /api/zk/payloads — single-flight + session cache (sync poll was spamming this). */
+export async function fetchZkPayloadRows({ force = false } = {}) {
+  if (!force && payloadRowsCache) return payloadRowsCache;
+  if (!force && payloadRowsInflight) return payloadRowsInflight;
+  payloadRowsInflight = api("/api/zk/payloads")
+    .then((r) => r.json())
+    .then((data) => {
+      const rows = data.payloads ?? [];
+      payloadRowsCache = rows;
+      payloadRowsInflight = null;
+      return rows;
+    })
+    .catch((err) => {
+      payloadRowsInflight = null;
+      throw err;
+    });
+  return payloadRowsInflight;
+}
+
 /** Label when graph title was redacted and this user has no ciphertext row (#216 hybrid multi-user). */
 export const SEALED_TITLE_LABEL = "(sealed)";
 
@@ -30,6 +60,7 @@ async function putPayloadBatches(payloads) {
       body: JSON.stringify({ payloads: payloads.slice(i, i + BULK) }),
     });
   }
+  invalidateZkPayloadCache();
 }
 
 async function sealNodes(nodes, githubLogin, contentByKey) {
@@ -89,11 +120,8 @@ async function sealNodes(nodes, githubLogin, contentByKey) {
 export async function migrateV1PayloadsToAccountKey(githubLogin, accountKey, key_fp) {
   if (!(await hasZkKeyPair(githubLogin))) return 0;
 
-  const resp = await api("/api/zk/payloads");
-  const { payloads } = await resp.json();
-  const v1Rows = (payloads ?? []).filter(
-    (row) => parseEnvelopeVersion(row.encrypted_payload) === 1,
-  );
+  const payloads = await fetchZkPayloadRows();
+  const v1Rows = payloads.filter((row) => parseEnvelopeVersion(row.encrypted_payload) === 1);
   if (v1Rows.length === 0) {
     clearZkMigrationIncomplete();
     await deleteZkKeyPair(githubLogin);
@@ -159,10 +187,8 @@ export function isZkMigrationIncomplete() {
 }
 
 async function loadSealedIssueKeys() {
-  const payloadResp = await api("/api/zk/payloads")
-    .then((r) => r.json())
-    .catch(() => ({ payloads: [] }));
-  return new Set((payloadResp.payloads ?? []).map((p) => p.issue_key));
+  const payloads = await fetchZkPayloadRows().catch(() => []);
+  return new Set(payloads.map((p) => p.issue_key));
 }
 
 /**
@@ -260,10 +286,8 @@ export async function syncZkContentFromGitHub(nodes, githubLogin, githubToken) {
 export async function applyZkDecryption(nodes, githubLogin, opts = {}) {
   const { accountKeyMode = false } = opts;
 
-  const { payloads } = await api("/api/zk/payloads")
-    .then((r) => r.json())
-    .catch(() => ({ payloads: [] }));
-  const byKey = new Map((payloads ?? []).map((p) => [p.issue_key, p]));
+  const payloads = await fetchZkPayloadRows().catch(() => []);
+  const byKey = new Map(payloads.map((p) => [p.issue_key, p]));
 
   if (accountKeyMode && !isZkUnlocked()) {
     for (const node of nodes) {

--- a/frontend/zk-sync.test.js
+++ b/frontend/zk-sync.test.js
@@ -33,13 +33,40 @@ vi.mock("./zk-crypto.js", () => ({
 
 const {
   applyZkDecryption,
+  fetchZkPayloadRows,
+  invalidateZkPayloadCache,
   migrateV1PayloadsToAccountKey,
   isZkMigrationIncomplete,
   LOCKED_TITLE_LABEL,
 } = await import("./zk-sync.js");
 
+describe("fetchZkPayloadRows", () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+    invalidateZkPayloadCache();
+  });
+
+  it("dedupes concurrent GETs and serves cache on subsequent calls", async () => {
+    apiMock.mockResolvedValue({
+      json: async () => ({ payloads: [{ issue_key: "Roxabi/live#1" }] }),
+    });
+
+    const [a, b] = await Promise.all([fetchZkPayloadRows(), fetchZkPayloadRows()]);
+    expect(a).toEqual(b);
+    expect(apiMock).toHaveBeenCalledTimes(1);
+
+    await fetchZkPayloadRows();
+    expect(apiMock).toHaveBeenCalledTimes(1);
+
+    invalidateZkPayloadCache();
+    await fetchZkPayloadRows();
+    expect(apiMock).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("applyZkDecryption", () => {
   beforeEach(() => {
+    invalidateZkPayloadCache();
     apiMock.mockReset();
     isZkUnlockedMock.mockReset();
     ensureZkKeyPairMock.mockReset();
@@ -67,6 +94,7 @@ describe("applyZkDecryption", () => {
 
 describe("migrateV1PayloadsToAccountKey", () => {
   beforeEach(() => {
+    invalidateZkPayloadCache();
     sessionStorage.clear();
     apiMock.mockReset();
     hasZkKeyPairMock.mockReset();

--- a/worker/src/auth/post-oauth.ts
+++ b/worker/src/auth/post-oauth.ts
@@ -35,13 +35,47 @@ function htmlAttrEscape(value: string): string {
 export function authNavigateHtml(dest: string, extraSetCookies: string[] = []): Response {
   const safeDest = sanitizeAuthRedirect(dest);
   const html = `<!DOCTYPE html>
-<html lang="fr">
+<html lang="fr" data-theme="dark">
 <head>
 <meta charset="utf-8">
-<title>Connexion…</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<title>Connexion · Roxabi Live</title>
+<link rel="icon" href="/assets/logo/foundation-block-16.svg" type="image/svg+xml">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@500;600;700&amp;display=swap">
+<style>
+:root{color-scheme:dark;--bg:#0d1117;--bg-elevated:#13191f;--border:#21262d;--border-hi:#30363d;--text:#f0ede6;--text-muted:#8b93a1;--accent:#f0b429;--accent-dim:rgba(240,180,41,.14);--accent-glow:rgba(240,180,41,.35);--panel-shadow:0 8px 24px rgba(0,0,0,.5);--radius-lg:14px;--font-body:"Inter",system-ui,sans-serif}
+*{box-sizing:border-box;margin:0;padding:0}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px;background:var(--bg);color:var(--text);font-family:var(--font-body);font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;background:radial-gradient(ellipse 80% 50% at 50% -10%,var(--accent-glow),transparent 55%),radial-gradient(ellipse 40% 30% at 100% 0%,rgba(20,184,166,.08),transparent 50%);z-index:0}
+.auth-nav-shell{position:relative;z-index:1;width:100%;max-width:380px}
+.auth-nav-card{background:var(--bg-elevated);border:1px solid var(--border-hi);border-radius:var(--radius-lg);box-shadow:var(--panel-shadow);padding:32px 28px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:18px}
+.auth-nav-brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:18px;letter-spacing:-.02em}
+.auth-nav-brand img{width:28px;height:28px}
+.auth-nav-brand .accent{color:var(--accent)}
+.auth-nav-spinner{width:40px;height:40px;border-radius:50%;border:3px solid var(--border);border-top-color:var(--accent);animation:auth-nav-spin .9s linear infinite}
+@keyframes auth-nav-spin{to{transform:rotate(360deg)}}
+.auth-nav-msg{font-weight:500;margin:0}
+.auth-nav-hint{color:var(--text-muted);font-size:13px;margin:0;max-width:28ch}
+.auth-nav-link{color:var(--accent);font-weight:600;text-decoration:none}
+.auth-nav-link:hover{text-decoration:underline}
+.auth-nav-foot{color:var(--text-muted);font-size:12px;margin:0}
+</style>
 </head>
 <body>
-<p id="msg">Connexion en cours…</p>
+<main class="auth-nav-shell" role="main">
+  <div class="auth-nav-card" role="status" aria-live="polite" aria-busy="true">
+    <div class="auth-nav-brand">
+      <img src="/assets/logo/foundation-block-16.svg" alt="" width="28" height="28" />
+      <span>Roxabi <span class="accent">Live</span></span>
+    </div>
+    <div class="auth-nav-spinner" aria-hidden="true"></div>
+    <p class="auth-nav-msg" id="msg">Connexion en cours…</p>
+    <p class="auth-nav-hint" id="hint">Préparation de votre session sécurisée</p>
+  </div>
+  <p class="auth-nav-foot">Ne fermez pas cet onglet</p>
+</main>
 <script>
 (function (next) {
   var tries = 0;
@@ -49,12 +83,13 @@ export function authNavigateHtml(dest: string, extraSetCookies: string[] = []): 
   function go() { location.replace(next); }
   function showSlowLink() {
     var msg = document.getElementById("msg");
-    msg.textContent = "";
-    var a = document.createElement("a");
-    a.href = next;
-    a.textContent = "continuer";
-    msg.appendChild(document.createTextNode("Session lente — "));
-    msg.appendChild(a);
+    var hint = document.getElementById("hint");
+    var card = msg && msg.closest(".auth-nav-card");
+    if (card) card.setAttribute("aria-busy", "false");
+    if (msg) msg.textContent = "Session lente";
+    if (hint) {
+      hint.innerHTML = 'La connexion prend plus de temps que prévu. <a class="auth-nav-link" href="' + next.replace(/&/g, "&amp;").replace(/"/g, "&quot;") + '">Continuer vers le dashboard</a>';
+    }
   }
   function poll() {
     fetch("/api/me", { credentials: "same-origin", cache: "no-store" })
@@ -71,7 +106,9 @@ export function authNavigateHtml(dest: string, extraSetCookies: string[] = []): 
   setTimeout(poll, 50);
 })(${JSON.stringify(safeDest)});
 </script>
-<noscript><p><a href="${htmlAttrEscape(safeDest)}">Continuer</a></p></noscript>
+<noscript>
+  <p style="text-align:center;margin-top:16px"><a class="auth-nav-link" href="${htmlAttrEscape(safeDest)}">Continuer vers le dashboard</a></p>
+</noscript>
 </body>
 </html>`;
   const headers = new Headers({

--- a/worker/src/auth/session.test.ts
+++ b/worker/src/auth/session.test.ts
@@ -457,9 +457,9 @@ describe("authNavigateHtml", () => {
   it("renders safe noscript fallback link for ZK destinations", async () => {
     const res = authNavigateHtml("/dashboard?zk_handoff=abc");
     const body = await res.text();
-    expect(body).toMatch(
-      /<noscript><p><a href="\/dashboard\?zk_handoff=abc">Continuer<\/a><\/p><\/noscript>/,
-    );
+    expect(body).toContain('href="/dashboard?zk_handoff=abc"');
+    expect(body).toContain("Continuer vers le dashboard");
+    expect(body).toContain("Connexion en cours");
     expect(body).not.toContain("<script>alert");
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.21.1"
+APP_RELEASE = "0.21.0"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -72,7 +72,7 @@ workers_dev = true
 # Worker also serves robots.txt + X-Robots-Tag when GITHUB_APP_SLUG is staging.
 
 [env.staging.vars]
-APP_RELEASE = "0.21.1"
+APP_RELEASE = "0.21.0"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.21.0"
+APP_RELEASE = "0.21.1"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -72,7 +72,7 @@ workers_dev = true
 # Worker also serves robots.txt + X-Robots-Tag when GITHUB_APP_SLUG is staging.
 
 [env.staging.vars]
-APP_RELEASE = "0.21.0"
+APP_RELEASE = "0.21.1"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"


### PR DESCRIPTION
## Promotion: staging → main (0.21.1)

### Bug Fixes

* **zk:** fix double passphrase prompt (migration races, parallel unlock paths, IndexedDB persistence errors)
* **zk:** refresh decrypted titles immediately after unlock (BFCache / poll race showed `(locked)` until reload)
* **zk:** cache `GET /api/zk/payloads` — stop sync-progress poll from spamming the endpoint every 2s
* **auth:** branded post-OAuth interstitial (Roxabi card + spinner instead of blank white page)

## Pre-flight

- [x] CI passing on staging (6/6 success, 1 pending)
- [x] Open PRs on staging acknowledged (dependabot #259, #260 — unrelated)
- [x] Deploy preview skipped (no workflow; validated on staging)
- [x] Release notes committed to staging

---
Generated with `/promote`