### PR TITLE
feat(app): restore legacy dashboard chrome (brand header + view segs + list styling)

### DIFF
--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -1,13 +1,35 @@
 /**
- * AppShell — authenticated app chrome (header + main). Rendered only inside the
- * ready branch of AuthGate, so useAuth() is always populated here.
+ * AppShell — authenticated app chrome (sticky header + main). Rendered only
+ * inside the ready branch of AuthGate, so useAuth() is always populated here.
+ *
+ * Header layout mirrors the legacy dashboard (frontend/dashboard/index.html):
+ *   left  — brand mark + "Roxabi <accent>Live</accent>" + corpus stats subtitle
+ *   right — view segs (Graph/List/Table) + ZK lock + org picker + user menu
  */
 
 import { useAuth } from "@/auth/AuthContext";
 import { OrgPicker } from "@/auth/OrgPicker";
 import { SettingsUiProvider } from "@/auth/SettingsUi";
 import { UserMenu } from "@/auth/UserMenu";
+import { BrandMark } from "@/components/BrandMark";
+import { ViewToggle } from "@/components/ViewToggle";
+import { useGraphData } from "@/hooks/useGraphData";
 import { ZkLockButton } from "@/zk/ZkLockButton";
+
+/** Corpus counts subtitle — "N issues · N open · N closed" (legacy #subtitle). */
+function CorpusStats() {
+  const { nodes, isLoading } = useGraphData();
+  if (isLoading && nodes.length === 0) {
+    return <div className="mt-1 font-mono text-xs text-muted-foreground">Loading…</div>;
+  }
+  const open = nodes.reduce((n, x) => n + (x.state === "open" ? 1 : 0), 0);
+  const closed = nodes.length - open;
+  return (
+    <div className="mt-1 font-mono text-xs text-muted-foreground">
+      {nodes.length} issues · {open} open · {closed} closed
+    </div>
+  );
+}
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const me = useAuth();
@@ -15,15 +37,26 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <SettingsUiProvider>
       <div className="min-h-screen bg-background text-foreground">
-        <header className="flex items-center gap-3 border-b border-border px-6 py-3">
-          <span className="text-lg font-semibold tracking-tight text-foreground">Roxabi Live</span>
-          <div className="ml-auto flex items-center gap-3">
-            <ZkLockButton />
-            <OrgPicker me={me} />
-            <UserMenu />
+        <header className="sticky top-0 z-50 border-b border-border bg-background px-6 pb-3 pt-4">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <BrandMark className="size-7 shrink-0" />
+              <div>
+                <h1 className="text-[22px] font-black leading-none tracking-[-0.04em] text-foreground">
+                  Roxabi <span className="text-primary">Live</span>
+                </h1>
+                <CorpusStats />
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <ViewToggle />
+              <ZkLockButton />
+              <OrgPicker me={me} />
+              <UserMenu />
+            </div>
           </div>
         </header>
-        <main className="p-6">{children}</main>
+        <main className="px-6 py-5">{children}</main>
       </div>
     </SettingsUiProvider>
   );

--- a/apps/app/src/components/BoardView.tsx
+++ b/apps/app/src/components/BoardView.tsx
@@ -3,7 +3,6 @@ import { FilterBar } from "@/components/FilterBar";
 import { GraphPanel } from "@/components/GraphPanel";
 import { IssueTable } from "@/components/IssueTable";
 import { PivotMatrix } from "@/components/PivotMatrix";
-import { ViewToggle } from "@/components/ViewToggle";
 import { useFilteredNodes } from "@/hooks/useFilteredNodes";
 import { cn } from "@/lib/utils";
 import { useDashboardStore } from "@/store/dashboardStore";
@@ -122,17 +121,18 @@ export function BoardView({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gra
   const filtered = useFilteredNodes(nodes, edges);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
+      {/* Filters row (legacy .toolbar-filters) */}
+      <FilterBar nodes={nodes} />
+      {/* Layout row (legacy .toolbar-layout): per-view controls + filtered count */}
       <div className="flex flex-wrap items-center gap-3">
-        <ViewToggle />
         {view === "list" && <ListControls />}
         {view === "pivot" && <PivotControls />}
         {view === "graph" && <GraphControls />}
-        <span className="ml-auto text-sm text-muted-foreground">
+        <span className="ml-auto font-mono text-xs text-muted-foreground">
           {filtered.length} of {nodes.length}
         </span>
       </div>
-      <FilterBar nodes={nodes} />
       {view === "list" && (
         <IssueTable nodes={filtered} edges={edges} group={listGroup} group2={listGroup2} />
       )}

--- a/apps/app/src/components/BrandMark.tsx
+++ b/apps/app/src/components/BrandMark.tsx
@@ -1,0 +1,22 @@
+/**
+ * BrandMark — Roxabi Live logo (amber tile + foundation-block glyph).
+ * Inlined from brand/assets/logo-mark.svg so the header mark needs no extra
+ * request and renders on the dark cockpit canvas.
+ */
+export function BrandMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 56 56"
+      fill="none"
+      className={className}
+      role="img"
+      aria-label="Roxabi Live"
+    >
+      <rect width="56" height="56" rx="12" fill="#f0b429" />
+      <rect x="11" y="11" width="15.5" height="15.5" rx="3" fill="#0b0e14" opacity=".9" />
+      <rect x="29.5" y="11" width="15.5" height="15.5" rx="3" fill="#0b0e14" opacity=".6" />
+      <rect x="11" y="29.5" width="15.5" height="15.5" rx="3" fill="#0b0e14" opacity=".6" />
+      <rect x="29.5" y="29.5" width="15.5" height="15.5" rx="3" fill="#0b0e14" opacity=".3" />
+    </svg>
+  );
+}

