### PR TITLE
chore: promote staging to main (0.21.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.21.2](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.1...roxabi-live/v0.21.2) (2026-06-23)
+
+
+### Bug Fixes
+
+* **graph:** centralize hover-chain highlight across table, list, and graph views (single `hover.js` module)
+* **graph:** default Order by to `none` with `localStorage` persistence (migrates legacy `sessionStorage`)
+* **graph:** cap column spacing so sparse bands no longer stretch across half the page
+
+
 ## [0.21.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.0...roxabi-live/v0.21.1) (2026-06-22)
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6,7 +6,7 @@ import {
   requireAuthGate,
   stripStaleOAuthCallbackUrl,
 } from "./auth.js";
-import { clearSearchHighlight, initGraph } from "./graph.js";
+import { initGraph } from "./graph.js";
 import { clearPinned } from "./hover.js";
 import { ensureSyncStarted, startSyncProgressMonitor } from "./initial-sync.js";
 import { renderList } from "./list.js";
@@ -241,17 +241,17 @@ searchClear.addEventListener("click", () => {
   searchInput.value = "";
   setState({ search: "" });
   searchInput.focus();
-  clearSearchHighlight();
+  clearPinned();
   render();
 });
 
-// ESC key clears search + graph highlight
+// ESC key clears search + highlight chain
 searchInput.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
     e.preventDefault();
     searchInput.value = "";
     setState({ search: "" });
-    clearSearchHighlight();
+    clearPinned();
     render();
   }
 });

--- a/frontend/graph.js
+++ b/frontend/graph.js
@@ -1,113 +1,12 @@
 // graph.js — v6 graph view with v5 layout
 // Uses layout.js for positioning and render_graph.js for DOM rendering
 
+import { initGraphHover } from "./hover.js";
 import { runLayout } from "./layout.js";
-import { getEdgeElements, getLabelElements, renderGraph } from "./render_graph.js";
+import { getEdgeElements, renderGraph } from "./render_graph.js";
 import { filteredNodesForGraph, state } from "./state.js";
 
 let loaded = false;
