### PR TITLE
feat(deploy): prod cutover via wrangler + deploy-main.yml

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,26 +1,22 @@
-name: Deploy staging
+name: Deploy production
 
-# Auto-deploy the three staging Workers on push to `staging`.
+# Auto-deploy production Workers on push to `main`.
+# Same model as deploy-staging.yml — GHA builds + wrangler deploy (CF Workers Builds
+# is not connected). Requires CLOUDFLARE_API_TOKEN repo secret.
 #
-# CF Workers Builds is NOT connected on this repo (infra/workers-builds.json is an
-# unapplied spec — no Cloudflare GitHub App, zero GitHub Deployments). GitHub
-# Actions + wrangler is the real automation. CI (ci.yml) stays quality-gates-only.
-#
-#   apps/api       → roxabi-live-staging          → api-staging.live.roxabi.dev
-#   apps/app       → roxabi-live-app-staging       → app-staging.live.roxabi.dev
-#   apps/marketing → roxabi-live-marketing-staging → marketing-staging.live.roxabi.dev
-#
-# Prod: see deploy-main.yml (push to `main`).
+#   apps/api       → roxabi-live       → api.live.roxabi.dev
+#   apps/app       → roxabi-live-app   → app.live.roxabi.dev
+#   apps/marketing → roxabi-live-marketing → live.roxabi.dev (when apex cutover is live)
 
 on:
   push:
-    branches: [staging]
+    branches: [main]
     paths:
       - "apps/api/**"
       - "apps/app/**"
       - "apps/marketing/**"
       - "packages/**"
-      - "scripts/deploy-staging.sh"
+      - "scripts/deploy-production.sh"
       - "bun.lock"
   workflow_dispatch: {}
 
@@ -28,12 +24,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-staging-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-main-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  # Account IDs are not secret; mirror scripts/deploy-staging.sh.
   CLOUDFLARE_ACCOUNT_ID: b5e90be971920ce406f7b679c4f1cd33
 
 jobs:
@@ -44,12 +39,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      - name: Deploy roxabi-live-staging (D1 migrate + wrangler)
-        run: bash scripts/deploy-staging.sh
+      - name: Deploy roxabi-live (D1 migrate + wrangler)
+        run: bash scripts/deploy-production.sh
 
   app:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: api
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Bun
@@ -58,12 +54,13 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Build (app)
         run: bun --filter @roxabi-live/app build
-      - name: Deploy roxabi-live-app-staging
-        run: cd apps/app && bunx wrangler deploy --config wrangler.staging.jsonc
+      - name: Deploy roxabi-live-app
+        run: cd apps/app && bunx wrangler deploy --config wrangler.deploy.jsonc
 
   marketing:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: api
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Bun
@@ -72,5 +69,5 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Build (marketing)
         run: bun --filter @roxabi-live/marketing build
-      - name: Deploy roxabi-live-marketing-staging
-        run: cd apps/marketing && bunx wrangler deploy --config wrangler.staging.jsonc
+      - name: Deploy roxabi-live-marketing
+        run: cd apps/marketing && bunx wrangler deploy --config wrangler.deploy.jsonc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,12 +154,16 @@ Rules: add/delete/move → update P | new `apps/api/src/` or `apps/app/src/` sub
 
 Manual: `gh workflow run deploy-staging.yml --ref staging`
 
-**Prod (manual wrangler for now — Workers Builds never connected)**
+**Prod (GitHub Actions on `main` + break-glass wrangler)**
 
-`infra/workers-builds.json` is an **unapplied** spec (no Cloudflare GitHub App on the repo):
+`.github/workflows/deploy-main.yml` — same token, order: api → app + marketing:
 - `roxabi-live` (api) — `scripts/deploy-production.sh` → `api.live.roxabi.dev`
