### PR TITLE
feat(app): dashboard i18n + ZK title self-heal/import banner + marketing Connexion CTAs

### DIFF
--- a/apps/app/src/auth/AuthGate.tsx
+++ b/apps/app/src/auth/AuthGate.tsx
@@ -16,21 +16,24 @@ import { ConsentGate } from "@/auth/ConsentGate";
 import { InstallGate } from "@/auth/InstallGate";
 import { SignInScreen } from "@/auth/SignInScreen";
 import { useMe } from "@/auth/useMe";
+import { useT } from "@/i18n";
 import { CircleNotch } from "@phosphor-icons/react";
 
 function AuthLoading() {
+  const t = useT();
   return (
     <div
       className="flex min-h-[60vh] items-center justify-center text-muted-foreground"
       data-testid="auth-loading"
     >
       <CircleNotch className="size-6 animate-spin" aria-hidden />
-      <span className="sr-only">Loading your session…</span>
+      <span className="sr-only">{t("auth.loading.srOnly")}</span>
     </div>
   );
 }
 
 export function AuthGate({ children }: { children: React.ReactNode }) {
+  const t = useT();
   const { data: me, isLoading, error } = useMe();
 
   if (isLoading) return <AuthLoading />;
@@ -43,7 +46,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
         data-testid="auth-error"
         role="alert"
       >
-        Impossible de charger votre session : {error.message}
+        {t("auth.error.loadSession", { message: error.message })}
       </div>
     );
   }

--- a/apps/app/src/auth/ConsentGate.tsx
+++ b/apps/app/src/auth/ConsentGate.tsx
@@ -9,28 +9,29 @@ import { OnboardingSteps } from "@/auth/OnboardingSteps";
 import { useConsent, useLogout } from "@/auth/useAuthMutations";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { useT } from "@/i18n";
 import type { MePayload } from "@roxabi-live/shared";
 
