### PR TITLE
fix(wrangler): move staging routes=[] out of [env.staging.vars] to stop live.roxabi.dev leak

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -70,16 +70,18 @@ name = "roxabi-live-staging"
 workers_dev = true
 # Edge gate: CF Access Email OTP on the workers.dev URL (scripts/setup-staging-access.sh).
 # Worker also serves robots.txt + X-Robots-Tag when GITHUB_APP_SLUG is staging.
+# `routes` is inheritable — without this explicit empty override a staging
+# deploy would inherit the top-level live.roxabi.dev custom domain (#101) and
+# bind it to the staging Worker. MUST live under [env.staging] (a config key),
+# NOT [env.staging.vars] — under .vars it silently becomes a no-op var named
+# "routes" and the custom domain leaks to staging on the next deploy.
+routes = []
 
 [env.staging.vars]
 APP_RELEASE = "0.21.2"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"
-# `routes` is inheritable — without this explicit empty override a staging
-# deploy would inherit the top-level live.roxabi.dev custom domain (#101) and
-# bind it to the staging Worker. Keep this even though staging has no routes.
-routes = []
 
 [[env.staging.d1_databases]]
 binding        = "DB"


### PR DESCRIPTION
## Problem

`routes = []` for the staging env was placed under `[env.staging.vars]` → TOML parsed it as a **no-op var named `routes`** (seen in deploy output as `env.routes ([])`), not the `routes` config key. So `[env.staging]` never overrode the **inheritable** top-level `routes = [{pattern = "live.roxabi.dev", custom_domain = true }]`.

Result: a `wrangler deploy --env staging` (2026-06-24) **reassigned the prod custom domain `live.roxabi.dev` to the staging worker** (staging D1) — `live.roxabi.dev` was briefly served by `roxabi-live-staging`. The deploy output gave it away:

```
Deployed roxabi-live-staging triggers
  https://roxabi-live-staging.mickael-b5e.workers.dev
  live.roxabi.dev (custom domain)   ← leaked
```

## Fix

Move `routes = []` up into `[env.staging]` (a config key, before the `.vars` sub-table). Strengthen the comment to explain the footgun.

## Verification (live)

- Redeployed `roxabi-live` to reclaim the domain; CF API `workers/domains?hostname=live.roxabi.dev` → `service=roxabi-live`, `env=production` ✅
- Redeployed staging with this fix → triggers list **only** `roxabi-live-staging.mickael-b5e.workers.dev` (no `live.roxabi.dev`) ✅
- `live.roxabi.dev/graph.js` md5 `721a3bf6…` (hover fix) + `/api/version` HTTP 200 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)