### PR TITLE
chore(release): 0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.21.3](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.2...roxabi-live/v0.21.3) (2026-06-24)
+
+
+### Bug Fixes
+
+* **graph:** restore DOM-based hover chain for graph view (the centralized `hover.js` graph path regressed hover highlighting in production)
+* **zk:** stop idle-lock loop in 30-day remember mode — `REMEMBER_IDLE_MS` exceeded `setTimeout`'s 32-bit cap (~24.8 days), overflowed to fire immediately, and looped `zk.lock.idle` → silent device restore; now re-armed in bounded chunks against an absolute deadline ([#267](https://github.com/Roxabi/roxabi-live/pull/267))
+* **wrangler:** move staging `routes=[]` out of `[env.staging.vars]` so a `--env staging` deploy can no longer hijack the `live.roxabi.dev` custom domain ([#266](https://github.com/Roxabi/roxabi-live/pull/266))
+
+
 ## [0.21.2](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.21.1...roxabi-live/v0.21.2) (2026-06-23)
 
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,7 +23,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.21.2"
+APP_RELEASE = "0.21.3"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -78,7 +78,7 @@ workers_dev = true
 routes = []
 
 [env.staging.vars]
-APP_RELEASE = "0.21.2"
+APP_RELEASE = "0.21.3"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"


### PR DESCRIPTION
Release prep for 0.21.3 → committed to staging before the promotion PR. Bumps APP_RELEASE + CHANGELOG (graph hover restore, zk idle-lock overflow #267, staging routes leak #266).

🤖 Generated with [Claude Code](https://claude.com/claude-code)