-- `roxabi-live-app` (SPA) — `bun --filter @roxabi-live/app build` → `wrangler.deploy.jsonc` → `app.live.roxabi.dev` (DNS pending)
-- marketing (`apps/marketing`) — Astro Worker/Pages target at apex `live.roxabi.dev` (not yet live; prod apex still serves legacy `frontend/`)
+- `roxabi-live-app` (SPA) — `wrangler.deploy.jsonc` → `app.live.roxabi.dev`
+- `roxabi-live-marketing` (Astro) — `wrangler.deploy.jsonc` → `live.roxabi.dev`
+
+Break-glass (BW global key): `source scripts/bw-cloudflare-global-env.sh` then the deploy scripts / `wrangler deploy`.
+
+`infra/workers-builds.json` is **unapplied** until the Cloudflare GitHub App is authorized in the dashboard; GHA is the live automation.
 
 Secrets (set once on the api worker; `CLOUDFLARE_ACCOUNT_ID` required — token sees 2 accounts):
 ```bash

--- a/apps/app/wrangler.deploy.jsonc
+++ b/apps/app/wrangler.deploy.jsonc
@@ -5,13 +5,7 @@
   "name": "roxabi-live-app",
   "main": "worker.ts",
   "compatibility_date": "2025-06-01",
-  "routes": [
-    {
-      "pattern": "app.live.roxabi.dev/*",
-      "zone_name": "live.roxabi.dev"
-      // "custom_domain": true  // uncomment at domain cutover
-    }
-  ],
+  "routes": [{ "pattern": "app.live.roxabi.dev", "custom_domain": true }],
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",

--- a/apps/marketing/wrangler.deploy.jsonc
+++ b/apps/marketing/wrangler.deploy.jsonc
@@ -1,0 +1,10 @@
+{
+  // Production marketing site — Astro SSG → static assets Worker.
+  // Apex live.roxabi.dev: wrangler attaches custom_domain on first deploy;
+  // if the apex is still on roxabi-live, delete that domain first (see scripts/cutover-marketing-apex.sh).
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "roxabi-live-marketing",
+  "compatibility_date": "2025-06-01",
+  "assets": { "directory": "./dist" },
+  "routes": [{ "pattern": "live.roxabi.dev", "custom_domain": true }]
+}

--- a/infra/workers-builds.json
+++ b/infra/workers-builds.json
@@ -64,6 +64,17 @@
         "branchIncludes": ["staging"],
         "branchExcludes": []
       }
+    },
+    {
+      "workerName": "roxabi-live-marketing",
+      "trigger": {
+        "name": "Deploy production (marketing)",
+        "rootDirectory": "/",
+        "buildCommand": "bun install --frozen-lockfile && bun --filter @roxabi-live/marketing build",
+        "deployCommand": "cd apps/marketing && bunx wrangler deploy --config wrangler.deploy.jsonc",
+        "branchIncludes": ["main"],
+        "branchExcludes": []
+      }
     }
   ]
 }

--- a/scripts/cutover-marketing-apex.sh
+++ b/scripts/cutover-marketing-apex.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Move apex live.roxabi.dev from roxabi-live (legacy api worker) to roxabi-live-marketing.
+# Requires CLOUDFLARE_EMAIL + CLOUDFLARE_API_KEY (source scripts/bw-cloudflare-global-env.sh).
+set -euo pipefail
+
+: "${CLOUDFLARE_ACCOUNT_ID:=b5e90be971920ce406f7b679c4f1cd33}"
+APEX="live.roxabi.dev"
+
+list_domains() {
+  curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains" \
+    -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+    -H "X-Auth-Key: ${CLOUDFLARE_API_KEY}"
+}
+
+delete_domain() {
+  local id="$1"
+  curl -s -X DELETE \
+    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains/${id}" \
+    -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+    -H "X-Auth-Key: ${CLOUDFLARE_API_KEY}"
+}
+
+domain_id="$(list_domains | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for d in data.get('result', []):
+    if d.get('hostname') == '${APEX}':
+        print(d['id'])
+        break
+")"
+
+if [[ -z "${domain_id}" ]]; then
+  echo "✓ No worker domain on ${APEX} — safe to deploy roxabi-live-marketing"
+  exit 0
+fi
+
+service="$(list_domains | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for d in data.get('result', []):
+    if d.get('hostname') == '${APEX}':
+        print(d.get('service',''))
+        break
+")"
+
+echo "→ ${APEX} currently on worker: ${service}"
+if [[ "${service}" != "roxabi-live" ]]; then
+  echo "Refusing to delete — unexpected service. Reconcile manually in the dashboard." >&2
+  exit 1
+fi
+
+echo "→ Removing ${APEX} from roxabi-live (api worker keeps api.live.roxabi.dev)"
+delete_domain "${domain_id}" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('success') else 1)"
+echo "✓ Apex detached — run: cd apps/marketing && bunx wrangler deploy --config wrangler.deploy.jsonc"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -18,6 +18,6 @@ echo "→ D1 migrations (production)"
 bunx wrangler d1 migrations apply DB --remote
 
 echo "→ wrangler deploy (production)"
-bunx wrangler deploy --old-asset-ttl 0
+bunx wrangler deploy --env="" --old-asset-ttl 0
 
 echo "✓ roxabi-live (api) production deployed"


### PR DESCRIPTION
## Summary
Production Workers deployed via wrangler + BW global API key:
- `api.live.roxabi.dev` → `roxabi-live`
- `app.live.roxabi.dev` → `roxabi-live-app` (created)
- `live.roxabi.dev` → `roxabi-live-marketing` (Astro apex)

Adds `deploy-main.yml` for auto-deploy on push to `main` (after promote).

## Post-merge checklist (human)
- [ ] GitHub App: webhook → `https://api.live.roxabi.dev/webhook/github`
- [ ] GitHub App: OAuth callback → `https://app.live.roxabi.dev/oauth/callback`
- [ ] CF Access on `api.live.roxabi.dev` (bypass `/webhook/*`)