### PR TITLE
fix(zk): stop idle-lock loop in 30-day remember mode (setTimeout overflow)

### DIFF
--- a/frontend/zk-session.js
+++ b/frontend/zk-session.js
@@ -2,12 +2,19 @@
 
 const IDLE_MS = 15 * 60 * 1000;
 const REMEMBER_IDLE_MS = 30 * 24 * 60 * 60 * 1000;
+// setTimeout coerces its delay to a signed 32-bit int; any value above this
+// ceiling (~24.8 days) overflows to a negative delay and fires immediately.
+// REMEMBER_IDLE_MS (30 days) exceeds it, so the idle lock used to fire on the
+// next tick and loop (zk.lock.idle → silent device restore → re-arm → repeat).
+// Re-arm in bounded chunks against an absolute deadline instead.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 /** @type {CryptoKey|null} */
 let sessionKey = null;
 /** @type {string|null} */
 let sessionKeyFp = null;
 let idleTimer = null;
+let idleDeadline = 0;
 let idleWired = false;
 let pageHideWired = false;
 let pageShowWired = false;
@@ -68,14 +75,30 @@ export function clearZkSession() {
   }
 }
 
+function fireIdleLock() {
+  clearZkSession();
+  console.info("[zk]", { event: "zk.lock.idle", remember: rememberMode });
+  onAutoLock?.();
+}
+
+// Re-arm the idle timer in chunks no larger than MAX_TIMEOUT_MS so a long
+// REMEMBER_IDLE_MS deadline never overflows setTimeout and fires early.
+function armIdleChunk() {
+  if (idleTimer) clearTimeout(idleTimer);
+  if (!sessionKey) return;
+  const remaining = idleDeadline - Date.now();
+  if (remaining <= 0) {
+    fireIdleLock();
+    return;
+  }
+  idleTimer = setTimeout(armIdleChunk, Math.min(remaining, MAX_TIMEOUT_MS));
+}
+
 function resetIdleTimer() {
   if (idleTimer) clearTimeout(idleTimer);
   if (!sessionKey) return;
-  idleTimer = setTimeout(() => {
-    clearZkSession();
-    console.info("[zk]", { event: "zk.lock.idle", remember: rememberMode });
-    onAutoLock?.();
-  }, currentIdleMs());
+  idleDeadline = Date.now() + currentIdleMs();
+  armIdleChunk();
 }
 
 /** Register callback when idle lock fires (e.g. show unlock gate). */

--- a/frontend/zk-session.test.js
+++ b/frontend/zk-session.test.js
@@ -7,6 +7,7 @@ const {
   setZkPageRestoreHandler,
   setZkAutoLockHandler,
   setZkSessionReadyHandler,
+  setZkRememberMode,
   wirePageHideLock,
   wireIdleLock,
 } = await import("./zk-session.js");
@@ -78,6 +79,7 @@ describe("wireIdleLock", () => {
     vi.useRealTimers();
     clearZkSession();
     setZkAutoLockHandler(null);
+    setZkRememberMode(false);
   });
 
   it("fires auto-lock handler after 15 minutes idle", () => {
@@ -88,6 +90,26 @@ describe("wireIdleLock", () => {
 
     vi.advanceTimersByTime(15 * 60 * 1000);
 
+    expect(isZkUnlocked()).toBe(false);
+    expect(onLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-lock immediately in 30-day remember mode (setTimeout overflow guard)", () => {
+    const onLock = vi.fn();
+    setZkAutoLockHandler(onLock);
+    setZkRememberMode(true);
+    wireIdleLock();
+    setZkSession({}, "fp12345678");
+
+    // Regression: REMEMBER_IDLE_MS (30d) used to overflow setTimeout's 32-bit
+    // cap and fire on the next tick, looping idle→restore. Advancing well past
+    // any short interval must NOT lock.
+    vi.advanceTimersByTime(60 * 60 * 1000); // 1 h
+    expect(isZkUnlocked()).toBe(true);
+    expect(onLock).not.toHaveBeenCalled();
+
+    // It still locks once the full remember window elapses.
+    vi.advanceTimersByTime(30 * 24 * 60 * 60 * 1000); // +30 d
     expect(isZkUnlocked()).toBe(false);
     expect(onLock).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Hotfix → main (prod-down: console + network spam)

### Problem
`REMEMBER_IDLE_MS = 30 * 24 * 60 * 60 * 1000 = 2,592,000,000 ms` exceeds `setTimeout`'s 32-bit signed-int ceiling (`2**31 - 1 ≈ 24.8 days`). The oversized delay overflows to a negative value → the timer fires on the **next tick**. So when "remember passphrase 30d" is on (and an enrolled device session exists), the idle auto-lock loops instantly:

```
resetIdleTimer → setTimeout(30d) → overflow → fire immediately
  → zk.lock.idle (clearZkSession)
  → onAutoLock → ensureZkUnlocked → fetchKeyBackup (GET) → device restore
  → zk.device.restore (setZkSession) → resetIdleTimer → overflow → repeat
```

→ console spam + continuous key-backup GETs + re-decrypt. Same family as the recent `fix(zk): … stop sync-poll spam`.

**Why prod and not staging:** the silent restore needs an enrolled device session in that origin's IndexedDB (present on `live.roxabi.dev`, absent on the staging origin). Frontend code + `/api/version` are identical between envs — verified.

### Fix
Track an absolute `idleDeadline` and re-arm the idle timer in chunks bounded by `MAX_TIMEOUT_MS` (`2**31 - 1`). Long remember windows are honoured (true 30d) without overflow; the 15-min path is unchanged.

### Tests
`frontend/zk-session.test.js`: new regression test — remember-mode must NOT lock immediately, still locks after the full 30-day window. Full suite green (97/97), biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)