### PR TITLE
feat(zk): auto-handoff GitHub token for enrolled users + enrol kick-off + info banner

### DIFF
--- a/apps/api/src/auth/oauth.test.ts
+++ b/apps/api/src/auth/oauth.test.ts
@@ -1308,4 +1308,114 @@ describe("callbackRoute", () => {
       expect(targets.some((t) => t.login === "Roxabi" && t.type === "Organization")).toBe(true);
     });
   });
+
+  // An enrolled ZK user (zk_key_backups row) must get the browser-side GitHub
+  // token handed off on EVERY login — not just ?zk=1 — so the dashboard never has
+  // to nag with a "Link GitHub" banner to seal newly-synced titles.
+  describe("ZK auto-handoff", () => {
+    function makeAutoHandoffDb(captured: FakeStmt[], enrolled: boolean, reauth = 0): D1Database {
+      const db = makeFakeDb((sql, args) => {
+        const lower = sql.toLowerCase();
+        let row: FakeResult | null = null;
+        if (lower.includes("oauth_state") && lower.includes("delete")) {
+          // Normal login (no ?zk=1); reauth flag is parametrised.
+          row = { redirect_after: "/", zk_token_handoff: 0, reauth, remember: 0 } as FakeResult;
+        } else if (lower.includes("users") && lower.includes("returning")) {
+          row = { id: 1 } as FakeResult;
+        } else if (lower.includes("tenants") && lower.includes("returning")) {
+          row = { id: 10 } as FakeResult;
+        } else if (lower.includes("zk_key_backups")) {
+          row = enrolled ? ({ ok: 1 } as FakeResult) : null;
+        }
+        const stmt = makeFakeStmt(sql, args, row ? [row] : [], 0);
+        (stmt as { first: <T>() => Promise<T | null> }).first = vi.fn().mockResolvedValue(row);
+        captured.push(stmt);
+        return stmt;
+      });
+      applyBatchOverride(db);
+      return db;
+    }
+
+    function stubGithub(): void {
+      let n = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          n++;
+          const json = (b: unknown) =>
+            new Response(JSON.stringify(b), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          if (n === 1) return json({ access_token: "tok" });
+          if (n === 2) return json({ id: 42, login: "alice" });
+          return json({ installations: [{ id: 9, account: { login: "Roxabi", type: "Organization" } }] });
+        }),
+      );
+    }
+
+    const dek = () => btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))));
+
+    async function run(env: Env, state: string): Promise<void> {
+      const app = new Hono<{ Bindings: Env }>();
+      app.get("/oauth/callback", callbackRoute);
+      await app.request(
+        `http://localhost/oauth/callback?code=c&state=${state}`,
+        { method: "GET" },
+        env,
+      );
+    }
+
+    it("mints a handoff on a normal login when the user is enrolled (flag on)", async () => {
+      const captured: FakeStmt[] = [];
+      const db = makeAutoHandoffDb(captured, true);
+      stubGithub();
+      const env = { ...makeEnv(db), ZK_ACCOUNT_KEY: "1", INSTALL_TOKEN_KEY: dek() } as unknown as Env;
+      await run(env, "a".repeat(32));
+      expect(captured.some((s) => s.sql.toLowerCase().includes("user_token_handoffs"))).toBe(true);
+    });
+
+    it("does NOT mint a handoff when the user is not enrolled", async () => {
+      const captured: FakeStmt[] = [];
+      const db = makeAutoHandoffDb(captured, false);
+      stubGithub();
+      const env = { ...makeEnv(db), ZK_ACCOUNT_KEY: "1", INSTALL_TOKEN_KEY: dek() } as unknown as Env;
+      await run(env, "b".repeat(32));
+      expect(captured.some((s) => s.sql.toLowerCase().includes("zk_key_backups"))).toBe(true);
+      expect(captured.some((s) => s.sql.toLowerCase().includes("user_token_handoffs"))).toBe(false);
+    });
+
+    it("does NOT query zk_key_backups when the ZK flag is off", async () => {
+      const captured: FakeStmt[] = [];
+      const db = makeAutoHandoffDb(captured, true);
+      stubGithub();
+      const env = { ...makeEnv(db), INSTALL_TOKEN_KEY: dek() } as unknown as Env; // ZK_ACCOUNT_KEY unset
+      await run(env, "d".repeat(32));
+      expect(captured.some((s) => s.sql.toLowerCase().includes("zk_key_backups"))).toBe(false);
+      expect(captured.some((s) => s.sql.toLowerCase().includes("user_token_handoffs"))).toBe(false);
+    });
+
+    it("does NOT auto-handoff on a reauth login (reauth takes precedence)", async () => {
+      const captured: FakeStmt[] = [];
+      const db = makeAutoHandoffDb(captured, true, 1); // enrolled, but reauth=1
+      stubGithub();
+      const env = { ...makeEnv(db), ZK_ACCOUNT_KEY: "1", INSTALL_TOKEN_KEY: dek() } as unknown as Env;
+      await run(env, "e".repeat(32));
+      // The !wantsReauth guard must short-circuit before the enrolled-check.
+      expect(captured.some((s) => s.sql.toLowerCase().includes("zk_key_backups"))).toBe(false);
+      expect(captured.some((s) => s.sql.toLowerCase().includes("user_token_handoffs"))).toBe(false);
+      // The reauth branch ran instead.
+      expect(captured.some((s) => s.sql.toLowerCase().includes("zk_reauth_proofs"))).toBe(true);
+    });
+
+    it("does NOT query zk_key_backups when INSTALL_TOKEN_KEY is absent (no DEK)", async () => {
+      const captured: FakeStmt[] = [];
+      const db = makeAutoHandoffDb(captured, true);
+      stubGithub();
+      const env = { ...makeEnv(db), ZK_ACCOUNT_KEY: "1" } as unknown as Env; // INSTALL_TOKEN_KEY unset
+      await run(env, "f".repeat(32));
+      expect(captured.some((s) => s.sql.toLowerCase().includes("zk_key_backups"))).toBe(false);
+      expect(captured.some((s) => s.sql.toLowerCase().includes("user_token_handoffs"))).toBe(false);
+    });
+  });
 });

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -17,6 +17,7 @@ import { completeOAuthSession } from "./post-oauth";
 import { mintSession, revokeOtherSessions, validateSession } from "./session";
 import { pickSessionTenantId, supersedeStaleTenants } from "./tenant-supersede";
 import { createUserTokenHandoff } from "./userTokenHandoff";
