### PR TITLE
fix(auth): restore logo on post-OAuth loading screen

### DIFF
--- a/apps/api/src/auth/post-oauth.ts
+++ b/apps/api/src/auth/post-oauth.ts
@@ -52,7 +52,7 @@ body::before{content:"";position:fixed;inset:0;pointer-events:none;background:ra
 .auth-nav-shell{position:relative;z-index:1;width:100%;max-width:380px}
 .auth-nav-card{background:var(--bg-elevated);border:1px solid var(--border-hi);border-radius:var(--radius-lg);box-shadow:var(--panel-shadow);padding:32px 28px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:18px}
 .auth-nav-brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:18px;letter-spacing:-.02em}
-.auth-nav-brand img{width:28px;height:28px}
+.auth-nav-brand svg{width:28px;height:28px;flex-shrink:0}
 .auth-nav-brand .accent{color:var(--accent)}
 .auth-nav-spinner{width:40px;height:40px;border-radius:50%;border:3px solid var(--border);border-top-color:var(--accent);animation:auth-nav-spin .9s linear infinite}
 @keyframes auth-nav-spin{to{transform:rotate(360deg)}}
@@ -67,7 +67,7 @@ body::before{content:"";position:fixed;inset:0;pointer-events:none;background:ra
 <main class="auth-nav-shell" role="main">
   <div class="auth-nav-card" role="status" aria-live="polite" aria-busy="true">
     <div class="auth-nav-brand">
-      <img src="/assets/logo/foundation-block-16.svg" alt="" width="28" height="28" />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="28" height="28" aria-hidden="true"><polygon points="3,5.5 8,8 8,13 3,10.5" fill="#11161d"/><polygon points="13,5.5 13,10.5 8,13 8,8" fill="#171e27"/><polygon points="8,3 13,5.5 8,8 3,5.5" fill="#1c2431"/><polygon points="8,4 11,5.5 8,7 5,5.5" fill="#f0b429"/><path d="M8,3 13,5.5 13,10.5 8,13 3,10.5 3,5.5Z" fill="none" stroke="#f0b429" stroke-width="0.8" stroke-linejoin="round"/><path d="M3,5.5 8,8 8,13 M13,5.5 8,8" fill="none" stroke="#f0b429" stroke-width="0.6" stroke-linejoin="round" opacity="0.7"/></svg>
       <span>Roxabi <span class="accent">Live</span></span>
     </div>
     <div class="auth-nav-spinner" aria-hidden="true"></div>

--- a/apps/app/public/assets/logo/foundation-block-16.svg
+++ b/apps/app/public/assets/logo/foundation-block-16.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" role="img" aria-label="Roxabi">
+  <!-- Favicon variant of "C / Open top" — same silhouette, simplified for 16px:
+       solid faces, a flat amber top aperture, crisp amber edges, no blur. -->
+  <polygon points="3,5.5 8,8 8,13 3,10.5"  fill="#11161d"/>   <!-- left  -->
+  <polygon points="13,5.5 13,10.5 8,13 8,8" fill="#171e27"/>   <!-- right -->
+  <polygon points="8,3 13,5.5 8,8 3,5.5"    fill="#1c2431"/>   <!-- top   -->
+  <polygon points="8,4 11,5.5 8,7 5,5.5"    fill="#f0b429"/>   <!-- open top aperture (flat amber) -->
+  <path d="M8,3 13,5.5 13,10.5 8,13 3,10.5 3,5.5Z" fill="none" stroke="#f0b429" stroke-width="0.8" stroke-linejoin="round"/>
+  <path d="M3,5.5 8,8 8,13 M13,5.5 8,8" fill="none" stroke="#f0b429" stroke-width="0.6" stroke-linejoin="round" opacity="0.7"/>
+</svg>


### PR DESCRIPTION
## Summary

- Fixes the broken Roxabi logo on the post-GitHub OAuth interstitial ("Connexion en cours…").
- Inlines the foundation-block SVG in `post-oauth.ts` so the mark renders without a separate asset request.
- Adds `apps/app/public/assets/logo/foundation-block-16.svg` so Pages serves the favicon/brand asset at `/assets/logo/…`.

## Root cause

After the SPA cutover, `/assets/logo/foundation-block-16.svg` was only present in legacy `frontend/` assets, not in the React app `public/` folder served by Cloudflare Pages.

## Test plan

- [x] `bun test src/auth/session.test.ts` (authNavigateHtml)
- [ ] Sign in via GitHub on staging and confirm the loading screen shows the logo