-const SCOPES = [
-  "Issues, labels, milestones et relations parent/enfant",
-  "Métadonnées des dépôts (nom, visibilité, archivage)",
-  "Données stockées dans Cloudflare D1, limitées à votre organisation",
-];
-
 export function ConsentGate({ me }: { me: MePayload }) {
+  const t = useT();
   const consent = useConsent();
   const logout = useLogout();
+
+  const SCOPES = [
+    t("auth.consent.scope.issues"),
+    t("auth.consent.scope.repoMeta"),
+    t("auth.consent.scope.d1"),
+  ];
 
   return (
     <Dialog open>
       <DialogContent showClose={false} className="max-w-xl">
         <OnboardingSteps active="consent" />
         <DialogTitle className="text-xl font-semibold text-foreground">
-          Accès aux données
+          {t("auth.consent.title")}
         </DialogTitle>
         <p className="text-sm text-muted-foreground">
-          L'application est installée. Avant la première synchronisation, confirmez que Roxabi Live
-          peut lire les métadonnées GitHub suivantes :
+          {t("auth.consent.description")}
         </p>
         <div className="space-y-1.5">
           {SCOPES.map((scope) => (
@@ -51,17 +52,16 @@ export function ConsentGate({ me }: { me: MePayload }) {
             rel="noopener noreferrer"
             className="text-primary underline-offset-4 hover:underline"
           >
-            paramètres GitHub
+            {t("auth.consent.githubSettingsLink")}
           </a>
           .
         </p>
         <p className="rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-sm text-foreground">
-          <strong>Les titres et corps d'issues sont chiffrés côté client avant stockage.</strong> La
-          structure du graphe (état, blockers, labels) reste lisible par l'opérateur.
+          {t("auth.consent.encryptionNotice")}
         </p>
         {consent.isError && (
           <p className="text-sm text-blocked" role="alert">
-            Enregistrement impossible — vérifiez votre connexion et réessayez.
+            {t("auth.consent.error")}
           </p>
         )}
         <div className="flex items-center justify-between gap-3">
@@ -70,10 +70,10 @@ export function ConsentGate({ me }: { me: MePayload }) {
             onClick={() => logout.mutate(undefined)}
             loading={logout.isPending}
           >
-            Se déconnecter
+            {t("auth.signout")}
           </Button>
           <Button onClick={() => consent.mutate()} loading={consent.isPending}>
-            J'ai compris — lancer la synchronisation
+            {t("auth.consent.confirmButton")}
           </Button>
         </div>
       </DialogContent>

--- a/apps/app/src/auth/InstallGate.tsx
+++ b/apps/app/src/auth/InstallGate.tsx
@@ -140,7 +140,7 @@ export function InstallGate({ me }: { me: MePayload }) {
         <div className="flex items-center justify-between gap-3">
           <Button
             variant="ghost"
-            onClick={() => logout.mutate({ to: "/" })}
+            onClick={() => logout.mutate(undefined)}
             loading={logout.isPending}
           >
             Se déconnecter

--- a/apps/app/src/auth/InstallGate.tsx
+++ b/apps/app/src/auth/InstallGate.tsx
@@ -10,35 +10,40 @@ import { OnboardingSteps } from "@/auth/OnboardingSteps";
 import { installRefresh, useLogout } from "@/auth/useAuthMutations";
 import { ME_QUERY_KEY } from "@/auth/useMe";
 import { Button } from "@/components/ui/button";
+import { useT } from "@/i18n";
 import type { InstallOption, MePayload } from "@roxabi-live/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const DEFAULT_FALLBACK = "/login?intent=install&redirect=%2Fdashboard";
 
-function optionCopy(opt: InstallOption): { title: string; name: string; hint: string } {
+function optionCopy(
+  opt: InstallOption,
+  t: (key: string) => string,
+): { title: string; name: string; hint: string } {
   if (opt.kind === "picker") {
     return {
-      title: "Organisation",
-      name: "Choisir sur GitHub",
-      hint: "GitHub liste les organisations où vous pouvez installer l'app",
+      title: t("auth.install.option.orgTitle"),
+      name: t("auth.install.option.pickerName"),
+      hint: t("auth.install.option.pickerHint"),
     };
   }
   if (opt.kind === "personal") {
     return {
-      title: "Compte personnel",
+      title: t("auth.install.option.personalTitle"),
       name: opt.login ?? "",
-      hint: "Vos dépôts uniquement — idéal en solo",
+      hint: t("auth.install.option.personalHint"),
     };
   }
   return {
-    title: "Organisation",
+    title: t("auth.install.option.orgTitle"),
     name: opt.login ?? "",
-    hint: "Installer sur cette org — tous les dépôts ou une sélection sur GitHub",
+    hint: t("auth.install.option.orgHint"),
   };
 }
 
 export function InstallGate({ me }: { me: MePayload }) {
+  const t = useT();
   const qc = useQueryClient();
   const logout = useLogout();
   const [checking, setChecking] = useState(false);
@@ -86,11 +91,9 @@ export function InstallGate({ me }: { me: MePayload }) {
         if (res.status !== "pending" && advanceIfLinked(res.onboarding_step)) return;
         await new Promise((r) => setTimeout(r, 2000));
       }
-      setHint(
-        `Installation pas encore détectée. Réessayez ou reconnectez-vous via GitHub (${fallback}).`,
-      );
+      setHint(t("auth.install.notDetectedHint", { fallbackUrl: fallback }));
     } catch {
-      setHint("Session expirée ou erreur réseau — rechargez la page ou reconnectez-vous.");
+      setHint(t("auth.install.sessionErrorHint"));
     } finally {
       setChecking(false);
     }
@@ -102,16 +105,14 @@ export function InstallGate({ me }: { me: MePayload }) {
     <div className="mx-auto max-w-xl py-12">
       <OnboardingSteps active="install" />
       <div className="space-y-5 rounded-lg border border-border bg-card p-6">
-        <h2 className="text-xl font-semibold text-foreground">Installer Roxabi Live sur GitHub</h2>
+        <h2 className="text-xl font-semibold text-foreground">{t("auth.install.title")}</h2>
         <p className="text-sm text-muted-foreground">
-          Connecté en tant que <strong className="text-foreground">{me.user.github_login}</strong>{" "}
-          (étape&nbsp;1 terminée). Choisissez où installer l'application : compte personnel,
-          organisation, ou dépôts sélectionnés uniquement.
+          {t("auth.install.description", { login: me.user.github_login })}
         </p>
 
         <div className="space-y-2">
           {options.map((opt) => {
-            const c = optionCopy(opt);
+            const c = optionCopy(opt, t);
             return (
               <a
                 key={`${opt.kind}:${opt.login ?? "picker"}`}
@@ -127,16 +128,13 @@ export function InstallGate({ me }: { me: MePayload }) {
             );
           })}
           <div className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
-            <span className="block font-medium text-foreground">Dépôts sélectionnés</span>
-            Choisissez un compte ci-dessus, puis sur GitHub :{" "}
-            <strong className="text-foreground">Only select repositories</strong> et sélectionnez
-            les dépôts à synchroniser.
+            <span className="block font-medium text-foreground">{t("auth.install.selectedRepos.label")}</span>
+            {t("auth.install.selectedRepos.hint")}
           </div>
         </div>
 
         <p className="text-xs text-muted-foreground">
-          GitHub vous demandera quels dépôts autoriser, puis vous ramènera ici. Si la redirection
-          échoue, revenez et cliquez <strong>J'ai installé — continuer</strong>.
+          {t("auth.install.redirectHint")}
         </p>
 
         <div className="flex items-center justify-between gap-3">
@@ -148,7 +146,7 @@ export function InstallGate({ me }: { me: MePayload }) {
             Se déconnecter
           </Button>
           <Button onClick={onContinue} loading={checking}>
-            J'ai installé — continuer
+            {t("auth.install.continueButton")}
           </Button>
         </div>
 

--- a/apps/app/src/auth/OnboardingSteps.tsx
+++ b/apps/app/src/auth/OnboardingSteps.tsx
@@ -4,21 +4,23 @@
  * handoff (step 2 done, step 3 prepped).
  */
 
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 
 type Active = "github" | "install" | "consent" | "sync";
 
 const STEPS = [
-  { id: "github", label: "Connexion GitHub" },
-  { id: "install", label: "Installation" },
-  { id: "sync", label: "Synchronisation" },
+  { id: "github", key: "auth.onboarding.step.github" as const },
+  { id: "install", key: "auth.onboarding.step.install" as const },
+  { id: "sync", key: "auth.onboarding.step.sync" as const },
 ] as const;
 
 export function OnboardingSteps({ active }: { active: Active }) {
+  const t = useT();
   const activeIdx = active === "consent" ? 1 : STEPS.findIndex((s) => s.id === active);
 
   return (
-    <nav aria-label="Progression de l'installation" className="mb-6">
+    <nav aria-label={t("auth.onboarding.navAriaLabel")} className="mb-6">
       <ol className="flex items-center gap-2 text-sm">
         {STEPS.map((step, i) => {
           const done = i < activeIdx;
@@ -42,7 +44,7 @@ export function OnboardingSteps({ active }: { active: Active }) {
                 {marker}
               </span>
               <span className={cn(current ? "text-foreground" : "text-muted-foreground")}>
-                {step.label}
+                {t(step.key)}
               </span>
               {i < STEPS.length - 1 && <span className="mx-1 h-px w-6 bg-border" aria-hidden />}
             </li>

--- a/apps/app/src/auth/OrgPicker.tsx
+++ b/apps/app/src/auth/OrgPicker.tsx
@@ -5,15 +5,17 @@
 
 import { useActiveTenant } from "@/auth/useAuthMutations";
 import { SingleSelect } from "@/components/SingleSelect";
+import { useT } from "@/i18n";
 import type { MePayload } from "@roxabi-live/shared";
 
 export function OrgPicker({ me }: { me: MePayload }) {
   const switchTenant = useActiveTenant();
+  const t = useT();
   if (me.installations.length <= 1) return null;
 
   return (
     <SingleSelect
-      ariaLabel="Active installation"
+      ariaLabel={t("auth.orgPicker.ariaLabel")}
       value={String(me.active_tenant_id ?? "")}
       options={me.installations.map((inst) => ({
         value: String(inst.tenant_id),

--- a/apps/app/src/auth/SettingsDialog.tsx
+++ b/apps/app/src/auth/SettingsDialog.tsx
@@ -10,6 +10,7 @@ import { clearDisplayName, getDisplayName, setDisplayName } from "@/auth/display
 import { useLogout } from "@/auth/useAuthMutations";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { useT } from "@/i18n";
 import { type ApiError, apiFetch } from "@/lib/api";
 import { PassphraseChangeSection } from "@/zk/PassphraseChangeSection";
 import { hasEnrolledThisSession } from "@/zk/enroll";
@@ -51,6 +52,7 @@ export function SettingsDialog({
 }) {
   const login = me.user.github_login;
   const logout = useLogout();
+  const t = useT();
   const [name, setName] = useState(() => getDisplayName(login));
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const installUrl = configureUrl(me);
@@ -83,7 +85,7 @@ export function SettingsDialog({
         requestSettingsReauth("delete", window.location.pathname);
         return;
       }
-      setDeleteError("Suppression impossible — réessayez.");
+      setDeleteError(t("settings.deleteAccount.error"));
     },
   });
 
@@ -96,9 +98,7 @@ export function SettingsDialog({
   function onDelete() {
     setDeleteError(null);
     if (
-      !window.confirm(
-        "Supprimer toutes vos données Roxabi Live et vous déconnecter ? Action irréversible.",
-      )
+      !window.confirm(t("settings.deleteAccount.confirmPrompt"))
     ) {
       return;
     }
@@ -119,12 +119,12 @@ export function SettingsDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg" data-testid="settings-dialog">
-        <DialogTitle className="text-xl font-semibold text-foreground">Paramètres</DialogTitle>
+        <DialogTitle className="text-xl font-semibold text-foreground">{t("settings.title")}</DialogTitle>
 
         <section className="space-y-2">
-          <h3 className="text-sm font-semibold text-foreground">Profil</h3>
+          <h3 className="text-sm font-semibold text-foreground">{t("settings.profile.heading")}</h3>
           <label className="block space-y-1">
-            <span className="text-xs text-muted-foreground">Nom affiché</span>
+            <span className="text-xs text-muted-foreground">{t("settings.profile.displayName.label")}</span>
             <input
               type="text"
               value={name}
@@ -136,15 +136,14 @@ export function SettingsDialog({
             />
           </label>
           <p className="text-xs text-muted-foreground">
-            Affiché dans l'en-tête. Login GitHub :{" "}
-            <strong className="text-foreground">{login}</strong>.
+            {t("settings.profile.displayName.hint", { login })}
           </p>
         </section>
 
         <section className="space-y-2">
-          <h3 className="text-sm font-semibold text-foreground">Dépôts</h3>
+          <h3 className="text-sm font-semibold text-foreground">{t("settings.repos.heading")}</h3>
           <p className="text-xs text-muted-foreground">
-            Ajoutez ou retirez les dépôts auxquels l'App GitHub accède.
+            {t("settings.repos.hint")}
           </p>
           {installations.length ? (
             <ul className="space-y-1 text-sm">
@@ -157,7 +156,7 @@ export function SettingsDialog({
             </ul>
           ) : (
             <p className="text-sm text-muted-foreground">
-              Aucune installation liée pour l'instant.
+              {t("settings.repos.empty")}
             </p>
           )}
           {installUrl && (
@@ -167,7 +166,7 @@ export function SettingsDialog({
               rel="noopener noreferrer"
               className="inline-block text-sm text-primary underline-offset-4 hover:underline"
             >
-              Configurer les dépôts sur GitHub
+              {t("settings.repos.configure")}
             </a>
           )}
         </section>
@@ -184,9 +183,9 @@ export function SettingsDialog({
         )}
 
         <section className="space-y-2 rounded-md border border-blocked/30 bg-blocked/5 p-3">
-          <h3 className="text-sm font-semibold text-blocked">Supprimer le compte</h3>
+          <h3 className="text-sm font-semibold text-blocked">{t("settings.deleteAccount.heading")}</h3>
           <p className="text-xs text-muted-foreground">
-            Efface vos données Roxabi et vous déconnecte. Révoquez l'app sur GitHub séparément.
+            {t("settings.deleteAccount.hint")}
           </p>
           <Button
             variant="destructive"
@@ -195,7 +194,7 @@ export function SettingsDialog({
             loading={deleteAccount.isPending}
             data-testid="settings-delete"
           >
-            Supprimer mes données &amp; se déconnecter
+            {t("settings.deleteAccount.button")}
           </Button>
           {deleteError && (
             <p className="text-xs text-blocked" role="alert">

--- a/apps/app/src/auth/SettingsDialog.tsx
+++ b/apps/app/src/auth/SettingsDialog.tsx
@@ -78,7 +78,7 @@ export function SettingsDialog({
       clearZkReauthProof();
       await clearLocalZkState(login);
       clearDisplayName(login);
-      logout.mutate({ to: "/" });
+      logout.mutate(undefined);
     },
     onError: (err) => {
       if (err.status === 403) {

--- a/apps/app/src/auth/SignInScreen.tsx
+++ b/apps/app/src/auth/SignInScreen.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button } from "@/components/ui/button";
+import { useT } from "@/i18n";
 import { GithubLogo } from "@phosphor-icons/react";
 import { useState } from "react";
 
@@ -31,6 +32,7 @@ export function SignInScreen({
   mode?: "signin" | "signup";
   reason?: "session-lost";
 }) {
+  const t = useT();
   const [remember, setRemember] = useState(
     () => localStorage.getItem(REMEMBER_SESSION_KEY) === "1",
   );
@@ -46,20 +48,20 @@ export function SignInScreen({
     <div className="flex min-h-[60vh] items-center justify-center" data-testid="signin-screen">
       <div className="w-full max-w-sm space-y-5 rounded-lg border border-border bg-card p-8">
         <h1 className="text-xl font-semibold text-foreground">
-          {isSignup ? "Create your account" : "Sign in"}
+          {isSignup ? t("auth.signup.title") : t("auth.signin.title")}
         </h1>
         {reason === "session-lost" && (
           <p className="rounded-md border border-blocked/30 bg-blocked/10 px-3 py-2 text-sm text-blocked">
-            Session expirée. Reconnectez-vous pour continuer.
+            {t("auth.sessionLost")}
           </p>
         )}
         <p className="text-sm text-muted-foreground">
-          Roxabi Live se connecte à votre compte GitHub pour piloter votre flotte d'agents.
+          {t("auth.signin.description")}
         </p>
         <Button asChild className="w-full">
           <a href={loginUrl(remember)} data-testid="github-login">
             <GithubLogo className="size-5" weight="fill" aria-hidden />
-            <span>{isSignup ? "Continuer avec GitHub" : "Se connecter avec GitHub"}</span>
+            <span>{isSignup ? t("auth.signup.githubButton") : t("auth.signin.githubButton")}</span>
           </a>
         </Button>
         <label className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -69,7 +71,7 @@ export function SignInScreen({
             onChange={(e) => onRememberChange(e.target.checked)}
             className="size-4 rounded border-border"
           />
-          Rester connecté sur cet appareil
+          {t("auth.signin.rememberMe")}
         </label>
       </div>
     </div>

--- a/apps/app/src/auth/UserMenu.tsx
+++ b/apps/app/src/auth/UserMenu.tsx
@@ -10,10 +10,12 @@ import { useSettingsUi } from "@/auth/SettingsUi";
 import { getDisplayName } from "@/auth/displayName";
 import { useLogout } from "@/auth/useAuthMutations";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useT } from "@/i18n";
 import { Gear, SignOut } from "@phosphor-icons/react";
 import { useState } from "react";
 
 export function UserMenu() {
+  const t = useT();
   const me = useAuth();
   const logout = useLogout();
   const settings = useSettingsUi();
@@ -26,7 +28,7 @@ export function UserMenu() {
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger
           title={name}
-          aria-label="Account menu"
+          aria-label={t("auth.userMenu.trigger")}
           data-testid="user-menu-trigger"
           className="flex size-9 items-center justify-center overflow-hidden rounded-full border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
@@ -51,7 +53,7 @@ export function UserMenu() {
             className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-foreground hover:bg-card"
           >
             <Gear className="size-4" aria-hidden />
-            Settings
+            {t("auth.userMenu.settings")}
           </button>
           <button
             type="button"
@@ -63,7 +65,7 @@ export function UserMenu() {
             className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-foreground hover:bg-card"
           >
             <SignOut className="size-4" aria-hidden />
-            Sign out
+            {t("auth.userMenu.signOut")}
           </button>
         </PopoverContent>
       </Popover>

--- a/apps/app/src/auth/UserMenu.tsx
+++ b/apps/app/src/auth/UserMenu.tsx
@@ -60,7 +60,7 @@ export function UserMenu() {
             data-testid="user-menu-signout"
             onClick={() => {
               setOpen(false);
-              logout.mutate({ to: "/" });
+              logout.mutate(undefined);
             }}
             className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-foreground hover:bg-card"
           >

--- a/apps/app/src/auth/useAuthMutations.ts
+++ b/apps/app/src/auth/useAuthMutations.ts
@@ -64,7 +64,7 @@ export async function installRefresh(): Promise<InstallRefreshResult> {
   return (await res.json()) as InstallRefreshResult;
 }
 
-/** POST /logout — revoke the session, then navigate to the marketing root. */
+/** POST /logout — revoke the session, then land on the neutral sign-in screen. */
 export function useLogout() {
   const qc = useQueryClient();
   return useMutation<void, ApiError, { to?: string } | undefined>({
@@ -73,7 +73,10 @@ export function useLogout() {
     },
     onSuccess: (_data, vars) => {
       qc.clear();
-      window.location.href = vars?.to ?? "/";
+      // Default to /sign-in (a neutral SignInScreen). Landing on "/" would let
+      // AuthGate read the now-revoked session as a 401 and flash the alarming
+      // "Session expired" banner — wrong after a deliberate logout.
+      window.location.href = vars?.to ?? "/sign-in";
     },
   });
 }

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -12,27 +12,31 @@ import { OrgPicker } from "@/auth/OrgPicker";
 import { SettingsUiProvider } from "@/auth/SettingsUi";
 import { UserMenu } from "@/auth/UserMenu";
 import { BrandMark } from "@/components/BrandMark";
+import { LangToggle } from "@/components/LangToggle";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { ViewToggle } from "@/components/ViewToggle";
 import { useGraphData } from "@/hooks/useGraphData";
+import { useT } from "@/i18n";
 import { ZkLockButton } from "@/zk/ZkLockButton";
 
 /** Corpus counts subtitle — "N issues · N open · N closed" (legacy #subtitle). */
 function CorpusStats() {
+  const t = useT();
   const { nodes, isLoading } = useGraphData();
   if (isLoading && nodes.length === 0) {
-    return <div className="mt-1 font-mono text-xs text-muted-foreground">Loading…</div>;
+    return <div className="mt-1 font-mono text-xs text-muted-foreground">{t("header.loading")}</div>;
   }
   const open = nodes.reduce((n, x) => n + (x.state === "open" ? 1 : 0), 0);
   const closed = nodes.length - open;
   return (
     <div className="mt-1 font-mono text-xs text-muted-foreground">
-      {nodes.length} issues · {open} open · {closed} closed
+      {t("header.corpusStats", { total: nodes.length, open, closed })}
     </div>
   );
 }
 
 export function AppShell({ children }: { children: React.ReactNode }) {
+  const t = useT();
   const me = useAuth();
 
   return (
@@ -44,7 +48,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               <BrandMark className="size-7 shrink-0" />
               <div>
                 <h1 className="text-[22px] font-black leading-none tracking-[-0.04em] text-foreground">
-                  Roxabi <span className="text-primary">Live</span>
+                  {t("header.brandName")}
                 </h1>
                 <CorpusStats />
               </div>
@@ -53,6 +57,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               <ViewToggle />
               <ZkLockButton />
               <OrgPicker me={me} />
+              <LangToggle />
               <ThemeToggle />
               <UserMenu />
             </div>

--- a/apps/app/src/components/BoardView.tsx
+++ b/apps/app/src/components/BoardView.tsx
@@ -4,11 +4,13 @@ import { GraphPanel } from "@/components/GraphPanel";
 import { IssueTable } from "@/components/IssueTable";
 import { PivotMatrix } from "@/components/PivotMatrix";
 import { useFilteredNodes } from "@/hooks/useFilteredNodes";
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { useDashboardStore } from "@/store/dashboardStore";
 import type { AnnotatedNode, GraphEdge } from "@roxabi-live/shared";
 
 function PivotControls() {
+  const t = useT();
   const pivotRow = useDashboardStore((s) => s.pivotRow);
   const pivotCol = useDashboardStore((s) => s.pivotCol);
   const tableGroup = useDashboardStore((s) => s.tableGroup);
@@ -17,18 +19,18 @@ function PivotControls() {
   return (
     <div className="flex flex-wrap items-center gap-3">
       <DimSelect
-        label="Rows"
+        label={t("dim.label.rows")}
         value={pivotRow}
         onChange={(v) => patch({ pivotRow: v })}
         allowNone={false}
       />
       <DimSelect
-        label="Cols"
+        label={t("dim.label.cols")}
         value={pivotCol}
         onChange={(v) => patch({ pivotCol: v })}
         allowNone={false}
       />
-      <DimSelect label="Group" value={tableGroup} onChange={(v) => patch({ tableGroup: v })} />
+      <DimSelect label={t("dim.label.group")} value={tableGroup} onChange={(v) => patch({ tableGroup: v })} />
     </div>
   );
 }
@@ -64,6 +66,7 @@ function ToggleSeg({
 }
 
 function GraphControls() {
+  const t = useT();
   const graphRow = useDashboardStore((s) => s.graphRow);
   const graphCol = useDashboardStore((s) => s.graphCol);
   const showClosedUnderOpenEpic = useDashboardStore((s) => s.showClosedUnderOpenEpic);
@@ -73,23 +76,23 @@ function GraphControls() {
   return (
     <div className="flex flex-wrap items-center gap-3">
       <DimSelect
-        label="Rows"
+        label={t("dim.label.rows")}
         value={graphRow}
         onChange={(v) => patch({ graphRow: v })}
         allowNone={false}
       />
-      <DimSelect label="Order by" value={graphCol} onChange={(v) => patch({ graphCol: v })} />
+      <DimSelect label={t("dim.label.orderBy")} value={graphCol} onChange={(v) => patch({ graphCol: v })} />
       <ToggleSeg
-        label="Closed"
+        label={t("graph.toggle.closed.label")}
         testid="graph-closed-toggle"
-        title="Show closed issues whose parent epic is still open"
+        title={t("graph.toggle.closed.title")}
         pressed={showClosedUnderOpenEpic}
         onClick={() => patch({ showClosedUnderOpenEpic: !showClosedUnderOpenEpic })}
       />
       <ToggleSeg
-        label="Assignees"
+        label={t("graph.toggle.assignees.label")}
         testid="graph-assignees-toggle"
-        title="Show assignee logins on issue nodes"
+        title={t("graph.toggle.assignees.title")}
         pressed={showAssignees}
         onClick={() => patch({ showAssignees: !showAssignees })}
       />
@@ -98,14 +101,15 @@ function GraphControls() {
 }
 
 function ListControls() {
+  const t = useT();
   const listGroup = useDashboardStore((s) => s.listGroup);
   const listGroup2 = useDashboardStore((s) => s.listGroup2);
   const patch = useDashboardStore((s) => s.patch);
 
   return (
     <div className="flex flex-wrap items-center gap-3">
-      <DimSelect label="Group" value={listGroup} onChange={(v) => patch({ listGroup: v })} />
-      <DimSelect label="Subgroup" value={listGroup2} onChange={(v) => patch({ listGroup2: v })} />
+      <DimSelect label={t("dim.label.group")} value={listGroup} onChange={(v) => patch({ listGroup: v })} />
+      <DimSelect label={t("dim.label.subgroup")} value={listGroup2} onChange={(v) => patch({ listGroup2: v })} />
     </div>
   );
 }
@@ -115,6 +119,7 @@ function ListControls() {
  * Owns the view toggle, pivot controls, filter bar, and the active view.
  */
 export function BoardView({ nodes, edges }: { nodes: AnnotatedNode[]; edges: GraphEdge[] }) {
+  const t = useT();
   const view = useDashboardStore((s) => s.view);
   const listGroup = useDashboardStore((s) => s.listGroup);
   const listGroup2 = useDashboardStore((s) => s.listGroup2);
@@ -130,7 +135,7 @@ export function BoardView({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gra
         {view === "pivot" && <PivotControls />}
         {view === "graph" && <GraphControls />}
         <span className="ml-auto font-mono text-xs text-muted-foreground">
-          {filtered.length} of {nodes.length}
+          {t("toolbar.filteredCount", { count: filtered.length, total: nodes.length })}
         </span>
       </div>
       {view === "list" && (

--- a/apps/app/src/components/BoardView.tsx
+++ b/apps/app/src/components/BoardView.tsx
@@ -44,7 +44,7 @@ function ToggleSeg({
 }: {
   label: string;
   pressed: boolean;
-  title: string;
+  title?: string;
   testid: string;
   onClick: () => void;
 }) {
@@ -69,8 +69,6 @@ function GraphControls() {
   const t = useT();
   const graphRow = useDashboardStore((s) => s.graphRow);
   const graphCol = useDashboardStore((s) => s.graphCol);
-  const showClosedUnderOpenEpic = useDashboardStore((s) => s.showClosedUnderOpenEpic);
-  const showAssignees = useDashboardStore((s) => s.showAssignees);
   const patch = useDashboardStore((s) => s.patch);
 
   return (
@@ -82,20 +80,52 @@ function GraphControls() {
         allowNone={false}
       />
       <DimSelect label={t("dim.label.orderBy")} value={graphCol} onChange={(v) => patch({ graphCol: v })} />
+    </div>
+  );
+}
+
+/**
+ * DisplayToggles — the "Display" group of view toggles, set off by a separator.
+ * Epics (showParents) applies to every view; Closed + Assignees are graph-only
+ * render options, so they appear only in the graph view.
+ */
+function DisplayToggles() {
+  const t = useT();
+  const view = useDashboardStore((s) => s.view);
+  const showParents = useDashboardStore((s) => s.showParents);
+  const showClosedUnderOpenEpic = useDashboardStore((s) => s.showClosedUnderOpenEpic);
+  const showAssignees = useDashboardStore((s) => s.showAssignees);
+  const patch = useDashboardStore((s) => s.patch);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="mx-1 h-5 w-px bg-border" aria-hidden />
+      <span className="font-mono text-[11px] text-muted-foreground">{t("toolbar.display")}</span>
       <ToggleSeg
-        label={t("graph.toggle.closed.label")}
-        testid="graph-closed-toggle"
-        title={t("graph.toggle.closed.title")}
-        pressed={showClosedUnderOpenEpic}
-        onClick={() => patch({ showClosedUnderOpenEpic: !showClosedUnderOpenEpic })}
+        label={t("filter.epics.label")}
+        testid="facet-epics"
+        title={t("filter.epics.title")}
+        pressed={showParents}
+        onClick={() => patch({ showParents: !showParents })}
       />
-      <ToggleSeg
-        label={t("graph.toggle.assignees.label")}
-        testid="graph-assignees-toggle"
-        title={t("graph.toggle.assignees.title")}
-        pressed={showAssignees}
-        onClick={() => patch({ showAssignees: !showAssignees })}
-      />
+      {view === "graph" && (
+        <>
+          <ToggleSeg
+            label={t("graph.toggle.closed.label")}
+            testid="graph-closed-toggle"
+            title={t("graph.toggle.closed.title")}
+            pressed={showClosedUnderOpenEpic}
+            onClick={() => patch({ showClosedUnderOpenEpic: !showClosedUnderOpenEpic })}
+          />
+          <ToggleSeg
+            label={t("graph.toggle.assignees.label")}
+            testid="graph-assignees-toggle"
+            title={t("graph.toggle.assignees.title")}
+            pressed={showAssignees}
+            onClick={() => patch({ showAssignees: !showAssignees })}
+          />
+        </>
+      )}
     </div>
   );
 }
@@ -134,6 +164,7 @@ export function BoardView({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gra
         {view === "list" && <ListControls />}
         {view === "pivot" && <PivotControls />}
         {view === "graph" && <GraphControls />}
+        <DisplayToggles />
         <span className="ml-auto font-mono text-xs text-muted-foreground">
           {t("toolbar.filteredCount", { count: filtered.length, total: nodes.length })}
         </span>

--- a/apps/app/src/components/DimSelect.tsx
+++ b/apps/app/src/components/DimSelect.tsx
@@ -1,16 +1,17 @@
 import { SingleSelect } from "@/components/SingleSelect";
+import { useT } from "@/i18n";
 import type { Dim } from "@roxabi-live/shared";
 
-const DIMS: { value: Dim; label: string }[] = [
-  { value: "none", label: "None" },
-  { value: "milestone", label: "Milestone" },
-  { value: "priority", label: "Priority" },
-  { value: "repo", label: "Repo" },
-  { value: "lane", label: "Lane" },
-  { value: "size", label: "Size" },
-  { value: "status", label: "Status" },
-  { value: "parent", label: "Parent" },
-  { value: "assignee", label: "Assignee" },
+const DIM_VALUES: Dim[] = [
+  "none",
+  "milestone",
+  "priority",
+  "repo",
+  "lane",
+  "size",
+  "status",
+  "parent",
+  "assignee",
 ];
 
 interface DimSelectProps {
@@ -22,7 +23,11 @@ interface DimSelectProps {
 
 /** A small labelled dimension picker (pivot rows/cols/group) — themed dropdown. */
 export function DimSelect({ label, value, onChange, allowNone = true }: DimSelectProps) {
-  const options = DIMS.filter((d) => allowNone || d.value !== "none");
+  const t = useT();
+  const options = DIM_VALUES.filter((d) => allowNone || d !== "none").map((d) => ({
+    value: d,
+    label: t(`dim.option.${d}`),
+  }));
   return (
     <SingleSelect
       label={label}

--- a/apps/app/src/components/FilterBar.tsx
+++ b/apps/app/src/components/FilterBar.tsx
@@ -1,12 +1,11 @@
 import { FilterMultiSelect } from "@/components/FilterMultiSelect";
 import { useFilterOptions } from "@/hooks/useFilterOptions";
 import { useT } from "@/i18n";
-import { cn } from "@/lib/utils";
 import { type FacetKey, useDashboardStore } from "@/store/dashboardStore";
 import { MagnifyingGlass } from "@phosphor-icons/react";
 import type { AnnotatedNode } from "@roxabi-live/shared";
 
-/** The cockpit filter row: search + per-facet multi-selects + parent toggle. */
+/** The cockpit filter row: search + per-facet multi-selects + reset. */
 export function FilterBar({ nodes }: { nodes: AnnotatedNode[] }) {
   const t = useT();
   const options = useFilterOptions(nodes);
@@ -27,7 +26,6 @@ export function FilterBar({ nodes }: { nodes: AnnotatedNode[] }) {
   const label = useDashboardStore((s) => s.label);
   const assignee = useDashboardStore((s) => s.assignee);
   const search = useDashboardStore((s) => s.search);
-  const showParents = useDashboardStore((s) => s.showParents);
 
   const patch = useDashboardStore((s) => s.patch);
   const toggleFacet = useDashboardStore((s) => s.toggleFacet);
@@ -71,19 +69,6 @@ export function FilterBar({ nodes }: { nodes: AnnotatedNode[] }) {
           onClear={() => clearFacet(key)}
         />
       ))}
-
-      <button
-        type="button"
-        data-testid="facet-epics"
-        onClick={() => patch({ showParents: !showParents })}
-        aria-pressed={showParents}
-        className={cn(
-          "inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs transition-colors hover:border-primary/60",
-          showParents ? "border-primary/50 text-foreground" : "border-border text-muted-foreground",
-        )}
-      >
-        {t("filter.epics.label")}
-      </button>
 
       <button
         type="button"

--- a/apps/app/src/components/FilterBar.tsx
+++ b/apps/app/src/components/FilterBar.tsx
@@ -1,22 +1,24 @@
 import { FilterMultiSelect } from "@/components/FilterMultiSelect";
 import { useFilterOptions } from "@/hooks/useFilterOptions";
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { type FacetKey, useDashboardStore } from "@/store/dashboardStore";
 import { MagnifyingGlass } from "@phosphor-icons/react";
 import type { AnnotatedNode } from "@roxabi-live/shared";
 
-const FACETS: { key: FacetKey; label: string }[] = [
-  { key: "status", label: "Status" },
-  { key: "repo", label: "Repo" },
-  { key: "milestone", label: "Milestone" },
-  { key: "priority", label: "Priority" },
-  { key: "label", label: "Label" },
-  { key: "assignee", label: "Assignee" },
-];
-
 /** The cockpit filter row: search + per-facet multi-selects + parent toggle. */
 export function FilterBar({ nodes }: { nodes: AnnotatedNode[] }) {
+  const t = useT();
   const options = useFilterOptions(nodes);
+
+  const FACETS: { key: FacetKey; label: string }[] = [
+    { key: "status", label: t("filter.facet.status") },
+    { key: "repo", label: t("filter.facet.repo") },
+    { key: "milestone", label: t("filter.facet.milestone") },
+    { key: "priority", label: t("filter.facet.priority") },
+    { key: "label", label: t("filter.facet.label") },
+    { key: "assignee", label: t("filter.facet.assignee") },
+  ];
 
   const status = useDashboardStore((s) => s.status);
   const repo = useDashboardStore((s) => s.repo);
@@ -53,8 +55,8 @@ export function FilterBar({ nodes }: { nodes: AnnotatedNode[] }) {
           type="search"
           value={search}
           onChange={(e) => patch({ search: e.target.value })}
-          placeholder="Search issues…"
-          aria-label="Search issues"
+          placeholder={t("filter.search.placeholder")}
+          aria-label={t("filter.search.ariaLabel")}
           className="h-8 w-52 rounded-md border border-border bg-background pl-7 pr-2 text-xs text-foreground placeholder:text-muted-foreground focus:border-primary/60 focus:outline-none"
         />
       </div>
@@ -80,7 +82,7 @@ export function FilterBar({ nodes }: { nodes: AnnotatedNode[] }) {
           showParents ? "border-primary/50 text-foreground" : "border-border text-muted-foreground",
         )}
       >
-        Epics
+        {t("filter.epics.label")}
       </button>
 
       <button
@@ -89,7 +91,7 @@ export function FilterBar({ nodes }: { nodes: AnnotatedNode[] }) {
         onClick={resetFilters}
         className="ml-auto inline-flex h-8 items-center rounded-md px-2.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
       >
-        Reset
+        {t("filter.reset.label")}
       </button>
     </div>
   );

--- a/apps/app/src/components/FilterMultiSelect.tsx
+++ b/apps/app/src/components/FilterMultiSelect.tsx
@@ -1,5 +1,6 @@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import type { FilterOption } from "@/hooks/useFilterOptions";
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { CaretDown } from "@phosphor-icons/react";
 
@@ -20,6 +21,7 @@ export function FilterMultiSelect({
   onToggle,
   onClear,
 }: FilterMultiSelectProps) {
+  const t = useT();
   const count = selected.length;
 
   return (
@@ -45,7 +47,7 @@ export function FilterMultiSelect({
       <PopoverContent className="w-56 p-1">
         <div className="rl-scroll max-h-72 overflow-y-auto overflow-x-hidden">
           {options.length === 0 ? (
-            <div className="px-2 py-1.5 text-xs text-muted-foreground">No options</div>
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">{t("filter.multiselect.noOptions")}</div>
           ) : (
             options.map((o) => {
               const on = selected.includes(o.value);
@@ -84,7 +86,7 @@ export function FilterMultiSelect({
             onClick={onClear}
             className="mt-1 w-full rounded-sm px-2 py-1 text-left text-xs text-muted-foreground hover:bg-background hover:text-foreground"
           >
-            Clear {label.toLowerCase()}
+            {t("filter.multiselect.clear", { label: label.toLowerCase() })}
           </button>
         )}
       </PopoverContent>

--- a/apps/app/src/components/GraphPanel.tsx
+++ b/apps/app/src/components/GraphPanel.tsx
@@ -1,5 +1,6 @@
 import "@/components/graph-anim.css";
 import { useHighlightChain } from "@/hooks/useHighlightChain";
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { useDashboardStore } from "@/store/dashboardStore";
 import {
@@ -44,8 +45,9 @@ function GraphNode({
   const blocked = status === "blocked";
   // Epics (parent issues) render as a slightly larger rounded square to stand
   // out from leaf issues — matches the legacy `.gg-node.parent` (14px, r:3px).
+  const t = useT();
   const isParent = node.isParent;
-  const title = `#${node.number} — ${node.title ?? ""}`;
+  const title = t("graph.node.title", { number: node.number, title: node.title ?? "" });
   const hover = {
     onMouseEnter: () => onHover(node.key),
     onMouseLeave: () => onHover(null),
@@ -139,11 +141,12 @@ export function GraphPanel({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gr
   );
   const byKey = useMemo(() => new Map(nodes.map((n) => [n.key, n])), [nodes]);
   const chain = useHighlightChain(hovered, edges);
+  const t = useT();
 
   if (!nodes.length) {
     return (
       <div className="rounded-lg border border-border p-8 text-center text-sm text-muted-foreground">
-        No issues match the current filter.
+        {t("graph.empty")}
       </div>
     );
   }
@@ -213,7 +216,7 @@ export function GraphPanel({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gr
           preserveAspectRatio="none"
           aria-hidden
         >
-          <title>Dependency edges</title>
+          <title>{t("graph.edgesTitle")}</title>
           {edges.map((e) => {
             const s = layout.positions.get(e.src);
             const d = layout.positions.get(e.dst);

--- a/apps/app/src/components/GraphPanel.tsx
+++ b/apps/app/src/components/GraphPanel.tsx
@@ -1,6 +1,7 @@
 import "@/components/graph-anim.css";
 import { useHighlightChain } from "@/hooks/useHighlightChain";
 import { useT } from "@/i18n";
+import { localizedDimLabel } from "@/i18n/dimLabel";
 import { cn } from "@/lib/utils";
 import { useDashboardStore } from "@/store/dashboardStore";
 import {
@@ -174,7 +175,9 @@ export function GraphPanel({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gr
               )}
               style={{ top: `${r.y}%`, height: `${r.height}%` }}
             >
-              <div className="font-mono text-xs font-bold tracking-wide text-primary">{r.label}</div>
+              <div className="font-mono text-xs font-bold tracking-wide text-primary">
+                {localizedDimLabel(t, r.code, graphRow, r.label)}
+              </div>
               {r.name && <div className="truncate text-[10px] text-muted-foreground">{r.name}</div>}
             </div>
           ))}
@@ -205,7 +208,7 @@ export function GraphPanel({ nodes, edges }: { nodes: AnnotatedNode[]; edges: Gr
             className="absolute top-0 -translate-x-1/2 whitespace-nowrap text-[10px] uppercase tracking-wide text-muted-foreground"
             style={{ left: `${c.x}%` }}
           >
-            {c.label}
+            {localizedDimLabel(t, c.code, graphCol, c.label)}
           </div>
         ))}
 

--- a/apps/app/src/components/IssueCard.tsx
+++ b/apps/app/src/components/IssueCard.tsx
@@ -1,3 +1,4 @@
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { type AnnotatedNode, type StatusKey, displayStatus } from "@roxabi-live/shared";
 
@@ -25,6 +26,7 @@ function Badge({ children }: { children: string }) {
 
 /** Compact issue card used inside pivot cells. */
 export function IssueCard({ node, showRepo = true }: { node: AnnotatedNode; showRepo?: boolean }) {
+  const t = useT();
   const status = displayStatus(node);
   return (
     <a
@@ -39,7 +41,7 @@ export function IssueCard({ node, showRepo = true }: { node: AnnotatedNode; show
       <div className="flex items-center gap-1.5">
         <span className={cn("size-1.5 shrink-0 rounded-full", STATUS_DOT[status])} aria-hidden />
         <span className="font-mono text-[10px] text-muted-foreground">#{node.number}</span>
-        <span className="truncate text-foreground">{node.title ?? `Issue #${node.number}`}</span>
+        <span className="truncate text-foreground">{node.title ?? t("table.card.issueTitle", { number: node.number })}</span>
       </div>
       {(showRepo || node.priority || node.size) && (
         <div className="mt-1 flex flex-wrap gap-1">

--- a/apps/app/src/components/IssueRow.tsx
+++ b/apps/app/src/components/IssueRow.tsx
@@ -1,3 +1,4 @@
+import { useT } from "@/i18n";
 import { StatusBadge } from "@/components/StatusBadge";
 import { type AnnotatedNode, displayStatus } from "@roxabi-live/shared";
 
@@ -31,6 +32,7 @@ function CountCell({ refs }: { refs: string[] }) {
 
 /** One issue row in the Launch Board table (10 columns, mirrors frontend/list.js). */
 export function IssueRow({ node, refs = EMPTY_REFS }: { node: AnnotatedNode; refs?: RowEdgeRefs }) {
+  const t = useT();
   const status = displayStatus(node);
   const ref = `${node.repo}#${node.number}`;
 
@@ -54,15 +56,15 @@ export function IssueRow({ node, refs = EMPTY_REFS }: { node: AnnotatedNode; ref
         )}
       </td>
       <td className="px-3 py-2 align-middle text-sm text-foreground">
-        {node.title ? node.title : <span className="italic text-muted-foreground">untitled</span>}
+        {node.title ? node.title : <span className="italic text-muted-foreground">{t("table.row.untitled")}</span>}
         {node.is_stub && (
           <span className="ml-2 rounded-sm border border-border px-1 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-            stub
+            {t("table.row.stubBadge")}
           </span>
         )}
         {node.isParent && (
           <span className="ml-2 rounded-sm border border-border px-1 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-            epic
+            {t("table.row.epicBadge")}
           </span>
         )}
       </td>

--- a/apps/app/src/components/IssueTable.tsx
+++ b/apps/app/src/components/IssueTable.tsx
@@ -1,12 +1,12 @@
 import { IssueRow, type RowEdgeRefs } from "@/components/IssueRow";
 import { useT } from "@/i18n";
+import { localizedDimLabel } from "@/i18n/dimLabel";
 import {
   type AnnotatedNode,
   type Dim,
   type GraphEdge,
   type StatusKey,
   compareDimValues,
-  dimDisplayLabel,
   dimValue,
   displayStatus,
   isEmptyDimValue,
@@ -295,7 +295,7 @@ export function IssueTable({
                     <span aria-hidden className="mr-1 text-muted-foreground">
                       {collapsed.has(it.collapseKey) ? "▸" : "▾"}
                     </span>
-                    {dimDisplayLabel(it.value, it.dim)}
+                    {localizedDimLabel(t, it.value, it.dim)}
                     {it.title && (
                       <span className="ml-2 font-sans font-normal text-muted-foreground">
                         {it.title}

--- a/apps/app/src/components/IssueTable.tsx
+++ b/apps/app/src/components/IssueTable.tsx
@@ -1,4 +1,5 @@
 import { IssueRow, type RowEdgeRefs } from "@/components/IssueRow";
+import { useT } from "@/i18n";
 import {
   type AnnotatedNode,
   type Dim,
@@ -29,16 +30,16 @@ const STATUS_RANK: Record<StatusKey, number> = { ready: 0, running: 1, blocked: 
 const PRIORITY_RANK: Record<string, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
 
 const COLUMNS: { col: SortCol; label: string; center?: boolean }[] = [
-  { col: "status", label: "Status" },
-  { col: "issue", label: "Issue" },
-  { col: "title", label: "Title" },
-  { col: "milestone", label: "Milestone" },
-  { col: "priority", label: "Priority" },
-  { col: "lane", label: "Lane", center: true },
-  { col: "size", label: "Size", center: true },
-  { col: "blocks", label: "Blocks", center: true },
-  { col: "blockedby", label: "Blocked by", center: true },
-  { col: "parentof", label: "Parent of", center: true },
+  { col: "status", label: "table.col.status" },
+  { col: "issue", label: "table.col.issue" },
+  { col: "title", label: "table.col.title" },
+  { col: "milestone", label: "table.col.milestone" },
+  { col: "priority", label: "table.col.priority" },
+  { col: "lane", label: "table.col.lane", center: true },
+  { col: "size", label: "table.col.size", center: true },
+  { col: "blocks", label: "table.col.blocks", center: true },
+  { col: "blockedby", label: "table.col.blockedBy", center: true },
+  { col: "parentof", label: "table.col.parentOf", center: true },
 ];
 
 function issueCompare(a: AnnotatedNode, b: AnnotatedNode): number {
@@ -212,6 +213,7 @@ export function IssueTable({
   group?: Dim;
   group2?: Dim;
 }) {
+  const t = useT();
   const [sortCol, setSortCol] = useState<SortCol>("status");
   const [dir, setDir] = useState<1 | -1>(1);
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
@@ -248,7 +250,7 @@ export function IssueTable({
   if (nodes.length === 0) {
     return (
       <div className="rounded-lg border border-border p-8 text-center text-sm text-muted-foreground">
-        No issues to show.
+        {t("table.empty")}
       </div>
     );
   }
@@ -268,7 +270,7 @@ export function IssueTable({
                   onClick={() => toggle(col)}
                   className="inline-flex items-center gap-1 uppercase tracking-wide transition-colors hover:text-foreground"
                 >
-                  {label}
+                  {t(label as any)}
                   {sortCol === col && <span aria-hidden>{dir === 1 ? "↑" : "↓"}</span>}
                 </button>
               </th>

--- a/apps/app/src/components/LangToggle.tsx
+++ b/apps/app/src/components/LangToggle.tsx
@@ -1,0 +1,22 @@
+import { useLocale } from "@/i18n";
+
+/** FR/EN language toggle — header control. Shows the language it switches TO
+ * (matches the marketing site's langSwitch convention). Sized to match the
+ * theme toggle / avatar (size-9) so the header controls stay aligned. */
+export function LangToggle() {
+  const { locale, setLocale } = useLocale();
+  const next = locale === "fr" ? "en" : "fr";
+
+  return (
+    <button
+      type="button"
+      data-testid="lang-toggle"
+      title={`Switch to ${next.toUpperCase()}`}
+      aria-label={`Switch language to ${next.toUpperCase()}`}
+      onClick={() => setLocale(next)}
+      className="inline-flex size-9 items-center justify-center rounded-md border border-border bg-card font-mono text-[11px] font-bold tracking-wide text-muted-foreground transition-colors hover:border-primary/60 hover:text-primary"
+    >
+      {next.toUpperCase()}
+    </button>
+  );
+}

--- a/apps/app/src/components/PivotMatrix.tsx
+++ b/apps/app/src/components/PivotMatrix.tsx
@@ -1,4 +1,5 @@
 import { IssueCard } from "@/components/IssueCard";
+import { useT } from "@/i18n";
 import { useDashboardStore } from "@/store/dashboardStore";
 import {
   type AnnotatedNode,
@@ -91,6 +92,7 @@ function CellBody({
 
 /** Pivot (matrix) view — rows × cols of issue cards. Ported from frontend/pivot.js. */
 export function PivotMatrix({ nodes, edges }: { nodes: AnnotatedNode[]; edges: GraphEdge[] }) {
+  const t = useT();
   const pivotRow = useDashboardStore((s) => s.pivotRow);
   const pivotCol = useDashboardStore((s) => s.pivotCol);
   const tableGroup = useDashboardStore((s) => s.tableGroup);
@@ -132,7 +134,7 @@ export function PivotMatrix({ nodes, edges }: { nodes: AnnotatedNode[]; edges: G
   if (!nodes.length) {
     return (
       <div className="rounded-lg border border-border p-8 text-center text-sm text-muted-foreground">
-        No issues match the current filter.
+        {t("pivot.empty")}
       </div>
     );
   }

--- a/apps/app/src/components/PivotMatrix.tsx
+++ b/apps/app/src/components/PivotMatrix.tsx
@@ -1,12 +1,12 @@
 import { IssueCard } from "@/components/IssueCard";
 import { useT } from "@/i18n";
+import { localizedDimLabel } from "@/i18n/dimLabel";
 import { useDashboardStore } from "@/store/dashboardStore";
 import {
   type AnnotatedNode,
   type Dim,
   type GraphEdge,
   compareDimValues,
-  dimDisplayLabel,
   dimValue,
 } from "@roxabi-live/shared";
 import { Fragment, useMemo, useState } from "react";
@@ -154,7 +154,7 @@ export function PivotMatrix({ nodes, edges }: { nodes: AnnotatedNode[]; edges: G
             key={cv}
             className="border-b border-border bg-card/40 p-2 font-medium uppercase tracking-wide text-muted-foreground"
           >
-            {dimDisplayLabel(cv, pivotCol)}
+            {localizedDimLabel(t, cv, pivotCol)}
           </div>
         ))}
 
@@ -162,7 +162,7 @@ export function PivotMatrix({ nodes, edges }: { nodes: AnnotatedNode[]; edges: G
         {rowVals.map((rv) => (
           <Fragment key={rv}>
             <div className="sticky left-0 z-10 border-r border-b border-border bg-card/60 p-2 font-medium text-foreground">
-              {dimDisplayLabel(rv, pivotRow)}
+              {localizedDimLabel(t, rv, pivotRow)}
             </div>
             {colVals.map((cv) => {
               const cellNodes = matrix.get(rv)?.get(cv) ?? [];

--- a/apps/app/src/components/StatusBadge.tsx
+++ b/apps/app/src/components/StatusBadge.tsx
@@ -1,3 +1,4 @@
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 
 export type Status = "ready" | "blocked" | "running" | "done";
@@ -7,37 +8,25 @@ interface StatusBadgeProps {
   className?: string;
 }
 
-const statusConfig: Record<Status, { label: string; className: string }> = {
-  ready: {
-    label: "Ready",
-    className: "bg-ready/15 text-ready border-ready/30",
-  },
-  blocked: {
-    label: "Blocked",
-    className: "bg-blocked/15 text-blocked border-blocked/30",
-  },
-  running: {
-    label: "Running",
-    className: "bg-running/15 text-running border-running/30",
-  },
-  done: {
-    label: "Done",
-    className: "bg-done/20 text-done border-done/30",
-  },
+const statusClass: Record<Status, string> = {
+  ready: "bg-ready/15 text-ready border-ready/30",
+  blocked: "bg-blocked/15 text-blocked border-blocked/30",
+  running: "bg-running/15 text-running border-running/30",
+  done: "bg-done/20 text-done border-done/30",
 };
 
 export function StatusBadge({ status, className }: StatusBadgeProps) {
-  const config = statusConfig[status];
+  const t = useT();
   return (
     <span
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
-        config.className,
+        statusClass[status],
         className,
       )}
     >
       <span className="size-1.5 rounded-full bg-current" aria-hidden />
-      {config.label}
+      {t(`status.${status}`)}
     </span>
   );
 }

--- a/apps/app/src/components/SyncProgressBanner.tsx
+++ b/apps/app/src/components/SyncProgressBanner.tsx
@@ -1,4 +1,5 @@
 import type { SyncStatus } from "@roxabi-live/shared";
+import { useT } from "@/i18n";
 
 /**
  * Non-blocking first-import banner (ported from frontend/initial-sync.js). Shows
@@ -7,6 +8,7 @@ import type { SyncStatus } from "@roxabi-live/shared";
  * lives in useSyncProgressMonitor.
  */
 export function SyncProgressBanner({ status }: { status: SyncStatus | null }) {
+  const t = useT();
   if (!status) return null;
 
   if (status.sync_halted) {
@@ -16,9 +18,9 @@ export function SyncProgressBanner({ status }: { status: SyncStatus | null }) {
         data-testid="sync-banner-halted"
         className="rounded-lg border border-blocked/30 bg-blocked/10 p-3 text-xs"
       >
-        <strong className="text-foreground">Sync interrupted</strong>
+        <strong className="text-foreground">{t("sync.halted.title")}</strong>
         <span className="ml-2 text-muted-foreground">
-          {status.repos_synced} / {status.repos_total} repos · GitHub authentication error
+          {t("sync.halted.detail", { reposSynced: status.repos_synced, reposTotal: status.repos_total })}
         </span>
       </div>
     );
@@ -38,9 +40,9 @@ export function SyncProgressBanner({ status }: { status: SyncStatus | null }) {
       className="block rounded-lg border border-primary/30 bg-primary/5 p-3"
     >
       <div className="flex items-center justify-between text-xs">
-        <strong className="text-foreground">Syncing your repositories…</strong>
+        <strong className="text-foreground">{t("sync.inProgress.title")}</strong>
         <span className="text-muted-foreground">
-          {synced} / {total} repos · {status.issue_count} issues
+          {t("sync.inProgress.detail", { reposSynced: synced, reposTotal: total, issueCount: status.issue_count })}
         </span>
       </div>
       <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-border">

--- a/apps/app/src/components/ThemeToggle.tsx
+++ b/apps/app/src/components/ThemeToggle.tsx
@@ -1,18 +1,21 @@
+import { useT } from "@/i18n";
 import { type Theme, applyTheme, readTheme } from "@/lib/theme";
 import { Moon, Sun } from "@phosphor-icons/react";
 import { useState } from "react";
 
 /** Dark/light theme toggle — legacy header `.theme-btn` (🌙). */
 export function ThemeToggle() {
+  const t = useT();
   const [theme, setTheme] = useState<Theme>(() => readTheme());
   const next: Theme = theme === "dark" ? "light" : "dark";
+  const nextLabel = next === "dark" ? t("settings.theme.dark") : t("settings.theme.light");
 
   return (
     <button
       type="button"
       data-testid="theme-toggle"
-      title={`Switch to ${next} theme`}
-      aria-label={`Switch to ${next} theme`}
+      title={t("settings.theme.switchTo", { next: nextLabel })}
+      aria-label={t("settings.theme.switchTo", { next: nextLabel })}
       onClick={() => {
         applyTheme(next);
         setTheme(next);

--- a/apps/app/src/components/TitleSyncBanner.test.ts
+++ b/apps/app/src/components/TitleSyncBanner.test.ts
@@ -1,0 +1,33 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { LocaleProvider } from "@/i18n";
+import { TitleSyncBanner } from "./TitleSyncBanner";
+
+// Forced-French provider so assertions match the FR catalog copy.
+const html = (props: { syncing: boolean; count: number }) =>
+  renderToStaticMarkup(
+    createElement(LocaleProvider, {
+      initialLocale: "fr",
+      children: createElement(TitleSyncBanner, props),
+    }),
+  );
+
+describe("TitleSyncBanner", () => {
+  it("renders nothing when not syncing", () => {
+    expect(html({ syncing: false, count: 5 })).toBe("");
+  });
+
+  it("shows the spinner banner + count while titles import", () => {
+    const out = html({ syncing: true, count: 12 });
+    expect(out).toContain('data-testid="title-sync-banner"');
+    expect(out).toContain("Importation des titres");
+    expect(out).toContain("12 à déchiffrer");
+  });
+
+  it("omits the detail count when there is none", () => {
+    const out = html({ syncing: true, count: 0 });
+    expect(out).toContain('data-testid="title-sync-banner"');
+    expect(out).not.toContain("à déchiffrer");
+  });
+});

--- a/apps/app/src/components/TitleSyncBanner.tsx
+++ b/apps/app/src/components/TitleSyncBanner.tsx
@@ -1,0 +1,28 @@
+import { CircleNotch } from "@phosphor-icons/react";
+import { useT } from "@/i18n";
+
+/**
+ * Client-side title-import banner. While the ZK seal pass fetches issue
+ * titles/bodies from GitHub and re-seals them (e.g. just after a token handoff
+ * imports recently-synced issues), redacted titles render blank — this spinner
+ * banner tells the user the import is in flight rather than stuck. Pure: the
+ * `syncing`/`count` signal is computed in useDecryptedGraph.
+ */
+export function TitleSyncBanner({ syncing, count }: { syncing: boolean; count: number }) {
+  const t = useT();
+  if (!syncing) return null;
+
+  return (
+    <output
+      aria-live="polite"
+      data-testid="title-sync-banner"
+      className="flex items-center gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3 text-xs"
+    >
+      <CircleNotch className="size-4 shrink-0 animate-spin text-primary" aria-hidden />
+      <strong className="text-foreground">{t("sync.titles.inProgress")}</strong>
+      {count > 0 && (
+        <span className="text-muted-foreground">{t("sync.titles.detail", { count })}</span>
+      )}
+    </output>
+  );
+}

--- a/apps/app/src/components/ViewToggle.tsx
+++ b/apps/app/src/components/ViewToggle.tsx
@@ -1,28 +1,31 @@
+import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { type ViewKey, useDashboardStore } from "@/store/dashboardStore";
 import { type Icon, ListBullets, Table, TreeStructure } from "@phosphor-icons/react";
 
-// Order + labels mirror the legacy header view-segs (Graph / List / Table).
-// The store key `pivot` is the legacy "Table" (pivot-matrix) renderer.
-const VIEWS: { key: ViewKey; label: string; Icon: Icon }[] = [
-  { key: "graph", label: "Graph", Icon: TreeStructure },
-  { key: "list", label: "List", Icon: ListBullets },
-  { key: "pivot", label: "Table", Icon: Table },
+// Order mirrors the legacy header view-segs (Graph / List / Table). The store
+// key `pivot` is the legacy "Table" (pivot-matrix) renderer → catalog key view.table.
+const VIEWS: { key: ViewKey; tkey: string; Icon: Icon }[] = [
+  { key: "graph", tkey: "graph", Icon: TreeStructure },
+  { key: "list", tkey: "list", Icon: ListBullets },
+  { key: "pivot", tkey: "table", Icon: Table },
 ];
 
 /** Segmented view control (Graph / List / Table) — legacy `.view-segs`. */
 export function ViewToggle() {
+  const t = useT();
   const view = useDashboardStore((s) => s.view);
   const patch = useDashboardStore((s) => s.patch);
 
   return (
     <div
       role="group"
-      aria-label="View"
+      aria-label={t("view.groupAriaLabel")}
       className="inline-flex h-9 overflow-hidden rounded-md border border-border bg-card"
     >
-      {VIEWS.map(({ key, label, Icon }, i) => {
+      {VIEWS.map(({ key, tkey, Icon }, i) => {
         const on = view === key;
+        const label = t(`view.${tkey}`);
         return (
           <button
             key={key}

--- a/apps/app/src/hooks/useFilterOptions.ts
+++ b/apps/app/src/hooks/useFilterOptions.ts
@@ -4,6 +4,7 @@
  * the option lists and their counts stay stable as the user filters.
  */
 
+import { useT } from "@/i18n";
 import type { FacetKey } from "@/store/dashboardStore";
 import {
   type AnnotatedNode,
@@ -23,12 +24,6 @@ export interface FilterOption {
 export type FilterOptions = Record<FacetKey, FilterOption[]>;
 
 const STATUS_ORDER: StatusKey[] = ["ready", "running", "blocked", "done"];
-const STATUS_LABEL: Record<StatusKey, string> = {
-  ready: "Ready",
-  running: "Running",
-  blocked: "Blocked",
-  done: "Done",
-};
 const PRIORITY_ORDER = ["P0", "P1", "P2", "P3", EMPTY_DIM];
 
 // Structured/metadata labels conveyed by dedicated facets (size, priority, lane)
@@ -66,6 +61,7 @@ function bump(map: Map<string, number>, key: string): void {
 }
 
 export function useFilterOptions(nodes: AnnotatedNode[]): FilterOptions {
+  const t = useT();
   return useMemo(() => {
     const repo = new Map<string, number>();
     const milestone = new Map<string, number>();
@@ -103,27 +99,29 @@ export function useFilterOptions(nodes: AnnotatedNode[]): FilterOptions {
 
     return {
       status: STATUS_ORDER.filter((s) => status.has(s)).map((s) =>
-        opt(s, STATUS_LABEL[s], status.get(s) ?? 0),
+        opt(s, t(`status.${s}`), status.get(s) ?? 0),
       ),
       repo: [...repo]
         .map(([v, c]) => opt(v, v.replace(/^[^/]+\//, ""), c))
         .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label)),
       milestone: [...milestone]
-        .map(([v, c]) => opt(v, v === EMPTY_DIM ? "No milestone" : (msMeta.get(v)?.name ?? v), c))
+        .map(([v, c]) =>
+          opt(v, v === EMPTY_DIM ? t("filter.empty.milestone") : (msMeta.get(v)?.name ?? v), c),
+        )
         .sort(
           (a, b) =>
             (msMeta.get(a.value)?.sortKey ?? 99999) - (msMeta.get(b.value)?.sortKey ?? 99999) ||
             a.label.localeCompare(b.label),
         ),
       priority: [...priority]
-        .map(([v, c]) => opt(v, v === EMPTY_DIM ? "No priority" : v, c))
+        .map(([v, c]) => opt(v, v === EMPTY_DIM ? t("filter.empty.priority") : v, c))
         .sort((a, b) => PRIORITY_ORDER.indexOf(a.value) - PRIORITY_ORDER.indexOf(b.value)),
       label: [...label]
         .map(([v, c]) => opt(v, v, c))
         .sort((a, b) => a.label.localeCompare(b.label)),
       assignee: [...assignee]
-        .map(([v, c]) => opt(v, v === EMPTY_ASSIGNEE ? "Unassigned" : v, c))
+        .map(([v, c]) => opt(v, v === EMPTY_ASSIGNEE ? t("filter.empty.assignee") : v, c))
         .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label)),
     };
-  }, [nodes]);
+  }, [nodes, t]);
 }

--- a/apps/app/src/i18n/dimLabel.ts
+++ b/apps/app/src/i18n/dimLabel.ts
@@ -1,0 +1,21 @@
+import type { TFunc } from "@/i18n";
+import { type Dim, dimDisplayLabel, isEmptyDimValue } from "@roxabi-live/shared";
+
+// Dims whose empty "(None)" bucket has a localized label (dim.empty.*). Other
+// dims' values are pure data (milestone names, P1, repo names, …) and never
+// translate — for those we keep the shared display label as-is.
+const TRANSLATED_EMPTY = new Set<Dim>(["milestone", "priority", "lane", "size", "assignee"]);
+
+/**
+ * Localized group/band label for a dimension value. The empty bucket of a
+ * known dim is translated via the i18n catalog; everything else falls back to
+ * `fallback` (when the caller already computed a specially-formatted label,
+ * e.g. the repo column header) or to the shared `dimDisplayLabel`.
+ *
+ * This is the app-side bridge for `packages/shared` dimDisplayLabel, which is a
+ * pure-logic package with no React/locale context of its own.
+ */
+export function localizedDimLabel(t: TFunc, code: string, dim: Dim, fallback?: string): string {
+  if (TRANSLATED_EMPTY.has(dim) && isEmptyDimValue(code, dim)) return t(`dim.empty.${dim}`);
+  return fallback ?? dimDisplayLabel(code, dim);
+}

--- a/apps/app/src/i18n/en.ts
+++ b/apps/app/src/i18n/en.ts
@@ -1,0 +1,327 @@
+/**
+ * en.ts — English catalog. Structurally typed against the French source so the
+ * two stay in lockstep (missing/extra keys fail typecheck).
+ */
+
+import type { Translations } from "./fr";
+
+export const en: Translations = {
+  header: {
+    loading: "Loading…",
+    corpusStats: "{total} issues · {open} open · {closed} closed",
+    brandName: "Roxabi Live",
+  },
+  view: {
+    graph: "Graph",
+    list: "List",
+    table: "Table",
+    groupAriaLabel: "View",
+  },
+  settings: {
+    theme: {
+      switchTo: "Switch to {next} theme",
+      dark: "dark",
+      light: "light",
+    },
+    title: "Settings",
+    profile: {
+      heading: "Profile",
+      displayName: {
+        label: "Display name",
+        hint: "Shown in the header. GitHub login: {login}.",
+      },
+    },
+    repos: {
+      heading: "Repositories",
+      hint: "Add or remove repositories that the GitHub App can access.",
+      empty: "No linked installation yet.",
+      configure: "Configure repositories on GitHub",
+    },
+    deleteAccount: {
+      heading: "Delete account",
+      hint: "Erases your Roxabi data and logs you out. Revoke the app on GitHub separately.",
+      button: "Delete my data & sign out",
+      confirmPrompt: "Delete all your Roxabi Live data and sign out? This action is irreversible.",
+      error: "Deletion failed — please try again.",
+    },
+    encryption: {
+      heading: "Encryption",
+    },
+  },
+  auth: {
+    userMenu: {
+      trigger: "Account menu",
+      triggerTitle: "{name}",
+      avatarAlt: "{login}",
+      settings: "Settings",
+      signOut: "Sign out",
+    },
+    orgPicker: {
+      ariaLabel: "Active installation",
+    },
+    signin: {
+      title: "Sign in",
+      description: "Roxabi Live connects to your GitHub account to manage your fleet of agents.",
+      githubButton: "Sign in with GitHub",
+      rememberMe: "Stay signed in on this device",
+    },
+    signup: {
+      title: "Create your account",
+      githubButton: "Continue with GitHub",
+    },
+    sessionLost: "Session expired. Please sign in again to continue.",
+    consent: {
+      title: "Data access",
+      description: "The application is installed. Before the first sync, confirm that Roxabi Live may read the following GitHub metadata:",
+      scope: {
+        issues: "Issues, labels, milestones and parent/child relations",
+        repoMeta: "Repository metadata (name, visibility, archiving)",
+        d1: "Data stored in Cloudflare D1, limited to your organisation",
+      },
+      loggedInAs: "Signed in as {login}. You can revoke access from your {githubSettingsLink}.",
+      githubSettingsLink: "GitHub settings",
+      encryptionNotice: "Issue titles and bodies are encrypted client-side before storage. The graph structure (status, blockers, labels) remains readable by the operator.",
+      error: "Could not save — check your connection and try again.",
+      confirmButton: "Understood — start sync",
+    },
+    signout: "Sign out",
+    install: {
+      title: "Install Roxabi Live on GitHub",
+      description: "Signed in as {login} (step 1 done). Choose where to install the application: personal account, organisation, or selected repositories only.",
+      option: {
+        orgTitle: "Organisation",
+        personalTitle: "Personal account",
+        pickerName: "Choose on GitHub",
+        pickerHint: "GitHub lists the organisations where you can install the app",
+        personalHint: "Your repositories only — ideal for solo use",
+        orgHint: "Install on this org — all repositories or a selection on GitHub",
+      },
+      selectedRepos: {
+        label: "Selected repositories",
+        hint: "Choose an account above, then on GitHub: Only select repositories and select the repositories to sync.",
+      },
+      redirectHint: "GitHub will ask which repositories to authorise, then bring you back here. If the redirect fails, come back and click I've installed — continue.",
+      continueButton: "I've installed — continue",
+      notDetectedHint: "Installation not yet detected. Retry or sign in again via GitHub ({fallbackUrl}).",
+      sessionErrorHint: "Session expired or network error — reload the page or sign in again.",
+    },
+    onboarding: {
+      navAriaLabel: "Installation progress",
+      step: {
+        github: "GitHub login",
+        install: "Installation",
+        sync: "Sync",
+      },
+    },
+    loading: {
+      srOnly: "Loading your session…",
+    },
+    error: {
+      loadSession: "Unable to load your session: {message}",
+    },
+    signOut: "Sign out",
+  },
+  sync: {
+    halted: {
+      title: "Sync interrupted",
+      detail: "{reposSynced} / {reposTotal} repos · GitHub authentication error",
+    },
+    inProgress: {
+      title: "Syncing your repositories…",
+      detail: "{reposSynced} / {reposTotal} repos · {issueCount} issues",
+    },
+  },
+  dim: {
+    label: {
+      rows: "Rows",
+      cols: "Cols",
+      group: "Group",
+      orderBy: "Order by",
+      subgroup: "Subgroup",
+    },
+    option: {
+      none: "None",
+      milestone: "Milestone",
+      priority: "Priority",
+      repo: "Repo",
+      lane: "Lane",
+      size: "Size",
+      status: "Status",
+      parent: "Parent",
+      assignee: "Assignee",
+    },
+  },
+  graph: {
+    toggle: {
+      closed: {
+        label: "Closed",
+        title: "Show closed issues whose parent epic is still open",
+      },
+      assignees: {
+        label: "Assignees",
+        title: "Show assignee logins on issue nodes",
+      },
+    },
+    empty: "No issues match the current filter.",
+    edgesTitle: "Dependency edges",
+    node: {
+      title: "#{number} — {title}",
+    },
+  },
+  toolbar: {
+    filteredCount: "{count} of {total}",
+  },
+  filter: {
+    search: {
+      placeholder: "Search issues…",
+      ariaLabel: "Search issues",
+    },
+    facet: {
+      status: "Status",
+      repo: "Repo",
+      milestone: "Milestone",
+      priority: "Priority",
+      label: "Label",
+      assignee: "Assignee",
+    },
+    epics: {
+      label: "Epics",
+    },
+    reset: {
+      label: "Reset",
+    },
+    multiselect: {
+      noOptions: "No options",
+      clear: "Clear {label}",
+    },
+    empty: {
+      milestone: "No milestone",
+      priority: "No priority",
+      assignee: "Unassigned",
+    },
+  },
+  table: {
+    col: {
+      status: "Status",
+      issue: "Issue",
+      title: "Title",
+      milestone: "Milestone",
+      priority: "Priority",
+      lane: "Lane",
+      size: "Size",
+      blocks: "Blocks",
+      blockedBy: "Blocked by",
+      parentOf: "Parent of",
+    },
+    empty: "No issues to show.",
+    row: {
+      untitled: "untitled",
+      stubBadge: "stub",
+      epicBadge: "epic",
+    },
+    card: {
+      issueTitle: "Issue #{number}",
+    },
+  },
+  pivot: {
+    empty: "No issues match the current filter.",
+  },
+  status: {
+    ready: "Ready",
+    blocked: "Blocked",
+    running: "Running",
+    done: "Done",
+  },
+  zk: {
+    reset: {
+      changePassphraseButton: "Change passphrase",
+      currentPassphrase: {
+        label: "Current passphrase",
+      },
+      newPassphrase: {
+        label: "New passphrase",
+      },
+      confirmPassphrase: {
+        label: "Confirm new passphrase",
+      },
+      cancel: "Cancel",
+      saveButton: "Save passphrase",
+      warning: {
+        title: "Reset encryption?",
+        irreversibleBold: "This action is irreversible.",
+        body: "All encrypted issue titles stored for your account on the server will be deleted. Your previously encrypted titles can no longer be decrypted — they are permanently lost. You will choose a new passphrase and re-seal the content from GitHub.",
+        githubRequired: "A GitHub connection is required to confirm this action.",
+        verifyGithub: "Verify with GitHub",
+      },
+      execute: {
+        title: "Confirm reset",
+        description: "GitHub verified. Delete all your encrypted data and set a new passphrase?",
+        confirmButton: "Reset and start over",
+        errorReauthExpired: "Verification expired — please try again.",
+        errorRateLimited: "Too many resets — please try again later.",
+        errorGeneric: "Reset failed. Please try again.",
+      },
+    },
+    enroll: {
+      title: "Set encryption passphrase",
+      description: "Choose a passphrase to protect your encryption key. It never leaves this browser; only an encrypted backup is stored on the server. This device retains your key after setup — the passphrase will be required on other devices or after a lock.",
+      passphrase: {
+        label: "Passphrase",
+      },
+      confirmPassphrase: {
+        label: "Confirm passphrase",
+      },
+      remember: {
+        label: "Remember passphrase on this device for 30 days",
+      },
+      submitButton: "Create backup",
+      error: {
+        tooShort: "The passphrase must be at least 8 characters.",
+        mismatch: "Passphrases do not match.",
+        alreadyEnrolled: "Already enrolled — unlock with your passphrase instead.",
+        generic: "Enrollment failed. Please try again.",
+      },
+    },
+    unlock: {
+      title: "Unlock encryption",
+      description: "Enter your encryption passphrase to decrypt issue titles and bodies on this device.",
+      passphraseLabel: "Passphrase",
+      rememberDevice: "Remember the passphrase on this device for 30 days",
+      forgotPassword: "Forgot passphrase?",
+      submit: "Unlock",
+      errorWrongPassphrase: "Incorrect passphrase. Please try again.",
+    },
+    common: {
+      logout: "Log out",
+      cancel: "Cancel",
+    },
+    device2: {
+      title: "Complete setup on your original device",
+      body1: "Encrypted issue titles on this account were sealed in another browser before passphrase backup was configured. This device cannot decrypt them or complete enrollment until you open Roxabi on your original device to finalise the encryption there.",
+      body2Prefix: "Once setup is complete on the original device, you can also",
+      linkGithub: "link GitHub",
+      body2Suffix: "here to re-seal the content from GitHub.",
+      reload: "Reload",
+    },
+    notice: {
+      info: {
+        body: "The titles and content of your issues are encrypted and never accessible in plaintext on the server. Your passphrase is not recoverable: if lost, you will need to generate a new one.",
+        dismiss: "Close",
+      },
+      githubLink: {
+        body: "Some titles remain encrypted on the server. Link GitHub to import and re-seal their content.",
+        cta: "Link GitHub",
+      },
+      migration: {
+        body: "Encryption migration incomplete — some older titles could not be converted. Open Roxabi on the original device to complete it.",
+      },
+    },
+    lock: {
+      title: "Lock encryption (clear key from memory)",
+      label: "Lock",
+    },
+    gate: {
+      loadingSrOnly: "Unlocking encryption…",
+    },
+  },
+};

--- a/apps/app/src/i18n/en.ts
+++ b/apps/app/src/i18n/en.ts
@@ -130,6 +130,10 @@ export const en: Translations = {
       title: "Syncing your repositories…",
       detail: "{reposSynced} / {reposTotal} repos · {issueCount} issues",
     },
+    titles: {
+      inProgress: "Importing issue titles…",
+      detail: "{count} to decrypt",
+    },
   },
   dim: {
     label: {

--- a/apps/app/src/i18n/en.ts
+++ b/apps/app/src/i18n/en.ts
@@ -150,6 +150,13 @@ export const en: Translations = {
       parent: "Parent",
       assignee: "Assignee",
     },
+    empty: {
+      milestone: "No milestone",
+      priority: "No priority",
+      lane: "No lane",
+      size: "No size",
+      assignee: "Unassigned",
+    },
   },
   graph: {
     toggle: {
@@ -170,6 +177,7 @@ export const en: Translations = {
   },
   toolbar: {
     filteredCount: "{count} of {total}",
+    display: "Display",
   },
   filter: {
     search: {
@@ -186,6 +194,7 @@ export const en: Translations = {
     },
     epics: {
       label: "Epics",
+      title: "Show epics (parent issues)",
     },
     reset: {
       label: "Reset",

--- a/apps/app/src/i18n/fr.ts
+++ b/apps/app/src/i18n/fr.ts
@@ -149,6 +149,13 @@ export const fr = {
       parent: "Parent",
       assignee: "Assigné",
     },
+    empty: {
+      milestone: "Aucun milestone",
+      priority: "Aucune priorité",
+      lane: "Aucun couloir",
+      size: "Aucune taille",
+      assignee: "Non assigné",
+    },
   },
   graph: {
     toggle: {
@@ -169,6 +176,7 @@ export const fr = {
   },
   toolbar: {
     filteredCount: "{count} sur {total}",
+    display: "Affichage",
   },
   filter: {
     search: {
@@ -185,6 +193,7 @@ export const fr = {
     },
     epics: {
       label: "Epics",
+      title: "Afficher les epics (issues parentes)",
     },
     reset: {
       label: "Réinitialiser",

--- a/apps/app/src/i18n/fr.ts
+++ b/apps/app/src/i18n/fr.ts
@@ -1,0 +1,328 @@
+/**
+ * fr.ts — French catalog (source of truth). en.ts conforms to "typeof fr",
+ * so adding a key here is a compile error until en.ts matches. Generated from
+ * the extraction sweep, then hand-reviewed.
+ */
+
+export const fr = {
+  header: {
+    loading: "Chargement…",
+    corpusStats: "{total} issues · {open} ouvertes · {closed} fermées",
+    brandName: "Roxabi Live",
+  },
+  view: {
+    graph: "Graphe",
+    list: "Liste",
+    table: "Tableau",
+    groupAriaLabel: "Vue",
+  },
+  settings: {
+    theme: {
+      switchTo: "Passer au thème {next}",
+      dark: "sombre",
+      light: "clair",
+    },
+    title: "Paramètres",
+    profile: {
+      heading: "Profil",
+      displayName: {
+        label: "Nom affiché",
+        hint: "Affiché dans l'en-tête. Login GitHub : {login}.",
+      },
+    },
+    repos: {
+      heading: "Dépôts",
+      hint: "Ajoutez ou retirez les dépôts auxquels l'App GitHub accède.",
+      empty: "Aucune installation liée pour l'instant.",
+      configure: "Configurer les dépôts sur GitHub",
+    },
+    deleteAccount: {
+      heading: "Supprimer le compte",
+      hint: "Efface vos données Roxabi et vous déconnecte. Révoquez l'app sur GitHub séparément.",
+      button: "Supprimer mes données & se déconnecter",
+      confirmPrompt: "Supprimer toutes vos données Roxabi Live et vous déconnecter ? Action irréversible.",
+      error: "Suppression impossible — réessayez.",
+    },
+    encryption: {
+      heading: "Chiffrement",
+    },
+  },
+  auth: {
+    userMenu: {
+      trigger: "Menu du compte",
+      triggerTitle: "{name}",
+      avatarAlt: "{login}",
+      settings: "Paramètres",
+      signOut: "Se déconnecter",
+    },
+    orgPicker: {
+      ariaLabel: "Installation active",
+    },
+    signin: {
+      title: "Se connecter",
+      description: "Roxabi Live se connecte à votre compte GitHub pour piloter votre flotte d'agents.",
+      githubButton: "Se connecter avec GitHub",
+      rememberMe: "Rester connecté sur cet appareil",
+    },
+    signup: {
+      title: "Créer votre compte",
+      githubButton: "Continuer avec GitHub",
+    },
+    sessionLost: "Session expirée. Reconnectez-vous pour continuer.",
+    consent: {
+      title: "Accès aux données",
+      description: "L'application est installée. Avant la première synchronisation, confirmez que Roxabi Live peut lire les métadonnées GitHub suivantes :",
+      scope: {
+        issues: "Issues, labels, milestones et relations parent/enfant",
+        repoMeta: "Métadonnées des dépôts (nom, visibilité, archivage)",
+        d1: "Données stockées dans Cloudflare D1, limitées à votre organisation",
+      },
+      loggedInAs: "Connecté en tant que {login}. Vous pouvez révoquer l'accès depuis vos {githubSettingsLink}.",
+      githubSettingsLink: "paramètres GitHub",
+      encryptionNotice: "Les titres et corps d'issues sont chiffrés côté client avant stockage. La structure du graphe (état, blockers, labels) reste lisible par l'opérateur.",
+      error: "Enregistrement impossible — vérifiez votre connexion et réessayez.",
+      confirmButton: "J'ai compris — lancer la synchronisation",
+    },
+    signout: "Se déconnecter",
+    install: {
+      title: "Installer Roxabi Live sur GitHub",
+      description: "Connecté en tant que {login} (étape 1 terminée). Choisissez où installer l'application : compte personnel, organisation, ou dépôts sélectionnés uniquement.",
+      option: {
+        orgTitle: "Organisation",
+        personalTitle: "Compte personnel",
+        pickerName: "Choisir sur GitHub",
+        pickerHint: "GitHub liste les organisations où vous pouvez installer l'app",
+        personalHint: "Vos dépôts uniquement — idéal en solo",
+        orgHint: "Installer sur cette org — tous les dépôts ou une sélection sur GitHub",
+      },
+      selectedRepos: {
+        label: "Dépôts sélectionnés",
+        hint: "Choisissez un compte ci-dessus, puis sur GitHub : Only select repositories et sélectionnez les dépôts à synchroniser.",
+      },
+      redirectHint: "GitHub vous demandera quels dépôts autoriser, puis vous ramènera ici. Si la redirection échoue, revenez et cliquez J'ai installé — continuer.",
+      continueButton: "J'ai installé — continuer",
+      notDetectedHint: "Installation pas encore détectée. Réessayez ou reconnectez-vous via GitHub ({fallbackUrl}).",
+      sessionErrorHint: "Session expirée ou erreur réseau — rechargez la page ou reconnectez-vous.",
+    },
+    onboarding: {
+      navAriaLabel: "Progression de l'installation",
+      step: {
+        github: "Connexion GitHub",
+        install: "Installation",
+        sync: "Synchronisation",
+      },
+    },
+    loading: {
+      srOnly: "Chargement de votre session…",
+    },
+    error: {
+      loadSession: "Impossible de charger votre session : {message}",
+    },
+    signOut: "Se déconnecter",
+  },
+  sync: {
+    halted: {
+      title: "Synchronisation interrompue",
+      detail: "{reposSynced} / {reposTotal} dépôts · Erreur d'authentification GitHub",
+    },
+    inProgress: {
+      title: "Synchronisation de vos dépôts…",
+      detail: "{reposSynced} / {reposTotal} dépôts · {issueCount} issues",
+    },
+  },
+  dim: {
+    label: {
+      rows: "Lignes",
+      cols: "Cols",
+      group: "Groupe",
+      orderBy: "Trier par",
+      subgroup: "Sous-groupe",
+    },
+    option: {
+      none: "Aucun",
+      milestone: "Milestone",
+      priority: "Priorité",
+      repo: "Dépôt",
+      lane: "Couloir",
+      size: "Taille",
+      status: "Statut",
+      parent: "Parent",
+      assignee: "Assigné",
+    },
+  },
+  graph: {
+    toggle: {
+      closed: {
+        label: "Fermés",
+        title: "Afficher les issues fermées dont l'epic parent est encore ouverte",
+      },
+      assignees: {
+        label: "Assignés",
+        title: "Afficher les logins des assignés sur les nœuds d'issue",
+      },
+    },
+    empty: "Aucune issue ne correspond au filtre actuel.",
+    edgesTitle: "Liens de dépendance",
+    node: {
+      title: "#{number} — {title}",
+    },
+  },
+  toolbar: {
+    filteredCount: "{count} sur {total}",
+  },
+  filter: {
+    search: {
+      placeholder: "Rechercher des issues…",
+      ariaLabel: "Rechercher des issues",
+    },
+    facet: {
+      status: "Statut",
+      repo: "Dépôt",
+      milestone: "Milestone",
+      priority: "Priorité",
+      label: "Label",
+      assignee: "Assigné",
+    },
+    epics: {
+      label: "Epics",
+    },
+    reset: {
+      label: "Réinitialiser",
+    },
+    multiselect: {
+      noOptions: "Aucune option",
+      clear: "Effacer {label}",
+    },
+    empty: {
+      milestone: "Aucun milestone",
+      priority: "Aucune priorité",
+      assignee: "Non assigné",
+    },
+  },
+  table: {
+    col: {
+      status: "Statut",
+      issue: "Issue",
+      title: "Titre",
+      milestone: "Milestone",
+      priority: "Priorité",
+      lane: "File",
+      size: "Taille",
+      blocks: "Bloque",
+      blockedBy: "Bloqué par",
+      parentOf: "Parent de",
+    },
+    empty: "Aucune issue à afficher.",
+    row: {
+      untitled: "sans titre",
+      stubBadge: "ébauche",
+      epicBadge: "epic",
+    },
+    card: {
+      issueTitle: "Issue #{number}",
+    },
+  },
+  pivot: {
+    empty: "Aucune issue ne correspond au filtre actuel.",
+  },
+  status: {
+    ready: "Prêt",
+    blocked: "Bloqué",
+    running: "En cours",
+    done: "Terminé",
+  },
+  zk: {
+    reset: {
+      changePassphraseButton: "Changer la passphrase",
+      currentPassphrase: {
+        label: "Passphrase actuelle",
+      },
+      newPassphrase: {
+        label: "Nouvelle passphrase",
+      },
+      confirmPassphrase: {
+        label: "Confirmer la nouvelle passphrase",
+      },
+      cancel: "Annuler",
+      saveButton: "Enregistrer la passphrase",
+      warning: {
+        title: "Réinitialiser le chiffrement ?",
+        irreversibleBold: "Cette action est irréversible.",
+        body: "Tous les titres d'issues chiffrés stockés pour votre compte sur le serveur seront supprimés. Vos titres précédemment chiffrés ne pourront plus être déchiffrés — ils sont définitivement perdus. Vous choisirez une nouvelle passphrase et re-scellerez le contenu depuis GitHub.",
+        githubRequired: "Une connexion GitHub est requise pour confirmer cette action.",
+        verifyGithub: "Vérifier avec GitHub",
+      },
+      execute: {
+        title: "Confirmer la réinitialisation",
+        description: "GitHub vérifié. Supprimer toutes vos données chiffrées et définir une nouvelle passphrase ?",
+        confirmButton: "Réinitialiser et recommencer",
+        errorReauthExpired: "Vérification expirée — réessayez.",
+        errorRateLimited: "Trop de réinitialisations — réessayez plus tard.",
+        errorGeneric: "Échec de la réinitialisation. Réessayez.",
+      },
+    },
+    enroll: {
+      title: "Définir la passphrase de chiffrement",
+      description: "Choisissez une passphrase pour protéger votre clé de chiffrement. Elle ne quitte jamais ce navigateur ; seule une sauvegarde chiffrée est stockée sur le serveur. Cet appareil retient votre clé après la configuration — la passphrase sera requise sur d'autres appareils ou après un verrouillage.",
+      passphrase: {
+        label: "Passphrase",
+      },
+      confirmPassphrase: {
+        label: "Confirmer la passphrase",
+      },
+      remember: {
+        label: "Retenir la passphrase sur cet appareil pendant 30 jours",
+      },
+      submitButton: "Créer la sauvegarde",
+      error: {
+        tooShort: "La passphrase doit comporter au moins 8 caractères.",
+        mismatch: "Les passphrases ne correspondent pas.",
+        alreadyEnrolled: "Déjà enrôlé — déverrouillez plutôt avec votre passphrase.",
+        generic: "Échec de l'enrôlement. Réessayez.",
+      },
+    },
+    unlock: {
+      title: "Déverrouiller le chiffrement",
+      description: "Entrez votre passphrase de chiffrement pour déchiffrer les titres et corps d'issues sur cet appareil.",
+      passphraseLabel: "Passphrase",
+      rememberDevice: "Retenir la passphrase sur cet appareil pendant 30 jours",
+      forgotPassword: "Mot de passe oublié ?",
+      submit: "Déverrouiller",
+      errorWrongPassphrase: "Passphrase incorrecte. Réessayez.",
+    },
+    common: {
+      logout: "Se déconnecter",
+      cancel: "Annuler",
+    },
+    device2: {
+      title: "Terminez la configuration sur votre appareil d'origine",
+      body1: "Des titres d'issues chiffrés sur ce compte ont été scellés dans un autre navigateur avant la configuration de la sauvegarde par passphrase. Cet appareil ne peut pas les déchiffrer ni terminer l'enrôlement tant que vous n'ouvrez pas Roxabi sur votre appareil d'origine pour y finaliser le chiffrement.",
+      body2Prefix: "Une fois la configuration faite sur l'appareil d'origine, vous pouvez aussi",
+      linkGithub: "lier GitHub",
+      body2Suffix: "ici pour re-sceller le contenu depuis GitHub.",
+      reload: "Recharger",
+    },
+    notice: {
+      info: {
+        body: "Les titres et le contenu de vos issues sont chiffrés et ne sont jamais accessibles en clair sur le serveur. Votre passphrase n'est pas récupérable : en cas de perte, vous devrez en générer une nouvelle.",
+        dismiss: "Fermer",
+      },
+      githubLink: {
+        body: "Certains titres restent chiffrés sur le serveur. Liez GitHub pour importer et re-sceller leur contenu.",
+        cta: "Lier GitHub",
+      },
+      migration: {
+        body: "Migration du chiffrement incomplète — certains anciens titres n'ont pas pu être convertis. Ouvrez Roxabi sur l'appareil d'origine pour la terminer.",
+      },
+    },
+    lock: {
+      title: "Verrouiller le chiffrement (effacer la clé de la mémoire)",
+      label: "Verrouiller",
+    },
+    gate: {
+      loadingSrOnly: "Déverrouillage du chiffrement…",
+    },
+  },
+};
+
+export type Translations = typeof fr;

--- a/apps/app/src/i18n/fr.ts
+++ b/apps/app/src/i18n/fr.ts
@@ -129,6 +129,10 @@ export const fr = {
       title: "Synchronisation de vos dépôts…",
       detail: "{reposSynced} / {reposTotal} dépôts · {issueCount} issues",
     },
+    titles: {
+      inProgress: "Importation des titres d'issues…",
+      detail: "{count} à déchiffrer",
+    },
   },
   dim: {
     label: {

--- a/apps/app/src/i18n/index.tsx
+++ b/apps/app/src/i18n/index.tsx
@@ -1,0 +1,119 @@
+/**
+ * i18n — FR/EN locale management for the cockpit (apps/app).
+ *
+ * Mirrors the marketing site's catalog shape (`fr` is the typed source of
+ * truth, `en` conforms to `typeof fr`) but adds a React runtime: a context
+ * provider holds the active locale, `useT()` returns a `t(key, vars)` resolver
+ * that walks the nested catalog by dot-path and interpolates `{vars}`. The
+ * choice persists to localStorage (`roxabi:locale`, same key as the legacy
+ * public pages) and drives `<html lang>`.
+ */
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { en } from "./en";
+import { fr } from "./fr";
+
+export type Locale = "fr" | "en";
+
+const CATALOG: Record<Locale, unknown> = { fr, en };
+const STORAGE_KEY = "roxabi:locale";
+
+/** Stored choice → browser language (fr* → fr) → en. */
+export function detectLocale(): Locale {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "fr" || stored === "en") return stored;
+  } catch {
+    /* storage disabled */
+  }
+  const nav = typeof navigator !== "undefined" ? navigator.language : "";
+  return nav?.toLowerCase().startsWith("fr") ? "fr" : "en";
+}
+
+function persistLocale(locale: Locale): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, locale);
+  } catch {
+    /* storage disabled */
+  }
+}
+
+/** Walk a nested catalog object by "a.b.c" and return the leaf string. */
+function resolve(catalog: unknown, key: string): string | undefined {
+  let cur: unknown = catalog;
+  for (const part of key.split(".")) {
+    if (cur && typeof cur === "object" && part in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof cur === "string" ? cur : undefined;
+}
+
+function interpolate(s: string, vars?: Record<string, string | number>): string {
+  if (!vars) return s;
+  return s.replace(/\{(\w+)\}/g, (m, k) => (k in vars ? String(vars[k]) : m));
+}
+
+export type TFunc = (key: string, vars?: Record<string, string | number>) => string;
+
+interface LocaleContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: TFunc;
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+export function LocaleProvider({
+  children,
+  initialLocale,
+}: {
+  children: ReactNode;
+  /** Force the starting locale (tests / SSR); defaults to runtime detection. */
+  initialLocale?: Locale;
+}) {
+  const [locale, setLocaleState] = useState<Locale>(() => initialLocale ?? detectLocale());
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  const setLocale = useCallback((next: Locale) => {
+    persistLocale(next);
+    setLocaleState(next);
+  }, []);
+
+  const t = useCallback<TFunc>(
+    (key, vars) => {
+      // active locale → en → fr fallback chain, then the raw key as last resort.
+      const hit = resolve(CATALOG[locale], key) ?? resolve(en, key) ?? resolve(fr, key);
+      return interpolate(hit ?? key, vars);
+    },
+    [locale],
+  );
+
+  const value = useMemo<LocaleContextValue>(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale(): LocaleContextValue {
+  const ctx = useContext(LocaleContext);
+  if (!ctx) throw new Error("useLocale must be used within a LocaleProvider");
+  return ctx;
+}
+
+/** Convenience hook for components that only need the translator. */
+export function useT(): TFunc {
+  return useLocale().t;
+}

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import { LocaleProvider } from "./i18n";
 import { initTheme } from "./lib/theme";
 import { router } from "./router";
 
@@ -23,8 +24,10 @@ if (!rootEl) throw new Error("Root element #root not found");
 
 createRoot(rootEl).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} context={{ queryClient }} />
-    </QueryClientProvider>
+    <LocaleProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} context={{ queryClient }} />
+      </QueryClientProvider>
+    </LocaleProvider>
   </StrictMode>,
 );

--- a/apps/app/src/router.tsx
+++ b/apps/app/src/router.tsx
@@ -6,6 +6,11 @@ import { BoardView } from "@/components/BoardView";
 import { SyncProgressBanner } from "@/components/SyncProgressBanner";
 import { useSyncProgressMonitor } from "@/hooks/useSyncProgressMonitor";
 import { useVersionPoll } from "@/hooks/useVersionPoll";
+import {
+  getGithubUserToken,
+  hasAttemptedHandoffRefresh,
+  refreshGithubTokenViaHandoff,
+} from "@/zk/github";
 import { ZkGate } from "@/zk/ZkGate";
 import { ZkNotices } from "@/zk/ZkNotices";
 import { ZkSessionProvider } from "@/zk/ZkSessionProvider";
@@ -17,7 +22,7 @@ import {
   createRoute,
   createRouter,
 } from "@tanstack/react-router";
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useEffect } from "react";
 
 interface RouterContext {
   queryClient: QueryClient;
@@ -51,6 +56,21 @@ function Dashboard() {
   // ZK is "active" once the feature flag is on and the user has enrolled a
   // passphrase (zk_key_backups row) — gates the encryption-info banner.
   const zkActive = me.user.zk_account_key_enabled && me.user.zk_enrolled;
+  const login = me.user.github_login;
+
+  // Self-heal stale sessions: an already-logged-in ZK user whose seal pass found
+  // unsealed titles (needsGithubLink) but has no GitHub token in sessionStorage
+  // gets a silent OAuth-handoff bounce to fetch one — so recent issue titles seal
+  // without a deco/reco. Guarded to fire at most once per session (inside the
+  // helper); no-ops once a token is present.
+  useEffect(() => {
+    if (zkActive && needsGithubLink) refreshGithubTokenViaHandoff(login);
+  }, [zkActive, needsGithubLink, login]);
+
+  // Fallback affordance: only surface the manual "Link GitHub" prompt to an
+  // active user once the silent bounce was exhausted (attempted + still no
+  // token) — e.g. the server couldn't mint a handoff — so they're never stuck.
+  const githubLinkExhausted = hasAttemptedHandoffRefresh(login) && !getGithubUserToken();
 
   return (
     <div className="space-y-3">
@@ -58,7 +78,8 @@ function Dashboard() {
         needsGithubLink={needsGithubLink}
         migrationIncomplete={zkMigrationIncomplete}
         zkActive={zkActive}
-        githubLogin={me.user.github_login}
+        allowGithubLink={githubLinkExhausted}
+        githubLogin={login}
       />
       <SyncProgressBanner status={syncStatus} />
       {isError ? (

--- a/apps/app/src/router.tsx
+++ b/apps/app/src/router.tsx
@@ -4,6 +4,7 @@ import { SignInScreen } from "@/auth/SignInScreen";
 import { AppShell } from "@/components/AppShell";
 import { BoardView } from "@/components/BoardView";
 import { SyncProgressBanner } from "@/components/SyncProgressBanner";
+import { TitleSyncBanner } from "@/components/TitleSyncBanner";
 import { useSyncProgressMonitor } from "@/hooks/useSyncProgressMonitor";
 import { useVersionPoll } from "@/hooks/useVersionPoll";
 import {
@@ -51,8 +52,17 @@ function Dashboard() {
   useVersionPoll();
   const me = useAuth();
   const syncStatus = useSyncProgressMonitor();
-  const { nodes, edges, isLoading, isError, error, needsGithubLink, zkMigrationIncomplete } =
-    useDecryptedGraph();
+  const {
+    nodes,
+    edges,
+    isLoading,
+    isError,
+    error,
+    needsGithubLink,
+    isSyncingTitles,
+    syncingTitleCount,
+    zkMigrationIncomplete,
+  } = useDecryptedGraph();
   // ZK is "active" once the feature flag is on and the user has enrolled a
   // passphrase (zk_key_backups row) — gates the encryption-info banner.
   const zkActive = me.user.zk_account_key_enabled && me.user.zk_enrolled;
@@ -82,6 +92,7 @@ function Dashboard() {
         githubLogin={login}
       />
       <SyncProgressBanner status={syncStatus} />
+      <TitleSyncBanner syncing={isSyncingTitles} count={syncingTitleCount} />
       {isError ? (
         <div className="rounded-lg border border-blocked/30 bg-blocked/10 p-4 text-sm text-blocked">
           Failed to load the corpus: {(error as Error).message}

--- a/apps/app/src/zk/PassphraseChangeSection.tsx
+++ b/apps/app/src/zk/PassphraseChangeSection.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Button } from "@/components/ui/button";
+import { useT } from "@/i18n";
 import { useState } from "react";
 import { ZkFormError } from "./ZkDialogShell";
 import { requestSettingsReauth } from "./settingsReauth";
@@ -21,6 +22,7 @@ export function PassphraseChangeSection({
   initialOpen?: boolean;
   onChanged?: () => void;
 }) {
+  const t = useT();
   const [formOpen, setFormOpen] = useState(initialOpen);
   const [current, setCurrent] = useState("");
   const [newPass, setNewPass] = useState("");
@@ -55,15 +57,15 @@ export function PassphraseChangeSection({
 
   return (
     <section className="space-y-2">
-      <h3 className="text-sm font-semibold text-foreground">Chiffrement</h3>
+      <h3 className="text-sm font-semibold text-foreground">{t("settings.encryption.heading")}</h3>
       {!formOpen ? (
         <Button variant="outline" size="sm" onClick={onChangeClick} data-testid="zk-change-pass">
-          Changer la passphrase
+          {t("zk.reset.changePassphraseButton")}
         </Button>
       ) : (
         <div className="space-y-2" data-testid="zk-pass-form">
           <label className="block space-y-1">
-            <span className="text-xs text-muted-foreground">Passphrase actuelle</span>
+            <span className="text-xs text-muted-foreground">{t("zk.reset.currentPassphrase.label")}</span>
             <input
               type="password"
               autoComplete="current-password"
@@ -74,7 +76,7 @@ export function PassphraseChangeSection({
             />
           </label>
           <label className="block space-y-1">
-            <span className="text-xs text-muted-foreground">Nouvelle passphrase</span>
+            <span className="text-xs text-muted-foreground">{t("zk.reset.newPassphrase.label")}</span>
             <input
               type="password"
               autoComplete="new-password"
@@ -86,7 +88,7 @@ export function PassphraseChangeSection({
             />
           </label>
           <label className="block space-y-1">
-            <span className="text-xs text-muted-foreground">Confirmer la nouvelle passphrase</span>
+            <span className="text-xs text-muted-foreground">{t("zk.reset.confirmPassphrase.label")}</span>
             <input
               type="password"
               autoComplete="new-password"
@@ -105,7 +107,7 @@ export function PassphraseChangeSection({
               onClick={() => setFormOpen(false)}
               data-testid="zk-pass-cancel"
             >
-              Annuler
+              {t("zk.reset.cancel")}
             </Button>
             <Button
               size="sm"
@@ -113,7 +115,7 @@ export function PassphraseChangeSection({
               onClick={onSave}
               data-testid="zk-pass-save"
             >
-              Enregistrer la passphrase
+              {t("zk.reset.saveButton")}
             </Button>
           </div>
         </div>

--- a/apps/app/src/zk/ZkDevice2Block.tsx
+++ b/apps/app/src/zk/ZkDevice2Block.tsx
@@ -7,39 +7,38 @@
 
 import { useLogout } from "@/auth/useAuthMutations";
 import { Button } from "@/components/ui/button";
+import { useT } from "@/i18n";
 import { ZkGateDialog } from "./ZkDialogShell";
 import { zkLoginUrl } from "./github";
 
 export function ZkDevice2Block() {
+  const t = useT();
   const logout = useLogout();
   return (
     <ZkGateDialog
-      title="Terminez la configuration sur votre appareil d'origine"
+      title={t("zk.device2.title")}
       testId="zk-device2-block"
     >
       <p className="text-sm text-muted-foreground">
-        Des titres d'issues chiffrés sur ce compte ont été scellés dans un autre navigateur avant la
-        configuration de la sauvegarde par passphrase. Cet appareil ne peut pas les déchiffrer ni
-        terminer l'enrôlement tant que vous n'ouvrez pas Roxabi sur votre{" "}
-        <strong>appareil d'origine</strong> pour y finaliser le chiffrement.
+        {t("zk.device2.body1")}
       </p>
       <p className="text-sm text-muted-foreground">
-        Une fois la configuration faite sur l'appareil d'origine, vous pouvez aussi{" "}
+        {t("zk.device2.body2Prefix")}{" "}
         <a
           href={zkLoginUrl()}
           className="text-primary underline-offset-4 hover:underline"
           data-testid="zk-device2-link"
         >
-          lier GitHub
+          {t("zk.device2.linkGithub")}
         </a>{" "}
-        ici pour re-sceller le contenu depuis GitHub.
+        {t("zk.device2.body2Suffix")}
       </p>
       <div className="flex items-center justify-between gap-3 pt-1">
         <Button type="button" variant="ghost" onClick={() => logout.mutate(undefined)}>
-          Se déconnecter
+          {t("zk.common.logout")}
         </Button>
         <Button type="button" variant="secondary" onClick={() => window.location.reload()}>
-          Recharger
+          {t("zk.device2.reload")}
         </Button>
       </div>
     </ZkGateDialog>

--- a/apps/app/src/zk/ZkEnrollDialog.tsx
+++ b/apps/app/src/zk/ZkEnrollDialog.tsx
@@ -7,6 +7,7 @@
 
 import { useLogout } from "@/auth/useAuthMutations";
 import { Button } from "@/components/ui/button";
+import { useT } from "@/i18n";
 import { useState } from "react";
 import { ZkFormError, ZkGateDialog } from "./ZkDialogShell";
 import {
@@ -18,6 +19,7 @@ import {
 import { zkLoginUrl } from "./github";
 
 export function ZkEnrollDialog({ login }: { login: string }) {
+  const t = useT();
   const logout = useLogout();
   const [pass, setPass] = useState("");
   const [confirm, setConfirm] = useState("");
@@ -34,11 +36,11 @@ export function ZkEnrollDialog({ login }: { login: string }) {
     e.preventDefault();
     setError(null);
     if (pass.length < 8) {
-      setError("La passphrase doit comporter au moins 8 caractères.");
+      setError(t("zk.enroll.error.tooShort"));
       return;
     }
     if (pass !== confirm) {
-      setError("Les passphrases ne correspondent pas.");
+      setError(t("zk.enroll.error.mismatch"));
       return;
     }
     setBusy(true);
@@ -55,24 +57,21 @@ export function ZkEnrollDialog({ login }: { login: string }) {
       const msg = String((err as Error)?.message ?? "");
       setError(
         msg.includes("409")
-          ? "Déjà enrôlé — déverrouillez plutôt avec votre passphrase."
-          : (err as Error)?.message || "Échec de l'enrôlement. Réessayez.",
+          ? t("zk.enroll.error.alreadyEnrolled")
+          : (err as Error)?.message || t("zk.enroll.error.generic"),
       );
       setBusy(false);
     }
   }
 
   return (
-    <ZkGateDialog title="Définir la passphrase de chiffrement" testId="zk-enroll-gate">
+    <ZkGateDialog title={t("zk.enroll.title")} testId="zk-enroll-gate">
       <p className="text-sm text-muted-foreground">
-        Choisissez une passphrase pour protéger votre clé de chiffrement. Elle ne quitte jamais ce
-        navigateur ; seule une sauvegarde chiffrée est stockée sur le serveur. Cet appareil retient
-        votre clé après la configuration — la passphrase sera requise sur d'autres appareils ou
-        après un verrouillage.
+        {t("zk.enroll.description")}
       </p>
       <form className="space-y-3" onSubmit={onSubmit}>
         <label className="block space-y-1">
-          <span className="text-xs text-muted-foreground">Passphrase</span>
+          <span className="text-xs text-muted-foreground">{t("zk.enroll.passphrase.label")}</span>
           <input
             type="password"
             autoComplete="new-password"
@@ -87,7 +86,7 @@ export function ZkEnrollDialog({ login }: { login: string }) {
           />
         </label>
         <label className="block space-y-1">
-          <span className="text-xs text-muted-foreground">Confirmer la passphrase</span>
+          <span className="text-xs text-muted-foreground">{t("zk.enroll.confirmPassphrase.label")}</span>
           <input
             type="password"
             autoComplete="new-password"
@@ -107,15 +106,15 @@ export function ZkEnrollDialog({ login }: { login: string }) {
             data-testid="zk-remember"
             className="size-4"
           />
-          <span>Retenir la passphrase sur cet appareil pendant 30 jours</span>
+          <span>{t("zk.enroll.remember.label")}</span>
         </label>
         <ZkFormError message={error} />
         <div className="flex items-center justify-between gap-3 pt-1">
           <Button type="button" variant="ghost" onClick={() => logout.mutate(undefined)}>
-            Se déconnecter
+            {t("auth.signOut")}
           </Button>
           <Button type="submit" loading={busy} data-testid="zk-enroll-submit">
-            Créer la sauvegarde
+            {t("zk.enroll.submitButton")}
           </Button>
         </div>
       </form>

--- a/apps/app/src/zk/ZkGate.tsx
+++ b/apps/app/src/zk/ZkGate.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useAuth } from "@/auth/AuthContext";
+import { useT } from "@/i18n";
 import { CircleNotch } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { ZkDevice2Block } from "./ZkDevice2Block";
@@ -27,13 +28,14 @@ import { clearZkResetPending, isZkResetPending } from "./reset";
 import { ensurePrivateMode } from "./sync";
 
 function ZkGateLoading() {
+  const t = useT();
   return (
     <div
       className="flex min-h-[60vh] items-center justify-center text-muted-foreground"
       data-testid="zk-loading"
     >
       <CircleNotch className="size-6 animate-spin" aria-hidden />
-      <span className="sr-only">Déverrouillage du chiffrement…</span>
+      <span className="sr-only">{t("zk.gate.loadingSrOnly")}</span>
     </div>
   );
 }

--- a/apps/app/src/zk/ZkLockButton.tsx
+++ b/apps/app/src/zk/ZkLockButton.tsx
@@ -6,10 +6,12 @@
  */
 
 import { Lock } from "@phosphor-icons/react";
+import { useT } from "@/i18n";
 import { useZkRuntime, useZkSession } from "./ZkSessionProvider";
 import { lockZkSession } from "./enroll";
 
 export function ZkLockButton() {
+  const t = useT();
   const { unlocked } = useZkSession();
   const { githubLogin, zkAccountKeyEnabled } = useZkRuntime();
 
@@ -19,12 +21,12 @@ export function ZkLockButton() {
     <button
       type="button"
       data-testid="zk-lock-btn"
-      title="Verrouiller le chiffrement (effacer la clé de la mémoire)"
+      title={t("zk.lock.title")}
       onClick={() => lockZkSession(githubLogin)}
       className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <Lock className="size-4" aria-hidden />
-      Verrouiller
+      {t("zk.lock.label")}
     </button>
   );
 }

--- a/apps/app/src/zk/ZkNotices.test.ts
+++ b/apps/app/src/zk/ZkNotices.test.ts
@@ -10,6 +10,7 @@ const html = (props: {
   needsGithubLink: boolean;
   migrationIncomplete: boolean;
   zkActive?: boolean;
+  allowGithubLink?: boolean;
   githubLogin?: string;
 }) =>
   renderToStaticMarkup(
@@ -49,5 +50,19 @@ describe("ZkNotices", () => {
     expect(out).toContain('data-testid="zk-info-notice"');
     expect(out).not.toContain('data-testid="zk-github-link-notice"');
     expect(out).not.toContain("Lier GitHub");
+  });
+
+  it("re-surfaces the GitHub-link prompt for active users once the silent bounce is exhausted", () => {
+    const out = html({
+      needsGithubLink: true,
+      migrationIncomplete: false,
+      zkActive: true,
+      allowGithubLink: true,
+    });
+    // Silent handoff failed to yield a token → fall back to the manual prompt
+    // (alongside the info banner) so the user is never stuck without a path.
+    expect(out).toContain('data-testid="zk-info-notice"');
+    expect(out).toContain('data-testid="zk-github-link-notice"');
+    expect(out).toContain("Lier GitHub");
   });
 });

--- a/apps/app/src/zk/ZkNotices.test.ts
+++ b/apps/app/src/zk/ZkNotices.test.ts
@@ -1,14 +1,23 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import { LocaleProvider } from "@/i18n";
 import { ZkNotices } from "./ZkNotices";
 
+// Render inside a forced-French provider so the assertions below match the FR
+// catalog copy (the components now resolve strings through useT()).
 const html = (props: {
   needsGithubLink: boolean;
   migrationIncomplete: boolean;
   zkActive?: boolean;
   githubLogin?: string;
-}) => renderToStaticMarkup(createElement(ZkNotices, props));
+}) =>
+  renderToStaticMarkup(
+    createElement(LocaleProvider, {
+      initialLocale: "fr",
+      children: createElement(ZkNotices, props),
+    }),
+  );
 
 describe("ZkNotices", () => {
   it("shows the dismissable encryption-info banner when ZK is active", () => {

--- a/apps/app/src/zk/ZkNotices.tsx
+++ b/apps/app/src/zk/ZkNotices.tsx
@@ -5,8 +5,12 @@
  *     server-side and that the passphrase is unrecoverable.
  *  2. GitHub link (fallback): titles stayed "(sealed)" because no GitHub user
  *     token is available to import + encrypt them. Rare now — the server
- *     auto-hands-off the token on every login of an enrolled user, and the first
- *     enrolment kicks off the handoff itself — so this only shows if that failed.
+ *     auto-hands-off the token on every login of an enrolled user, the first
+ *     enrolment kicks off the handoff itself, and an active session with unsealed
+ *     titles bounces silently through the handoff (refreshGithubTokenViaHandoff).
+ *     This manual prompt only re-surfaces for active users once that silent
+ *     bounce is exhausted (allowGithubLink), or for the legacy non-account-key
+ *     path (!zkActive).
  *  3. Migration: a v1→v2 migration left undecryptable rows behind.
  */
 
@@ -33,21 +37,25 @@ export function ZkNotices({
   needsGithubLink,
   migrationIncomplete,
   zkActive = false,
+  allowGithubLink = false,
   githubLogin = "",
 }: {
   needsGithubLink: boolean;
   migrationIncomplete: boolean;
   zkActive?: boolean;
+  allowGithubLink?: boolean;
   githubLogin?: string;
 }) {
   const t = useT();
   const dismissKey = infoDismissKey(githubLogin);
   const [infoDismissed, setInfoDismissed] = useState(() => readInfoDismissed(dismissKey));
   const showInfo = zkActive && !infoDismissed;
-  // The manual "link GitHub" prompt is a pre-auto-handoff relic: an active ZK
-  // user gets their token handed off on every login, so never surface it to
-  // them — the reassuring info banner is the replacement.
-  const showGithubLink = needsGithubLink && !zkActive;
+  // An active ZK user gets their token handed off automatically (silent bounce on
+  // an active session, or auto-handoff on login), so the manual prompt stays
+  // hidden — the reassuring info banner is the replacement. It only re-surfaces
+  // for active users once that silent path is exhausted (allowGithubLink); the
+  // legacy non-account-key path (!zkActive) still shows it directly.
+  const showGithubLink = needsGithubLink && (!zkActive || allowGithubLink);
 
   if (!showInfo && !showGithubLink && !migrationIncomplete) return null;
 

--- a/apps/app/src/zk/ZkNotices.tsx
+++ b/apps/app/src/zk/ZkNotices.tsx
@@ -12,6 +12,7 @@
 
 import { GithubLogo, Warning } from "@phosphor-icons/react";
 import { useState } from "react";
+import { useT } from "@/i18n";
 import { zkLoginUrl } from "./github";
 
 // Per-user so a shared browser doesn't suppress the notice for another account
@@ -39,6 +40,7 @@ export function ZkNotices({
   zkActive?: boolean;
   githubLogin?: string;
 }) {
+  const t = useT();
   const dismissKey = infoDismissKey(githubLogin);
   const [infoDismissed, setInfoDismissed] = useState(() => readInfoDismissed(dismissKey));
   const showInfo = zkActive && !infoDismissed;
@@ -60,17 +62,12 @@ export function ZkNotices({
             🔒
           </span>
           <span className="min-w-0">
-            Les titres et le contenu de vos issues sont{" "}
-            <strong className="font-medium text-foreground">chiffrés</strong> et ne sont{" "}
-            <strong className="font-medium text-foreground">jamais accessibles en clair sur le
-            serveur</strong>. Votre passphrase n'est{" "}
-            <strong className="font-medium text-foreground">pas récupérable</strong> : en cas de
-            perte, vous devrez en générer une nouvelle.
+            {t("zk.notice.info.body")}
           </span>
           <button
             type="button"
             data-testid="zk-info-dismiss"
-            aria-label="Fermer"
+            aria-label={t("zk.notice.info.dismiss")}
             onClick={() => {
               try {
                 localStorage.setItem(dismissKey, "1");
@@ -92,14 +89,13 @@ export function ZkNotices({
         >
           <GithubLogo className="size-4 shrink-0" aria-hidden />
           <span>
-            Certains titres restent chiffrés sur le serveur. Liez GitHub pour importer et re-sceller
-            leur contenu.
+            {t("zk.notice.githubLink.body")}
           </span>
           <a
             href={zkLoginUrl()}
             className="ml-auto font-medium text-primary underline-offset-4 hover:underline"
           >
-            Lier GitHub
+            {t("zk.notice.githubLink.cta")}
           </a>
         </div>
       )}
@@ -110,8 +106,7 @@ export function ZkNotices({
         >
           <Warning className="size-4 shrink-0" aria-hidden />
           <span>
-            Migration du chiffrement incomplète — certains anciens titres n'ont pas pu être
-            convertis. Ouvrez Roxabi sur l'appareil d'origine pour la terminer.
+            {t("zk.notice.migration.body")}
           </span>
         </div>
       )}

--- a/apps/app/src/zk/ZkResetDialog.tsx
+++ b/apps/app/src/zk/ZkResetDialog.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Button } from "@/components/ui/button";
+import { useT } from "@/i18n";
 import { useState } from "react";
 import { ZkFormError, ZkGateDialog } from "./ZkDialogShell";
 import { clearZkReauthProof, zkReauthLoginUrl } from "./github";
@@ -21,21 +22,19 @@ import {
 } from "./reset";
 
 export function ZkResetWarningDialog({ onCancel }: { onCancel: () => void }) {
+  const t = useT();
   function onVerify() {
     setZkResetPending();
     const redirect = `${window.location.pathname}${window.location.search}`;
     window.location.href = zkReauthLoginUrl(redirect);
   }
   return (
-    <ZkGateDialog title="Réinitialiser le chiffrement ?" testId="zk-reset-warning">
+    <ZkGateDialog title={t("zk.reset.warning.title")} testId="zk-reset-warning">
       <p className="rounded-md border border-blocked/30 bg-blocked/10 p-3 text-sm text-foreground">
-        <strong>Cette action est irréversible.</strong> Tous les titres d'issues chiffrés stockés
-        pour votre compte sur le serveur seront supprimés. Vos titres précédemment chiffrés ne
-        pourront plus être déchiffrés — ils sont définitivement perdus. Vous choisirez une nouvelle
-        passphrase et re-scellerez le contenu depuis GitHub.
+        <strong>{t("zk.reset.warning.irreversibleBold")}</strong> {t("zk.reset.warning.body")}
       </p>
       <p className="text-sm text-muted-foreground">
-        Une connexion GitHub est requise pour confirmer cette action.
+        {t("zk.reset.warning.githubRequired")}
       </p>
       <div className="flex items-center justify-between gap-3 pt-1">
         <Button
@@ -47,10 +46,10 @@ export function ZkResetWarningDialog({ onCancel }: { onCancel: () => void }) {
           }}
           data-testid="zk-reset-cancel"
         >
-          Annuler
+          {t("zk.common.cancel")}
         </Button>
         <Button type="button" onClick={onVerify} data-testid="zk-reset-verify">
-          Vérifier avec GitHub
+          {t("zk.reset.warning.verifyGithub")}
         </Button>
       </div>
     </ZkGateDialog>
@@ -64,6 +63,7 @@ export function ZkResetExecuteDialog({
   login: string;
   onCancel: () => void;
 }) {
+  const t = useT();
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -77,21 +77,21 @@ export function ZkResetExecuteDialog({
       const code = err instanceof ZkResetError ? err.code : undefined;
       const message = err instanceof Error ? err.message : "";
       if (code === "reauth_required" || message === "reauth_required") {
-        setError("Vérification expirée — réessayez.");
+        setError(t("zk.reset.execute.errorReauthExpired"));
         clearZkReauthProof();
       } else if (code === "rate_limited") {
-        setError("Trop de réinitialisations — réessayez plus tard.");
+        setError(t("zk.reset.execute.errorRateLimited"));
       } else {
-        setError("Échec de la réinitialisation. Réessayez.");
+        setError(t("zk.reset.execute.errorGeneric"));
       }
       setBusy(false);
     }
   }
 
   return (
-    <ZkGateDialog title="Confirmer la réinitialisation" testId="zk-reset-execute">
+    <ZkGateDialog title={t("zk.reset.execute.title")} testId="zk-reset-execute">
       <p className="text-sm text-muted-foreground">
-        GitHub vérifié. Supprimer toutes vos données chiffrées et définir une nouvelle passphrase ?
+        {t("zk.reset.execute.description")}
       </p>
       <ZkFormError message={error} />
       <div className="flex items-center justify-between gap-3 pt-1">
@@ -105,7 +105,7 @@ export function ZkResetExecuteDialog({
           }}
           data-testid="zk-reset-abort"
         >
-          Annuler
+          {t("zk.common.cancel")}
         </Button>
         <Button
           type="button"
@@ -114,7 +114,7 @@ export function ZkResetExecuteDialog({
           onClick={onConfirm}
           data-testid="zk-reset-confirm"
         >
-          Réinitialiser et recommencer
+          {t("zk.reset.execute.confirmButton")}
         </Button>
       </div>
     </ZkGateDialog>

--- a/apps/app/src/zk/ZkUnlockDialog.tsx
+++ b/apps/app/src/zk/ZkUnlockDialog.tsx
@@ -7,6 +7,7 @@
 
 import { useLogout } from "@/auth/useAuthMutations";
 import { Button } from "@/components/ui/button";
+import { useT } from "@/i18n";
 import { useState } from "react";
 import { ZkFormError, ZkGateDialog } from "./ZkDialogShell";
 import { ZkResetWarningDialog } from "./ZkResetDialog";
@@ -19,6 +20,7 @@ import {
 import { isZkUnlocked } from "./session";
 
 export function ZkUnlockDialog({ login }: { login: string }) {
+  const t = useT();
   const logout = useLogout();
   const [pass, setPass] = useState("");
   const [remember, setRemember] = useState(() => isZkRememberPreferred());
@@ -50,20 +52,19 @@ export function ZkUnlockDialog({ login }: { login: string }) {
       // unlocked flips → ZkGate renders the dashboard.
     } catch {
       if (isZkUnlocked()) return; // a concurrent unlock won the race.
-      setError("Passphrase incorrecte. Réessayez.");
+      setError(t("zk.unlock.errorWrongPassphrase"));
       setBusy(false);
     }
   }
 
   return (
-    <ZkGateDialog title="Déverrouiller le chiffrement" testId="zk-unlock-gate">
+    <ZkGateDialog title={t("zk.unlock.title")} testId="zk-unlock-gate">
       <p className="text-sm text-muted-foreground">
-        Entrez votre passphrase de chiffrement pour déchiffrer les titres et corps d'issues sur cet
-        appareil.
+        {t("zk.unlock.description")}
       </p>
       <form className="space-y-3" onSubmit={onSubmit}>
         <label className="block space-y-1">
-          <span className="text-xs text-muted-foreground">Passphrase</span>
+          <span className="text-xs text-muted-foreground">{t("zk.unlock.passphraseLabel")}</span>
           <input
             type="password"
             autoComplete="current-password"
@@ -84,7 +85,7 @@ export function ZkUnlockDialog({ login }: { login: string }) {
             data-testid="zk-remember"
             className="size-4"
           />
-          <span>Retenir la passphrase sur cet appareil pendant 30 jours</span>
+          <span>{t("zk.unlock.rememberDevice")}</span>
         </label>
         <ZkFormError message={error} />
         <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
@@ -95,14 +96,14 @@ export function ZkUnlockDialog({ login }: { login: string }) {
             onClick={() => setShowResetWarning(true)}
             data-testid="zk-lost-pass"
           >
-            Mot de passe oublié ?
+            {t("zk.unlock.forgotPassword")}
           </Button>
           <div className="flex items-center gap-3">
             <Button type="button" variant="ghost" onClick={() => logout.mutate(undefined)}>
-              Se déconnecter
+              {t("zk.common.logout")}
             </Button>
             <Button type="submit" loading={busy} data-testid="zk-unlock-submit">
-              Déverrouiller
+              {t("zk.unlock.submit")}
             </Button>
           </div>
         </div>

--- a/apps/app/src/zk/flows.test.ts
+++ b/apps/app/src/zk/flows.test.ts
@@ -21,6 +21,8 @@ import {
   consumeZkReauthFromUrl,
   getGithubUserToken,
   getZkReauthProof,
+  hasAttemptedHandoffRefresh,
+  refreshGithubTokenViaHandoff,
   setGithubUserToken,
   zkLoginUrl,
   zkReauthLoginUrl,
@@ -94,6 +96,57 @@ describe("github token + reauth", () => {
     expect(await consumeZkHandoffFromUrl()).toBe(true);
     expect(getGithubUserToken()).toBe("ghu_handoff");
     expect(window.location.search).toBe("");
+  });
+});
+
+describe("silent handoff refresh (self-heal stale sessions)", () => {
+  // jsdom makes location.assign non-configurable, so vi.spyOn can't wrap it.
+  // Stub the whole window.location (the window property IS configurable) with a
+  // plain object carrying the path pieces the helper reads + a mock assign().
+  const realLocation = window.location;
+  let assignSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { pathname: "/", search: "?foo=1", hash: "", assign: assignSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: realLocation,
+    });
+  });
+
+  it("bounces through the OAuth handoff once when no token is present", () => {
+    expect(hasAttemptedHandoffRefresh("octocat")).toBe(false);
+
+    expect(refreshGithubTokenViaHandoff("octocat")).toBe(true);
+    expect(hasAttemptedHandoffRefresh("octocat")).toBe(true);
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(assignSpy).toHaveBeenCalledWith(zkLoginUrl("/?foo=1"));
+
+    // Loop guard: a bounce that returned no token must not re-trigger.
+    expect(refreshGithubTokenViaHandoff("octocat")).toBe(false);
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("never bounces when a github token already exists", () => {
+    setGithubUserToken("ghu_present");
+    expect(refreshGithubTokenViaHandoff("octocat")).toBe(false);
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(hasAttemptedHandoffRefresh("octocat")).toBe(false);
+  });
+
+  it("scopes the attempt guard per github login", () => {
+    expect(refreshGithubTokenViaHandoff("alice")).toBe(true);
+    expect(hasAttemptedHandoffRefresh("alice")).toBe(true);
+    expect(hasAttemptedHandoffRefresh("bob")).toBe(false);
   });
 });
 

--- a/apps/app/src/zk/github.ts
+++ b/apps/app/src/zk/github.ts
@@ -93,6 +93,54 @@ export function zkLoginUrl(redirect = "/"): string {
   return `/login?zk=1&redirect=${dest}`;
 }
 
+// Per-login so a shared browser doesn't gate one account on another's attempt
+// (matches the githubLogin-scoping of the ZK device/remember keys). sessionStorage
+// because the token it guards also lives there — both die with the tab/session.
+const HANDOFF_ATTEMPT_PREFIX = "roxabi:zk-handoff-attempted:";
+
+function handoffAttemptKey(githubLogin: string): string {
+  return `${HANDOFF_ATTEMPT_PREFIX}${githubLogin}`;
+}
+
+/** True once a silent handoff refresh was attempted this session (loop guard). */
+export function hasAttemptedHandoffRefresh(githubLogin: string): boolean {
+  try {
+    return sessionStorage.getItem(handoffAttemptKey(githubLogin)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Silently refresh the GitHub user token for an active ZK session that has
+ * unsealed titles but no token in sessionStorage — e.g. the session predates the
+ * auto-handoff deploy, or its ephemeral sessionStorage token is gone. Bounces
+ * through the OAuth handoff (GitHub re-authorises instantly for an already-
+ * installed app), which returns with ?zk_handoff=; ZkSessionProvider consumes it
+ * on the next mount, so the seal pass catches the new titles with no deco/reco.
+ *
+ * Once per session per login (loop guard): if the bounce returns without a token
+ * (server couldn't mint one), the caller falls back to the manual "Link GitHub"
+ * affordance instead of redirect-looping. No-ops when a token already exists.
+ *
+ * Returns true when a redirect was initiated (the page is navigating away).
+ */
+export function refreshGithubTokenViaHandoff(githubLogin: string): boolean {
+  if (getGithubUserToken()) return false;
+  if (hasAttemptedHandoffRefresh(githubLogin)) return false;
+  try {
+    // Set the guard BEFORE navigating: without it a bounce that returns no token
+    // would re-trigger on the next mount and loop. If storage is unavailable we
+    // can't guard, so we must not redirect at all.
+    sessionStorage.setItem(handoffAttemptKey(githubLogin), "1");
+  } catch {
+    return false;
+  }
+  const here = window.location.pathname + window.location.search + window.location.hash;
+  window.location.assign(zkLoginUrl(here));
+  return true;
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: GraphQL variables are caller-shaped
 type GraphqlVariables = Record<string, any> | undefined;
 

--- a/apps/app/src/zk/useDecryptedGraph.ts
+++ b/apps/app/src/zk/useDecryptedGraph.ts
@@ -43,6 +43,7 @@ export function useDecryptedGraph() {
   const [nodes, setNodes] = useState<AnnotatedNode[] | null>(null);
   const [sealTick, setSealTick] = useState(0);
   const [needsGithubLink, setNeedsGithubLink] = useState(false);
+  const [isSealingTitles, setIsSealingTitles] = useState(false);
   const sealedFor = useRef<GraphResponse | null>(null);
 
   // Decrypt → annotate whenever the graph, the lock state, or a fresh seal lands.
@@ -74,6 +75,12 @@ export function useDecryptedGraph() {
     sealedFor.current = data;
     let cancelled = false;
     (async () => {
+      // A linked GitHub token means the seal pass will fetch + import title
+      // content (potentially several batched GraphQL roundtrips) — surface that
+      // as a sync banner so redacted titles don't look stuck. No token → nothing
+      // to import here (the handoff bounce / fallback prompt handles that case).
+      const hasToken = Boolean(getGithubUserToken());
+      if (hasToken && !cancelled) setIsSealingTitles(true);
       try {
         const clones = data.nodes.map((n) => ({ ...n }));
         const sealResult = await ensureAccountKeySealing(githubLogin, clones);
@@ -82,13 +89,15 @@ export function useDecryptedGraph() {
         // is linked to pull issue content — surface the prompt (legacy
         // showZkGithubLinkNotice). Mirrors frontend/app.js init.
         if (!cancelled && sealResult?.needsGithubLink) setNeedsGithubLink(true);
-        if (getGithubUserToken()) {
+        if (hasToken) {
           const { synced } = await syncZkContentFromGitHub(clones, githubLogin);
           if (synced > 0) changed = true;
         }
         if (changed && !cancelled) setSealTick((t) => t + 1);
       } catch {
         /* sealing/sync is best-effort — titles fall back to "(sealed)" */
+      } finally {
+        if (!cancelled) setIsSealingTitles(false);
       }
     })();
     return () => {
@@ -96,14 +105,26 @@ export function useDecryptedGraph() {
     };
   }, [data, unlocked, zkAccountKeyEnabled, githubLogin]);
 
+  const annotated = nodes ?? [];
+  // Titles still being imported: null after decrypt (no ciphertext yet),
+  // excluding closed-hop stubs which legitimately carry no title.
+  const syncingTitleCount = annotated.reduce(
+    (n, node) => (node.title == null && !node.is_stub ? n + 1 : n),
+    0,
+  );
+
   return {
     ...query,
-    nodes: nodes ?? [],
+    nodes: annotated,
     edges: (data?.edges ?? []) as GraphEdge[],
     repos: (data?.repos ?? []) as RepoSummary[],
     // Hold "loading" through the first decrypt so titles never flash redacted.
     isLoading: query.isLoading || (Boolean(data) && nodes === null),
     needsGithubLink,
+    // True only while the GitHub-fetch seal pass runs AND titles remain redacted
+    // — gates the import banner (and suppresses its flicker once everything seals).
+    isSyncingTitles: isSealingTitles && syncingTitleCount > 0,
+    syncingTitleCount,
     // Re-read each render; sealTick state change after a migration re-evaluates it.
     zkMigrationIncomplete: isZkMigrationIncomplete(),
   };

--- a/apps/marketing/src/components/CtaBand.astro
+++ b/apps/marketing/src/components/CtaBand.astro
@@ -17,7 +17,7 @@ const { t } = Astro.props;
       </h2>
       <p class="cta-body">{t.cta.body}</p>
       <div class="cta-actions">
-        <a href="/admin" class="btn btn-primary">
+        <a href="https://app.live.roxabi.dev" data-app-link class="btn btn-primary">
           {t.cta.ctaPrimary}
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/apps/marketing/src/components/Hero.astro
+++ b/apps/marketing/src/components/Hero.astro
@@ -23,7 +23,7 @@ const { t } = Astro.props;
         </h1>
         <p class="hero-lead">{t.hero.lead}</p>
         <div class="hero-ctas">
-          <a href="#cta" class="btn btn-primary">{t.hero.ctaPrimary}</a>
+          <a href="https://app.live.roxabi.dev" data-app-link class="btn btn-primary">{t.hero.ctaPrimary}</a>
           <a href="#demo" class="btn btn-ghost">{t.hero.ctaGhost}</a>
         </div>
         <p class="hero-note">{t.hero.note}</p>

--- a/apps/marketing/src/components/SiteHeader.astro
+++ b/apps/marketing/src/components/SiteHeader.astro
@@ -30,8 +30,22 @@ const { t } = Astro.props;
 
     <div class="header-actions">
       <a href={t.langSwitchHref} class="btn-header-login">{t.langSwitchLabel}</a>
-      <a href="/admin" class="btn-header-login">{t.header.loginLabel}</a>
+      <a href="https://app.live.roxabi.dev" data-app-link class="btn-header-login">{t.header.loginLabel}</a>
       <a href="#cta" class="btn-header-cta">{t.header.ctaLabel}</a>
     </div>
   </div>
 </header>
+
+<script is:inline>
+  // The marketing site and the app live on sibling subdomains; point every
+  // login link at the app env matching the current marketing env (staging ↔
+  // staging, prod ↔ prod) so a staging visitor isn't bounced to the prod app.
+  // Default href in markup is the prod app, so the link works without JS too.
+  (function () {
+    var app = location.hostname.indexOf("staging") !== -1
+      ? "https://app-staging.live.roxabi.dev"
+      : "https://app.live.roxabi.dev";
+    var links = document.querySelectorAll("[data-app-link]");
+    for (var i = 0; i < links.length; i++) links[i].setAttribute("href", app);
+  })();
+</script>

--- a/apps/marketing/src/components/SiteHeader.astro
+++ b/apps/marketing/src/components/SiteHeader.astro
@@ -30,22 +30,30 @@ const { t } = Astro.props;
 
     <div class="header-actions">
       <a href={t.langSwitchHref} class="btn-header-login">{t.langSwitchLabel}</a>
-      <a href="https://app.live.roxabi.dev" data-app-link class="btn-header-login">{t.header.loginLabel}</a>
-      <a href="#cta" class="btn-header-cta">{t.header.ctaLabel}</a>
+      <a href="https://app.live.roxabi.dev" data-app-link class="btn-header-cta">{t.header.loginLabel}</a>
     </div>
   </div>
 </header>
 
 <script is:inline>
   // The marketing site and the app live on sibling subdomains; point every
-  // login link at the app env matching the current marketing env (staging ↔
-  // staging, prod ↔ prod) so a staging visitor isn't bounced to the prod app.
-  // Default href in markup is the prod app, so the link works without JS too.
+  // [data-app-link] (header + hero + CTA band) at the app env matching the
+  // current marketing env (staging ↔ staging, prod ↔ prod) so a staging visitor
+  // isn't bounced to the prod app. The markup default is the prod app URL, so
+  // the links work without JS too. Wait for DOMContentLoaded so links rendered
+  // below this header (hero, CTA band) are already in the DOM.
   (function () {
-    var app = location.hostname.indexOf("staging") !== -1
-      ? "https://app-staging.live.roxabi.dev"
-      : "https://app.live.roxabi.dev";
-    var links = document.querySelectorAll("[data-app-link]");
-    for (var i = 0; i < links.length; i++) links[i].setAttribute("href", app);
+    function wire() {
+      var app = location.hostname.indexOf("staging") !== -1
+        ? "https://app-staging.live.roxabi.dev"
+        : "https://app.live.roxabi.dev";
+      var links = document.querySelectorAll("[data-app-link]");
+      for (var i = 0; i < links.length; i++) links[i].setAttribute("href", app);
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", wire);
+    } else {
+      wire();
+    }
   })();
 </script>

--- a/apps/marketing/src/i18n/en.ts
+++ b/apps/marketing/src/i18n/en.ts
@@ -11,7 +11,6 @@ export const en: Translations = {
     navComment:   "Feedback",
     navAdmin:     "Admin",
     loginLabel:   "Sign in",
-    ctaLabel:     "Early access",
   },
 
   // ── Hero ──────────────────────────────────────────────────────────────────
@@ -21,7 +20,7 @@ export const en: Translations = {
     h1Part1:      "Launch ten agents at once.",
     h1Accent:     "Without collisions.",
     lead:         "The bottleneck for an agent fleet is no longer writing code — it's concurrency. Roxabi Live reads your GitHub issues and their blocked-by links to reveal, at a glance, what you can run in parallel.",
-    ctaPrimary:   "Request early access",
+    ctaPrimary:   "Sign in",
     ctaGhost:     "View demo",
     note:         "Native GitHub Issues · no third-party tools · zero adoption friction",
     boardTitle:   "roxabi-live · dashboard",
@@ -151,13 +150,13 @@ export const en: Translations = {
 
   // ── CTA Band ──────────────────────────────────────────────────────────────
   cta: {
-    kicker:      "Early access",
+    kicker:      "Get started",
     h2Part1:     "Ready to run your fleet",
     h2Accent:    "without collisions?",
     body:        "Join the teams orchestrating their Claude agents with GitHub dependency graphs, in real time.",
-    ctaPrimary:  "Request early access",
+    ctaPrimary:  "Sign in",
     ctaGhost:    "View demo",
-    reassurance: "Invite-only access · Native GitHub Issues · no card required",
+    reassurance: "Native GitHub Issues · no card required · zero adoption friction",
   },
 
   // ── Footer ────────────────────────────────────────────────────────────────

--- a/apps/marketing/src/i18n/fr.ts
+++ b/apps/marketing/src/i18n/fr.ts
@@ -9,7 +9,6 @@ export const fr = {
     navComment:   "Commentaires",
     navAdmin:     "Admin",
     loginLabel:   "Connexion",
-    ctaLabel:     "Accès anticipé",
   },
 
   // ── Hero ──────────────────────────────────────────────────────────────────
@@ -19,7 +18,7 @@ export const fr = {
     h1Part1:      "Lancez dix agents à la fois.",
     h1Accent:     "Sans qu'ils se marchent dessus.",
     lead:         "Le goulot d'étranglement d'une flotte d'agents, ce n'est plus l'écriture du code — c'est la concurrence. Roxabi Live lit vos issues GitHub et leurs liens blocked-by pour révéler, d'un coup d'œil, ce que vous pouvez lancer en parallèle.",
-    ctaPrimary:   "Demander l'accès anticipé",
+    ctaPrimary:   "Se connecter",
     ctaGhost:     "Voir la démo",
     note:         "GitHub Issues natif · aucun outil tiers · zéro friction d'adoption",
     boardTitle:   "roxabi-live · tableau de bord",
@@ -149,13 +148,13 @@ export const fr = {
 
   // ── CTA Band ──────────────────────────────────────────────────────────────
   cta: {
-    kicker:      "Accès anticipé",
+    kicker:      "Commencer",
     h2Part1:     "Prêt à piloter votre flotte",
     h2Accent:    "sans collision ?",
     body:        "Rejoignez les équipes qui orchestrent leurs agents Claude avec des graphes de dépendances GitHub, en temps réel.",
-    ctaPrimary:  "Demander l'accès anticipé",
+    ctaPrimary:  "Se connecter",
     ctaGhost:    "Voir la démo",
-    reassurance: "Accès sur invitation · GitHub Issues natif · aucune carte requise",
+    reassurance: "GitHub Issues natif · aucune carte requise · zéro friction d'adoption",
   },
 
   // ── Footer ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up work pushed onto the #278 branch after that PR auto-merged at `cea13bd9`. Seven commits, stranded on the branch → this PR lands them on `staging`.

## Dashboard (apps/app)
- **FR/EN i18n** for the cockpit (slice 8): `fr.ts` typed source + `en.ts = typeof fr`, `useT()` dot-path + `{var}`, `LangToggle`, `roxabi:locale`, default = browser lang.
- **dim empty-labels localized** via `i18n/dimLabel.ts` `localizedDimLabel()` (graph gutter, table, pivot); Epics regrouped under a "Display" cluster.

## ZK (zero-knowledge titles)
- **Self-heal stale sessions** — silent OAuth-handoff bounce (`refreshGithubTokenViaHandoff`) when an active session has unsealed titles but no GitHub token, with a once-per-session loop guard + manual-link fallback. No more deco/reco to seal recent issues.
- **Import banner** (`TitleSyncBanner`) while the seal pass fetches titles from GitHub — `isSyncingTitles` gated on unsealed count to avoid flicker.

## Marketing (apps/marketing)
- **Header "Connexion" → app** (was `/admin`), env-aware via hostname (`data-app-link` + `is:inline` DOMContentLoaded script): staging marketing → app-staging, prod → app.
- **CTAs switched from "early access" → Connexion / Se connecter → app** (header, hero, CTA band — one pointed at `/admin`); dropped the early-access framing copy. "Voir la démo" left for later.

## Verification
- app 58/58 · api 802/802 · Biome clean · both typechecks · marketing + app builds green.
- Browser-verified on prod builds: i18n FR/EN, dim labels, Epics group, import banner (spinner against compiled CSS), `/sign-in` neutral (logout fix), all 3 marketing CTAs env-aware (prod + staging hostnames).
- app-staging deployed throughout the session for live checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)