### PR TITLE
chore: promote staging to main (v0.22.2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    cooldown:
+      default-days: 3
+      semver-major-days: 3
+      semver-minor-days: 3
+      semver-patch-days: 3
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -15,3 +20,8 @@ updates:
     labels:
       - dependencies
       - ci
+    cooldown:
+      default-days: 3
+      semver-major-days: 3
+      semver-minor-days: 3
+      semver-patch-days: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.22.2](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.22.1...roxabi-live/v0.22.2) (2026-07-02)
+
+
+### Bug Fixes
+
+* **auth:** restore logo on post-OAuth loading screen ([#289](https://github.com/Roxabi/roxabi-live/pull/289))
+* **auth:** stop showing "session expired" for unauthenticated visits ([#290](https://github.com/Roxabi/roxabi-live/pull/290))
+* **auth:** harden OAuth callback GitHub REST calls (versioned headers, retry, install fallback) ([#291](https://github.com/Roxabi/roxabi-live/pull/291))
+
+
+### Changed
+
+* **deps:** add 72h Dependabot cooldown for version updates
+* **docs:** dedup dev-workflow rules to ssot operator shard
+
+
 ## [0.22.1](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.22.0...roxabi-live/v0.22.1) (2026-06-26)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,6 @@ Let:
 
 `plugins/roxabi-issues/` — Claude Code plugin (own `.claude-plugin/marketplace.json`), relocated from dev-core 2026-06-09. Skill `issue-triage` (invoked `roxabi-issues:issue-triage`): set labels (size/priority/lane/type) + manage blocked-by deps + parent/child sub-issues on GitHub issues. **Labels + native relations only — no ProjectV2 board** (board read is the cockpit's job). Self-contained bun project (`bun run typecheck|test`). Registered in `roxabi-plugins/.claude-plugin/external-registry.json`.
 
-## TL;DR
-
-- Entry: `/dev #N` → tier (S/F-lite/F-full) → lifecycle
-- ¬`--force` | ¬`--hard` | ¬`--amend`
-
 ## Key files
 
 **Worker (prod — primary)**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,4 @@
 @.claude/stack.yml
-@~/.claude/shared/global-patterns.md
 
 # CLAUDE.md — Instructions for Claude Code
 
@@ -25,7 +24,6 @@ Let:
 ## TL;DR
 
 - Entry: `/dev #N` → tier (S/F-lite/F-full) → lifecycle
-- Decisions → global-patterns.md
 - ¬`--force` | ¬`--hard` | ¬`--amend`
 
 ## Key files
@@ -89,7 +87,7 @@ apps/
   marketing/          # Astro SSG — apex live.roxabi.dev (CF Pages)
 packages/
   shared/             # @roxabi-live/shared — API types + graph/dims/layout helpers
-frontend/             # LEGACY vanilla shell — ASSETS fallback only (deleted post-cutover)
+frontend/             # LEGACY vanilla shell (sign-in/dashboard HTML) — LIVE, git-tracked; wired as the ASSETS binding of the apps/api worker (apps/api/wrangler.toml [assets] directory=../../frontend). Permanent until an explicit cleanup PR drops [assets] + the /dashboard,/sign-in routes — do not delete on the strength of this comment alone
 ```
 
 **Plugin (issue mgmt — relocated from dev-core)**

--- a/apps/api/src/auth/github-rest.test.ts
+++ b/apps/api/src/auth/github-rest.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { githubRestGet, githubRestHeaders } from "./github-rest";
+
+describe("githubRestHeaders", () => {
+  it("includes API version and user agent", () => {
+    const headers = githubRestHeaders("tok");
+    expect(headers).toMatchObject({
+      Authorization: "Bearer tok",
+      Accept: "application/vnd.github+json",
+      "User-Agent": "roxabi-live-worker",
+      "X-GitHub-Api-Version": "2022-11-28",
+    });
+  });
+});
+
+describe("githubRestGet", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("retries transient 503 then succeeds", async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1) return new Response("busy", { status: 503 });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }),
+    );
+
+    const res = await githubRestGet("https://api.github.com/user", "tok", { retries: 1 });
+    expect(res.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/api/src/auth/github-rest.ts
+++ b/apps/api/src/auth/github-rest.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared GitHub REST helpers — versioned headers + short retry for transient 5xx/429.
+ * OAuth and sync paths must stay aligned (oauth.ts previously omitted X-GitHub-Api-Version).
+ */
+
+export const GITHUB_REST_API_VERSION = "2022-11-28" as const;
+
+const RETRYABLE = new Set([429, 502, 503, 504]);
+
+export function githubRestHeaders(token?: string): HeadersInit {
+  return {
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    Accept: "application/vnd.github+json",
+    "User-Agent": "roxabi-live-worker",
+    "X-GitHub-Api-Version": GITHUB_REST_API_VERSION,
+  };
+}
+
+function retryDelayMs(res: Response, attempt: number): number {
+  const retryAfter = Number(res.headers.get("retry-after") || "0");
+  if (retryAfter > 0) return retryAfter * 1000;
+  return 250 * (attempt + 1);
+}
+
+/** GET against api.github.com with versioned headers and bounded retries. */
+export async function githubRestGet(
+  url: string,
+  token: string,
+  opts: { retries?: number; timeoutMs?: number } = {},
+): Promise<Response> {
+  const retries = opts.retries ?? 2;
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  let last: Response | null = null;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, {
+      headers: githubRestHeaders(token),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.ok || !RETRYABLE.has(res.status)) return res;
+    last = res;
+    if (attempt < retries) {
+      await new Promise((r) => setTimeout(r, retryDelayMs(res, attempt)));
+    }
+  }
+
+  return last as Response;
+}

--- a/apps/api/src/auth/oauth.test.ts
+++ b/apps/api/src/auth/oauth.test.ts
@@ -1082,10 +1082,32 @@ describe("callbackRoute", () => {
       expect(res.status).toBe(502);
     });
 
-    it("returns 502 when /user/installations fetch returns non-ok status", async () => {
-      // Arrange — token exchange + /user succeed but /user/installations returns 500
-      const { db } = makeStateOnlyDb();
+    it("continues install-pending when /user/installations fetch returns non-ok status", async () => {
+      const captured: FakeStmt[] = [];
       const stateValue = "a".repeat(32);
+      let oauthDeleteCallCount = 0;
+      const db = makeFakeDb((sql, args) => {
+        const isOauthDelete =
+          sql.toLowerCase().includes("oauth_state") && sql.toLowerCase().includes("delete");
+        oauthDeleteCallCount += isOauthDelete ? 1 : 0;
+        const row =
+          isOauthDelete && oauthDeleteCallCount === 1
+            ? ({ redirect_after: "/" } as FakeResult)
+            : null;
+        const isUsersInsert =
+          sql.toLowerCase().includes("users") && sql.toLowerCase().includes("returning");
+        const usersRow = isUsersInsert ? ({ id: 1 } as FakeResult) : null;
+        const stmt = makeFakeStmt(sql, args, [], 0);
+        if (isOauthDelete) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi.fn().mockResolvedValue(row);
+        } else if (isUsersInsert) {
+          (stmt as { first: <T>() => Promise<T | null> }).first = vi
+            .fn()
+            .mockResolvedValue(usersRow);
+        }
+        captured.push(stmt);
+        return stmt;
+      });
 
       let fetchCallCount = 0;
       vi.stubGlobal(
@@ -1093,35 +1115,33 @@ describe("callbackRoute", () => {
         vi.fn(async () => {
           fetchCallCount++;
           if (fetchCallCount === 1) {
-            // Token exchange succeeds
             return new Response(JSON.stringify({ access_token: "tok-abc" }), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             });
           }
           if (fetchCallCount === 2) {
-            // /user succeeds
             return new Response(JSON.stringify({ id: 1, login: "alice" }), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             });
           }
-          // /user/installations returns 500
-          return new Response("Internal Server Error", { status: 500 });
+          if (fetchCallCount === 3) {
+            return new Response("Internal Server Error", { status: 500 });
+          }
+          return new Response(JSON.stringify([]), { status: 200 });
         }),
       );
 
       const { app, env } = makeApp(db);
-
-      // Act
       const res = await app.request(
         `http://localhost/oauth/callback?code=goodcode&state=${stateValue}`,
         { method: "GET" },
         env,
       );
 
-      // Assert — deleting the if (!installRes.ok) guard would let the route parse a 500 body
-      expect(res.status).toBe(502);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Set-Cookie") ?? "").toContain("roxabi_session=");
     });
   });
 

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -11,6 +11,7 @@
 import type { Context } from "hono";
 import type { Env } from "../types";
 import { authRedirect, readSessionToken, sanitizeAuthRedirect, stripInstallParam } from "./cookies";
+import { githubRestGet } from "./github-rest";
 import { tryLinkInstallPendingSession } from "./link-install";
 import { serveLoginPrompt } from "./login-prompt";
 import { completeOAuthSession } from "./post-oauth";
@@ -221,40 +222,44 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
   }
   const access_token = tokenBody.access_token;
 
-  const ghHeaders = {
-    Authorization: `Bearer ${access_token}`,
-    "User-Agent": "roxabi-live",
-    Accept: "application/vnd.github+json",
-  };
-
   // Fetch authenticated user
-  const userRes = await fetch("https://api.github.com/user", {
-    headers: ghHeaders,
-  });
+  const userRes = await githubRestGet("https://api.github.com/user", access_token);
   if (!userRes.ok) {
-    return c.json({ error: "github_unavailable" }, 502);
+    console.warn("oauth: github /user failed", { status: userRes.status });
+    return c.json({ error: "github_unavailable", step: "user", status: userRes.status }, 502);
   }
   const ghUser = (await userRes.json()) as { id: number; login: string };
 
-  // Fetch user installations
-  const installRes = await fetch("https://api.github.com/user/installations", {
-    headers: ghHeaders,
-  });
-  if (!installRes.ok) {
-    return c.json({ error: "github_unavailable" }, 502);
+  // Fetch user installations — fall back to install-pending when GitHub is flaky here.
+  let installations: Array<{
+    id: number;
+    account: { login: string; type: string };
+  }> = [];
+  const installRes = await githubRestGet(
+    "https://api.github.com/user/installations",
+    access_token,
+  );
+  if (installRes.ok) {
+    const body = (await installRes.json()) as {
+      installations?: Array<{
+        id: number;
+        account: { login: string; type: string };
+      }>;
+    };
+    installations = body.installations ?? [];
+  } else {
+    console.warn("oauth: github /user/installations failed; continuing install-pending", {
+      status: installRes.status,
+      login: ghUser.login,
+    });
   }
-  const { installations } = (await installRes.json()) as {
-    installations: Array<{
-      id: number;
-      account: { login: string; type: string };
-    }>;
-  };
 
   // No installations — mint install-pending session and show our install guide
   if (installations.length === 0) {
-    const orgsRes = await fetch("https://api.github.com/user/orgs?per_page=100", {
-      headers: ghHeaders,
-    });
+    const orgsRes = await githubRestGet(
+      "https://api.github.com/user/orgs?per_page=100",
+      access_token,
+    );
     const orgs = orgsRes.ok ? ((await orgsRes.json()) as Array<{ id: number; login: string }>) : [];
 
     const installTargets = [

--- a/apps/api/src/auth/post-oauth.ts
+++ b/apps/api/src/auth/post-oauth.ts
@@ -52,7 +52,7 @@ body::before{content:"";position:fixed;inset:0;pointer-events:none;background:ra
 .auth-nav-shell{position:relative;z-index:1;width:100%;max-width:380px}
 .auth-nav-card{background:var(--bg-elevated);border:1px solid var(--border-hi);border-radius:var(--radius-lg);box-shadow:var(--panel-shadow);padding:32px 28px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:18px}
 .auth-nav-brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:18px;letter-spacing:-.02em}
-.auth-nav-brand img{width:28px;height:28px}
+.auth-nav-brand svg{width:28px;height:28px;flex-shrink:0}
 .auth-nav-brand .accent{color:var(--accent)}
 .auth-nav-spinner{width:40px;height:40px;border-radius:50%;border:3px solid var(--border);border-top-color:var(--accent);animation:auth-nav-spin .9s linear infinite}
 @keyframes auth-nav-spin{to{transform:rotate(360deg)}}
@@ -67,7 +67,7 @@ body::before{content:"";position:fixed;inset:0;pointer-events:none;background:ra
 <main class="auth-nav-shell" role="main">
   <div class="auth-nav-card" role="status" aria-live="polite" aria-busy="true">
     <div class="auth-nav-brand">
-      <img src="/assets/logo/foundation-block-16.svg" alt="" width="28" height="28" />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="28" height="28" aria-hidden="true"><polygon points="3,5.5 8,8 8,13 3,10.5" fill="#11161d"/><polygon points="13,5.5 13,10.5 8,13 8,8" fill="#171e27"/><polygon points="8,3 13,5.5 8,8 3,5.5" fill="#1c2431"/><polygon points="8,4 11,5.5 8,7 5,5.5" fill="#f0b429"/><path d="M8,3 13,5.5 13,10.5 8,13 3,10.5 3,5.5Z" fill="none" stroke="#f0b429" stroke-width="0.8" stroke-linejoin="round"/><path d="M3,5.5 8,8 8,13 M13,5.5 8,8" fill="none" stroke="#f0b429" stroke-width="0.6" stroke-linejoin="round" opacity="0.7"/></svg>
       <span>Roxabi <span class="accent">Live</span></span>
     </div>
     <div class="auth-nav-spinner" aria-hidden="true"></div>

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -18,7 +18,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.21.3"
+APP_RELEASE = "0.22.2"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -62,7 +62,7 @@ routes = [
 ]
 
 [env.staging.vars]
-APP_RELEASE = "0.21.3"
+APP_RELEASE = "0.22.2"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"

--- a/apps/app/public/assets/logo/foundation-block-16.svg
+++ b/apps/app/public/assets/logo/foundation-block-16.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" role="img" aria-label="Roxabi">
+  <!-- Favicon variant of "C / Open top" — same silhouette, simplified for 16px:
+       solid faces, a flat amber top aperture, crisp amber edges, no blur. -->
+  <polygon points="3,5.5 8,8 8,13 3,10.5"  fill="#11161d"/>   <!-- left  -->
+  <polygon points="13,5.5 13,10.5 8,13 8,8" fill="#171e27"/>   <!-- right -->
+  <polygon points="8,3 13,5.5 8,8 3,5.5"    fill="#1c2431"/>   <!-- top   -->
+  <polygon points="8,4 11,5.5 8,7 5,5.5"    fill="#f0b429"/>   <!-- open top aperture (flat amber) -->
+  <path d="M8,3 13,5.5 13,10.5 8,13 3,10.5 3,5.5Z" fill="none" stroke="#f0b429" stroke-width="0.8" stroke-linejoin="round"/>
+  <path d="M3,5.5 8,8 8,13 M13,5.5 8,8" fill="none" stroke="#f0b429" stroke-width="0.6" stroke-linejoin="round" opacity="0.7"/>
+</svg>

--- a/apps/app/src/auth/AuthGate.tsx
+++ b/apps/app/src/auth/AuthGate.tsx
@@ -2,7 +2,7 @@
  * AuthGate — the server-owned onboarding gate, ported from frontend/auth.js
  * requireAuthGate(). Resolves GET /api/me, then routes:
  *
- *   401 / no session   → <SignInScreen/>  (marketing landing owns this post-cutover)
+ *   401 / no session   → <SignInScreen/> (neutral — not "session expired")
  *   onboarding "install" → <InstallGate/>
  *   onboarding "consent" → <ConsentGate/>
  *   onboarding "ready"   → <AuthProvider> children
@@ -39,7 +39,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   if (isLoading) return <AuthLoading />;
 
   if (error) {
-    if (error.status === 401) return <SignInScreen reason="session-lost" />;
+    if (error.status === 401) return <SignInScreen />;
     return (
       <div
         className="mx-auto max-w-md py-16 text-center text-sm text-blocked"

--- a/apps/app/src/auth/SignInScreen.tsx
+++ b/apps/app/src/auth/SignInScreen.tsx
@@ -25,6 +25,10 @@ function loginUrl(remember: boolean): string {
   return `/login?${params}`;
 }
 
+function sessionLostFromUrl(): boolean {
+  return new URLSearchParams(location.search).get("reason") === "session-lost";
+}
+
 export function SignInScreen({
   mode = "signin",
   reason,
@@ -33,6 +37,7 @@ export function SignInScreen({
   reason?: "session-lost";
 }) {
   const t = useT();
+  const showSessionLost = reason === "session-lost" || sessionLostFromUrl();
   const [remember, setRemember] = useState(
     () => localStorage.getItem(REMEMBER_SESSION_KEY) === "1",
   );
@@ -50,7 +55,7 @@ export function SignInScreen({
         <h1 className="text-xl font-semibold text-foreground">
           {isSignup ? t("auth.signup.title") : t("auth.signin.title")}
         </h1>
-        {reason === "session-lost" && (
+        {showSessionLost && (
           <p className="rounded-md border border-blocked/30 bg-blocked/10 px-3 py-2 text-sm text-blocked">
             {t("auth.sessionLost")}
           </p>

--- a/apps/app/src/auth/useAuthMutations.ts
+++ b/apps/app/src/auth/useAuthMutations.ts
@@ -73,9 +73,8 @@ export function useLogout() {
     },
     onSuccess: (_data, vars) => {
       qc.clear();
-      // Default to /sign-in (a neutral SignInScreen). Landing on "/" would let
-      // AuthGate read the now-revoked session as a 401 and flash the alarming
-      // "Session expired" banner — wrong after a deliberate logout.
+      // Default to /sign-in — explicit guest entry. AuthGate also shows a neutral
+      // sign-in on "/" when unauthenticated (no "session expired" banner).
       window.location.href = vars?.to ?? "/sign-in";
     },
   });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 license = { text = "AGPL-3.0-or-later" }
 name = "roxabi-live"
-version = "0.22.1"
+version = "0.22.2"
 description = "Roxabi Live — repo tooling (Worker + frontend are the application)"
 requires-python = ">=3.12,<3.13"
 dependencies = []

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -9,7 +9,7 @@
 apps/api/src/sync/sync.test.ts  # 1758 lines — #180 integration harness for runSync; #216 structure-only (+biome reflow)
 apps/api/src/api/zk-key-backup.test.ts  # 506 lines — #216 backup API security + CAS/reauth tests; fp enforcement + atomic UPSERT tests
 apps/api/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-apps/api/src/auth/oauth.test.ts  # 1145 lines — #180 OAuth + install-pending; mustReOAuth webhook-link short-circuit
+apps/api/src/auth/oauth.test.ts  # 1162 lines — #180 OAuth + install-pending; github-rest fallback test
 apps/api/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 apps/api/src/api/graph.test.ts  # 776 lines — tenant-scoped graph + zk + repo activity stats tests
 apps/api/src/migrations.test.ts  # 323 lines — schema tests incl. users.consent_at (0020)

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "roxabi-live"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Promotion: staging → main (v0.22.2)

### Bug Fixes

* **auth:** restore logo on post-OAuth loading screen ([#289](https://github.com/Roxabi/roxabi-live/pull/289))
* **auth:** stop showing "session expired" for unauthenticated visits ([#290](https://github.com/Roxabi/roxabi-live/pull/290))
* **auth:** harden OAuth callback GitHub REST calls ([#291](https://github.com/Roxabi/roxabi-live/pull/291))

### Changed

* **deps:** add 72h Dependabot cooldown for version updates
* **docs:** dedup dev-workflow rules to ssot operator shard

## Pre-flight

- [x] CI passing on staging
- [x] Open PR on staging acknowledged (#288 docs only)
- [x] Release notes committed to staging (`chore(release): 0.22.2`)

---

⚠️ Merge with **merge commit** (not squash).