--- a/apps/app/src/components/IssueRow.tsx
+++ b/apps/app/src/components/IssueRow.tsx
@@ -45,12 +45,12 @@ export function IssueRow({ node, refs = EMPTY_REFS }: { node: AnnotatedNode; ref
             href={node.url}
             target="_blank"
             rel="noreferrer"
-            className="font-mono text-xs text-muted-foreground transition-colors hover:text-primary"
+            className="font-mono text-[11px] font-bold text-primary hover:underline"
           >
             {ref}
           </a>
         ) : (
-          <span className="font-mono text-xs text-muted-foreground">{ref}</span>
+          <span className="font-mono text-[11px] font-bold text-primary">{ref}</span>
         )}
       </td>
       <td className="px-3 py-2 align-middle text-sm text-foreground">

--- a/apps/app/src/components/IssueTable.tsx
+++ b/apps/app/src/components/IssueTable.tsx
@@ -261,7 +261,7 @@ export function IssueTable({
             {COLUMNS.map(({ col, label, center }) => (
               <th
                 key={col}
-                className={`px-3 py-2 text-xs font-medium text-muted-foreground ${center ? "text-center" : ""}`}
+                className={`px-3 py-2 font-mono text-[10px] font-semibold tracking-[0.04em] text-muted-foreground ${center ? "text-center" : ""}`}
               >
                 <button
                   type="button"
@@ -288,14 +288,20 @@ export function IssueTable({
                     type="button"
                     onClick={() => toggleCollapse(it.collapseKey)}
                     aria-expanded={!collapsed.has(it.collapseKey)}
-                    className={`flex w-full items-center px-3 py-1.5 text-left text-xs font-medium text-foreground hover:bg-card ${it.level === 2 ? "pl-8" : ""}`}
+                    className={`flex w-full items-center px-3 py-1.5 text-left font-mono font-semibold hover:bg-card ${it.level === 2 ? "pl-8 text-[10px] text-muted-foreground" : "text-xs text-primary"}`}
                   >
                     <span aria-hidden className="mr-1 text-muted-foreground">
                       {collapsed.has(it.collapseKey) ? "▸" : "▾"}
                     </span>
                     {dimDisplayLabel(it.value, it.dim)}
-                    {it.title && <span className="ml-2 text-muted-foreground">{it.title}</span>}
-                    <span className="ml-2 text-muted-foreground tabular-nums">{it.count}</span>
+                    {it.title && (
+                      <span className="ml-2 font-sans font-normal text-muted-foreground">
+                        {it.title}
+                      </span>
+                    )}
+                    <span className="ml-2 font-normal text-muted-foreground tabular-nums">
+                      {it.count}
+                    </span>
                   </button>
                 </td>
               </tr>

--- a/apps/app/src/components/ViewToggle.tsx
+++ b/apps/app/src/components/ViewToggle.tsx
@@ -1,35 +1,49 @@
 import { cn } from "@/lib/utils";
 import { type ViewKey, useDashboardStore } from "@/store/dashboardStore";
+import { type Icon, ListBullets, Table, TreeStructure } from "@phosphor-icons/react";
 
-const VIEWS: { key: ViewKey; label: string }[] = [
-  { key: "list", label: "List" },
-  { key: "pivot", label: "Pivot" },
-  { key: "graph", label: "Graph" },
+// Order + labels mirror the legacy header view-segs (Graph / List / Table).
+// The store key `pivot` is the legacy "Table" (pivot-matrix) renderer.
+const VIEWS: { key: ViewKey; label: string; Icon: Icon }[] = [
+  { key: "graph", label: "Graph", Icon: TreeStructure },
+  { key: "list", label: "List", Icon: ListBullets },
+  { key: "pivot", label: "Table", Icon: Table },
 ];
 
-/** Segmented control: List / Pivot / Graph. */
+/** Segmented view control (Graph / List / Table) — legacy `.view-segs`. */
 export function ViewToggle() {
   const view = useDashboardStore((s) => s.view);
   const patch = useDashboardStore((s) => s.patch);
 
   return (
-    <div className="inline-flex rounded-md border border-border p-0.5">
-      {VIEWS.map((v) => (
-        <button
-          key={v.key}
-          type="button"
-          data-testid={`view-${v.key}`}
-          onClick={() => patch({ view: v.key })}
-          className={cn(
-            "rounded-[5px] px-3 py-1 text-xs transition-colors",
-            view === v.key
-              ? "bg-primary/15 text-primary"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          {v.label}
-        </button>
-      ))}
+    <div
+      role="group"
+      aria-label="View"
+      className="inline-flex overflow-hidden rounded-md border border-border bg-card"
+    >
+      {VIEWS.map(({ key, label, Icon }, i) => {
+        const on = view === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            data-testid={`view-${key}`}
+            onClick={() => patch({ view: key })}
+            aria-pressed={on}
+            title={label}
+            className={cn(
+              "inline-flex items-center gap-1.5 px-3 py-1.5 font-mono text-[11px] tracking-[0.02em] transition-colors",
+              i > 0 && "border-l border-border",
+              on
+                ? "bg-[var(--accent-dim)] font-semibold text-primary"
+                : "font-medium text-[var(--text-dim)] hover:bg-[var(--bg-elevated)] hover:text-foreground",
+            )}
+          >
+            <Icon size={13} weight={on ? "fill" : "regular"} aria-hidden />
+            {label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/app/src/dev/DevTablePage.tsx
+++ b/apps/app/src/dev/DevTablePage.tsx
@@ -1,4 +1,5 @@
 import { BoardView } from "@/components/BoardView";
+import { ViewToggle } from "@/components/ViewToggle";
 import { annotateNodes } from "@roxabi-live/shared";
 import { useMemo } from "react";
 import { fixtureGraph } from "./fixture";
@@ -12,8 +13,11 @@ export default function DevTablePage() {
   const nodes = useMemo(() => annotateNodes(fixtureGraph.nodes, fixtureGraph.edges), []);
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-foreground">Launch Board — fixture</h1>
+    <div className="space-y-4 p-6">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-bold text-foreground">Launch Board — fixture</h1>
+        <ViewToggle />
+      </div>
       <BoardView nodes={nodes} edges={fixtureGraph.edges} />
     </div>
   );

--- a/apps/app/src/router.tsx
+++ b/apps/app/src/router.tsx
@@ -48,8 +48,7 @@ function Dashboard() {
     useDecryptedGraph();
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-foreground">Launch Board</h1>
+    <div className="space-y-3">
       <ZkNotices needsGithubLink={needsGithubLink} migrationIncomplete={zkMigrationIncomplete} />
       <SyncProgressBanner status={syncStatus} />
       {isError ? (


### PR DESCRIPTION
## What

Rebuilds the React dashboard chrome to mirror the prod (vanilla) look at `live.roxabi.dev/dashboard`. The monorepo port had drifted: oversized "Launch Board" h1, no brand mark, no corpus-stats line, view toggle in the body instead of the header.

## Changes
- **Header (`AppShell`)** — brand mark (amber tile) + `Roxabi <accent>Live</accent>` + corpus stats subtitle (`N issues · N open · N closed`); right side = view segs + ZK lock + org picker + user menu. Sticky, mirrors `frontend/dashboard/index.html`.
- **`ViewToggle`** — legacy `.view-segs` segmented control: **Graph / List / Table** order + icons. Store key `pivot` is surfaced under its legacy label **"Table"** (it is the pivot-matrix `renderTable` view).
- **`BoardView`** — drop the in-body toggle (now header-owned); reorder toolbar to legacy filters→controls.
- Drop the oversized **"Launch Board"** h1 (the legacy title is the header brand).
- **List** — amber bold issue keys, JetBrains-Mono column headers, amber level-1 group headers (mirrors `frontend/app.css .list-table`).
- `DevTablePage` keeps a standalone `ViewToggle` (it renders `BoardView` without `AppShell`).

## Verification
- Browser-verified on the **prod build** (`vite preview` + mocked API) across all 3 views — Graph / List / Table chrome now consistent with legacy.
- `typecheck` ✓ · `biome` ✓ · app vitest **46 passed**.

## Notes
- Theme (🌙) toggle intentionally omitted — no light theme is defined in `brand/` yet (slice 8). 
- Filter facets remain dropdowns (vs legacy "All repos" pills) by design — cleaner and already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)