+import { zkAccountKeyEnabled } from "./zk-flags";
 import { createZkReauthCode } from "./zk-reauth";
 
 export type LoginIntent = "signin" | "install" | "reauth" | "zk" | "prompt";
@@ -360,12 +361,26 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
   const rawToken = await mintSession(c.env.DB, userId, sessionTenantId, rememberSession);
   await revokeOtherSessions(c.env.DB, userId, rawToken);
 
+  // Auto-handoff: an already-enrolled ZK user (has a zk_key_backups row) needs the
+  // browser-side GitHub token every session to seal newly-synced titles. Mint it on
+  // any normal login — not just an explicit ?zk=1 — so the dashboard never has to
+  // nag with a "Link GitHub" banner. The first enrolment kicks off ?zk=1 itself.
+  let doZkHandoff = wantsZkHandoff;
+  if (!doZkHandoff && !wantsReauth && zkAccountKeyEnabled(c.env) && c.env.INSTALL_TOKEN_KEY) {
+    const enrolledRow = await c.env.DB.prepare(
+      "SELECT 1 AS ok FROM zk_key_backups WHERE user_id = ? LIMIT 1",
+    )
+      .bind(userId)
+      .first<{ ok: number }>();
+    doZkHandoff = enrolledRow != null;
+  }
+
   if (wantsReauth) {
     const reauthCode = await createZkReauthCode(c.env, userId);
     const dest = new URL(redirectAfter, origin);
     dest.searchParams.set("zk_reauth", reauthCode);
     redirectAfter = `${dest.pathname}${dest.search}`;
-  } else if (wantsZkHandoff) {
+  } else if (doZkHandoff) {
     try {
       const handoffCode = await createUserTokenHandoff(c.env, userId, access_token);
       const dest = new URL(redirectAfter, origin);

--- a/apps/app/src/router.tsx
+++ b/apps/app/src/router.tsx
@@ -1,4 +1,5 @@
 import { AuthGate } from "@/auth/AuthGate";
+import { useAuth } from "@/auth/AuthContext";
 import { SignInScreen } from "@/auth/SignInScreen";
 import { AppShell } from "@/components/AppShell";
 import { BoardView } from "@/components/BoardView";
@@ -43,13 +44,22 @@ const indexRoute = createRoute({
 /** The authenticated dashboard body — mounts only inside ZkGate's unlocked branch. */
 function Dashboard() {
   useVersionPoll();
+  const me = useAuth();
   const syncStatus = useSyncProgressMonitor();
   const { nodes, edges, isLoading, isError, error, needsGithubLink, zkMigrationIncomplete } =
     useDecryptedGraph();
+  // ZK is "active" once the feature flag is on and the user has enrolled a
+  // passphrase (zk_key_backups row) — gates the encryption-info banner.
+  const zkActive = me.user.zk_account_key_enabled && me.user.zk_enrolled;
 
   return (
     <div className="space-y-3">
-      <ZkNotices needsGithubLink={needsGithubLink} migrationIncomplete={zkMigrationIncomplete} />
+      <ZkNotices
+        needsGithubLink={needsGithubLink}
+        migrationIncomplete={zkMigrationIncomplete}
+        zkActive={zkActive}
+        githubLogin={me.user.github_login}
+      />
       <SyncProgressBanner status={syncStatus} />
       {isError ? (
         <div className="rounded-lg border border-blocked/30 bg-blocked/10 p-4 text-sm text-blocked">

--- a/apps/app/src/zk/ZkEnrollDialog.tsx
+++ b/apps/app/src/zk/ZkEnrollDialog.tsx
@@ -15,6 +15,7 @@ import {
   isZkRememberPreferred,
   setZkRememberPreferred,
 } from "./enroll";
+import { zkLoginUrl } from "./github";
 
 export function ZkEnrollDialog({ login }: { login: string }) {
   const logout = useLogout();
@@ -44,7 +45,12 @@ export function ZkEnrollDialog({ login }: { login: string }) {
     try {
       await enrollAccountKey(pass, login);
       await applyZkRememberChoice(login, pass, remember);
-      // unlocked is now true; ZkGate re-renders to the dashboard.
+      // Kick off the GitHub token handoff so titles are imported + sealed right
+      // away (otherwise they'd stay "(sealed)" until the next login picks up the
+      // server auto-handoff). enrollAccountKey() saved a device session, so the
+      // post-OAuth return auto-unlocks — no second passphrase prompt.
+      window.location.assign(zkLoginUrl(window.location.pathname + window.location.search));
+      return;
     } catch (err) {
       const msg = String((err as Error)?.message ?? "");
       setError(

--- a/apps/app/src/zk/ZkNotices.test.ts
+++ b/apps/app/src/zk/ZkNotices.test.ts
@@ -1,0 +1,36 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ZkNotices } from "./ZkNotices";
+
+const html = (props: {
+  needsGithubLink: boolean;
+  migrationIncomplete: boolean;
+  zkActive?: boolean;
+  githubLogin?: string;
+}) => renderToStaticMarkup(createElement(ZkNotices, props));
+
+describe("ZkNotices", () => {
+  it("shows the dismissable encryption-info banner when ZK is active", () => {
+    const out = html({ needsGithubLink: false, migrationIncomplete: false, zkActive: true });
+    expect(out).toContain("jamais accessibles en clair sur le");
+    expect(out).toContain("pas récupérable");
+    expect(out).toContain("générer une nouvelle");
+    expect(out).toContain('data-testid="zk-info-dismiss"');
+  });
+
+  it("renders nothing when no notice is active", () => {
+    expect(html({ needsGithubLink: false, migrationIncomplete: false, zkActive: false })).toBe("");
+  });
+
+  it("still surfaces the GitHub-link fallback when titles cannot be sealed", () => {
+    const out = html({ needsGithubLink: true, migrationIncomplete: false, zkActive: false });
+    expect(out).toContain("Lier GitHub");
+    expect(out).toContain('data-testid="zk-github-link-notice"');
+  });
+
+  it("does not show the info banner when ZK is inactive even if a fallback is shown", () => {
+    const out = html({ needsGithubLink: true, migrationIncomplete: false, zkActive: false });
+    expect(out).not.toContain('data-testid="zk-info-notice"');
+  });
+});

--- a/apps/app/src/zk/ZkNotices.tsx
+++ b/apps/app/src/zk/ZkNotices.tsx
@@ -1,24 +1,86 @@
 /**
- * ZkNotices — dashboard banners ported from frontend/app.js showZkGithubLinkNotice
- * / showZkMigrationNotice. Surfaces two sealing side-effects the gate cannot fix
- * silently: (1) titles stayed "(sealed)" because no GitHub user token is linked
- * to pull issue content; (2) a v1→v2 migration left undecryptable rows behind.
+ * ZkNotices — dashboard banners for the ZK (zero-knowledge) encryption mode.
+ *
+ *  1. Info (dismissable): reassures that issue titles/content are encrypted
+ *     server-side and that the passphrase is unrecoverable.
+ *  2. GitHub link (fallback): titles stayed "(sealed)" because no GitHub user
+ *     token is available to import + encrypt them. Rare now — the server
+ *     auto-hands-off the token on every login of an enrolled user, and the first
+ *     enrolment kicks off the handoff itself — so this only shows if that failed.
+ *  3. Migration: a v1→v2 migration left undecryptable rows behind.
  */
 
 import { GithubLogo, Warning } from "@phosphor-icons/react";
+import { useState } from "react";
 import { zkLoginUrl } from "./github";
+
+// Per-user so a shared browser doesn't suppress the notice for another account
+// (matches the githubLogin-scoping of the ZK device/remember keys).
+function infoDismissKey(githubLogin: string): string {
+  return `rl:zk-info-dismissed:${githubLogin}`;
+}
+
+function readInfoDismissed(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
 
 export function ZkNotices({
   needsGithubLink,
   migrationIncomplete,
+  zkActive = false,
+  githubLogin = "",
 }: {
   needsGithubLink: boolean;
   migrationIncomplete: boolean;
+  zkActive?: boolean;
+  githubLogin?: string;
 }) {
-  if (!needsGithubLink && !migrationIncomplete) return null;
+  const dismissKey = infoDismissKey(githubLogin);
+  const [infoDismissed, setInfoDismissed] = useState(() => readInfoDismissed(dismissKey));
+  const showInfo = zkActive && !infoDismissed;
+
+  if (!showInfo && !needsGithubLink && !migrationIncomplete) return null;
 
   return (
     <div className="space-y-2">
+      {showInfo && (
+        <div
+          data-testid="zk-info-notice"
+          className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card/60 px-3 py-2 text-sm text-muted-foreground"
+        >
+          <span aria-hidden className="shrink-0 text-primary">
+            🔒
+          </span>
+          <span className="min-w-0">
+            Les titres et le contenu de vos issues sont{" "}
+            <strong className="font-medium text-foreground">chiffrés</strong> et ne sont{" "}
+            <strong className="font-medium text-foreground">jamais accessibles en clair sur le
+            serveur</strong>. Votre passphrase n'est{" "}
+            <strong className="font-medium text-foreground">pas récupérable</strong> : en cas de
+            perte, vous devrez en générer une nouvelle.
+          </span>
+          <button
+            type="button"
+            data-testid="zk-info-dismiss"
+            aria-label="Fermer"
+            onClick={() => {
+              try {
+                localStorage.setItem(dismissKey, "1");
+              } catch {
+                /* ignore disabled storage */
+              }
+              setInfoDismissed(true);
+            }}
+            className="ml-auto shrink-0 rounded px-1.5 text-lg leading-none text-muted-foreground transition-colors hover:text-foreground"
+          >
+            ×
+          </button>
+        </div>
+      )}
       {needsGithubLink && (
         <div
           data-testid="zk-github-link-notice"

--- a/apps/app/src/zk/github.ts
+++ b/apps/app/src/zk/github.ts
@@ -3,7 +3,7 @@
 // .json()) is replaced by `apiFetch<T>` (parsed JSON, throws ApiError on non-2xx);
 // behaviour is preserved: both throw on 401/5xx, GraphQL errors come back 200.
 
-import { apiFetch } from "@/lib/api";
+import { ApiError, apiFetch } from "@/lib/api";
 
 const TOKEN_KEY = "roxabi:gh-user-token";
 const REAUTH_KEY = "roxabi:zk-reauth-proof";
@@ -67,14 +67,24 @@ export async function consumeZkHandoffFromUrl(): Promise<boolean> {
   const code = params.get("zk_handoff");
   if (!code) return false;
 
-  stripQueryParam("zk_handoff");
-
-  const { github_token } = await apiFetch<{ github_token?: string }>("/api/zk/consume-handoff", {
-    method: "POST",
-    body: { code },
-  });
-  setGithubUserToken(github_token);
-  return true;
+  try {
+    const { github_token } = await apiFetch<{ github_token?: string }>("/api/zk/consume-handoff", {
+      method: "POST",
+      body: { code },
+    });
+    // The code is single-use server-side; strip it now that the server has
+    // acknowledged it (consumed or expired).
+    stripQueryParam("zk_handoff");
+    setGithubUserToken(github_token);
+    return Boolean(github_token);
+  } catch (err) {
+    // Definitive failure (4xx: bad/expired code) → strip so we don't loop.
+    // Transient failure (5xx / network) → leave the code in the URL so the next
+    // mount retries; silently dropping the token was the prior failure mode.
+    const status = err instanceof ApiError ? err.status : 0;
+    if (status >= 400 && status < 500) stripQueryParam("zk_handoff");
+    return false;
+  }
 }
 
 // Default "/" — see zkReauthLoginUrl. The legacy "/dashboard" path no longer exists.


### PR DESCRIPTION
Makes ZK title-sealing automatic so the dashboard stops nagging with a "Link GitHub" banner. Answers: *the passphrase sets up the key, but the server does structure-only sync (no titles) — the GitHub user token is what imports + encrypts titles client-side.*

## Changes
- **Server auto-handoff** (`oauth.ts`) — on ANY normal login, mint the browser-side GitHub token handoff for an already-enrolled user (`zk_key_backups` row), not only `?zk=1`. Gated by `ZK_ACCOUNT_KEY` **and** `INSTALL_TOKEN_KEY` (flag-off / DEK-less deploy never queries or mints). Reauth keeps precedence.
- **Enrol kick-off** (`ZkEnrollDialog`) — after enrolment, redirect to `zkLoginUrl(path+query)` for immediate import+seal. `enrollAccountKey` saved a device session, so the return auto-unlocks (no second passphrase prompt).
- **Resilient consume** (`github.ts`) — strip `?zk_handoff` only after the server responds (4xx → strip; 5xx/network → keep + retry), so a transient blip no longer drops the token silently.
- **Banner** (`ZkNotices` + `router.tsx`) — "Link GitHub" demoted to a rare fallback; a **dismissable info banner** (encryption + passphrase-not-recoverable) shows when ZK is active. Per-user dismiss key. Copy is **accurate**: encryption is client-side, the server only ever holds ciphertext.

## Review + tests
Authored with a 4-lens **adversarial review** (security/token-leak · OAuth state-machine · enroll-redirect · banner UX); all surfaced findings fixed (INSTALL_TOKEN_KEY gate, strip-on-resolve, per-user dismiss key, accurate copy, reauth precedence test).
- `+5` server tests (handoff only when enrolled+flag+DEK; reauth precedence; no-DEK) · `+4` banner branches.
- `typecheck` ✓ · `biome` ✓ · **api 802 / app 50** green.

## Known follow-up (low, pre-existing)
Handoff code rides in the URL query (`?zk_handoff`) — modern `strict-origin-when-cross-origin` referrer policy keeps it off third-party requests; moving it to a fragment/cookie is a separate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)