### PR TITLE
fix(zk): stop idle-lock loop in 30-day remember mode (setTimeout overflow)

### DIFF
--- a/frontend/zk-session.js
+++ b/frontend/zk-session.js
@@ -2,12 +2,19 @@
 
 const IDLE_MS = 15 * 60 * 1000;
 const REMEMBER_IDLE_MS = 30 * 24 * 60 * 60 * 1000;
+// setTimeout coerces its delay to a signed 32-bit int; any value above this
+// ceiling (~24.8 days) overflows to a negative delay and fires immediately.
+// REMEMBER_IDLE_MS (30 days) exceeds it, so the idle lock used to fire on the
+// next tick and loop (zk.lock.idle → silent device restore → re-arm → repeat).
+// Re-arm in bounded chunks against an absolute deadline instead.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 /** @type {CryptoKey|null} */
 let sessionKey = null;
 /** @type {string|null} */
 let sessionKeyFp = null;
 let idleTimer = null;
+let idleDeadline = 0;
 let idleWired = false;
 let pageHideWired = false;
 let pageShowWired = false;
@@ -68,14 +75,30 @@ export function clearZkSession() {
   }
 }
 
+function fireIdleLock() {
+  clearZkSession();
+  console.info("[zk]", { event: "zk.lock.idle", remember: rememberMode });
+  onAutoLock?.();
+}
+
+// Re-arm the idle timer in chunks no larger than MAX_TIMEOUT_MS so a long
+// REMEMBER_IDLE_MS deadline never overflows setTimeout and fires early.
+function armIdleChunk() {
+  if (idleTimer) clearTimeout(idleTimer);
+  if (!sessionKey) return;
+  const remaining = idleDeadline - Date.now();
+  if (remaining <= 0) {
+    fireIdleLock();
+    return;
+  }
+  idleTimer = setTimeout(armIdleChunk, Math.min(remaining, MAX_TIMEOUT_MS));
+}
+
 function resetIdleTimer() {
   if (idleTimer) clearTimeout(idleTimer);
   if (!sessionKey) return;
-  idleTimer = setTimeout(() => {
-    clearZkSession();
-    console.info("[zk]", { event: "zk.lock.idle", remember: rememberMode });
-    onAutoLock?.();
-  }, currentIdleMs());
+  idleDeadline = Date.now() + currentIdleMs();
+  armIdleChunk();
 }
 
 /** Register callback when idle lock fires (e.g. show unlock gate). */

--- a/frontend/zk-session.test.js
+++ b/frontend/zk-session.test.js
@@ -7,6 +7,7 @@ const {
   setZkPageRestoreHandler,
   setZkAutoLockHandler,
   setZkSessionReadyHandler,
+  setZkRememberMode,
   wirePageHideLock,
   wireIdleLock,
 } = await import("./zk-session.js");
@@ -78,6 +79,7 @@ describe("wireIdleLock", () => {
     vi.useRealTimers();
     clearZkSession();
     setZkAutoLockHandler(null);
+    setZkRememberMode(false);
   });
 
   it("fires auto-lock handler after 15 minutes idle", () => {
@@ -88,6 +90,26 @@ describe("wireIdleLock", () => {
 
     vi.advanceTimersByTime(15 * 60 * 1000);
 
+    expect(isZkUnlocked()).toBe(false);
+    expect(onLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-lock immediately in 30-day remember mode (setTimeout overflow guard)", () => {
+    const onLock = vi.fn();
+    setZkAutoLockHandler(onLock);
+    setZkRememberMode(true);
+    wireIdleLock();
+    setZkSession({}, "fp12345678");
+
+    // Regression: REMEMBER_IDLE_MS (30d) used to overflow setTimeout's 32-bit
+    // cap and fire on the next tick, looping idle→restore. Advancing well past
+    // any short interval must NOT lock.
+    vi.advanceTimersByTime(60 * 60 * 1000); // 1 h
+    expect(isZkUnlocked()).toBe(true);
+    expect(onLock).not.toHaveBeenCalled();
+
+    // It still locks once the full remember window elapses.
+    vi.advanceTimersByTime(30 * 24 * 60 * 60 * 1000); // +30 d
     expect(isZkUnlocked()).toBe(false);
     expect(onLock).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Backport to `staging` of the prod hotfix #267 (already merged to `main` + deployed to live.roxabi.dev).

`REMEMBER_IDLE_MS` (30d) exceeded `setTimeout`'s 32-bit cap (~24.8d) → overflowed → idle lock fired immediately and looped (`zk.lock.idle` → silent device restore → re-arm → repeat). Fixed by tracking an absolute deadline and re-arming in chunks bounded by `MAX_TIMEOUT_MS`. Regression test added. Full frontend suite green, biome clean.

Cherry-pick of 20a29f69. Keeps staging in sync so the next `/promote` doesn't revert the hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)