### PR TITLE
fix(auth): harden OAuth callback GitHub REST calls

### DIFF
--- a/apps/api/src/auth/github-rest.test.ts
+++ b/apps/api/src/auth/github-rest.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { githubRestGet, githubRestHeaders } from "./github-rest";
+
+describe("githubRestHeaders", () => {
+  it("includes API version and user agent", () => {
+    const headers = githubRestHeaders("tok");
+    expect(headers).toMatchObject({
+      Authorization: "Bearer tok",
+      Accept: "application/vnd.github+json",
+      "User-Agent": "roxabi-live-worker",
+      "X-GitHub-Api-Version": "2022-11-28",
+    });
+  });
+});
+
+describe("githubRestGet", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("retries transient 503 then succeeds", async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1) return new Response("busy", { status: 503 });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }),
+    );
+
+    const res = await githubRestGet("https://api.github.com/user", "tok", { retries: 1 });
+    expect(res.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/api/src/auth/github-rest.ts
+++ b/apps/api/src/auth/github-rest.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared GitHub REST helpers — versioned headers + short retry for transient 5xx/429.
+ * OAuth and sync paths must stay aligned (oauth.ts previously omitted X-GitHub-Api-Version).
+ */
+
+export const GITHUB_REST_API_VERSION = "2022-11-28" as const;
+
+const RETRYABLE = new Set([429, 502, 503, 504]);
+
+export function githubRestHeaders(token?: string): HeadersInit {
+  return {
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    Accept: "application/vnd.github+json",
+    "User-Agent": "roxabi-live-worker",
+    "X-GitHub-Api-Version": GITHUB_REST_API_VERSION,
+  };
+}
+
+function retryDelayMs(res: Response, attempt: number): number {
+  const retryAfter = Number(res.headers.get("retry-after") || "0");
+  if (retryAfter > 0) return retryAfter * 1000;
+  return 250 * (attempt + 1);
+}
+
+/** GET against api.github.com with versioned headers and bounded retries. */
+export async function githubRestGet(
+  url: string,
+  token: string,
+  opts: { retries?: number; timeoutMs?: number } = {},
+): Promise<Response> {
+  const retries = opts.retries ?? 2;
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  let last: Response | null = null;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, {
+      headers: githubRestHeaders(token),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.ok || !RETRYABLE.has(res.status)) return res;
+    last = res;
+    if (attempt < retries) {
+      await new Promise((r) => setTimeout(r, retryDelayMs(res, attempt)));
+    }
+  }
+
+  return last as Response;
+}

--- a/apps/api/src/auth/oauth.test.ts
+++ b/apps/api/src/auth/oauth.test.ts
@@ -1082,10 +1082,32 @@ describe("callbackRoute", () => {
       expect(res.status).toBe(502);
     });
 