-
-// ── Shared highlight helpers ────────────────────────────────────────────────
-function getReachableKeys(edges, startKey, dir) {
-  const visited = new Set();
-  const queue = [startKey];
-  while (queue.length) {
-    const k = queue.shift();
-    if (visited.has(k)) continue;
-    visited.add(k);
-    for (const e of edges) {
-      const next = dir === "up" ? e.dataset.src : e.dataset.dst;
-      const cur = dir === "up" ? e.dataset.dst : e.dataset.src;
-      if (cur === k && next) queue.push(next);
-    }
-  }
-  visited.delete(startKey);
-  return visited;
-}
-
-function applyHighlight(panel, edges, key) {
-  const labels = getLabelElements(panel);
-  const byKey = new Map();
-  for (const el of labels) {
-    const k = el.dataset.iss;
-    if (!k) continue;
-    if (!byKey.has(k)) byKey.set(k, []);
-    byKey.get(k).push(el);
-  }
-
-  panel.classList.add("hl-active");
-  (byKey.get(key) || []).forEach((n) => n.classList.add("hl-self"));
-
-  for (const k of getReachableKeys(edges, key, "up")) {
-    (byKey.get(k) || []).forEach((n) => n.classList.add("hl-upstream"));
-  }
-  for (const k of getReachableKeys(edges, key, "down")) {
-    (byKey.get(k) || []).forEach((n) => n.classList.add("hl-downstream"));
-  }
-
-  for (const e of edges) {
-    const src = e.dataset.src;
-    const dst = e.dataset.dst;
-    if (src && dst) {
-      const srcIsHl = (byKey.get(src) || []).some(
-        (n) =>
-          n.classList.contains("hl-self") ||
-          n.classList.contains("hl-upstream") ||
-          n.classList.contains("hl-downstream"),
-      );
-      const dstIsHl = (byKey.get(dst) || []).some(
-        (n) =>
-          n.classList.contains("hl-self") ||
-          n.classList.contains("hl-upstream") ||
-          n.classList.contains("hl-downstream"),
-      );
-      if (srcIsHl && dstIsHl) e.classList.add("hl-edge");
-    }
-  }
-}
-
-function clearHighlight(panel, edges) {
-  panel.classList.remove("hl-active");
-  panel
-    .querySelectorAll(".hl-self, .hl-upstream, .hl-downstream")
-    .forEach((el) => el.classList.remove("hl-self", "hl-upstream", "hl-downstream"));
-  edges.forEach((e) => e.classList.remove("hl-edge"));
-}
-
-// ── Hover-chain highlight ─────────────────────────────────────────────────
-function wireHoverChain(panel, edges) {
-  const labels = getLabelElements(panel);
-  const allItems = labels;
-
-  for (const el of allItems) {
-    el.addEventListener("mouseenter", () => {
-      clearHighlight(panel, edges);
-      applyHighlight(panel, edges, el.dataset.iss);
-    });
-    el.addEventListener("mouseleave", () => clearHighlight(panel, edges));
-  }
-}
-
-// ── Search highlight (tree-based, no filtering) ─────────────────────────────
-function applySearchHighlight(panel, nodes, edges) {
-  const search = (state.search ?? "").trim().toLowerCase();
-  if (!search) return;
-
-  // Find matching nodes
-  const matches = nodes.filter((n) => {
-    const hay = `${n.key} ${n.title ?? ""} ${(n.labels ?? []).join(" ")}`.toLowerCase();
-    return hay.includes(search);
-  });
-
-  if (matches.length === 0) return;
-
-  // Apply highlight to first match and its tree
-  const key = matches[0].key;
-  applyHighlight(panel, edges, key);
-}
-
-// Store current edges for clearSearchHighlight
-let currentEdges = [];
 
 // ── Main graph initialization ────────────────────────────────────────────
 export async function initGraph() {
@@ -127,7 +26,6 @@ export async function initGraph() {
       nodeKeys.has(e.dst) &&
       (e.kind === "blocks" || (state.showParents && e.kind === "parent")),
   );
-  currentEdges = [];
 
   if (nodes.length === 0) {
     panel.innerHTML = '<div class="error-msg">No issues match the current filters.</div>';
@@ -140,23 +38,15 @@ export async function initGraph() {
     const layoutResult = await runLayout(nodes, edges, state.graphRow, state.graphCol);
     renderGraph(panel, nodes, edges, layoutResult);
 
-    // Get DOM edge elements for highlight
-    currentEdges = getEdgeElements(panel);
-
-    wireHoverChain(panel, currentEdges);
-    applySearchHighlight(panel, nodes, currentEdges);
+    initGraphHover(panel, {
+      chainEdges: edges,
+      edgeElements: getEdgeElements(panel),
+      nodes,
+    });
     loaded = true;
   } catch (e) {
     panel.innerHTML = `<div class="error-msg">Graph layout failed: ${e.message}</div>`;
     console.error("Graph layout error:", e);
-  }
-}
-
-// ── Clear search highlight (for ESC key) ───────────────────────────────────
-export function clearSearchHighlight() {
-  const panel = document.getElementById("graph-panel");
-  if (panel && currentEdges.length) {
-    clearHighlight(panel, currentEdges);
   }
 }
 

--- a/frontend/hover.js
+++ b/frontend/hover.js
@@ -1,25 +1,40 @@
-// hover.js — hover-chain highlight for table and list views
-// Lifted from v5 hover.js, adapted for v6 module system
+// hover.js — centralized hover-chain highlight (table, list, graph)
 
 import { state } from "./state.js";
 
-// ── Build adjacency maps from edges ───────────────────────────────────────────
-function buildAdjacency() {
-  const blockers = new Map(); // key → keys that block it
-  const unblocks = new Map(); // key → keys it unblocks
+/** @typedef {{ src: string, dst: string, kind?: string }} ChainEdge */
 
-  for (const e of state.edges) {
-    if (e.kind === "blocks" || !e.kind) {
-      if (!blockers.has(e.dst)) blockers.set(e.dst, []);
-      blockers.get(e.dst).push(e.src);
-      if (!unblocks.has(e.src)) unblocks.set(e.src, []);
-      unblocks.get(e.src).push(e.dst);
-    }
+/** @typedef {{
+ *   panel: HTMLElement,
+ *   chainEdges: ChainEdge[],
+ *   edgeElements: Element[],
+ *   targetSelector: string,
+ * }} HoverSession */
+
+let activeSession = null;
+let pinnedKey = null;
+let searchPinWired = false;
+
+// ── Graph traversal ───────────────────────────────────────────────────────────
+
+/**
+ * Build upstream/downstream adjacency from the supplied edge list.
+ * Callers choose which kinds to include (table/list: blocks only; graph: blocks + parent).
+ * @param {ChainEdge[]} edges
+ */
+export function buildAdjacency(edges) {
+  const blockers = new Map();
+  const unblocks = new Map();
+  for (const e of edges) {
+    if (!blockers.has(e.dst)) blockers.set(e.dst, []);
+    blockers.get(e.dst).push(e.src);
+    if (!unblocks.has(e.src)) unblocks.set(e.src, []);
+    unblocks.get(e.src).push(e.dst);
   }
   return { blockers, unblocks };
 }
 
-// ── Traverse graph to find upstream/downstream ────────────────────────────────
+/** @param {string} start @param {Map<string, string[]>} adj */
 function traverse(start, adj) {
   const seen = new Set();
   const stack = [start];
@@ -35,142 +50,216 @@ function traverse(start, adj) {
   return seen;
 }
 
-// ── Highlight logic ────────────────────────────────────────────────────────────
-let panelEl = null;
-const targetsFn = null;
-let edgesFn = null;
-let pinnedKey = null;
+/** @param {string} key @param {ChainEdge[]} edges */
+export function getHighlightChain(key, edges) {
+  const { blockers, unblocks } = buildAdjacency(edges);
+  const upstream = traverse(key, blockers);
+  const downstream = traverse(key, unblocks);
+  const all = new Set([key, ...upstream, ...downstream]);
+  return { upstream, downstream, all };
+}
 
-function highlightKey(k, byKey, edges) {
-  const { blockers, unblocks } = buildAdjacency();
-  const up = traverse(k, blockers);
-  const down = traverse(k, unblocks);
+// ── DOM helpers ─────────────────────────────────────────────────────────────
 
-  panelEl.classList.add("hl-active");
-  (byKey.get(k) || []).forEach((n) => n.classList.add("hl-self"));
-  up.forEach((key) => (byKey.get(key) || []).forEach((n) => n.classList.add("hl-upstream")));
-  down.forEach((key) => (byKey.get(key) || []).forEach((n) => n.classList.add("hl-downstream")));
+/** @param {ParentNode} panel @param {string} [selector] */
+export function bucketTargets(panel, selector = "[data-iss]") {
+  const byKey = new Map();
+  for (const el of panel.querySelectorAll(selector)) {
+    const k = el.dataset.iss;
+    if (!k) continue;
+    if (!byKey.has(k)) byKey.set(k, []);
+    byKey.get(k).push(el);
+  }
+  return byKey;
+}
 
-  const chain = new Set([k, ...up, ...down]);
-  edges.forEach((e) => {
-    if (chain.has(e.dataset.src) && chain.has(e.dataset.tgt)) {
+// ── Apply / clear ─────────────────────────────────────────────────────────────
+
+/**
+ * @param {HTMLElement} panel
+ * @param {string} key
+ * @param {{ byKey: Map<string, Element[]>, chainEdges: ChainEdge[], edgeElements?: Element[] }} opts
+ */
+export function applyHighlight(panel, key, { byKey, chainEdges, edgeElements = [] }) {
+  const { upstream, downstream, all } = getHighlightChain(key, chainEdges);
+
+  panel.classList.add("hl-active");
+  (byKey.get(key) || []).forEach((n) => n.classList.add("hl-self"));
+  for (const k of upstream) {
+    (byKey.get(k) || []).forEach((n) => n.classList.add("hl-upstream"));
+  }
+  for (const k of downstream) {
+    (byKey.get(k) || []).forEach((n) => n.classList.add("hl-downstream"));
+  }
+
+  for (const e of edgeElements) {
+    const src = e.dataset.src;
+    const dst = e.dataset.dst;
+    if (src && dst && all.has(src) && all.has(dst)) {
       e.classList.add("hl-edge");
     }
-  });
+  }
 }
 
-function clearHighlight() {
-  if (!panelEl) return;
-  panelEl.classList.remove("hl-active");
-  panelEl
+/** @param {HTMLElement} panel @param {Element[]} [edgeElements] */
+export function clearHighlight(panel, edgeElements = []) {
+  panel.classList.remove("hl-active");
+  panel
     .querySelectorAll(".hl-self, .hl-upstream, .hl-downstream")
     .forEach((el) => el.classList.remove("hl-self", "hl-upstream", "hl-downstream"));
-  (edgesFn ? edgesFn() : []).forEach((e) => e.classList.remove("hl-edge"));
+  edgeElements.forEach((e) => e.classList.remove("hl-edge"));
 }
 
-function restorePinned(byKey, edges) {
-  clearHighlight();
-  if (pinnedKey) highlightKey(pinnedKey, byKey, edges);
-}
-
-// ── Wire hover events on all targets ───────────────────────────────────────────
-function wireTargets(targets, byKey, edges) {
-  targets.forEach((el) => {
-    el.addEventListener("mouseenter", () => {
-      clearHighlight();
-      highlightKey(el.dataset.iss, byKey, edges);
-    });
-    el.addEventListener("mouseleave", () => restorePinned(byKey, edges));
+function restorePinned(session) {
+  clearHighlight(session.panel, session.edgeElements);
+  if (!pinnedKey) return;
+  applyHighlight(session.panel, pinnedKey, {
+    byKey: bucketTargets(session.panel, session.targetSelector),
+    chainEdges: session.chainEdges,
+    edgeElements: session.edgeElements,
   });
 }
 
-// ── Wire search input for pinned highlight ─────────────────────────────────────
-let searchWired = false;
+// ── Wiring ────────────────────────────────────────────────────────────────────
 
-function wireSearch(input) {
-  if (!input || searchWired) return;
-  searchWired = true;
+/** @param {HoverSession} session */
+function wireHoverChain(session) {
+  const { panel, targetSelector, edgeElements } = session;
+  const targets = panel.querySelectorAll(targetSelector);
+  for (const el of targets) {
+    el.addEventListener("mouseenter", () => {
+      clearHighlight(panel, edgeElements);
+      applyHighlight(panel, el.dataset.iss, {
+        byKey: bucketTargets(panel, targetSelector),
+        chainEdges: session.chainEdges,
+        edgeElements,
+      });
+    });
+    el.addEventListener("mouseleave", () => restorePinned(session));
+  }
+}
 
-  function applySearch() {
+/** Issue-number pin for table/list search (highlights chain without re-render). */
+function wireSearchPin(input) {
+  if (!input || searchPinWired) return;
+  searchPinWired = true;
+
+  input.addEventListener("input", () => {
+    if (state.view === "graph") return;
     const raw = input.value.trim().replace(/^#/, "");
     if (!raw) {
       pinnedKey = null;
-      clearHighlight();
+      if (activeSession) clearHighlight(activeSession.panel, activeSession.edgeElements);
       return;
     }
-    // Rebuild byNum from current view panel DOM on each search (handles filtered nodes)
-    const byNum = new Map();
-    const currentByKey = new Map();
-    const panel = panelEl || document.querySelector(".view-active");
+    const panel = activeSession?.panel || document.querySelector(".view-active");
     if (!panel) return;
-    panel.querySelectorAll("[data-iss]").forEach((el) => {
+
+    const byNum = new Map();
+    const byKey = new Map();
+    for (const el of panel.querySelectorAll("[data-iss]")) {
       const k = el.dataset.iss;
-      if (!k) return;
-      if (!currentByKey.has(k)) currentByKey.set(k, []);
-      currentByKey.get(k).push(el);
+      if (!k) continue;
+      if (!byKey.has(k)) byKey.set(k, []);
+      byKey.get(k).push(el);
       const m = /#(\d+)$/.exec(k);
-      if (!m) return;
+      if (!m) continue;
       const num = m[1];
       if (!byNum.has(num)) byNum.set(num, []);
       byNum.get(num).push(k);
-    });
+    }
+
     const keys = byNum.get(raw);
-    if (!keys || keys.length === 0) {
+    if (!keys?.length) {
       pinnedKey = null;
-      clearHighlight();
+      clearHighlight(panel, activeSession?.edgeElements ?? []);
       return;
     }
+
     pinnedKey = keys[0];
-    clearHighlight();
-    // Get current edge elements from graph if visible
-    const edges = Array.from(panel.querySelectorAll(".gg-edge[data-src]"));
-    highlightKey(pinnedKey, currentByKey, edges);
-  }
-
-  input.addEventListener("input", applySearch);
-
-  // Esc clears search
-  document.addEventListener("keydown", (e) => {
-    if (e.key !== "Escape") return;
-    if (!input.value && !pinnedKey) return;
-    input.value = "";
-    applySearch();
-    if (document.activeElement === input) input.blur();
+    const session = activeSession ?? {
+      panel,
+      chainEdges: state.edges.filter((e) => e.kind === "blocks" || !e.kind),
+      edgeElements: [],
+      targetSelector: "[data-iss]",
+    };
+    clearHighlight(panel, session.edgeElements);
+    applyHighlight(panel, pinnedKey, {
+      byKey,
+      chainEdges: session.chainEdges,
+      edgeElements: session.edgeElements,
+    });
   });
 }
 
-// ── Public: initialize hover for a view container ──────────────────────────────
-export function initHover(panel, viewName) {
-  panelEl = panel;
+// ── Public API ────────────────────────────────────────────────────────────────
 
-  // Get all elements with data-iss (issue cards, list rows, etc.)
-  const targets = Array.from(panel.querySelectorAll("[data-iss]"));
-  if (targets.length === 0) return;
+/** Table and list views — blocks edges only, no SVG edges. */
+export function initHover(panel) {
+  const session = {
+    panel,
+    chainEdges: state.edges.filter((e) => e.kind === "blocks" || !e.kind),
+    edgeElements: [],
+    targetSelector: "[data-iss]",
+  };
+  activeSession = session;
+  wireHoverChain(session);
 
-  // Bucket elements by issue key
-  const byKey = new Map();
-  targets.forEach((el) => {
-    const k = el.dataset.iss;
-    if (!byKey.has(k)) byKey.set(k, []);
-    byKey.get(k).push(el);
-  });
-
-  // Get edge elements if any (for graph view)
-  const edges =
-    viewName === "graph" ? Array.from(panel.querySelectorAll(".gg-edge[data-src]")) : [];
-
-  edgesFn = () => edges;
-
-  wireTargets(targets, byKey, edges);
-
-  // Wire search once (guarded by searchWired flag)
   const searchInput = document.getElementById("search-input");
-  if (searchInput) {
-    wireSearch(searchInput);
-  }
+  if (searchInput) wireSearchPin(searchInput);
 }
 
-// ── Clear pinned key when filters change ───────────────────────────────────────
+/**
+ * Graph view — uses filtered chain edges (blocks + optional parent) and SVG edge elements.
+ * @param {HTMLElement} panel
+ * @param {{ chainEdges: ChainEdge[], edgeElements: Element[], nodes: Array<{ key: string, title?: string|null, labels?: string[] }> }} opts
+ */
+export function initGraphHover(panel, { chainEdges, edgeElements, nodes }) {
+  const session = {
+    panel,
+    chainEdges,
+    edgeElements,
+    targetSelector: ".gg-node[data-iss], .gg-ilabel[data-iss]",
+  };
+  activeSession = session;
+  wireHoverChain(session);
+  applyGraphSearchHighlight(panel, nodes, session);
+}
+
+/**
+ * Graph search: highlight first text match + dependency chain (does not filter nodes).
+ * @param {HTMLElement} panel
+ * @param {Array<{ key: string, title?: string|null, labels?: string[] }>} nodes
+ * @param {HoverSession} session
+ */
+export function applyGraphSearchHighlight(panel, nodes, session = activeSession) {
+  if (!session) return;
+  const search = (state.search ?? "").trim().toLowerCase();
+  if (!search) {
+    pinnedKey = null;
+    return;
+  }
+
+  const match = nodes.find((n) => {
+    const hay = `${n.key} ${n.title ?? ""} ${(n.labels ?? []).join(" ")}`.toLowerCase();
+    return hay.includes(search);
+  });
+  if (!match) {
+    pinnedKey = null;
+    return;
+  }
+
+  pinnedKey = match.key;
+  clearHighlight(panel, session.edgeElements);
+  applyHighlight(panel, pinnedKey, {
+    byKey: bucketTargets(panel, session.targetSelector),
+    chainEdges: session.chainEdges,
+    edgeElements: session.edgeElements,
+  });
+}
+
+/** Clear pinned search highlight (ESC, filter changes, search clear). */
 export function clearPinned() {
   pinnedKey = null;
+  if (activeSession) clearHighlight(activeSession.panel, activeSession.edgeElements);
 }

--- a/frontend/hover.test.js
+++ b/frontend/hover.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getHighlightChain } from "./hover.js";
+
+describe("highlight chain traversal", () => {
+  const edges = [
+    { src: "Org/a#1", dst: "Org/a#2", kind: "blocks" },
+    { src: "Org/a#2", dst: "Org/a#3", kind: "blocks" },
+    { src: "Org/a#10", dst: "Org/a#11", kind: "parent" },
+  ];
+
+  it("walks upstream and downstream along blocks edges only", () => {
+    const chain = getHighlightChain("Org/a#2", edges);
+    expect(chain.upstream.has("Org/a#1")).toBe(true);
+    expect(chain.downstream.has("Org/a#3")).toBe(true);
+    expect(chain.all.has("Org/a#2")).toBe(true);
+    expect(chain.all.has("Org/a#10")).toBe(false);
+    expect(chain.all.has("Org/a#11")).toBe(false);
+  });
+
+  it("traverses parent edges when the caller includes them in chainEdges", () => {
+    const parentEdges = edges.filter((e) => e.kind === "parent");
+    const chain = getHighlightChain("Org/a#10", parentEdges);
+    expect(chain.downstream.has("Org/a#11")).toBe(true);
+    expect(chain.upstream.size).toBe(0);
+  });
+});

--- a/frontend/layout.js
+++ b/frontend/layout.js
@@ -10,6 +10,8 @@ const Y_TOP = 1.5;
 const Y_BOT = 88.0;
 const MIN_NODE_X = 8.0;
 const MIN_VIS_NODE_GAP = 4.0;
+/** Max center-to-center step between order-by columns (avoids half-page gaps). */
+const MAX_COL_CENTER_STEP = 24.0;
 const MAX_BAND_GAP_PX = 80;
 const MIN_CONTAINER_H = 320;
 
@@ -37,12 +39,13 @@ export function edgePath(x1, y1, x2, y2) {
   return `M ${x1.toFixed(2)},${y1.toFixed(2)} C ${x1.toFixed(2)},${ymid.toFixed(2)} ${x2.toFixed(2)},${ymid.toFixed(2)} ${x2.toFixed(2)},${y2.toFixed(2)}`;
 }
 
-/** Full-lane column anchors (repo, lane, …). */
+/** Column anchors (repo, lane, …). Uses full lane when crowded; caps step when few columns. */
 function xFromColIdx(idx, colCount) {
   const pageSpan = LANE_X_END - LANE_X_START;
   const pageCenter = (LANE_X_START + LANE_X_END) / 2;
   if (colCount <= 1) return pageCenter;
-  const step = pageSpan / (colCount - 1);
+  const naturalStep = pageSpan / (colCount - 1);
+  const step = Math.min(naturalStep, MAX_COL_CENTER_STEP);
   const span = step * (colCount - 1);
   const xStart = pageCenter - span / 2;
   return xStart + idx * step;

--- a/frontend/layout.test.js
+++ b/frontend/layout.test.js
@@ -134,6 +134,16 @@ describe("layoutV5 column grouping", () => {
     }
   });
 
+  it("does not stretch two sparse column groups across half the page", () => {
+    const nodes = [
+      node("Org/repo-a#1", { repo: "Org/repo-a" }),
+      node("Org/repo-b#2", { repo: "Org/repo-b" }),
+    ];
+    const result = layoutV5(nodes, [], "milestone", "repo");
+    const xs = [...result.positions.values()].map((p) => p.x);
+    expect(Math.max(...xs) - Math.min(...xs)).toBeLessThan(40);
+  });
+
   it("keeps repo columns apart on the same band when order by is repo", () => {
     const nodes = [
       node("Org/repo-a#1", { repo: "Org/repo-a" }),

--- a/frontend/list.js
+++ b/frontend/list.js
@@ -437,5 +437,5 @@ export function renderList(container) {
   container.appendChild(table);
 
   // Wire hover-chain highlighting
-  initHover(container, "list");
+  initHover(container);
 }

--- a/frontend/pivot.js
+++ b/frontend/pivot.js
@@ -437,5 +437,5 @@ export function renderTable(container) {
   container.appendChild(grid);
 
   // Wire hover-chain highlighting
-  initHover(container, "table");
+  initHover(container);
 }

--- a/frontend/state-graph-prefs.test.js
+++ b/frontend/state-graph-prefs.test.js
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { setState, state } from "./state.js";
+
+describe("graph order-by preference", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("defaults graphCol to none when nothing is stored", async () => {
+    const mod = await import(`./state.js?${Date.now()}`);
+    expect(mod.state.graphCol).toBe("none");
+  });
+
+  it("reads graphCol from localStorage", async () => {
+    localStorage.setItem("v6:graphCol", "repo");
+    const mod = await import(`./state.js?${Date.now()}`);
+    expect(mod.state.graphCol).toBe("repo");
+  });
+
+  it("migrates legacy sessionStorage graphCol into localStorage", async () => {
+    sessionStorage.setItem("v6:graphCol", "lane");
+    const mod = await import(`./state.js?${Date.now()}`);
+    expect(mod.state.graphCol).toBe("lane");
+    expect(localStorage.getItem("v6:graphCol")).toBe("lane");
+  });
+
+  it("persists graphCol changes to localStorage via setState", () => {
+    setState({ graphCol: "priority" });
+    expect(state.graphCol).toBe("priority");
+    expect(localStorage.getItem("v6:graphCol")).toBe("priority");
+    expect(sessionStorage.getItem("v6:graphCol")).toBeNull();
+  });
+});

--- a/frontend/state-graph-prefs.test.js
+++ b/frontend/state-graph-prefs.test.js
@@ -1,31 +1,32 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { setState, state } from "./state.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("graph order-by preference", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+    vi.resetModules();
   });
 
   it("defaults graphCol to none when nothing is stored", async () => {
-    const mod = await import(`./state.js?${Date.now()}`);
-    expect(mod.state.graphCol).toBe("none");
+    const { state } = await import("./state.js");
+    expect(state.graphCol).toBe("none");
   });
 
   it("reads graphCol from localStorage", async () => {
     localStorage.setItem("v6:graphCol", "repo");
-    const mod = await import(`./state.js?${Date.now()}`);
-    expect(mod.state.graphCol).toBe("repo");
+    const { state } = await import("./state.js");
+    expect(state.graphCol).toBe("repo");
   });
 
   it("migrates legacy sessionStorage graphCol into localStorage", async () => {
     sessionStorage.setItem("v6:graphCol", "lane");
-    const mod = await import(`./state.js?${Date.now()}`);
-    expect(mod.state.graphCol).toBe("lane");
+    const { state } = await import("./state.js");
+    expect(state.graphCol).toBe("lane");
     expect(localStorage.getItem("v6:graphCol")).toBe("lane");
   });
 
-  it("persists graphCol changes to localStorage via setState", () => {
+  it("persists graphCol changes to localStorage via setState", async () => {
+    const { setState, state } = await import("./state.js");
     setState({ graphCol: "priority" });
     expect(state.graphCol).toBe("priority");
     expect(localStorage.getItem("v6:graphCol")).toBe("priority");

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -1,4 +1,22 @@
 // state.js — shared app state + sessionStorage persistence (per-tab)
+const GRAPH_COL_KEY = "v6:graphCol";
+
+export const LS = {
+  get(key, def) {
+    try {
+      const v = localStorage.getItem(key);
+      return v === null ? def : v;
+    } catch {
+      return def;
+    }
+  },
+  set(key, val) {
+    try {
+      localStorage.setItem(key, val);
+    } catch {}
+  },
+};
+
 export const SS = {
   get(key, def) {
     try {
@@ -43,6 +61,18 @@ function migrateRepo() {
   }
 }
 
+/** Graph "Order by" — localStorage (cross-tab), default none; migrates legacy sessionStorage. */
+function migrateGraphCol() {
+  const stored = LS.get(GRAPH_COL_KEY, null);
+  if (stored !== null) return stored;
+  const legacy = SS.get(GRAPH_COL_KEY, null);
+  if (legacy !== null) {
+    LS.set(GRAPH_COL_KEY, legacy);
+    return legacy;
+  }
+  return "none";
+}
+
 export const state = {
   view: SS.get("v6:view", "graph"),
   // multi-select arrays (empty = all)
@@ -56,7 +86,7 @@ export const state = {
   pivotRow: SS.get("v6:pivotRow", "milestone"),
   pivotCol: SS.get("v6:pivotCol", "priority"),
   graphRow: SS.get("v6:graphRow", "milestone"),
-  graphCol: SS.get("v6:graphCol", "lane"),
+  graphCol: migrateGraphCol(),
   listGroup: SS.get("v7:listGroup", "none"),
   listGroup2: SS.get("v7:listGroup2", "none"),
   tableGroup: SS.get("v7:tableGroup", "none"),
@@ -84,7 +114,6 @@ const SS_KEYS = {
   pivotRow: { key: "v6:pivotRow", json: false },
   pivotCol: { key: "v6:pivotCol", json: false },
   graphRow: { key: "v6:graphRow", json: false },
-  graphCol: { key: "v6:graphCol", json: false },
   listGroup: { key: "v7:listGroup", json: false },
   listGroup2: { key: "v7:listGroup2", json: false },
   tableGroup: { key: "v7:tableGroup", json: false },
@@ -95,6 +124,9 @@ const SS_KEYS = {
 
 export function setState(patch) {
   Object.assign(state, patch);
+  if ("graphCol" in patch) {
+    LS.set(GRAPH_COL_KEY, patch.graphCol);
+  }
   for (const [k, v] of Object.entries(patch)) {
     const meta = SS_KEYS[k];
     if (!meta) continue;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.21.1"
+APP_RELEASE = "0.21.2"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -72,7 +72,7 @@ workers_dev = true
 # Worker also serves robots.txt + X-Robots-Tag when GITHUB_APP_SLUG is staging.
 
 [env.staging.vars]
-APP_RELEASE = "0.21.1"
+APP_RELEASE = "0.21.2"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"


### PR DESCRIPTION
## Promotion: staging → main (0.21.2)

## [0.21.2] - 2026-06-23

### Bug Fixes

* **graph:** centralize hover-chain highlight across table, list, and graph views (single `hover.js` module)
* **graph:** default Order by to `none` with `localStorage` persistence (migrates legacy `sessionStorage`)
* **graph:** cap column spacing so sparse bands no longer stretch across half the page

## Pre-flight

- [x] CI passing on staging
- [x] Open PRs on staging acknowledged (2 dependabot PRs — non-blocking)
- [x] Deploy preview skipped (no `deploy-preview.yml` workflow)
- [x] Release notes committed to staging

---
Generated with `/promote`