### PR TITLE
fix(app): CSS cascade-layer regression + staging preview configs

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -54,9 +54,12 @@ bucket_name = "roxabi-live-logs"
 [env.staging]
 name = "roxabi-live-staging"
 workers_dev = true
-# `routes` is inheritable — explicit empty override keeps the api.* custom domain
-# off the staging worker (see cloudflare/workers-sdk#13925).
-routes = []
+# Public staging api domain — ONLY needed so GitHub can POST webhooks server→server
+# (the webhook can't go through the app proxy). Browser/OAuth traffic still reaches
+# this worker via the service binding from roxabi-live-app-staging.
+routes = [
+  { pattern = "api-staging.live.roxabi.dev", custom_domain = true },
+]
 
 [env.staging.vars]
 APP_RELEASE = "0.21.3"

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -1,5 +1,12 @@
+/* Layer order: brand sits BELOW Tailwind's components/utilities so utility
+   classes (text-2xl, bg-card, …) win over the brand design-system's element
+   styles (h1/body/links), which are authored for the marketing site. The brand
+   still supplies every design TOKEN (CSS custom properties resolve regardless of
+   layer), which @theme below bridges into Tailwind. Without this, unlayered brand
+   rules override ALL layered Tailwind output — the "lost CSS" prod regression. */
+@layer theme, base, brand, components, utilities;
 @import "tailwindcss";
-@import "../../../brand/styles.css";
+@import "../../../brand/styles.css" layer(brand);
 
 @theme {
   --color-background: var(--bg);

--- a/apps/app/wrangler.staging.jsonc
+++ b/apps/app/wrangler.staging.jsonc
@@ -1,0 +1,22 @@
+{
+  // Staging preview for the SPA worker (workers.dev, no custom domain).
+  // Proxies API/auth to the STAGING api worker (roxabi-live-staging) per worker.ts.
+  // CF Access OTP fronts the workers.dev URL; full GitHub OAuth needs the preview
+  // callback URL registered on the App (see docs/cutover-monorepo.md).
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "roxabi-live-app-staging",
+  "main": "worker.ts",
+  "compatibility_date": "2025-06-01",
+  "workers_dev": true,
+  // Stable staging URL so the GitHub OAuth callback can be registered (the
+  // workers.dev URL works too, but a named subdomain is cleaner + Access-gateable).
+  // The api worker needs NO public domain — it's reached via the service binding.
+  "routes": [{ "pattern": "app-staging.live.roxabi.dev", "custom_domain": true }],
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  },
+  "services": [{ "binding": "API", "service": "roxabi-live-staging" }]
+}

--- a/apps/marketing/wrangler.staging.jsonc
+++ b/apps/marketing/wrangler.staging.jsonc
@@ -1,0 +1,10 @@
+{
+  // Staging preview of the marketing/landing site (Astro SSG → static assets).
+  // Prod target is CF Pages at the apex live.roxabi.dev (dashboard git-connect);
+  // this assets-only Worker gives a stable staging URL in the meantime.
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "roxabi-live-marketing-staging",
+  "compatibility_date": "2025-06-01",
+  "assets": { "directory": "./dist" },
+  "routes": [{ "pattern": "marketing-staging.live.roxabi.dev", "custom_domain": true }]
+}


### PR DESCRIPTION
## Why
The prod build "lost its CSS" (huge unstyled headings). Root cause: the brand design-system was imported **unlayered**, so its element rules (h1/body authored for the marketing site) beat **every** Tailwind utility (which lives in `@layer utilities`). Unlayered CSS always wins over layered. Dev hid it (vite injects CSS differently) — only the production bundle exposed it.

## Fix
Order the brand import into `@layer brand` **below** Tailwind utilities. Utilities now win; brand still supplies all design **tokens** (CSS vars resolve regardless of layer, so `@theme` keeps working).

**Verified on the PROD build** (vite preview + mock API → real Launch Board): `h1` = 24px/700 (`text-2xl font-bold`), not the ~58px brand clamp; body bg = brand dark token. Screenshot confirms full styling.

## Also: staging-preview infra (reproducible + survives auto-deploys)
- `app-staging.live.roxabi.dev` — SPA + proxy (API→`roxabi-live-staging`)
- `api-staging.live.roxabi.dev` — webhook only (server→server)
- `marketing-staging.live.roxabi.dev` — landing (FR `/`, EN `/en/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)