-    it("returns 502 when /user/installations fetch returns non-ok status", async () => {
-      // Arrange — token exchange + /user succeed but /user/installations returns 500
-      const { db } = makeStateOnlyDb();
+    it("continues install-pending when /user/installations fetch returns non-ok status", async () => {
+      const captured: FakeStmt[] = [];
       const stateValue = "a".repeat(32);
+      let oauthDeleteCallCount = 0;
+      const db = makeFakeDb((sql, args) => {
+        const isOauthDelete =
+          sql.toLowerCase().includes("oauth_state") && sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
+        const row =
+          isOauthDelete && oauthDeleteCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") && sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthDelete) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi.fn().mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
 
       let fetchCallCount = 0;
       vi.stubGlobal(
@@ -1093,35 +1115,33 @@ describe("callbackRoute", () => {
         vi.fn(async () => {
           fetchCallCount++;
           if (fetchCallCount === 1) {
-            // Token exchange succeeds
             return new Response(JSON.stringify({ access_token: "tok-abc" }), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             });
           }
           if (fetchCallCount === 2) {
-            // /user succeeds
             return new Response(JSON.stringify({ id: 1, login: "alice" }), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             });
           }
-          // /user/installations returns 500
-          return new Response("Internal Server Error", { status: 500 });
+          if (fetchCallCount === 3) {
+            return new Response("Internal Server Error", { status: 500 });
+          }
+          return new Response(JSON.stringify([]), { status: 200 });
         }),
       );
 
       const { app, env } = makeApp(db);
-
-      // Act
       const res = await app.request(
         `http://localhost/oauth/callback?code=goodcode&state=${stateValue}`,
         { method: "GET" },
         env,
       );
 
-      // Assert — deleting the if (!installRes.ok) guard would let the route parse a 500 body
-      expect(res.status).toBe(502);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Set-Cookie") ?? "").toContain("roxabi_session=");
     });
   });
 

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -11,6 +11,7 @@
 import type { Context } from "hono";
 import type { Env } from "../types";
 import { authRedirect, readSessionToken, sanitizeAuthRedirect, stripInstallParam } from "./cookies";
+import { githubRestGet } from "./github-rest";
 import { tryLinkInstallPendingSession } from "./link-install";
 import { serveLoginPrompt } from "./login-prompt";
 import { completeOAuthSession } from "./post-oauth";
@@ -221,40 +222,44 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
   }
   const access_token = tokenBody.access_token;
 
-  const ghHeaders = {
-    Authorization: `Bearer ${access_token}`,
-    "User-Agent": "roxabi-live",
-    Accept: "application/vnd.github+json",
-  };
-
   // Fetch authenticated user
-  const userRes = await fetch("https://api.github.com/user", {
-    headers: ghHeaders,
-  });
+  const userRes = await githubRestGet("https://api.github.com/user", access_token);
   if (!userRes.ok) {
-    return c.json({ error: "github_unavailable" }, 502);
+    console.warn("oauth: github /user failed", { status: userRes.status });
+    return c.json({ error: "github_unavailable", step: "user", status: userRes.status }, 502);
   }
   const ghUser = (await userRes.json()) as { id: number; login: string };
 
-  // Fetch user installations
-  const installRes = await fetch("https://api.github.com/user/installations", {
-    headers: ghHeaders,
-  });
-  if (!installRes.ok) {
-    return c.json({ error: "github_unavailable" }, 502);
+  // Fetch user installations — fall back to install-pending when GitHub is flaky here.
+  let installations: Array<{
+    id: number;
+    account: { login: string; type: string };
+  }> = [];
+  const installRes = await githubRestGet(
+    "https://api.github.com/user/installations",
+    access_token,
+  );
+  if (installRes.ok) {
+    const body = (await installRes.json()) as {
+      installations?: Array<{
+        id: number;
+        account: { login: string; type: string };
+      }>;
+    };
+    installations = body.installations ?? [];
+  } else {
+    console.warn("oauth: github /user/installations failed; continuing install-pending", {
+      status: installRes.status,
+      login: ghUser.login,
+    });
   }
-  const { installations } = (await installRes.json()) as {
-    installations: Array<{
-      id: number;
-      account: { login: string; type: string };
-    }>;
-  };
 
   // No installations — mint install-pending session and show our install guide
   if (installations.length === 0) {
-    const orgsRes = await fetch("https://api.github.com/user/orgs?per_page=100", {
-      headers: ghHeaders,
-    });
+    const orgsRes = await githubRestGet(
+      "https://api.github.com/user/orgs?per_page=100",
+      access_token,
+    );
     const orgs = orgsRes.ok ? ((await orgsRes.json()) as Array<{ id: number; login: string }>) : [];
 
     const installTargets = [

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -9,7 +9,7 @@
 apps/api/src/sync/sync.test.ts  # 1758 lines — #180 integration harness for runSync; #216 structure-only (+biome reflow)
 apps/api/src/api/zk-key-backup.test.ts  # 506 lines — #216 backup API security + CAS/reauth tests; fp enforcement + atomic UPSERT tests
 apps/api/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-apps/api/src/auth/oauth.test.ts  # 1145 lines — #180 OAuth + install-pending; mustReOAuth webhook-link short-circuit
+apps/api/src/auth/oauth.test.ts  # 1162 lines — #180 OAuth + install-pending; github-rest fallback test
 apps/api/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 apps/api/src/api/graph.test.ts  # 776 lines — tenant-scoped graph + zk + repo activity stats tests
 apps/api/src/migrations.test.ts  # 323 lines — schema tests incl. users.consent_at (0020)


### PR DESCRIPTION
## Summary

Fixes `{"error":"github_unavailable"}` on `/oauth/callback` after a successful GitHub authorize redirect.

- Adds `github-rest` helper with `X-GitHub-Api-Version: 2022-11-28` (already used by sync/install paths, but missing in OAuth callback)
- Retries transient GitHub 429/5xx responses
- Logs failing step + HTTP status to worker logs
- Falls back to install-pending flow when `/user/installations` fails but `/user` succeeds

## Note

Recent logo/sign-in UI changes did not touch `oauth.ts`. This failure happens after token exchange, when the worker calls `api.github.com/user` or `/user/installations`.

## Test plan

- [x] `vitest run src/auth/oauth.test.ts src/auth/github-rest.test.ts`
- [ ] Retry GitHub login on staging/prod after API worker deploy