### PR TITLE
fix(ci): unify staging deploy + stop /dashboard redirects

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -23,7 +23,7 @@ lsp:
   server: typescript-language-server
 
 deploy:
-  platform: cloudflare  # Workers Builds (git-connected); push staging/main → CF auto deploy. SSOT: infra/workers-builds.json
+  platform: cloudflare  # Staging: GitHub Actions → wrangler (.github/workflows/deploy-staging.yml). Prod: manual wrangler for now.
 
 docs:
   framework: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,5 +102,6 @@ jobs:
   # the cockpit is apps/app (covered by the `app` job). Its retirement removes the
   # old `frontend` CI job. frontend/ itself is deleted once the cutover is live.
 
-  # Deploy: Cloudflare Workers Builds (git-connected). See docs/DEPLOY.md §8 and
-  # infra/workers-builds.json. CI runs quality gates only — no wrangler deploy here.
+  # Deploy: GitHub Actions (.github/workflows/deploy-staging.yml on push to staging).
+  # CF Workers Builds is not connected (infra/workers-builds.json is unapplied).
+  # CI runs quality gates only — no wrangler deploy here.

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,25 +1,26 @@
-name: Deploy staging frontend
+name: Deploy staging
 
-# Auto-deploy the two staging frontend Workers on a push to `staging`.
+# Auto-deploy the three staging Workers on push to `staging`.
 #
-# Why this lives in GitHub Actions and not CF Workers Builds: the repo's
-# infra/workers-builds.json is an UNAPPLIED spec — CF Workers Builds was never
-# actually connected (no Cloudflare GitHub App on the repo, zero GitHub
-# Deployments, every worker deploys via `wrangler` by hand). GitHub Actions is the
-# repo's real automation, so the staging auto-deploy belongs here. CI (ci.yml)
-# stays quality-gates-only; this is the deploy half, scoped to the two staging
-# preview Workers. The api worker + prod targets remain manual / out of scope.
+# CF Workers Builds is NOT connected on this repo (infra/workers-builds.json is an
+# unapplied spec — no Cloudflare GitHub App, zero GitHub Deployments). GitHub
+# Actions + wrangler is the real automation. CI (ci.yml) stays quality-gates-only.
 #
+#   apps/api       → roxabi-live-staging          → api-staging.live.roxabi.dev
 #   apps/app       → roxabi-live-app-staging       → app-staging.live.roxabi.dev
 #   apps/marketing → roxabi-live-marketing-staging → marketing-staging.live.roxabi.dev
+#
+# Prod targets remain manual until equivalent workflows exist on `main`.
 
 on:
   push:
     branches: [staging]
     paths:
+      - "apps/api/**"
       - "apps/app/**"
       - "apps/marketing/**"
       - "packages/**"
+      - "scripts/deploy-staging.sh"
       - "bun.lock"
   workflow_dispatch: {}
 
@@ -27,15 +28,25 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-staging-frontend-${{ github.ref }}
+  group: deploy-staging-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  # Account IDs are not secret; mirror the hardcoded default in scripts/deploy-staging.sh.
+  # Account IDs are not secret; mirror scripts/deploy-staging.sh.
   CLOUDFLARE_ACCOUNT_ID: b5e90be971920ce406f7b679c4f1cd33
 
 jobs:
+  api:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Deploy roxabi-live-staging (D1 migrate + wrangler)
+        run: bash scripts/deploy-staging.sh
+
   app:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,12 +145,21 @@ Rules: add/delete/move → update P | new `apps/api/src/` or `apps/app/src/` sub
 
 ## Deploy pattern
 
-**Prod (Cloudflare — CI-driven, 3 targets post-cutover)**
+**Staging (GitHub Actions — auto on push to `staging`)**
 
