### PR TITLE
fix(app): graph blocked nodes hollow + dashed tone (never red)

### DIFF
--- a/apps/app/src/components/GraphPanel.tsx
+++ b/apps/app/src/components/GraphPanel.tsx
@@ -10,7 +10,6 @@ import {
   displayStatus,
   edgePath,
   layoutV5,
-  statusColor,
   toneHex,
 } from "@roxabi-live/shared";
 import { useMemo, useState } from "react";
@@ -42,6 +41,7 @@ function GraphNode({
   const tone = toneHex(node.repo);
   const status = displayStatus(node);
   const done = node.computedStatus === "done";
+  const blocked = status === "blocked";
   // Epics (parent issues) render as a slightly larger rounded square to stand
   // out from leaf issues — matches the legacy `.gg-node.parent` (14px, r:3px).
   const isParent = node.isParent;
@@ -78,10 +78,11 @@ function GraphNode({
           )}
           style={{
             color: tone,
-            backgroundColor: done ? "transparent" : tone,
-            border: `1.5px solid ${tone}`,
-            boxShadow:
-              status === "blocked" ? `0 0 0 1.5px ${statusColor.blocked}` : "0 0 0 2px var(--bg)",
+            // Blocked = hollow + dashed border in the repo tone (legacy
+            // `.gg-node.blocked`) — never red. Done = hollow solid; open = filled.
+            backgroundColor: done || blocked ? "transparent" : tone,
+            border: blocked ? `2px dashed ${tone}` : `1.5px solid ${tone}`,
+            boxShadow: "0 0 0 2px var(--bg)",
           }}
           aria-hidden
         >


### PR DESCRIPTION
Per feedback (legacy reference image): blocked issues in the graph should not carry a red ring.

Restores the legacy `.gg-node.blocked` treatment — **transparent fill + 2px dashed border in the repo tone** — instead of the red status ring the React port added. This drops the last `statusColor` use in the graph, so the dependency view now carries **no status-red at all** (tone only; blocked is cued by the hollow dashed shape, a live blocker by edge opacity).

Browser-verified on the prod build: **0 red nodes**, blocked nodes render as hollow dashed tone rings (matches the reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)