### PR TITLE
feat(app): light theme + dropdown scroll polish + graph epics/edges

### DIFF
--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -12,6 +12,7 @@ import { OrgPicker } from "@/auth/OrgPicker";
 import { SettingsUiProvider } from "@/auth/SettingsUi";
 import { UserMenu } from "@/auth/UserMenu";
 import { BrandMark } from "@/components/BrandMark";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { ViewToggle } from "@/components/ViewToggle";
 import { useGraphData } from "@/hooks/useGraphData";
 import { ZkLockButton } from "@/zk/ZkLockButton";
@@ -52,6 +53,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               <ViewToggle />
               <ZkLockButton />
               <OrgPicker me={me} />
+              <ThemeToggle />
               <UserMenu />
             </div>
           </div>

--- a/apps/app/src/components/FilterMultiSelect.tsx
+++ b/apps/app/src/components/FilterMultiSelect.tsx
@@ -43,7 +43,7 @@ export function FilterMultiSelect({
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-1">
-        <div className="max-h-72 overflow-auto">
+        <div className="rl-scroll max-h-72 overflow-y-auto overflow-x-hidden">
           {options.length === 0 ? (
             <div className="px-2 py-1.5 text-xs text-muted-foreground">No options</div>
           ) : (
@@ -56,7 +56,7 @@ export function FilterMultiSelect({
                   data-testid={`facet-option-${o.value}`}
                   onClick={() => onToggle(o.value)}
                   className={cn(
-                    "flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left text-xs hover:bg-background",
+                    "flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left text-xs transition-colors hover:bg-[var(--bg-elevated)] focus:outline-none focus-visible:bg-[var(--accent-dim)] focus-visible:text-foreground",
                     on ? "text-foreground" : "text-muted-foreground",
                   )}
                 >

--- a/apps/app/src/components/GraphPanel.tsx
+++ b/apps/app/src/components/GraphPanel.tsx
@@ -42,6 +42,9 @@ function GraphNode({
   const tone = toneHex(node.repo);
   const status = displayStatus(node);
   const done = node.computedStatus === "done";
+  // Epics (parent issues) render as a slightly larger rounded square to stand
+  // out from leaf issues — matches the legacy `.gg-node.parent` (14px, r:3px).
+  const isParent = node.isParent;
   const title = `#${node.number} — ${node.title ?? ""}`;
   const hover = {
     onMouseEnter: () => onHover(node.key),
@@ -68,7 +71,11 @@ function GraphNode({
         className={cn("absolute -translate-x-1/2 -translate-y-1/2 transition-opacity", dim, active && "z-30")}
       >
         <span
-          className={cn("block size-2.5 rounded-full", devStateClasses(node.dev_state, done))}
+          className={cn(
+            "block",
+            isParent ? "size-3 rounded-[3px]" : "size-2.5 rounded-full",
+            devStateClasses(node.dev_state, done),
+          )}
           style={{
             color: tone,
             backgroundColor: done ? "transparent" : tone,
@@ -185,8 +192,13 @@ export function GraphPanel({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gr
             const d = layout.positions.get(e.dst);
             if (!s || !d) return null;
             const inChain = chain ? chain.all.has(e.src) && chain.all.has(e.dst) : true;
-            const blocked = byKey.get(e.dst)?.computedStatus === "blocked";
-            const stroke = blocked ? statusColor.blocked : toneHex(byKey.get(e.src)?.repo ?? "");
+            const isParent = e.kind === "parent";
+            const dstBlocked = byKey.get(e.dst)?.computedStatus === "blocked";
+            // Edges follow the source repo tone — never red (legacy `.gg-edge`).
+            // A live blocker (blocks → still-blocked node) is cued by opacity, not
+            // colour; parent (sub-issue) edges are dashed + faint.
+            const stroke = toneHex(byKey.get(e.src)?.repo ?? "");
+            const dimmed = chain && !inChain;
             return (
               <path
                 key={`${e.src}->${e.dst}:${e.kind}`}
@@ -194,8 +206,8 @@ export function GraphPanel({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gr
                 fill="none"
                 stroke={stroke}
                 strokeWidth={inChain ? 1.4 : 0.8}
-                strokeOpacity={chain && !inChain ? 0.07 : blocked ? 0.7 : 0.32}
-                strokeDasharray={e.kind === "parent" ? "2 2" : undefined}
+                strokeOpacity={dimmed ? 0.07 : isParent ? 0.3 : dstBlocked ? 0.85 : 0.45}
+                strokeDasharray={isParent ? "2 2" : undefined}
                 vectorEffect="non-scaling-stroke"
               />
             );

--- a/apps/app/src/components/ThemeToggle.tsx
+++ b/apps/app/src/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+import { type Theme, applyTheme, readTheme } from "@/lib/theme";
+import { Moon, Sun } from "@phosphor-icons/react";
+import { useState } from "react";
+
+/** Dark/light theme toggle — legacy header `.theme-btn` (🌙). */
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(() => readTheme());
+  const next: Theme = theme === "dark" ? "light" : "dark";
+
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      title={`Switch to ${next} theme`}
+      aria-label={`Switch to ${next} theme`}
+      onClick={() => {
+        applyTheme(next);
+        setTheme(next);
+      }}
+      className="inline-flex size-9 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:border-primary/60 hover:text-primary"
+    >
+      {theme === "dark" ? (
+        <Moon size={16} weight="fill" aria-hidden />
+      ) : (
+        <Sun size={16} weight="fill" aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -23,3 +23,61 @@
   --font-mono: var(--font-mono);
   --radius: var(--r-md);
 }
+
+/* ── Light theme ──────────────────────────────────────────────────────────
+   Overrides the brand dark :root tokens when <html data-theme="light">. The
+   @theme map above resolves var(--bg)/var(--text)/… at use-site, so every
+   Tailwind utility (bg-background, text-foreground, …) re-themes for free.
+   Unlayered → wins over the layered brand :root. Default stays dark. */
+[data-theme="light"] {
+  --bg: #f7f5f1;
+  --bg-elevated: #efece6;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f1eee8;
+  --border: #ddd6cc;
+  --border-hi: #c6bdb0;
+  --text: #1c1917;
+  --text-muted: #5d6470;
+  --text-dim: #8a8f9c;
+  --accent: #c2780a;
+  --accent-hover: #a8680a;
+  --accent-press: #8a5408;
+  --accent-dim: rgba(194, 120, 10, 0.12);
+  --accent-glow: rgba(194, 120, 10, 0.22);
+  --ready: #047857;
+  --ready-dim: rgba(4, 120, 87, 0.12);
+  --blocked: #be123c;
+  --blocked-dim: rgba(190, 18, 60, 0.1);
+  --running: #0369a1;
+  --running-dim: rgba(3, 105, 161, 0.12);
+  --done: #94a3b8;
+  --done-dim: rgba(148, 163, 184, 0.2);
+  --node: #6d28d9;
+  --node-hi: #7c3aed;
+  --node-dim: rgba(109, 40, 217, 0.14);
+  --node-done: #b0b6c0;
+  --edge: rgba(71, 85, 105, 0.45);
+  --edge-dim: rgba(71, 85, 105, 0.18);
+}
+
+/* ── Thin, themed scrollbar for overflow panels (dropdowns, lists) ────────── */
+.rl-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-hi) transparent;
+}
+.rl-scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.rl-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.rl-scroll::-webkit-scrollbar-thumb {
+  background: var(--border-hi);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.rl-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--text-dim);
+}

--- a/apps/app/src/lib/theme.ts
+++ b/apps/app/src/lib/theme.ts
@@ -1,0 +1,32 @@
+/**
+ * theme — dark/light toggle for the cockpit. Mirrors the legacy data-theme
+ * switch (frontend/settings.js): the brand :root is dark, and an [data-theme]
+ * attribute on <html> flips the token set. Persisted in localStorage.
+ */
+
+export type Theme = "dark" | "light";
+
+const KEY = "rl:theme";
+
+export function readTheme(): Theme {
+  try {
+    return localStorage.getItem(KEY) === "light" ? "light" : "dark";
+  } catch {
+    return "dark";
+  }
+}
+
+/** Set <html data-theme> and persist. Called by the toggle. */
+export function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute("data-theme", theme);
+  try {
+    localStorage.setItem(KEY, theme);
+  } catch {
+    // ignore quota / disabled storage
+  }
+}
+
+/** Apply the stored theme on boot without writing storage (no FOUC for light). */
+export function initTheme(): void {
+  document.documentElement.setAttribute("data-theme", readTheme());
+}

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -3,7 +3,11 @@ import { RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import { initTheme } from "./lib/theme";
 import { router } from "./router";
+
+// Apply the stored dark/light theme before first paint.
+initTheme();
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
Follow-up to #274. Four requested polish items.

## Changes
1. **Light theme** — `[data-theme="light"]` token overrides (warm off-white canvas, darker-amber accent, light status/node palette). The `@theme` map resolves `var(--bg)`/`var(--text)`/… at use-site, so every Tailwind utility re-themes for free. **`ThemeToggle`** (sun/moon) added to the header; `initTheme()` applies the stored choice before first paint. Default stays dark.
2. **Dropdown scroll** — thin themed scrollbar (`.rl-scroll`) on the facet panel; replaced the global `:focus-visible` amber outline (clipped by `overflow-auto` into a stray line — see report) with a `focus-visible` background highlight on options.
3. **Graph epics** — parent/epic nodes render as **rounded squares** (legacy `.gg-node.parent`, 14px r:3px) vs round leaf dots.
4. **Parent edges not red** — edges follow the **source repo tone**, never status-red; a live blocker is cued by opacity, parent (sub-issue) edges are dashed + faint — matching legacy `.gg-edge` (where `.blocked` only boosted opacity).

## Verification
Browser-verified on the **prod build** (`vite preview` + mocked API):
- Light theme renders list + graph (`data-theme=light`, `bodyBg rgb(247,245,241)`).
- Milestone dropdown: clipped amber line gone, thin scrollbar.
- Graph: **4 epic squares** + **0 red parent edges**.
- `typecheck` ✓ · `biome` ✓ · app vitest **46 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)