-CF Workers Builds (git-connected, SSoT `infra/workers-builds.json`):
-- `roxabi-live` (api) — push `main`/`staging` → `scripts/deploy-{production,staging}.sh` (bun install → D1 migrate → `wrangler deploy` from `apps/api`, route `api.live.roxabi.dev`)
-- `roxabi-live-app` (SPA) — push `main` → `bun --filter @roxabi-live/app build` → `wrangler deploy --config apps/app/wrangler.deploy.jsonc`, route `app.live.roxabi.dev`
-- marketing (`apps/marketing`) — CF **Pages** git-connect at apex `live.roxabi.dev`
+`.github/workflows/deploy-staging.yml` — wrangler deploy via `CLOUDFLARE_API_TOKEN` repo secret:
+- `roxabi-live-staging` (api) — `scripts/deploy-staging.sh` → `api-staging.live.roxabi.dev`
+- `roxabi-live-app-staging` (SPA) — build `@roxabi-live/app` → `app-staging.live.roxabi.dev`
+- `roxabi-live-marketing-staging` (Astro) — build `@roxabi-live/marketing` → `marketing-staging.live.roxabi.dev`
+
+Manual: `gh workflow run deploy-staging.yml --ref staging`
+
+**Prod (manual wrangler for now — Workers Builds never connected)**
+
+`infra/workers-builds.json` is an **unapplied** spec (no Cloudflare GitHub App on the repo):
+- `roxabi-live` (api) — `scripts/deploy-production.sh` → `api.live.roxabi.dev`
+- `roxabi-live-app` (SPA) — `bun --filter @roxabi-live/app build` → `wrangler.deploy.jsonc` → `app.live.roxabi.dev` (DNS pending)
+- marketing (`apps/marketing`) — Astro Worker/Pages target at apex `live.roxabi.dev` (not yet live; prod apex still serves legacy `frontend/`)
 
 Secrets (set once on the api worker; `CLOUDFLARE_ACCOUNT_ID` required — token sees 2 accounts):
 ```bash

--- a/apps/api/src/auth/cookies.test.ts
+++ b/apps/api/src/auth/cookies.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeAuthRedirect } from "./cookies";
+import { sanitizeAuthRedirect, stripInstallParam } from "./cookies";
 
 describe("sanitizeAuthRedirect", () => {
   // Post-cutover the safe default is the SPA index "/" (app.live.roxabi.dev),
@@ -26,5 +26,16 @@ describe("sanitizeAuthRedirect", () => {
     expect(sanitizeAuthRedirect('/x" onclick')).toBe("/");
     expect(sanitizeAuthRedirect("/x<script>")).toBe("/");
     expect(sanitizeAuthRedirect("/x'y")).toBe("/");
+  });
+});
+
+describe("stripInstallParam", () => {
+  it("keeps SPA index / after stripping install (not legacy /dashboard)", () => {
+    expect(stripInstallParam("/?install=1")).toBe("/");
+    expect(stripInstallParam("/")).toBe("/");
+  });
+
+  it("strips install from deeper paths", () => {
+    expect(stripInstallParam("/dashboard/?install=1")).toBe("/dashboard");
   });
 });

--- a/apps/api/src/auth/cookies.ts
+++ b/apps/api/src/auth/cookies.ts
@@ -64,7 +64,7 @@ export function stripInstallParam(path: string): string {
   const url = new URL(path, "https://_/");
   if (!url.searchParams.has("install")) return path;
   url.searchParams.delete("install");
-  const pathname = url.pathname.replace(/\/$/, "") || "/dashboard";
+  const pathname = url.pathname.replace(/\/$/, "") || "/";
   return `${pathname}${url.search}`;
 }
 

--- a/apps/app/src/auth/InstallGate.tsx
+++ b/apps/app/src/auth/InstallGate.tsx
@@ -15,7 +15,7 @@ import type { InstallOption, MePayload } from "@roxabi-live/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-const DEFAULT_FALLBACK = "/login?intent=install&redirect=%2Fdashboard";
+const DEFAULT_FALLBACK = "/login?intent=install&redirect=%2F";
 
 function optionCopy(
   opt: InstallOption,

--- a/apps/app/src/auth/SignInScreen.tsx
+++ b/apps/app/src/auth/SignInScreen.tsx
@@ -9,13 +9,13 @@ import { useT } from "@/i18n";
 import { GithubLogo } from "@phosphor-icons/react";
 import { useState } from "react";
 
-const DASHBOARD_PATH = "/dashboard";
+const COCKPIT_PATH = "/";
 const REMEMBER_SESSION_KEY = "roxabi:remember_session";
 
 function safeRedirect(raw: string | null): string {
   const c = raw?.trim();
   if (c && /^\/(?![/\\])/.test(c) && !/[\r\n\0]/.test(c) && !/["'<>]/.test(c)) return c;
-  return DASHBOARD_PATH;
+  return COCKPIT_PATH;
 }
 
 function loginUrl(remember: boolean): string {

--- a/apps/marketing/src/components/CtaBand.astro
+++ b/apps/marketing/src/components/CtaBand.astro
@@ -17,7 +17,7 @@ const { t } = Astro.props;
       </h2>
       <p class="cta-body">{t.cta.body}</p>
       <div class="cta-actions">
-        <a href="https://app.live.roxabi.dev" data-app-link class="btn btn-primary">
+        <a href="https://app.live.roxabi.dev/" data-app-link class="btn btn-primary">
           {t.cta.ctaPrimary}
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/apps/marketing/src/components/Hero.astro
+++ b/apps/marketing/src/components/Hero.astro
@@ -23,7 +23,7 @@ const { t } = Astro.props;
         </h1>
         <p class="hero-lead">{t.hero.lead}</p>
         <div class="hero-ctas">
-          <a href="https://app.live.roxabi.dev" data-app-link class="btn btn-primary">{t.hero.ctaPrimary}</a>
+          <a href="https://app.live.roxabi.dev/" data-app-link class="btn btn-primary">{t.hero.ctaPrimary}</a>
           <a href="#demo" class="btn btn-ghost">{t.hero.ctaGhost}</a>
         </div>
         <p class="hero-note">{t.hero.note}</p>

--- a/apps/marketing/src/components/SiteHeader.astro
+++ b/apps/marketing/src/components/SiteHeader.astro
@@ -30,7 +30,7 @@ const { t } = Astro.props;
 
     <div class="header-actions">
       <a href={t.langSwitchHref} class="btn-header-login">{t.langSwitchLabel}</a>
-      <a href="https://app.live.roxabi.dev" data-app-link class="btn-header-cta">{t.header.loginLabel}</a>
+      <a href="https://app.live.roxabi.dev/" data-app-link class="btn-header-cta">{t.header.loginLabel}</a>
     </div>
   </div>
 </header>
@@ -48,7 +48,7 @@ const { t } = Astro.props;
         ? "https://app-staging.live.roxabi.dev"
         : "https://app.live.roxabi.dev";
       var links = document.querySelectorAll("[data-app-link]");
-      for (var i = 0; i < links.length; i++) links[i].setAttribute("href", app);
+      for (var i = 0; i < links.length; i++) links[i].setAttribute("href", app + "/");
     }
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", wire);

--- a/apps/marketing/wrangler.staging.jsonc
+++ b/apps/marketing/wrangler.staging.jsonc
@@ -1,7 +1,7 @@
 {
   // Staging preview of the marketing/landing site (Astro SSG → static assets).
-  // Prod target is CF Pages at the apex live.roxabi.dev (dashboard git-connect);
-  // this assets-only Worker gives a stable staging URL in the meantime.
+  // Staging preview Worker. Prod apex live.roxabi.dev still serves legacy frontend/
+  // until the Astro marketing deploy is cut over (see docs/cutover-monorepo.md).
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "roxabi-live-marketing-staging",
   "compatibility_date": "2025-06-01",

--- a/infra/workers-builds.json
+++ b/infra/workers-builds.json
@@ -1,4 +1,5 @@
 {
+  "_note": "UNAPPLIED — CF Workers Builds was never connected (no Cloudflare GitHub App). Staging auto-deploy lives in .github/workflows/deploy-staging.yml. Do not treat this file as live infra.",
   "accountId": "b5e90be971920ce406f7b679c4f1cd33",
   "github": {
     "owner": "Roxabi",


### PR DESCRIPTION
## Summary
- Consolidate staging auto-deploy into `deploy-staging.yml` (api + app + marketing Workers)
- Align docs with reality (Workers Builds never connected; GHA is the automation)
- Fix post-auth redirects landing on legacy `/dashboard` instead of SPA `/`

## Test plan
- [ ] Merge → `deploy-staging` workflow runs green on staging
- [ ] `marketing-staging.live.roxabi.dev` Connexion → `app-staging.live.roxabi.dev/`
- [ ] OAuth round-trip lands on `/`, not `/dashboard`