### PR TITLE
fix(auth): stop showing session expired for unauthenticated visits

### DIFF
--- a/apps/app/src/auth/AuthGate.tsx
+++ b/apps/app/src/auth/AuthGate.tsx
@@ -2,7 +2,7 @@
  * AuthGate — the server-owned onboarding gate, ported from frontend/auth.js
  * requireAuthGate(). Resolves GET /api/me, then routes:
  *
- *   401 / no session   → <SignInScreen/>  (marketing landing owns this post-cutover)
+ *   401 / no session   → <SignInScreen/> (neutral — not "session expired")
  *   onboarding "install" → <InstallGate/>
  *   onboarding "consent" → <ConsentGate/>
  *   onboarding "ready"   → <AuthProvider> children
@@ -39,7 +39,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   if (isLoading) return <AuthLoading />;
 
   if (error) {
-    if (error.status === 401) return <SignInScreen reason="session-lost" />;
+    if (error.status === 401) return <SignInScreen />;
     return (
       <div
         className="mx-auto max-w-md py-16 text-center text-sm text-blocked"

--- a/apps/app/src/auth/SignInScreen.tsx
+++ b/apps/app/src/auth/SignInScreen.tsx
@@ -25,6 +25,10 @@ function loginUrl(remember: boolean): string {
   return `/login?${params}`;
 }
 
+function sessionLostFromUrl(): boolean {
+  return new URLSearchParams(location.search).get("reason") === "session-lost";
+}
+
 export function SignInScreen({
   mode = "signin",
   reason,
@@ -33,6 +37,7 @@ export function SignInScreen({
   reason?: "session-lost";
 }) {
   const t = useT();
+  const showSessionLost = reason === "session-lost" || sessionLostFromUrl();
   const [remember, setRemember] = useState(
     () => localStorage.getItem(REMEMBER_SESSION_KEY) === "1",
   );
@@ -50,7 +55,7 @@ export function SignInScreen({
         <h1 className="text-xl font-semibold text-foreground">
           {isSignup ? t("auth.signup.title") : t("auth.signin.title")}
         </h1>
-        {reason === "session-lost" && (
+        {showSessionLost && (
           <p className="rounded-md border border-blocked/30 bg-blocked/10 px-3 py-2 text-sm text-blocked">
             {t("auth.sessionLost")}
           </p>

--- a/apps/app/src/auth/useAuthMutations.ts
+++ b/apps/app/src/auth/useAuthMutations.ts
@@ -73,9 +73,8 @@ export function useLogout() {
     },
     onSuccess: (_data, vars) => {
       qc.clear();
-      // Default to /sign-in (a neutral SignInScreen). Landing on "/" would let
-      // AuthGate read the now-revoked session as a 401 and flash the alarming
-      // "Session expired" banner — wrong after a deliberate logout.
+      // Default to /sign-in — explicit guest entry. AuthGate also shows a neutral
+      // sign-in on "/" when unauthenticated (no "session expired" banner).
       window.location.href = vars?.to ?? "/sign-in";
     },
   });


### PR DESCRIPTION
## Summary

- Visiting `app.live.roxabi.dev/` without a session no longer shows "Session expired".
- `AuthGate` now renders a neutral sign-in screen on `GET /api/me` 401.
- The session-expired banner is reserved for an explicit `?reason=session-lost` URL when we know the session died mid-flight.

## Root cause

`AuthGate` passed `reason="session-lost"` for every 401, conflating "not signed in" (first visit, clean logout, bookmarked `/`) with an actual expired session.

## Test plan

- [x] `bun run typecheck` (apps/app)
- [ ] Visit `/` logged out → neutral sign-in, no red banner
- [ ] Visit `/?reason=session-lost` → banner still shown when intended