### PR TITLE
chore: promote staging to main (v0.22.3)

### DIFF
--- a/.github/workflows/context-lint.yml
+++ b/.github/workflows/context-lint.yml
@@ -6,12 +6,16 @@ on:
       - '**/CLAUDE.md'
       - '**/AGENTS.md'
       - '.claude/**'
+      - '.grok/**'
+      - '.agents/**'
   push:
     branches: [main, staging]
     paths:
       - '**/CLAUDE.md'
       - '**/AGENTS.md'
       - '.claude/**'
+      - '.grok/**'
+      - '.agents/**'
 
 permissions:
   contents: read
@@ -27,6 +31,13 @@ jobs:
         run: |
           set -u
           V=0
+          find_context_files() {
+            find . \( -name node_modules -o -name .worktrees -o -name worktrees -o -name .git \) -prune -o -type f \( \
+              -name 'CLAUDE.md' -o -name 'AGENTS.md' -o \
+              \( -name 'SKILL.md' \( -path '*/.grok/skills/*' -o -path '*/.claude/skills/*' -o -path '*/.agents/skills/*' \) \) -o \
+              \( -name '*.md' \( -path '*/.grok/rules/*' -o -path '*/.claude/rules/*' -o -path '*/.grok/agents/*' \) \) \
+            \) -print
+          }
           # dead repo-relative @imports (home-dir @~/... imports are machine-local — skipped on CI)
           while IFS= read -r file; do
             dir=$(dirname "$file")
@@ -38,7 +49,7 @@ jobs:
                 V=$((V + 1))
               fi
             done < <(grep -o '^@[^ ]*' "$file" || true)
-          done < <(find . \( -name node_modules -o -name .worktrees -o -name worktrees -o -name .git \) -prune -o \( -name 'CLAUDE.md' -o -name 'AGENTS.md' \) -print)
+          done < <(find_context_files)
           # unfilled scaffold placeholders
           while IFS= read -r f; do
             echo "::error file=$f::unfilled scaffold placeholder (gotchas)"

--- a/.github/workflows/context-lint.yml
+++ b/.github/workflows/context-lint.yml
@@ -1,0 +1,52 @@
+name: Context Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/CLAUDE.md'
+      - '**/AGENTS.md'
+      - '.claude/**'
+  push:
+    branches: [main, staging]
+    paths:
+      - '**/CLAUDE.md'
+      - '**/AGENTS.md'
+      - '.claude/**'
+
+permissions:
+  contents: read
+
+jobs:
+  context-lint:
+    name: Context lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint agent-context files (@imports + placeholders)
+        run: |
+          set -u
+          V=0
+          # dead repo-relative @imports (home-dir @~/... imports are machine-local — skipped on CI)
+          while IFS= read -r file; do
+            dir=$(dirname "$file")
+            while IFS= read -r imp; do
+              target=${imp#@}
+              case "$target" in "~/"*|/*) continue ;; esac
+              if [ ! -e "$dir/$target" ]; then
+                echo "::error file=$file::dead @import: $imp"
+                V=$((V + 1))
+              fi
+            done < <(grep -o '^@[^ ]*' "$file" || true)
+          done < <(find . \( -name node_modules -o -name .worktrees -o -name worktrees -o -name .git \) -prune -o \( -name 'CLAUDE.md' -o -name 'AGENTS.md' \) -print)
+          # unfilled scaffold placeholders
+          while IFS= read -r f; do
+            echo "::error file=$f::unfilled scaffold placeholder (gotchas)"
+            V=$((V + 1))
+          done < <(grep -rl 'Add project-specific gotchas here' --include=CLAUDE.md . 2>/dev/null || true)
+          if [ "$V" -eq 0 ]; then
+            echo "context-lint: clean"
+          else
+            echo "context-lint: $V violation(s)"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.22.3](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.22.2...roxabi-live/v0.22.3) (2026-07-02)
+
+
+### Added
+
+* **docs:** monorepo doc refresh for v0.22 three-host topology ([#293](https://github.com/Roxabi/roxabi-live/pull/293))
+* **docs:** agent workflow guide, `llms.txt`, and marketing `/for-agents` pages ([#293](https://github.com/Roxabi/roxabi-live/pull/293))
+
+
+### Fixed
+
+* **docs:** address code-review findings — DEPLOY paths, `P0-critical` label sync, marketing app links ([#293](https://github.com/Roxabi/roxabi-live/pull/293))
+* **sync:** map `P0-critical` priority label from issue-triage ([#293](https://github.com/Roxabi/roxabi-live/pull/293))
+
+
+### Changed
+
+* **chore:** add `context-lint` GitHub workflow for Grok + Claude harness paths
+* **plugins:** drop decision presentation protocol from issue-triage skill
+
+
 ## [0.22.2](https://github.com/Roxabi/roxabi-live/compare/roxabi-live/v0.22.1...roxabi-live/v0.22.2) (2026-07-02)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,7 @@
 ```bash
 git clone https://github.com/Roxabi/roxabi-live.git
 cd roxabi-live
-cd worker && npm ci
-cd ../frontend && npm ci
+bun install
 uv sync --group dev   # license check + pre-commit only
 ```
 
@@ -16,27 +15,43 @@ Install pre-commit hooks:
 uv run pre-commit install
 ```
 
+## Running Locally
+
+```bash
+# API worker (port 8787)
+cd apps/api && bunx wrangler dev
+
+# React SPA (separate terminal)
+cd apps/app && bun run dev
+
+# Marketing site
+bun run dev:marketing
+```
+
+Optional secrets: `apps/api/.dev.vars` (see [docs/getting-started.md](docs/getting-started.md)).
+
 ## Running Tests
 
 ```bash
-cd worker && npm test
-cd frontend && npm test
+bun install
+bun --filter @roxabi-live/api test
+bun --filter @roxabi-live/app test
+bun --filter @roxabi-live/shared typecheck
+cd plugins/roxabi-issues && bun test
+bun run test:e2e   # Playwright (requires running stack)
 ```
-
-Or from the repo root: `make test`
 
 ## Code Style
 
 ```bash
-cd worker && npm run lint && npm run typecheck
-cd frontend && npm test
+bunx biome check apps/api/src apps/app/src
+bunx biome check --write apps/api/src apps/app/src
 uv run ruff check tools
 ```
 
-Worker and frontend use **Biome** (`biome.json` at repo root). Pre-commit runs Biome, TruffleHog, license check, and worker typecheck on push.
+Biome is enforced in CI (`api` job) and pre-commit. Key constraints:
 
-Key constraints:
-- Max file length: 300 SLOC for `worker/src/**/*.ts` (see `tools/file_exemptions.txt`).
+- Max file length: 300 SLOC for `apps/api/src/**/*.ts` (see `tools/file_exemptions.txt`).
 - Secrets via `wrangler secret put` — never commit tokens.
 
 ## Commit Format
@@ -55,10 +70,10 @@ Types: `feat` | `fix` | `refactor` | `docs` | `style` | `test` | `chore` | `ci` 
 - Merge strategy: **merge commit** (no squash, no rebase).
 - Keep PRs focused — one feature or fix per PR.
 - Title must follow Conventional Commits format (enforced by CI).
-- All CI checks must pass: worker tests, frontend tests, Biome, license check, secret scan.
+- All CI checks must pass: api tests, app tests, Biome, license check, secret scan.
 
 ## Code Review
 
-- Reviewers check correctness, tenant isolation, and auth boundaries on Worker changes.
+- Reviewers check correctness, tenant isolation, and auth boundaries on API/app worker changes.
 - Functional Worker/frontend changes must include or update tests.
 - Doc changes (`.md`) do not require tests.

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -1,70 +1,61 @@
-# Roxabi Live — Monorepo migration (modeled on roxabi-links / enishu)
+# Roxabi Live — Monorepo
 
-Status: **Phase 1 done** (architecture/stack scaffold). Design implementation + the
-app/api split = **step 2**. Target model = enishu (`roxabi-links`): bun workspaces,
-marketing split out as its own deploy, a shared brand SSOT consumed by every surface.
+Status: **cutover complete** (v0.22.0+, PR #271 merged). Production runs the three-host topology modeled on [roxabi-links / enishu](https://github.com/Roxabi/roxabi-links).
 
-## Current production setup (unchanged by Phase 1)
+## Production topology
 
-A single Cloudflare Worker does everything:
+| Host | Target | Deploy |
+|------|--------|--------|
+| `live.roxabi.dev` (apex) | Marketing (Astro) | CF Pages → `apps/marketing` |
+| `app.live.roxabi.dev` | React SPA + API proxy | Worker `roxabi-live-app` → `apps/app` |
+| `api.live.roxabi.dev` | Hono API + webhook + cron | Worker `roxabi-live` → `apps/api` |
 
-| Piece | What | Touched in Phase 1? |
-|---|---|---|
-| `worker/` (Hono) | API + webhook + sync + serves the frontend via ASSETS | **No** — npm island, deploy untouched |
-| `frontend/` (vanilla HTML/CSS/JS) | landing + auth + zk + dashboard, served by the Worker | **No** |
-| `wrangler.toml` (root) | `main=worker/src/index.ts`, ASSETS=`./frontend`, D1 `DB`, R2 `LOGS`, route `live.roxabi.dev` | **No** |
-| `infra/workers-builds.json` | CF Workers Builds: `cd worker && npm ci` → `deploy-{prod,staging}.sh`, branches main/staging | **No** |
-| CI (`.github/workflows/ci.yml`) | per-subdir: tools=uv, `worker`=npm, `plugins/roxabi-issues`=bun, `frontend`=npm | **No** |
+The browser only talks to `app.live.roxabi.dev`. The app worker proxies `/api`, `/login`, `/oauth`, `/auth`, `/logout`, `/install`, `/admin`, `/health` to the API worker via a **service binding** (same-origin, no CORS).
 
-→ prod deploy + CI stay green on this branch. The new tree is purely additive.
+Runbook for the human cutover steps: [docs/cutover-monorepo.md](docs/cutover-monorepo.md).
 
-## Phase 1 — what landed (this branch)
+## Repo layout
 
 ```
-package.json            bun workspaces ["apps/*","packages/*"], packageManager bun@1.3.14
-bun.lock                (root npm package-lock.json removed)
-brand/                  SHARED DESIGN-SYSTEM SSOT — synced from Claude Design
-  styles.css              entry (consumers @import this only)
-  base.css                reset + amber-bloom canvas + utilities + graph keyframes
-  tokens/                 colors · typography · spacing · elevation · motion · fonts
-  assets/                 logo-mark · logo-glyph · wordmark (SVG)
-  BRAND-BOOK.md           the canonical brand doc
-packages/shared/        @roxabi-live/shared — TS contract (Phase 1: brand.ts token mirror)
-apps/marketing/         @roxabi-live/marketing — Astro SSG, consumes brand via
-                        @import "../../../../brand/styles.css"; → CF Pages target
+package.json            bun workspaces ["apps/*","packages/*"]
+apps/
+  api/                  @roxabi-live/api — Hono Worker, D1, sync, webhooks
+  app/                  @roxabi-live/app — React 19 SPA + edge proxy (worker.ts)
+  marketing/            @roxabi-live/marketing — Astro SSG, FR/EN landing
+packages/
+  shared/               @roxabi-live/shared — API types, graph helpers, brand tokens
+brand/                  Shared CSS design system (consumed by marketing + app)
+frontend/               Legacy vanilla shell — still ASSETS-bound on API worker (cleanup pending)
+plugins/
+  roxabi-issues/        issue-triage skill (bun, self-contained tests)
 ```
 
-Verified: `bun install` clean · `bun run build:marketing` → `dist/` with brand tokens
-bundled · `bun --filter @roxabi-live/shared typecheck` green · placeholder rendered in a
-real browser (deep-slate bg + amber bloom + Inter-900 headline).
+## Deploy model (Enishu)
 
-`apps/marketing/src/pages/index.astro` is a **placeholder smoke test**, not the final
-landing — the real landing (Claude Design `concept-b`) is ported in step 2.
+Cloudflare git-connected deploy; GitHub Actions = **CI only** (no CD).
 
-## Brand sharing (the enishu two-layer pattern)
+| Target | Mechanism | SSOT |
+|--------|-----------|------|
+| API | Workers Builds | `infra/workers-builds.json` |
+| App | Pages + thin proxy Worker | `infra/pages-app*.json`, `apps/app/wrangler.deploy.jsonc` |
+| Marketing | Pages | `infra/pages-marketing*.json` |
 
-- **CSS layer** → `brand/` (root dir, not a package). Marketing + the future app `@import`
-  `brand/styles.css` by relative path. SSOT for token *values*.
-- **TS layer** → `packages/shared/src/brand.ts` mirrors the hexes for code that can't read
-  CSS vars (graph rendering, email, OG). Keep in sync on re-sync from Claude Design.
+```bash
+bun run setup:cloudflare-deploy
+bun run verify:cloudflare
+```
 
-## Step 2 — open decisions + the "important changes"
+See [CLAUDE.md](CLAUDE.md) for branch → URL mapping and break-glass deploy scripts.
 
-These are the bigger, coupled changes (mostly **deploy/infra + the app rewrite**), deferred:
+## CI
 
-1. **Domain topology** *(blocks the app/api split)* — enishu = apex(marketing) + `app.` + `api.`
-   subdomains. To split, marketing → apex `live.roxabi.dev` (Pages) and the app/api Worker →
-   `app.live.roxabi.dev`. That changes the app URL + **CF Access** config (#150 cutover) +
-   **session cookie domain** + **zk** origin. Decide before splitting.
-2. **worker/ → apps/api/** rename + bun-unify → requires updating `infra/workers-builds.json`
-   (rootDirectory/build command) **and the CF Workers Builds dashboard** (otherwise auto-deploy
-   breaks). Coordinate; do NOT push the rename until CF is reconfigured.
-3. **apps/app/ (React SPA)** — migrate the vanilla `frontend/` dashboard to the enishu app stack:
-   **React 19 + Vite + TanStack Router/Query + Tailwind v4 + shadcn/ui (Radix + cva + tailwind-merge)
-   + Phosphor icons**, deployed as a Worker serving its dist + proxying `/api*` via service binding.
-   Big rewrite (graph/list/pivot/zk/auth) — this is where the Claude Design React components pay off.
-4. **Port the landing** into `apps/marketing` as real `.astro` components (SiteHeader, Hero +
-   LaunchBoard, Problem, Method, GitHub-native, CTA) + i18n (FR **and EN**).
-5. **CI** — add `apps/marketing` (+ later `apps/app`, `packages/shared`) jobs; add a marketing
-   Pages project in CF.
-6. **Re-sync brand** from Claude Design once the graph/cockpit design is finalised there.
+`.github/workflows/ci.yml` — jobs: `ci` (tools/license), `api` (Biome + vitest), `app` (typecheck + vitest + marketing Astro build), `plugin` (issue-triage tests).
+
+## Brand sharing
+
+- **CSS layer** → `brand/` at repo root. Marketing and app `@import brand/styles.css`.
+- **TS layer** → `packages/shared/src/brand.ts` mirrors hex values for code paths that cannot read CSS vars.
+
+## Legacy note
+
+The pre-2026-06 Python/FastAPI app and `worker/` directory are removed. `frontend/` remains temporarily as ASSETS on the API worker until an explicit cleanup PR drops it.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 |:---:|:---:|:---:|
 | ![Table](docs/images/table-view.png) | ![List](docs/images/list-view.png) | ![Graph](docs/images/graph-view.png) |
 
-Roxabi Live syncs GitHub issues from your org into [Cloudflare D1](https://developers.cloudflare.com/d1/) and serves a multi-view dashboard at **[app.live.roxabi.dev](https://app.live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via GitHub webhooks, and reconciles on a schedule — across three Cloudflare surfaces (marketing, app, API).
+Roxabi Live syncs GitHub issues from your org into [Cloudflare D1](https://developers.cloudflare.com/d1/) and serves a multi-view dashboard at **[app.live.roxabi.dev](https://app.live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via GitHub webhooks, and reconciles via bootstrap, manual `/admin/sync`, and optional cron (disabled in stock config) — across three Cloudflare surfaces (marketing, app, API).
 
 **Multi-user:** any GitHub user with access to the installed GitHub App can sign in via OAuth. The app is session-gated — `/api/*` requires an active session cookie. `/admin/*` additionally sits behind Cloudflare Access (Email-OTP).
 
@@ -51,7 +51,7 @@ Deploys are Cloudflare git-connected: push to `staging` → staging; push to `ma
 
 ```mermaid
 flowchart LR
-    CRON[Cron / manual sync]
+    CRON[Webhooks / manual sync]
     GH[GitHub Org\nGraphQL + webhooks]
     API[API Worker\napps/api]
     APP[App Worker\napps/app]
@@ -69,7 +69,7 @@ flowchart LR
 ```
 
 **Sync flow:**
-1. Scheduled reconcile and `POST /admin/sync` fetch issues via GitHub GraphQL (`subIssues`, `parent`, `blockedBy`, `blocking`) and upsert into D1.
+1. Webhooks, login bootstrap, and `POST /admin/sync` fetch issues via GitHub GraphQL (`subIssues`, `parent`, `blockedBy`, `blocking`) and upsert into D1 (optional daily cron: `crons = ["0 0 * * *"]` in `apps/api/wrangler.toml`).
 2. GitHub webhooks (`POST /webhook/github`, HMAC-verified) apply incremental updates.
 3. The React app at `app.live.roxabi.dev` proxies `/api/*` to the API worker and renders pivot, list, and graph views.
 
@@ -98,7 +98,7 @@ Browser traffic is same-origin on `app.live.roxabi.dev` (proxied to the API work
 | `/api/me` | GET | session | Current authenticated user info |
 | `/api/active-tenant` | POST | session | Set active org when user has >1 installation |
 | `/api/issues` | GET | session | List issues (`repo`, `state`, `label`, `limit`, `offset`) |
-| `/api/issues/{key}` | GET | session | Single issue by key, e.g. `Roxabi/lyra#123` |
+| `/api/issues/{owner}/{repo}%23{N}` | GET | session | Single issue, e.g. `Roxabi/lyra%23123` |
 | `/api/graph` | GET | session | Full dependency graph JSON, scoped to tenant |
 | `/admin/sync` | POST | CF Access + ADMIN_TOKEN Bearer | Out-of-band sync trigger |
 | `/webhook/github` | POST | HMAC-SHA256 | GitHub webhook receiver (on `api.*`) |

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@
 |:---:|:---:|:---:|
 | ![Table](docs/images/table-view.png) | ![List](docs/images/list-view.png) | ![Graph](docs/images/graph-view.png) |
 
-Roxabi Live pulls GitHub issues from the entire org into a [Cloudflare D1](https://developers.cloudflare.com/d1/) database and serves a multi-view dashboard at **[live.roxabi.dev](https://live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via a GitHub org webhook, and re-syncs daily via a Cron Trigger — all on a single Cloudflare Worker.
+Roxabi Live syncs GitHub issues from your org into [Cloudflare D1](https://developers.cloudflare.com/d1/) and serves a multi-view dashboard at **[app.live.roxabi.dev](https://app.live.roxabi.dev)**. It tracks parent/child relationships and blockers, applies real-time updates via GitHub webhooks, and reconciles on a schedule — across three Cloudflare surfaces (marketing, app, API).
 
-**Multi-user:** any GitHub user with access to the installed GitHub App can sign in via OAuth (`GET /login`). The app is session-gated — `/api/*` requires an active session cookie. `/admin/*` additionally sits behind Cloudflare Access (Email-OTP) as a defense-in-depth layer. The **staging** workers.dev URL is fully gated by CF Access (see `docs/s10-staging-access.md`).
+**Multi-user:** any GitHub user with access to the installed GitHub App can sign in via OAuth. The app is session-gated — `/api/*` requires an active session cookie. `/admin/*` additionally sits behind Cloudflare Access (Email-OTP).
+
+| Host | Role |
+|------|------|
+| [live.roxabi.dev](https://live.roxabi.dev) | Marketing (Astro, CF Pages) |
+| [app.live.roxabi.dev](https://app.live.roxabi.dev) | React SPA + same-origin API proxy |
+| [api.live.roxabi.dev](https://api.live.roxabi.dev) | Hono API, webhooks (+ optional cron) |
 
 ## Why
 
@@ -20,143 +26,135 @@ GitHub Projects and the default issue list give no cross-repo dependency view. R
 
 ## Quick Start
 
-Roxabi Live runs as a **Cloudflare Worker** at **[live.roxabi.dev](https://live.roxabi.dev)** — nothing to install to use it. Sign in with your GitHub account via `GET /login`.
+Nothing to install to **use** the product — sign in at [app.live.roxabi.dev](https://app.live.roxabi.dev).
+
+**Structure issues for the cockpit** with the `issue-triage` skill (`/issue-triage`) — see [docs/agent-workflow.md](docs/agent-workflow.md).
+
+**For LLM crawlers:** [llms.txt](llms.txt) · [docs/agent-workflow.md](docs/agent-workflow.md)
 
 Local development:
 
 ```bash
 git clone https://github.com/Roxabi/roxabi-live.git
-cd roxabi-live/worker
-npm ci
-npx wrangler dev          # local Worker + D1 → http://localhost:8787
+cd roxabi-live
+bun install
+cd apps/api && bunx wrangler dev    # API → http://localhost:8787
+# SPA (separate terminal):
+cd apps/app && bun run dev
 ```
 
-Create a `worker/.dev.vars` file (wrangler reads it automatically, never commit it) with the secrets listed in the [Configuration](#configuration) section.
+Create `apps/api/.dev.vars` (gitignored) with secrets listed in [Configuration](#configuration).
 
-Deploys are CI-driven: push to `staging` → staging Worker; push to `main` → production (`live.roxabi.dev`).
+Deploys are Cloudflare git-connected: push to `staging` → staging; push to `main` → production. See [CLAUDE.md](CLAUDE.md) deploy section.
 
 ## How It Works
 
 ```mermaid
 flowchart LR
-    CRON[Cron Trigger\n0 0 * * *]
-    GH[GitHub Org\nGraphQL API]
-    W[CF Worker\nHono]
-    DB[(D1\nroxabi-live-production)]
-    R2[(R2\nroxabi-live-logs)]
-    FE[Dashboard\nlive.roxabi.dev]
-    WH[GitHub Webhook\nPOST /webhook/github]
+    CRON[Cron / manual sync]
+    GH[GitHub Org\nGraphQL + webhooks]
+    API[API Worker\napps/api]
+    APP[App Worker\napps/app]
+    DB[(D1)]
+    R2[(R2 audit)]
+    MKT[Marketing\nlive.roxabi.dev]
 
-    CRON -->|daily scheduled| W
-    GH -->|GraphQL| W
-    W -->|upsert| DB
-    DB -->|read| W
-    W -->|JSON + static ASSETS| FE
-    WH -->|HMAC-gated events| W
-    W -->|per-run audit| R2
+    CRON --> API
+    GH --> API
+    API --> DB
+    APP -->|service binding| API
+    APP -->|SPA| Browser[Browser\napp.live.roxabi.dev]
+    API --> R2
+    MKT -.-> Browser
 ```
 
 **Sync flow:**
-1. A Cron Trigger (`0 0 * * *`) invokes the Worker's `scheduled` handler daily (full reconcile, #80); `POST /admin/sync` triggers it out-of-band.
-2. The Worker fetches issues via GitHub GraphQL — `subIssues`, `parent`, `blockedBy`, `blocking` fields — and upserts into D1 (tables: `issues`, `edges`, `repos`, `sync_state`).
-3. The Worker serves the corpus over a JSON API; the static frontend (ASSETS binding) builds the views client-side.
-4. The GitHub org webhook (`POST /webhook/github`, HMAC-verified) applies incremental updates in real time; each sync run writes a JSON audit to R2.
+1. Scheduled reconcile and `POST /admin/sync` fetch issues via GitHub GraphQL (`subIssues`, `parent`, `blockedBy`, `blocking`) and upsert into D1.
+2. GitHub webhooks (`POST /webhook/github`, HMAC-verified) apply incremental updates.
+3. The React app at `app.live.roxabi.dev` proxies `/api/*` to the API worker and renders pivot, list, and graph views.
 
 ## Features
 
 | Category | Feature |
 |---|---|
-| **Views** | Pivot matrix (milestones x lanes), flat list, SVG dependency graph |
+| **Views** | Pivot matrix (milestones × lanes), flat list, SVG dependency graph |
 | **Filters** | Multi-select: repo, milestone, priority, status; full-text search |
 | **Dependencies** | Parent/child edges + blocker edges; status propagation (blocked/ready/done) |
-| **Sync** | GitHub GraphQL sync; daily Cron Trigger; real-time webhook updates |
+| **Sync** | GitHub GraphQL sync; webhook updates; manual admin sync |
 | **Theme** | Light/dark toggle |
-| **Storage** | Cloudflare D1 (serverless SQLite) + R2 per-run audit log |
+| **Storage** | Cloudflare D1 + R2 per-run audit log |
 
 ## API Reference
+
+Browser traffic is same-origin on `app.live.roxabi.dev` (proxied to the API worker).
 
 | Endpoint | Method | Auth | Description |
 |---|---|---|---|
 | `/health` | GET | public | DB reachability + issue count |
 | `/api/version` | GET | public | Build/version info |
-| `/login` | GET | public | Start GitHub App OAuth flow; redirects to GitHub |
+| `/login` | GET | public | Start GitHub App OAuth flow |
 | `/oauth/callback` | GET | public (validates D1 state) | OAuth callback; sets `__Host-session` cookie |
 | `/logout` | POST | public (idempotent) | Clear session cookie |
 | `/api/me` | GET | session | Current authenticated user info |
-| `/api/active-tenant` | POST | session | Set active org when user has >1 GitHub App installation |
-| `/api/issues` | GET | session | List issues (`repo`, `state`, `label`, `limit`, `offset` query params) |
+| `/api/active-tenant` | POST | session | Set active org when user has >1 installation |
+| `/api/issues` | GET | session | List issues (`repo`, `state`, `label`, `limit`, `offset`) |
 | `/api/issues/{key}` | GET | session | Single issue by key, e.g. `Roxabi/lyra#123` |
-| `/api/graph` | GET | session | Full dependency graph JSON (nodes + edges), scoped to tenant |
+| `/api/graph` | GET | session | Full dependency graph JSON, scoped to tenant |
 | `/admin/sync` | POST | CF Access + ADMIN_TOKEN Bearer | Out-of-band sync trigger |
-| `/webhook/github` | POST | HMAC-SHA256 (`X-Hub-Signature-256`) | GitHub org webhook receiver; CF Access Bypass at edge |
-| `/*` | GET | public | Static frontend (ASSETS binding) |
+| `/webhook/github` | POST | HMAC-SHA256 | GitHub webhook receiver (on `api.*`) |
 
-**session** = `__Host-session` cookie validated against D1 `sessions` table (`requireSession` middleware).
+**session** = `__Host-session` cookie validated against D1 `sessions` table.
 
 ## Configuration
 
-Bindings live in [`wrangler.toml`](wrangler.toml); secrets are set per-environment via `wrangler secret put`.
+Bindings live in [`apps/api/wrangler.toml`](apps/api/wrangler.toml); secrets via `wrangler secret put`.
 
 ### Bindings
 
 | Binding | Type | Description |
 |---|---|---|
-| `DB` | D1 | Issue corpus + sessions (`roxabi-live-production` / `roxabi-live-staging`) |
-| `ASSETS` | Static | Serves `frontend/` via ASSETS binding |
-| `LOGS` | R2 | Per-run sync audit (`roxabi-live-logs` / `roxabi-live-logs-staging`) |
-| Cron | trigger | `0 0 * * *` — daily full reconcile |
+| `DB` | D1 | Issue corpus + sessions |
+| `ASSETS` | Static | Legacy `frontend/` shell (cleanup pending) |
+| `LOGS` | R2 | Per-run sync audit |
 
 ### Secrets
 
 | Secret | Required | Description |
 |---|---|---|
-| `GITHUB_WEBHOOK_SECRET` | yes | HMAC-SHA256 secret matching your GitHub org webhook (`X-Hub-Signature-256`) |
-| `GITHUB_APP_ID` | yes | GitHub App numeric ID (App-JWT generation for install-token flow) |
-| `GITHUB_APP_CLIENT_ID` | yes | GitHub App OAuth client ID (`/login` → `/oauth/callback` flow) |
-| `GITHUB_APP_CLIENT_SECRET` | yes | GitHub App OAuth client secret (token exchange in `/oauth/callback`) |
-| `GITHUB_APP_PRIVATE_KEY` | yes | base64-encoded PKCS#8 DER RSA private key for signing App-JWTs |
-| `GITHUB_APP_WEBHOOK_SECRET` | yes | App-level webhook HMAC secret (distinct from org `GITHUB_WEBHOOK_SECRET`) |
-| `INSTALL_TOKEN_KEY` | yes | base64-encoded 32-byte AES-GCM DEK for encrypting installation tokens at rest |
-| `GITHUB_ORG` | yes | GitHub org slug to sync (e.g. `Roxabi`); set via `wrangler secret put` |
-| `ADMIN_TOKEN` | optional | Bearer gate for `POST /admin/sync`; if unset, CF Access alone guards `/admin/*` |
-| `NOTIFY_URL` | optional | Webhook URL for sync circuit-breaker halt/auth-failure alerts |
+| `GITHUB_WEBHOOK_SECRET` | yes | Org webhook HMAC secret |
+| `GITHUB_APP_ID` | yes | GitHub App numeric ID |
+| `GITHUB_APP_CLIENT_ID` | yes | OAuth client ID |
+| `GITHUB_APP_CLIENT_SECRET` | yes | OAuth client secret |
+| `GITHUB_APP_PRIVATE_KEY` | yes | base64 PKCS#8 DER RSA key |
+| `GITHUB_APP_WEBHOOK_SECRET` | yes | App-level webhook secret |
+| `INSTALL_TOKEN_KEY` | yes | AES-GCM DEK for install tokens at rest |
+| `GITHUB_ORG` | yes | Org slug to sync |
+| `ADMIN_TOKEN` | optional | Bearer gate for `POST /admin/sync` |
+| `NOTIFY_URL` | optional | Circuit-breaker alert webhook |
 
 ```bash
-# wrangler.toml lives at the repo root, so run from worker/ with --config
-# set a secret (prod)
-cd worker && printf %s '<value>' | npx wrangler secret put GITHUB_APP_ID --config ../wrangler.toml
-
-# same secret on staging
-cd worker && printf %s '<value>' | npx wrangler secret put GITHUB_APP_ID --env staging --config ../wrangler.toml
+cd apps/api
+printf %s '<value>' | bunx wrangler secret put GITHUB_APP_ID
+printf %s '<value>' | bunx wrangler secret put GITHUB_APP_ID --env staging
 ```
 
-For local dev, put secrets in `worker/.dev.vars` (one `KEY=VALUE` per line; never commit this file).
+For local dev: `apps/api/.dev.vars` (never commit).
 
 ## Self-hosting
 
-Roxabi Live is designed to fork. See **[docs/DEPLOY.md](docs/DEPLOY.md)** for the complete step-by-step guide: creating a GitHub App, provisioning Cloudflare resources (Worker, D1, R2), setting repo CI secrets, and running migrations.
-
-Replace the following Roxabi-specific values with your own when forking:
-
-| Value | Where | How to obtain |
-|---|---|---|
-| `live.roxabi.dev` | `wrangler.toml` `routes` | Your own custom domain (or use `workers.dev`) |
-| `roxabi-live` / `roxabi-live-staging` | `wrangler.toml` `name` / `[env.staging]` | Your choice of Worker names |
-| D1 database IDs | `wrangler.toml` `[[d1_databases]]` | `wrangler d1 create <name>` |
-| R2 bucket names | `wrangler.toml` `[[r2_buckets]]` | `wrangler r2 bucket create <name>` |
-| GitHub App slug in install URL | `worker/src/` (redirect on no-install) | Your GitHub App's slug from App settings |
+See **[docs/DEPLOY.md](docs/DEPLOY.md)** for GitHub App setup, Cloudflare provisioning, and migrations.
 
 ## Plugins
 
-This repo also hosts the **`roxabi-issues`** Claude Code plugin (`plugins/roxabi-issues/`), relocated from `dev-core` — issue triage that pairs with the cockpit.
+**`roxabi-issues`** — issue triage skill that pairs with the cockpit:
 
 ```bash
 claude plugin marketplace add Roxabi/roxabi-live
 claude plugin install roxabi-issues
 ```
 
-The `issue-triage` skill (invoked `roxabi-issues:issue-triage`) sets labels (size / priority / lane / type) and manages blocked-by dependencies and parent/child sub-issues on GitHub issues — **labels + native relations only, no Projects V2 board** (the cockpit owns the read/dashboard side). Self-contained bun project.
+`/issue-triage` sets labels (size / priority / lane / type) and manages blocked-by + parent/child relations — **no Projects V2 board**. See [docs/agent-workflow.md](docs/agent-workflow.md).
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/getting-started.md](docs/getting-started.md).

--- a/apps/api/src/sync/label-vocab.ts
+++ b/apps/api/src/sync/label-vocab.ts
@@ -21,6 +21,7 @@ const _LEGACY_SIZE_MAP: Record<string, string> = { M: "F-lite" };
 const _LEGACY_SIZE_RAW = new Set(["XS", "S", "M", "L", "XL"]);
 const _PRIORITY_EXACT: Record<string, string> = {
   P0: "P0",
+  "P0-critical": "P0",
   "priority:P0": "P0",
   "P1-high": "P1",
   "priority:high": "P1",

--- a/apps/api/src/sync/sync.test.ts
+++ b/apps/api/src/sync/sync.test.ts
@@ -98,6 +98,11 @@ describe("extractFromLabels", () => {
     expect(priority).toBe("P1");
   });
 
+  it("extracts priority from P0-critical", () => {
+    const { priority } = extractFromLabels(["P0-critical"]);
+    expect(priority).toBe("P0");
+  });
+
   it("extracts priority from priority:P2", () => {
     const { priority } = extractFromLabels(["priority:P2"]);
     expect(priority).toBe("P2");
@@ -558,6 +563,7 @@ describe("auth failure helpers", () => {
 describe("extractFromLabels priority aliases", () => {
   it.each([
     ["P0", "P0"],
+    ["P0-critical", "P0"],
     ["priority:P0", "P0"],
     ["P1-high", "P1"],
     ["priority:high", "P1"],

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -18,7 +18,7 @@ routes = [
 ]
 
 [vars]
-APP_RELEASE = "0.22.2"
+APP_RELEASE = "0.22.3"
 ZK_ACCOUNT_KEY = "1"
 # structure-only MUST be "1" whenever ZK_ACCOUNT_KEY is "1" — otherwise the daily
 # cron re-fetches and stores plaintext issue titles in D1, breaking the ZK promise.
@@ -62,7 +62,7 @@ routes = [
 ]
 
 [env.staging.vars]
-APP_RELEASE = "0.22.2"
+APP_RELEASE = "0.22.3"
 GITHUB_APP_SLUG = "roxabi-live-staging"
 ZK_ACCOUNT_KEY = "1"
 ZK_STRUCTURE_ONLY = "1"

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
+    "prebuild": "cp ../../llms.txt public/llms.txt",
+    "predev": "cp ../../llms.txt public/llms.txt",
     "build": "astro build",
     "preview": "astro preview",
     "typecheck": "astro check"

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -6,7 +6,8 @@
 
 - Cockpit (sign in): https://app.live.roxabi.dev
 - Marketing: https://live.roxabi.dev
-- Agent guide: https://live.roxabi.dev/for-agents
+- Agent guide (FR): https://live.roxabi.dev/for-agents
+- Agent guide (EN): https://live.roxabi.dev/en/for-agents
 - API (server-to-server; browser uses app proxy): https://api.live.roxabi.dev
 
 ## Start here (agents & humans)
@@ -54,7 +55,7 @@ Invoke: `/issue-triage`
 
 - `GET /api/graph` — dependency graph JSON
 - `GET /api/issues` — filtered issue list
-- `GET /api/issues/{owner/repo#N}` — single issue
+- `GET /api/issues/{owner}/{repo}%23{N}` — single issue (URL-encoded `#`)
 
 ## Optional
 

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -1,0 +1,62 @@
+# Roxabi Live
+
+> Operations cockpit for GitHub issue dependency graphs. Reads native blocked-by and parent/child relations, computes ready/blocked/done, and helps orchestrate parallel coding-agent fleets. GitHub stays the source of truth.
+
+## Product URLs
+
+- Cockpit (sign in): https://app.live.roxabi.dev
+- Marketing: https://live.roxabi.dev
+- Agent guide: https://live.roxabi.dev/for-agents
+- API (server-to-server; browser uses app proxy): https://api.live.roxabi.dev
+
+## Start here (agents & humans)
+
+Docs track the `main` branch (stable). Roxabi development happens on `staging` first.
+
+- Agent workflow (GitHub + /issue-triage + cockpit): https://github.com/Roxabi/roxabi-live/blob/main/docs/agent-workflow.md
+- Issue triage skill (full command reference): https://github.com/Roxabi/roxabi-live/blob/main/plugins/roxabi-issues/skills/issue-triage/SKILL.md
+- Architecture: https://github.com/Roxabi/roxabi-live/blob/main/docs/ARCHITECTURE.md
+- Local dev: https://github.com/Roxabi/roxabi-live/blob/main/docs/getting-started.md
+- Self-hosting: https://github.com/Roxabi/roxabi-live/blob/main/docs/DEPLOY.md
+
+## Label vocabulary (required for cockpit sync)
+
+- Lane: `graph:lane/<id>` (e.g. `graph:lane/b`)
+- Size: `size:<S>` or bare `XS|S|M|L|XL`; canonical tiers `S`, `F-lite`, `F-full`
+- Priority: `P0-critical`, `P1-high`, `P2-medium`, `P3-low` (issue-triage canonical); also `P0`…`P3`, `priority:high|medium|low`
+
+Set via `/issue-triage` or GitHub UI. Org issue type (`--type`: feat, fix, epic, …) is separate from labels. Roxabi Live does not use GitHub Projects V2.
+
+## Dependency relations
+
+- Blockers: GitHub `blocked-by` / `blocking` → cockpit status **blocked** while blocker is open
+- Parent/child: GitHub sub-issues → structural hierarchy in graph and list views
+- Computed status: closed → **done**; open blocker → **blocked**; else **ready** (`packages/shared` client; `GET /api/graph?status=` filters server-side)
+
+## Plugin install (Claude Code)
+
+```
+claude plugin marketplace add Roxabi/roxabi-live
+claude plugin install roxabi-issues
+```
+
+Invoke: `/issue-triage`
+
+## Monorepo layout
+
+- `apps/api` — Hono Worker, sync, webhooks, D1
+- `apps/app` — React SPA, proxies API via service binding
+- `apps/marketing` — Astro landing (apex domain)
+- `plugins/roxabi-issues` — issue-triage skill (bun)
+- `packages/shared` — shared TypeScript types
+
+## API (session auth via app)
+
+- `GET /api/graph` — dependency graph JSON
+- `GET /api/issues` — filtered issue list
+- `GET /api/issues/{owner/repo#N}` — single issue
+
+## Optional
+
+- ZK encryption (redacted titles): https://github.com/Roxabi/roxabi-live/blob/main/docs/ZK_ENCRYPTION.md
+- Maintainer instructions: https://github.com/Roxabi/roxabi-live/blob/main/CLAUDE.md

--- a/apps/marketing/src/components/CtaBand.astro
+++ b/apps/marketing/src/components/CtaBand.astro
@@ -17,7 +17,7 @@ const { t } = Astro.props;
       </h2>
       <p class="cta-body">{t.cta.body}</p>
       <div class="cta-actions">
-        <a href="https://app.live.roxabi.dev/" data-app-link class="btn btn-primary">
+        <a href="https://app.live.roxabi.dev/" data-app-link data-app-path="/" class="btn btn-primary">
           {t.cta.ctaPrimary}
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/apps/marketing/src/components/Hero.astro
+++ b/apps/marketing/src/components/Hero.astro
@@ -23,7 +23,7 @@ const { t } = Astro.props;
         </h1>
         <p class="hero-lead">{t.hero.lead}</p>
         <div class="hero-ctas">
-          <a href="https://app.live.roxabi.dev/" data-app-link class="btn btn-primary">{t.hero.ctaPrimary}</a>
+          <a href="https://app.live.roxabi.dev/" data-app-link data-app-path="/" class="btn btn-primary">{t.hero.ctaPrimary}</a>
           <a href="#demo" class="btn btn-ghost">{t.hero.ctaGhost}</a>
         </div>
         <p class="hero-note">{t.hero.note}</p>

--- a/apps/marketing/src/components/SiteFooter.astro
+++ b/apps/marketing/src/components/SiteFooter.astro
@@ -24,7 +24,14 @@ const { t } = Astro.props;
 
       <ul class="footer-links" role="list">
         {t.footer.links.map((link) => (
-          <li><a href={link.href}>{link.label}</a></li>
+          <li>
+            <a
+              href={link.href}
+              {...("appPath" in link && link.appPath ? { "data-app-link": true, "data-app-path": link.appPath } : {})}
+            >
+              {link.label}
+            </a>
+          </li>
         ))}
       </ul>
 

--- a/apps/marketing/src/components/SiteHeader.astro
+++ b/apps/marketing/src/components/SiteHeader.astro
@@ -23,37 +23,16 @@ const { t } = Astro.props;
 
     <nav aria-label="Navigation principale">
       <ul class="header-nav">
-        <li><a href="/feedback">{t.header.navComment}</a></li>
-        <li><a href="/admin">{t.header.navAdmin}</a></li>
+        <li><a href={t.header.navCommentHref}>{t.header.navComment}</a></li>
+        <li><a href="https://app.live.roxabi.dev/admin" data-app-link data-app-path="/admin">{t.header.navAdmin}</a></li>
       </ul>
     </nav>
 
     <div class="header-actions">
       <a href={t.langSwitchHref} class="btn-header-login">{t.langSwitchLabel}</a>
-      <a href="https://app.live.roxabi.dev/" data-app-link class="btn-header-cta">{t.header.loginLabel}</a>
+      <a href="https://app.live.roxabi.dev/" data-app-link data-app-path="/" class="btn-header-cta">{t.header.loginLabel}</a>
     </div>
   </div>
 </header>
 
-<script is:inline>
-  // The marketing site and the app live on sibling subdomains; point every
-  // [data-app-link] (header + hero + CTA band) at the app env matching the
-  // current marketing env (staging ↔ staging, prod ↔ prod) so a staging visitor
-  // isn't bounced to the prod app. The markup default is the prod app URL, so
-  // the links work without JS too. Wait for DOMContentLoaded so links rendered
-  // below this header (hero, CTA band) are already in the DOM.
-  (function () {
-    function wire() {
-      var app = location.hostname.indexOf("staging") !== -1
-        ? "https://app-staging.live.roxabi.dev"
-        : "https://app.live.roxabi.dev";
-      var links = document.querySelectorAll("[data-app-link]");
-      for (var i = 0; i < links.length; i++) links[i].setAttribute("href", app + "/");
-    }
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", wire);
-    } else {
-      wire();
-    }
-  })();
-</script>
+

--- a/apps/marketing/src/i18n/en.ts
+++ b/apps/marketing/src/i18n/en.ts
@@ -10,6 +10,7 @@ export const en: Translations = {
   header: {
     navComment:   "Feedback",
     navAdmin:     "Admin",
+    navCommentHref: "https://github.com/Roxabi/roxabi-live/issues/new/choose",
     loginLabel:   "Sign in",
   },
 
@@ -163,9 +164,11 @@ export const en: Translations = {
   footer: {
     logoWordmark: "Live",
     links: [
-      { label: "Feedback", href: "/feedback" },
-      { label: "Admin",    href: "/admin"    },
-      { label: "GitHub",   href: "https://github.com/Roxabi" },
+      { label: "Agent guide", href: "/en/for-agents" },
+      { label: "llms.txt",    href: "/llms.txt" },
+      { label: "Feedback",    href: "https://github.com/Roxabi/roxabi-live/issues/new/choose" },
+      { label: "Admin",       href: "https://app.live.roxabi.dev/admin", appPath: "/admin" },
+      { label: "GitHub",      href: "https://github.com/Roxabi/roxabi-live" },
     ],
     copy: "© 2026 Roxabi",
   },

--- a/apps/marketing/src/i18n/fr.ts
+++ b/apps/marketing/src/i18n/fr.ts
@@ -8,6 +8,7 @@ export const fr = {
   header: {
     navComment:   "Commentaires",
     navAdmin:     "Admin",
+    navCommentHref: "https://github.com/Roxabi/roxabi-live/issues/new/choose",
     loginLabel:   "Connexion",
   },
 
@@ -161,9 +162,11 @@ export const fr = {
   footer: {
     logoWordmark: "Live",
     links: [
-      { label: "Commentaires", href: "/feedback" },
-      { label: "Admin",        href: "/admin"    },
-      { label: "GitHub",       href: "https://github.com/Roxabi" },
+      { label: "Guide agents", href: "/for-agents" },
+      { label: "llms.txt",     href: "/llms.txt" },
+      { label: "Commentaires", href: "https://github.com/Roxabi/roxabi-live/issues/new/choose" },
+      { label: "Admin",        href: "https://app.live.roxabi.dev/admin", appPath: "/admin" },
+      { label: "GitHub",       href: "https://github.com/Roxabi/roxabi-live" },
     ],
     copy: "© 2026 Roxabi",
   },

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -41,4 +41,24 @@ const altUrl      = lang === "fr" ? `${canonicalBase}/en/` : canonicalBase + "/"
   <body class="bloom-canvas">
     <slot />
   </body>
+  <script is:inline>
+    (function () {
+      function wire() {
+        var app = location.hostname.indexOf("staging") !== -1
+          ? "https://app-staging.live.roxabi.dev"
+          : "https://app.live.roxabi.dev";
+        var links = document.querySelectorAll("[data-app-link]");
+        for (var i = 0; i < links.length; i++) {
+          var el = links[i];
+          var path = el.getAttribute("data-app-path") || "/";
+          el.setAttribute("href", app + path);
+        }
+      }
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", wire);
+      } else {
+        wire();
+      }
+    })();
+  </script>
 </html>

--- a/apps/marketing/src/pages/en/for-agents.astro
+++ b/apps/marketing/src/pages/en/for-agents.astro
@@ -1,0 +1,140 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { en } from "../../i18n/index";
+import SiteHeader from "../../components/SiteHeader.astro";
+import SiteFooter from "../../components/SiteFooter.astro";
+
+const t = en;
+const appUrl = import.meta.env.PUBLIC_APP_URL ?? "https://app.live.roxabi.dev";
+---
+
+<Layout
+  lang="en"
+  title="Roxabi Live — Agent & LLM guide"
+  description="How to structure GitHub issues with /issue-triage and orchestrate coding-agent fleets via the Roxabi Live cockpit."
+>
+  <SiteHeader t={t} />
+  <main class="agents-doc">
+    <div class="container">
+      <p class="agents-kicker">For agents & LLMs</p>
+      <h1>GitHub + <code>/issue-triage</code> + cockpit</h1>
+      <p class="agents-lead">
+        GitHub stays the source of truth. Roxabi Live reads native relations
+        (<code>blocked-by</code>, parent/child) and computes <strong>ready</strong>,
+        <strong>blocked</strong>, <strong>done</strong> so you can run agents in parallel safely.
+      </p>
+
+      <section>
+        <h2>The loop</h2>
+        <ol>
+          <li><strong>Triage</strong> — <code>/issue-triage</code>: size, priority, lane, type labels + dependencies.</li>
+          <li><strong>Sync</strong> — webhooks + reconcile → up-to-date graph in the cockpit.</li>
+          <li><strong>Launch</strong> — start only <em>ready</em> issues (no open blockers).</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Install the skill</h2>
+        <pre><code>claude plugin marketplace add Roxabi/roxabi-live
+claude plugin install roxabi-issues</code></pre>
+        <p>Invoke <code>/issue-triage</code> — full reference on <a href="https://github.com/Roxabi/roxabi-live/blob/main/plugins/roxabi-issues/skills/issue-triage/SKILL.md">GitHub</a>.</p>
+      </section>
+
+      <section>
+        <h2>Label vocabulary (cockpit sync)</h2>
+        <ul>
+          <li><strong>Lane</strong> — <code>graph:lane/b</code>, <code>graph:lane/a1</code>, …</li>
+          <li><strong>Size</strong> — <code>size:M</code> or <code>XS|S|M|L|XL</code>; canonical tiers <code>S</code>, <code>F-lite</code>, <code>F-full</code></li>
+          <li><strong>Priority</strong> — <code>P0-critical</code>, <code>P1-high</code>, <code>P2-medium</code>, <code>P3-low</code> (issue-triage canonical)</li>
+        </ul>
+        <p>No GitHub Projects V2 required — labels + native relations are enough.</p>
+      </section>
+
+      <section>
+        <h2>Useful commands</h2>
+        <pre><code>/issue-triage list --untriaged
+/issue-triage set 42 --size M --priority High --lane b --type feat
+/issue-triage set 91 --blocked-by 117
+/issue-triage set 164 --parent 163
+/issue-triage create --title "..." --size S --parent 163</code></pre>
+        <p>Cross-repo: <code>Roxabi/lyra#728</code> in <code>--blocked-by</code>.</p>
+      </section>
+
+      <section>
+        <h2>Machine-readable resources</h2>
+        <ul class="agents-links">
+          <li><a href="/llms.txt"><code>llms.txt</code></a> — compact index for LLM crawlers</li>
+          <li><a href="https://github.com/Roxabi/roxabi-live/blob/main/docs/agent-workflow.md">agent-workflow.md</a> — detailed guide</li>
+          <li><a href="https://github.com/Roxabi/roxabi-live/blob/main/docs/ARCHITECTURE.md">ARCHITECTURE.md</a></li>
+        </ul>
+      </section>
+
+      <p class="agents-cta">
+        <a class="btn btn-primary" href={appUrl}>Open cockpit</a>
+        <a class="btn btn-ghost" href="/for-agents">Version française</a>
+      </p>
+    </div>
+  </main>
+  <SiteFooter t={t} />
+</Layout>
+
+<style>
+  .agents-doc {
+    padding: 48px 0 96px;
+  }
+  .agents-kicker {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 12px;
+  }
+  .agents-doc h1 {
+    font-size: clamp(28px, 4vw, 40px);
+    margin-bottom: 16px;
+    max-width: 22ch;
+  }
+  .agents-lead {
+    font-size: 18px;
+    color: var(--text-muted);
+    max-width: 62ch;
+    margin-bottom: 40px;
+    line-height: 1.6;
+  }
+  .agents-doc section {
+    margin-bottom: 36px;
+    max-width: 72ch;
+  }
+  .agents-doc h2 {
+    font-size: 20px;
+    margin-bottom: 12px;
+  }
+  .agents-doc pre {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    padding: 16px;
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .agents-doc code {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.92em;
+  }
+  .agents-doc li {
+    margin-bottom: 8px;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .agents-links a {
+    color: var(--accent);
+  }
+  .agents-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 48px;
+  }
+</style>

--- a/apps/marketing/src/pages/en/for-agents.astro
+++ b/apps/marketing/src/pages/en/for-agents.astro
@@ -5,7 +5,6 @@ import SiteHeader from "../../components/SiteHeader.astro";
 import SiteFooter from "../../components/SiteFooter.astro";
 
 const t = en;
-const appUrl = import.meta.env.PUBLIC_APP_URL ?? "https://app.live.roxabi.dev";
 ---
 
 <Layout
@@ -70,7 +69,7 @@ claude plugin install roxabi-issues</code></pre>
       </section>
 
       <p class="agents-cta">
-        <a class="btn btn-primary" href={appUrl}>Open cockpit</a>
+        <a class="btn btn-primary" href="https://app.live.roxabi.dev/" data-app-link data-app-path="/">Open cockpit</a>
         <a class="btn btn-ghost" href="/for-agents">Version française</a>
       </p>
     </div>

--- a/apps/marketing/src/pages/for-agents.astro
+++ b/apps/marketing/src/pages/for-agents.astro
@@ -5,7 +5,6 @@ import SiteHeader from "../components/SiteHeader.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 
 const t = fr;
-const appUrl = import.meta.env.PUBLIC_APP_URL ?? "https://app.live.roxabi.dev";
 ---
 
 <Layout
@@ -70,7 +69,7 @@ claude plugin install roxabi-issues</code></pre>
       </section>
 
       <p class="agents-cta">
-        <a class="btn btn-primary" href={appUrl}>Ouvrir le cockpit</a>
+        <a class="btn btn-primary" href="https://app.live.roxabi.dev/" data-app-link data-app-path="/">Ouvrir le cockpit</a>
         <a class="btn btn-ghost" href="/en/for-agents">English version</a>
       </p>
     </div>

--- a/apps/marketing/src/pages/for-agents.astro
+++ b/apps/marketing/src/pages/for-agents.astro
@@ -1,0 +1,140 @@
+---
+import Layout from "../layouts/Layout.astro";
+import { fr } from "../i18n/index";
+import SiteHeader from "../components/SiteHeader.astro";
+import SiteFooter from "../components/SiteFooter.astro";
+
+const t = fr;
+const appUrl = import.meta.env.PUBLIC_APP_URL ?? "https://app.live.roxabi.dev";
+---
+
+<Layout
+  lang="fr"
+  title="Roxabi Live — Guide agents & LLM"
+  description="Comment structurer vos issues GitHub avec /issue-triage et piloter une flotte d'agents via le cockpit Roxabi Live."
+>
+  <SiteHeader t={t} />
+  <main class="agents-doc">
+    <div class="container">
+      <p class="agents-kicker">Pour agents & LLM</p>
+      <h1>GitHub + <code>/issue-triage</code> + cockpit</h1>
+      <p class="agents-lead">
+        GitHub reste la source de vérité. Roxabi Live lit les relations natives
+        (<code>blocked-by</code>, parent/enfant) et calcule <strong>ready</strong>,
+        <strong>blocked</strong>, <strong>done</strong> pour orchestrer des agents en parallèle.
+      </p>
+
+      <section>
+        <h2>La boucle</h2>
+        <ol>
+          <li><strong>Triage</strong> — <code>/issue-triage</code> : labels taille, priorité, lane, type + dépendances.</li>
+          <li><strong>Sync</strong> — webhooks + réconciliation → graphe à jour dans le cockpit.</li>
+          <li><strong>Lancement</strong> — ne démarrer que les issues <em>ready</em> (aucun bloqueur ouvert).</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Installer le skill</h2>
+        <pre><code>claude plugin marketplace add Roxabi/roxabi-live
+claude plugin install roxabi-issues</code></pre>
+        <p>Invocation : <code>/issue-triage</code> — référence complète sur <a href="https://github.com/Roxabi/roxabi-live/blob/main/plugins/roxabi-issues/skills/issue-triage/SKILL.md">GitHub</a>.</p>
+      </section>
+
+      <section>
+        <h2>Vocabulaire des labels (sync cockpit)</h2>
+        <ul>
+          <li><strong>Lane</strong> — <code>graph:lane/b</code>, <code>graph:lane/a1</code>, …</li>
+          <li><strong>Taille</strong> — <code>size:M</code> ou <code>XS|S|M|L|XL</code> ; tiers canoniques <code>S</code>, <code>F-lite</code>, <code>F-full</code></li>
+          <li><strong>Priorité</strong> — <code>P0-critical</code>, <code>P1-high</code>, <code>P2-medium</code>, <code>P3-low</code> (canonique issue-triage)</li>
+        </ul>
+        <p>Pas de GitHub Projects V2 requis — labels + relations natives suffisent.</p>
+      </section>
+
+      <section>
+        <h2>Commandes utiles</h2>
+        <pre><code>/issue-triage list --untriaged
+/issue-triage set 42 --size M --priority High --lane b --type feat
+/issue-triage set 91 --blocked-by 117
+/issue-triage set 164 --parent 163
+/issue-triage create --title "..." --size S --parent 163</code></pre>
+        <p>Cross-repo : <code>Roxabi/lyra#728</code> dans <code>--blocked-by</code>.</p>
+      </section>
+
+      <section>
+        <h2>Ressources machine</h2>
+        <ul class="agents-links">
+          <li><a href="/llms.txt"><code>llms.txt</code></a> — index compact pour crawlers LLM</li>
+          <li><a href="https://github.com/Roxabi/roxabi-live/blob/main/docs/agent-workflow.md">agent-workflow.md</a> — guide détaillé (EN)</li>
+          <li><a href="https://github.com/Roxabi/roxabi-live/blob/main/docs/ARCHITECTURE.md">ARCHITECTURE.md</a></li>
+        </ul>
+      </section>
+
+      <p class="agents-cta">
+        <a class="btn btn-primary" href={appUrl}>Ouvrir le cockpit</a>
+        <a class="btn btn-ghost" href="/en/for-agents">English version</a>
+      </p>
+    </div>
+  </main>
+  <SiteFooter t={t} />
+</Layout>
+
+<style>
+  .agents-doc {
+    padding: 48px 0 96px;
+  }
+  .agents-kicker {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 12px;
+  }
+  .agents-doc h1 {
+    font-size: clamp(28px, 4vw, 40px);
+    margin-bottom: 16px;
+    max-width: 20ch;
+  }
+  .agents-lead {
+    font-size: 18px;
+    color: var(--text-muted);
+    max-width: 62ch;
+    margin-bottom: 40px;
+    line-height: 1.6;
+  }
+  .agents-doc section {
+    margin-bottom: 36px;
+    max-width: 72ch;
+  }
+  .agents-doc h2 {
+    font-size: 20px;
+    margin-bottom: 12px;
+  }
+  .agents-doc pre {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    padding: 16px;
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .agents-doc code {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.92em;
+  }
+  .agents-doc li {
+    margin-bottom: 8px;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .agents-links a {
+    color: var(--accent);
+  }
+  .agents-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 48px;
+  }
+</style>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,7 +187,7 @@ Cloudflare Workers have a subrequest limit per invocation. To stay within it wit
 - Watermark tracked in `sync_state.slot` per repo; `sync_control.sync_started_at` seeded by migration 0006
 - Known: with 34+ repos, slot 2 window `[40, 60)` may be empty → that tick is a no-op (expected, tracked #166)
 
-> **Daily full reconcile (#80):** The Cron trigger (`0 0 * * *`) runs `since=null` — all repos, no watermark filter. This heals deps-only edge drift (e.g. `blockedBy`/`blocking` changes that arrive only via the sync path, not webhook events). The webhook still handles real-time intra-day updates.
+> **Daily full reconcile (#80):** When enabled, the Cron trigger (`0 0 * * *` in `apps/api/wrangler.toml`) runs `since=null` — all repos, no watermark filter. Stock config has `crons = []`; sync is driven by webhooks, login bootstrap, and `POST /admin/sync`. Re-enabling cron heals deps-only edge drift the webhook path may miss.
 
 ### R2 audit
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,34 +1,37 @@
 # Architecture — Roxabi Live
 
-Roxabi Live is a serverless operations cockpit that syncs GitHub issues and their dependency graph from a GitHub App installation into a Cloudflare D1 database, then serves the graph as a filterable web UI. The entire stack runs on Cloudflare: a single Worker handles HTTP via Hono, a Cron Trigger drives a daily full reconcile, static frontend assets are served through the Worker's ASSETS binding, and R2 stores per-run audit logs. There is no persistent server, no Python runtime, and no local database in production.
+Roxabi Live is a serverless operations cockpit that syncs GitHub issues and their dependency graph from a GitHub App installation into Cloudflare D1, then serves the graph as a filterable React UI. The stack runs on Cloudflare across three hosts: marketing (Pages), app (SPA + API proxy Worker), and API (Hono + sync + webhooks). R2 stores per-run audit logs. No persistent server, no Python runtime, no local database in production.
 
 ---
 
 ## Serverless topology
 
 ```
-                       Cloudflare edge
- ┌─────────────────────────────────────────────────────────────┐
- │                                                             │
- │  CF Access (Email-OTP)          ┌─────────────────────┐    │
- │  gates /admin/*                 │   Cloudflare Worker  │    │
- │  Bypass on /webhook/*           │   (roxabi-live)      │    │
- │                                 │                      │    │
- │  Browser ──────────────────────►│  fetch handler       │    │
- │  GitHub webhook ───────────────►│    Hono router       │    │
- │  Cron (0 0 * * *) ────────────►│  scheduled handler   │    │
- │                                 └──────┬───────────────┘    │
- │                                        │                    │
- │              ┌─────────────────────────┼─────────────┐      │
- │              │                         │             │      │
- │              ▼                         ▼             ▼      │
- │         D1 (DB)              R2 (LOGS)        ASSETS        │
- │   roxabi-live-production    per-run audit    frontend/       │
- │   [YOUR_D1_ID_PROD]         JSON files       HTML/JS/CSS     │
- └─────────────────────────────────────────────────────────────┘
+                         Cloudflare edge
+ ┌──────────────────────────────────────────────────────────────────┐
+ │  live.roxabi.dev (Pages)     Marketing — apps/marketing          │
+ │                                                                  │
+ │  app.live.roxabi.dev         ┌────────────────────────────┐      │
+ │  Browser ───────────────────►│ Worker roxabi-live-app     │      │
+ │                              │  SPA ASSETS (apps/app)     │      │
+ │                              │  proxy /api,/login,… ──────┼──┐   │
+ │                              └────────────────────────────┘  │   │
+ │                                                              ▼   │
+ │  api.live.roxabi.dev         ┌────────────────────────────┐      │
+ │  GitHub webhook ────────────►│ Worker roxabi-live (api)   │      │
+ │  Cron / admin sync ─────────►│  Hono router               │      │
+ │                              └──────┬─────────────────────┘      │
+ │                                     │                            │
+ │                    ┌────────────────┼──────────────┐               │
+ │                    ▼                ▼              ▼               │
+ │               D1 (DB)         R2 (LOGS)    ASSETS (legacy)       │
+ │         roxabi-live-production  audit JSON   frontend/           │
+ └──────────────────────────────────────────────────────────────────┘
 ```
 
-Worker entry: `worker/src/index.ts` — exports `fetch` (HTTP) and `scheduled` (Cron) handlers. Routing via Hono in `worker/src/router.ts`.
+API worker entry: `apps/api/src/index.ts` — `fetch` (HTTP) and `scheduled` (Cron). Routing via Hono in `apps/api/src/router.ts`.
+
+The browser never calls `api.live.roxabi.dev` for app traffic — the app worker proxies via a service binding. `api.*` is reached directly only for GitHub webhooks and admin/cron (CF Access on `/admin/*`, Bypass on `/webhook/*`).
 
 ---
 
@@ -78,7 +81,7 @@ GET /webhook/github (POST)
   │
   ├─ Verify X-Hub-Signature-256 (Web Crypto, GITHUB_WEBHOOK_SECRET)
   ├─ Dispatch: issues / deps / sub_issues event handlers
-  └─ D1 upsert via worker/src/webhook/mutations.ts
+  └─ D1 upsert via apps/api/src/webhook/mutations.ts
 ```
 
 ---
@@ -129,7 +132,7 @@ All `/api/*` reads are scoped through `resolveVisibleRepos`:
 `POST /admin/sync` is protected by two independent layers:
 
 1. CF Access Email-OTP at the Cloudflare edge
-2. `Authorization: Bearer <ADMIN_TOKEN>` check in `worker/src/api/admin.ts`
+2. `Authorization: Bearer <ADMIN_TOKEN>` check in `apps/api/src/api/admin.ts`
 
 `ADMIN_TOKEN` unset = Worker-level gate disabled; CF Access alone guards.
 
@@ -167,7 +170,7 @@ Edge semantics:
 
 Per-issue upsert deletes only edges of the same `kind` before re-inserting — preserves the other kind.
 
-Frontend status computation (`frontend/state.js`):
+Frontend status computation (`apps/app` graph layer; legacy `frontend/state.js` uses the same rules):
 
 ```js
 if (node.state === 'closed') return 'done';
@@ -246,48 +249,50 @@ Applied in order at deploy time (`wrangler d1 migrations apply DB --remote`):
 
 ## Frontend
 
-Static assets in `frontend/` (landing, auth, legal, dashboard) are served via the Worker ASSETS binding. The dashboard reads `GET /api/graph` and related JSON endpoints.
+**Primary UI:** React SPA in `apps/app/` — deployed at `app.live.roxabi.dev`, proxies API routes via `worker.ts` service binding.
+
+**Legacy shell:** `frontend/` (vanilla HTML/JS) still bound as ASSETS on the API worker for direct hits; cleanup pending.
+
+The dashboard reads `GET /api/graph` and related JSON endpoints (same-origin through the app proxy).
 
 ---
 
 ## Key files
 
-### Worker (active)
+### API worker (`apps/api`)
 
 | File | Role |
 |------|------|
-| `worker/src/index.ts` | Worker entry point (`fetch` + `scheduled` handlers) |
-| `worker/src/router.ts` | Request routing (Hono) |
-| `worker/src/types.ts` | `Env` interface + shared types |
-| `worker/src/api/issues.ts` | `GET /api/issues`, `GET /api/issues/:key` |
-| `worker/src/api/graph.ts` | `GET /api/graph` |
-| `worker/src/api/admin.ts` | `POST /admin/sync` (ADMIN_TOKEN-gated) |
-| `worker/src/api/version.ts` | `GET /api/version` |
-| `worker/src/sync/sync.ts` | Daily reconcile orchestrator + R2 audit write |
-| `worker/src/sync/graphql.ts` | GitHub GraphQL client (`fetch()`) |
-| `worker/src/sync/queries.ts` | GraphQL query strings |
-| `worker/src/sync/parse.ts` | Issue/edge parsing |
-| `worker/src/webhook/handlers.ts` | Webhook dispatch (issues/deps/sub_issues) |
-| `worker/src/webhook/hmac.ts` | HMAC verification |
-| `worker/src/webhook/mutations.ts` | D1 write helpers |
-| `worker/migrations/` | D1 schema migrations |
-| `wrangler.toml` | Worker config (bindings, Cron, routes, environments) |
-| `frontend/` | Static HTML/JS/CSS served via ASSETS binding |
+| `apps/api/src/index.ts` | Worker entry (`fetch` + `scheduled`) |
+| `apps/api/src/router.ts` | Hono routing |
+| `apps/api/src/types.ts` | `Env` + shared types |
+| `apps/api/src/api/issues.ts` | `GET /api/issues`, `GET /api/issues/:key` |
+| `apps/api/src/api/graph.ts` | `GET /api/graph` |
+| `apps/api/src/api/admin.ts` | `POST /admin/sync` |
+| `apps/api/src/sync/sync.ts` | Reconcile orchestrator + R2 audit |
+| `apps/api/src/webhook/handlers.ts` | Webhook dispatch |
+| `apps/api/migrations/` | D1 schema migrations |
+| `apps/api/wrangler.toml` | API worker config (`api.live.roxabi.dev`) |
+
+### App worker (`apps/app`)
+
+| File | Role |
+|------|------|
+| `apps/app/worker.ts` | Edge worker: SPA ASSETS + API proxy |
+| `apps/app/src/` | React dashboard (graph, list, pivot, auth, ZK) |
+| `apps/app/wrangler.deploy.jsonc` | Deploy config |
 
 ### Package layout
 
 ```
-worker/
-  src/
-    index.ts          # fetch + scheduled entry
-    router.ts
-    types.ts
-    api/              # issues, graph, admin, version
-    sync/             # sync, graphql, queries, parse
-    webhook/          # handlers, hmac, mutations
-  migrations/
-wrangler.toml         # repo root — binds both envs
-frontend/             # served via ASSETS binding
+apps/
+  api/                # Hono API worker
+  app/                # React SPA + proxy worker
+  marketing/          # Astro landing
+packages/
+  shared/             # @roxabi-live/shared
+frontend/             # legacy ASSETS (API worker)
+plugins/roxabi-issues/  # issue-triage skill
 ```
 
 ---

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,6 +1,8 @@
 # Self-Hosting Guide
 
-End-to-end instructions to go from a fresh fork to a running deployment on Cloudflare Workers.
+End-to-end instructions to go from a fresh fork to a running deployment on Cloudflare.
+
+> **Monorepo topology (v0.22+):** production uses three hosts — `live.roxabi.dev` (marketing/Pages), `app.live.roxabi.dev` (SPA + API proxy Worker), `api.live.roxabi.dev` (API Worker). See [MONOREPO.md](../MONOREPO.md) and [cutover-monorepo.md](cutover-monorepo.md). Wrangler config for the API lives in **`apps/api/wrangler.toml`** (not repo root). Automated setup: `bun run setup:cloudflare-deploy`.
 
 ---
 
@@ -16,15 +18,15 @@ End-to-end instructions to go from a fresh fork to a running deployment on Cloud
 - [ ] A custom domain configured in Cloudflare DNS **OR** use the free `*.workers.dev` subdomain
 - [ ] A GitHub organization you administer (the App will be installed on it)
 - [ ] A GitHub App registered in that org or your personal account (step 4)
-- [ ] Node 20 and `npm` installed locally
-- [ ] Wrangler CLI available via `npx` (no global install required; `wrangler ^3.99.0` is in `worker/devDependencies`)
+- [ ] Bun 1.3+ and Node 22+ installed locally
+- [ ] Wrangler via `bunx wrangler` (`apps/api` devDependency)
 
 **Prerequisites — local tools:**
 
 ```bash
-node --version   # must be 20.x
-npm --version    # comes with Node
-npx wrangler --version   # pulls from worker/node_modules after npm ci
+bun --version
+node --version   # must be 22.x+
+cd apps/api && bunx wrangler --version
 ```
 
 ---
@@ -35,11 +37,10 @@ npx wrangler --version   # pulls from worker/node_modules after npm ci
 # Fork the repo on GitHub, then:
 git clone https://github.com/<YOUR_ORG>/<YOUR_FORK>.git
 cd <YOUR_FORK>
-cd worker && npm ci && cd ..
+bun install
 ```
 
-The wrangler config file (`wrangler.toml`) lives at the **repo root**, not inside `worker/`.
-All `wrangler` commands below pass `--config ../wrangler.toml` when run from `worker/`.
+The API wrangler config lives in **`apps/api/wrangler.toml`**. Run wrangler from `apps/api/` unless noted otherwise.
 
 ---
 
@@ -75,42 +76,42 @@ Save the token — used for manual `wrangler` ops and Workers Builds setup (step
 ### 2c. Create D1 databases
 
 ```bash
-cd worker
+cd apps/api
 
 # Production database
-npx wrangler d1 create <YOUR_APP>-production --config ../wrangler.toml
+bunx wrangler d1 create <YOUR_APP>-production
 # Note the output: database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 # Staging database
-npx wrangler d1 create <YOUR_APP>-staging --config ../wrangler.toml
+bunx wrangler d1 create <YOUR_APP>-staging
 # Note the output: database_id = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
 ```
 
 ### 2d. Create R2 buckets
 
 ```bash
-cd worker
+cd apps/api
 
 # Production audit log bucket
-npx wrangler r2 bucket create <YOUR_APP>-logs --config ../wrangler.toml
+bunx wrangler r2 bucket create <YOUR_APP>-logs
 
 # Staging audit log bucket
-npx wrangler r2 bucket create <YOUR_APP>-logs-staging --config ../wrangler.toml
+bunx wrangler r2 bucket create <YOUR_APP>-logs-staging
 ```
 
 ---
 
-## 3. Edit wrangler.toml
+## 3. Edit apps/api/wrangler.toml
 
 Replace the Roxabi-specific values with your own. Fields to change:
 
 ```toml
-# Top-level Worker name (prod)
+# Top-level API Worker name (prod)
 name = "<YOUR_APP>"                        # was: "roxabi-live"
 
-# Custom domain — remove this block if using workers.dev instead:
+# API custom domain — browser traffic uses app.* proxy; api.* is webhooks/admin
 routes = [
-  { pattern = "<YOUR_DOMAIN>", custom_domain = true },
+  { pattern = "api.<YOUR_DOMAIN>", custom_domain = true },
 ]
 # If using workers.dev (no custom domain), replace with:
 # workers_dev = true
@@ -121,7 +122,7 @@ routes = [
 binding        = "DB"
 database_name  = "<YOUR_APP>-production"  # was: "roxabi-live-production"
 database_id    = "<PROD_DB_ID>"           # captured in step 2c
-migrations_dir = "worker/migrations"
+migrations_dir = "migrations"
 
 # Prod R2 bucket
 [[r2_buckets]]
@@ -139,7 +140,7 @@ routes = []    # KEEP THIS — see note below
 binding        = "DB"
 database_name  = "<YOUR_APP>-staging"     # was: "roxabi-live-staging"
 database_id    = "<STAGING_DB_ID>"        # captured in step 2c
-migrations_dir = "worker/migrations"
+migrations_dir = "migrations"
 
 # Staging R2 bucket
 [[env.staging.r2_buckets]]
@@ -166,9 +167,11 @@ GitHub → Settings → Developer settings → GitHub Apps → New GitHub App (o
 | Field | Value |
 |---|---|
 | GitHub App name | `<YOUR_APP>` (must be unique on GitHub) |
-| Homepage URL | `https://<YOUR_DOMAIN>` |
-| Webhook URL | `https://<YOUR_DOMAIN>/webhook/github` |
+| Homepage URL | `https://<YOUR_APEX>` (marketing site, e.g. `live.example.com`) |
+| Webhook URL | `https://api.<YOUR_DOMAIN>/webhook/github` (API worker — server→server) |
 | Webhook secret | A strong random string — **save it** as `GITHUB_WEBHOOK_SECRET` |
+
+> **Three-host topology:** browser traffic (OAuth, cockpit, proxied `/api/*`) uses **`app.<YOUR_DOMAIN>`**. Webhooks and optional cron hit **`api.<YOUR_DOMAIN>`**. Marketing lives on the **apex** (`<YOUR_APEX>`).
 
 **Permissions (Repository):**
 
@@ -195,7 +198,8 @@ GitHub → Settings → Developer settings → GitHub Apps → New GitHub App (o
 
 | Field | Value |
 |---|---|
-| Callback URL | `https://<YOUR_DOMAIN>/oauth/callback` |
+| Callback URL | `https://app.<YOUR_DOMAIN>/oauth/callback` |
+| Setup URL (post-install) | `https://app.<YOUR_DOMAIN>/install/complete` |
 | Expire user authorization tokens | Yes (recommended) |
 | Request user authorization (OAuth) during installation | Yes |
 
@@ -252,13 +256,12 @@ seeds the tenant). No manual seeding is required.
 
 ---
 
-## 5. Set Worker secrets
+## 5. Set API Worker secrets
 
-Run these from the `worker/` directory. All commands pass `--config ../wrangler.toml`.
-Export `CLOUDFLARE_ACCOUNT_ID` before running.
+Run these from `apps/api/`. Export `CLOUDFLARE_ACCOUNT_ID` before running.
 
 ```bash
-cd worker
+cd apps/api
 export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
 ```
 
@@ -270,54 +273,54 @@ For each secret, run the command once without `--env staging` (prod) and once wi
 ```bash
 # Org-level webhook HMAC secret (must match the Webhook secret set in step 4a)
 printf %s '<GITHUB_WEBHOOK_SECRET>' \
-  | npx wrangler secret put GITHUB_WEBHOOK_SECRET --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_WEBHOOK_SECRET
 printf %s '<GITHUB_WEBHOOK_SECRET>' \
-  | npx wrangler secret put GITHUB_WEBHOOK_SECRET --env staging --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_WEBHOOK_SECRET --env staging
 
 # GitHub App numeric ID
 printf %s '<GITHUB_APP_ID>' \
-  | npx wrangler secret put GITHUB_APP_ID --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_ID
 printf %s '<GITHUB_APP_ID>' \
-  | npx wrangler secret put GITHUB_APP_ID --env staging --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_ID --env staging
 
 # GitHub App OAuth client ID
 printf %s '<GITHUB_APP_CLIENT_ID>' \
-  | npx wrangler secret put GITHUB_APP_CLIENT_ID --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_CLIENT_ID
 printf %s '<GITHUB_APP_CLIENT_ID>' \
-  | npx wrangler secret put GITHUB_APP_CLIENT_ID --env staging --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_CLIENT_ID --env staging
 
 # GitHub App OAuth client secret
 printf %s '<GITHUB_APP_CLIENT_SECRET>' \
-  | npx wrangler secret put GITHUB_APP_CLIENT_SECRET --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_CLIENT_SECRET
 printf %s '<GITHUB_APP_CLIENT_SECRET>' \
-  | npx wrangler secret put GITHUB_APP_CLIENT_SECRET --env staging --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_CLIENT_SECRET --env staging
 
 # GitHub App RSA private key (base64 PKCS#8 DER from step 4a)
 printf %s '<GITHUB_APP_PRIVATE_KEY>' \
-  | npx wrangler secret put GITHUB_APP_PRIVATE_KEY --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_PRIVATE_KEY
 printf %s '<GITHUB_APP_PRIVATE_KEY>' \
-  | npx wrangler secret put GITHUB_APP_PRIVATE_KEY --env staging --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_PRIVATE_KEY --env staging
 
 # App-level webhook secret (from step 4a — distinct from org webhook secret).
 # Note: the live POST /webhook/github handler verifies HMAC against GITHUB_WEBHOOK_SECRET
 # (org-level, above), NOT this GITHUB_APP_WEBHOOK_SECRET. This one is present in the Env
 # interface for completeness but is not read on the request path; set it anyway for parity.
 printf %s '<GITHUB_APP_WEBHOOK_SECRET>' \
-  | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_WEBHOOK_SECRET
 printf %s '<GITHUB_APP_WEBHOOK_SECRET>' \
-  | npx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --env staging --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_APP_WEBHOOK_SECRET --env staging
 
 # AES-GCM DEK for encrypting install tokens at rest (base64, 32 bytes, from step 4a)
 printf %s '<INSTALL_TOKEN_KEY>' \
-  | npx wrangler secret put INSTALL_TOKEN_KEY --config ../wrangler.toml
+  | bunx wrangler secret put INSTALL_TOKEN_KEY
 printf %s '<INSTALL_TOKEN_KEY>' \
-  | npx wrangler secret put INSTALL_TOKEN_KEY --env staging --config ../wrangler.toml
+  | bunx wrangler secret put INSTALL_TOKEN_KEY --env staging
 
 # GitHub org slug to sync (e.g. "MyOrg") — treated as a secret in practice
 printf %s '<YOUR_GITHUB_ORG>' \
-  | npx wrangler secret put GITHUB_ORG --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_ORG
 printf %s '<YOUR_GITHUB_ORG>' \
-  | npx wrangler secret put GITHUB_ORG --env staging --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_ORG --env staging
 ```
 
 ### Optional secrets
@@ -326,23 +329,23 @@ printf %s '<YOUR_GITHUB_ORG>' \
 # Bearer token for POST /admin/sync defense-in-depth gate.
 # If unset, the Worker-level gate is disabled (CF Access alone guards /admin/*).
 printf %s '<YOUR_ADMIN_TOKEN>' \
-  | npx wrangler secret put ADMIN_TOKEN --config ../wrangler.toml
+  | bunx wrangler secret put ADMIN_TOKEN
 printf %s '<YOUR_ADMIN_TOKEN>' \
-  | npx wrangler secret put ADMIN_TOKEN --env staging --config ../wrangler.toml
+  | bunx wrangler secret put ADMIN_TOKEN --env staging
 
 # Webhook URL for sync circuit-breaker halt/auth-failure alerts.
 # If unset, no external notification is sent.
 printf %s '<YOUR_NOTIFY_URL>' \
-  | npx wrangler secret put NOTIFY_URL --config ../wrangler.toml
+  | bunx wrangler secret put NOTIFY_URL
 printf %s '<YOUR_NOTIFY_URL>' \
-  | npx wrangler secret put NOTIFY_URL --env staging --config ../wrangler.toml
+  | bunx wrangler secret put NOTIFY_URL --env staging
 ```
 
 **Verify secrets are set:**
 
 ```bash
-npx wrangler secret list --config ../wrangler.toml
-npx wrangler secret list --env staging --config ../wrangler.toml
+bunx wrangler secret list
+bunx wrangler secret list --env staging
 ```
 
 ---
@@ -399,7 +402,7 @@ Set Worker secrets in the Cloudflare dashboard (or `wrangler secret put`) — **
 ```bash
 export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
 export CLOUDFLARE_API_TOKEN=<YOUR_CF_API_TOKEN>
-npm run deploy:staging      # or deploy:production
+bun run deploy:staging      # or deploy:production
 ```
 
 ---
@@ -413,30 +416,17 @@ Every deploy runs `wrangler d1 migrations apply` before `wrangler deploy` (see `
 ### Manually
 
 ```bash
-cd worker
+cd apps/api
 export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
 
 # Staging
-npx wrangler d1 migrations apply DB --env staging --remote --config ../wrangler.toml
+bunx wrangler d1 migrations apply DB --env staging --remote
 
 # Production
-npx wrangler d1 migrations apply DB --remote --config ../wrangler.toml
+bunx wrangler d1 migrations apply DB --remote
 ```
 
-Migrations are applied in order:
-
-```
-0001_initial.sql
-0002_repos.sql
-0003_data_version.sql
-0004_tenancy_auth.sql
-0005_sync_slot_seed.sql
-0006_sync_started_at_seed.sql
-0007_repo_access_is_private.sql
-0008_tenant_not_null.sql
-```
-
-Wrangler tracks applied migrations and skips already-applied ones — safe to re-run.
+Wrangler applies every file in `apps/api/migrations/` in order (currently through `0022_assignees.sql`). It tracks applied migrations and skips already-applied ones — safe to re-run.
 
 ---
 
@@ -445,8 +435,8 @@ Wrangler tracks applied migrations and skips already-applied ones — safe to re
 ### Auto-deploy on merge
 
 ```bash
-git push origin staging   # Workers Builds → roxabi-live-staging
-git push origin main      # Workers Builds → roxabi-live (live.roxabi.dev)
+git push origin staging   # → api-staging, app-staging, marketing-staging
+git push origin main      # → api.live.roxabi.dev, app.live.roxabi.dev, live.roxabi.dev (apex)
 ```
 
 Monitor builds: Cloudflare dashboard → Workers → **roxabi-live** → Builds.
@@ -457,8 +447,8 @@ Monitor builds: Cloudflare dashboard → Workers → **roxabi-live** → Builds.
 export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
 export CLOUDFLARE_API_TOKEN=<YOUR_CF_API_TOKEN>
 
-npm run deploy:staging
-npm run deploy:production
+bun run deploy:staging
+bun run deploy:production
 ```
 
 ---
@@ -468,30 +458,30 @@ npm run deploy:production
 ### Health check
 
 ```bash
-# Replace with your Worker URL (workers.dev or custom domain):
-curl https://<YOUR_DOMAIN>/health
+# Browser-facing app worker (proxies /api/* to the API worker):
+curl https://app.<YOUR_DOMAIN>/health
 # Expected: 200 JSON with issue count (0 before first sync)
 
-curl https://<YOUR_DOMAIN>/api/version
+curl https://app.<YOUR_DOMAIN>/api/version
 # Expected: 200 JSON with data_version timestamp
 ```
 
 ### Sign in
 
-1. Open `https://<YOUR_DOMAIN>` in a browser.
-2. The frontend auth gate redirects to `/login`.
-3. Authorize the GitHub App → OAuth callback sets the `__Host-session` cookie.
+1. Open `https://app.<YOUR_DOMAIN>` in a browser.
+2. The SPA redirects unauthenticated users to `/login`.
+3. Authorize the GitHub App → OAuth callback at `https://app.<YOUR_DOMAIN>/oauth/callback` sets the `__Host-session` cookie.
 4. If your App is not yet installed on any org, GitHub redirects you to the install page
    (`https://github.com/apps/<YOUR_APP_SLUG>/installations/new`). Install it, then return.
 5. The dashboard loads — issues and graph are empty until after the first sync.
 
 ### Trigger a sync
 
-The cron runs daily at 00:00 UTC (`0 0 * * *`). To trigger immediately:
+Sync is driven by GitHub webhooks, bootstrap on first login, and manual triggers. Cron is **disabled** in the stock `apps/api/wrangler.toml` (`crons = []`). To trigger immediately:
 
 ```bash
-# Requires ADMIN_TOKEN to be set (step 5):
-curl -X POST https://<YOUR_DOMAIN>/admin/sync \
+# Requires ADMIN_TOKEN to be set (step 5). Use app.* (proxied) or api.* directly:
+curl -X POST https://app.<YOUR_DOMAIN>/admin/sync \
   -H "Authorization: Bearer <YOUR_ADMIN_TOKEN>"
 # Expected: 200 (or 202) — sync queued/started
 ```
@@ -537,12 +527,11 @@ export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>
 
 ### Graph is empty after first login
 
-The graph is built from synced data. Either wait for the daily cron (fires at 00:00 UTC) or
-trigger a manual sync via `POST /admin/sync`. After sync, reload the dashboard.
+The graph is built from synced data. Trigger a manual sync via `POST /admin/sync` (or wait for webhook-driven updates after issue changes). After sync, reload the dashboard.
 
-`is_private` values for repos default to `1` (fail-closed, migration 0007). The daily
-sync corrects these from the GitHub API. After the first successful sync, private/public
-status will be accurate.
+`is_private` values for repos default to `1` (fail-closed, migration 0007). A full sync corrects these from the GitHub API. After the first successful sync, private/public status will be accurate.
+
+> **Optional cron:** re-enable daily reconcile by setting `crons = ["0 0 * * *"]` in `apps/api/wrangler.toml` and redeploying.
 
 ### Webhook returns 401 or signature failure
 
@@ -552,14 +541,15 @@ break HMAC verification — use `printf %s '<secret>'` (not `echo`) when setting
 secret:
 
 ```bash
+cd apps/api
 printf %s '<GITHUB_WEBHOOK_SECRET>' \
-  | npx wrangler secret put GITHUB_WEBHOOK_SECRET --config ../wrangler.toml
+  | bunx wrangler secret put GITHUB_WEBHOOK_SECRET
 ```
 
 Verify the secret is set:
 
 ```bash
-npx wrangler secret list --config ../wrangler.toml
+bunx wrangler secret list
 # Should show GITHUB_WEBHOOK_SECRET in the list
 ```
 
@@ -581,22 +571,13 @@ has TLS configured, or use the `*.workers.dev` URL (always HTTPS).
 
 ### Local dev
 
+See [docs/getting-started.md](getting-started.md). Quick version:
+
 ```bash
-cd worker
-npm ci
-
-# Create worker/.dev.vars with your secrets (do not commit this file):
-# GITHUB_WEBHOOK_SECRET=...
-# GITHUB_APP_ID=...
-# GITHUB_APP_CLIENT_ID=...
-# GITHUB_APP_CLIENT_SECRET=...
-# GITHUB_APP_PRIVATE_KEY=...
-# GITHUB_APP_WEBHOOK_SECRET=...
-# INSTALL_TOKEN_KEY=...
-# GITHUB_ORG=...
-
-npx wrangler dev   # uses --config ../wrangler.toml (set in package.json dev script)
-# → http://localhost:8787
+bun install
+cd apps/api && bunx wrangler dev    # API → http://localhost:8787
+# SPA (separate terminal):
+cd apps/app && bun run dev
 ```
 
-Wrangler dev automatically creates a local D1 preview database — no remote D1 is used.
+Create `apps/api/.dev.vars` with your secrets (never commit). Wrangler dev provisions a local D1 preview automatically.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -117,7 +117,7 @@ API (session cookie required — sign in via the app):
 |----------|-----|
 | `GET /api/graph` | Full dependency graph for visible repos |
 | `GET /api/issues` | Filtered issue list |
-| `GET /api/issues/{owner/repo#N}` | Single issue |
+| `GET /api/issues/{owner}/{repo}%23{N}` | Single issue (URL-encoded `#`, e.g. `Roxabi/roxabi-live%2342`) |
 
 Browser traffic is same-origin on `app.live.roxabi.dev` (app worker proxies to API).
 

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,160 @@
+# Agent workflow — GitHub Issues + Roxabi Live
+
+How humans and coding agents use Roxabi Live together. GitHub remains the source of truth; the cockpit reads it and computes **ready / blocked / done** from native dependencies.
+
+---
+
+## The loop
+
+```
+/issue-triage  →  GitHub (labels + relations)  →  webhook/sync  →  Roxabi Live cockpit  →  launch agents on "ready"
+```
+
+1. **Structure issues in GitHub** with size, priority, lane labels, org issue type (`--type`), and native relations (`blocked-by`, parent/child).
+2. **Roxabi Live syncs** via webhooks (real-time), bootstrap on login, and optional `POST /admin/sync` (cron is disabled in stock config).
+3. **Open the cockpit** at [app.live.roxabi.dev](https://app.live.roxabi.dev) — pivot, list, or graph view.
+4. **Launch work** only on issues whose blockers are closed and whose parent (if any) allows progress.
+
+No Project V2 board is required. Labels + GitHub's native issue relations are enough.
+
+---
+
+## Install the issue-triage skill
+
+The `roxabi-issues` plugin lives in this repo and is also published as a Claude Code marketplace plugin.
+
+```bash
+claude plugin marketplace add Roxabi/roxabi-live
+claude plugin install roxabi-issues
+```
+
+Invoke as `/issue-triage` (full id: `roxabi-issues:issue-triage`).
+
+Local development of the skill:
+
+```bash
+cd plugins/roxabi-issues
+bun install
+bun run typecheck
+bun test
+```
+
+---
+
+## Label vocabulary (cockpit sync)
+
+Roxabi Live extracts metadata from GitHub labels. Use these patterns so the dashboard filters and pivot matrix work.
+
+| Field | Label pattern | Examples |
+|-------|---------------|----------|
+| **Lane** | `graph:lane/<id>` | `graph:lane/b`, `graph:lane/a1`, `graph:lane/standalone` |
+| **Size** | `size:<S>` or bare legacy | `size:M`, `XS`, `S`, `M`, `L`, `XL` |
+| **Priority** | `priority:*` or `P0`…`P3` | `P0-critical`, `P1-high`, `P2-medium`, `P3-low` (issue-triage canonical) |
+| **Type** | org issue type (not a label) | `feat`, `fix`, `epic`, `chore`, … via `--type` |
+
+Canonical size tiers for agent planning: `S`, `F-lite`, `F-full` (aliases map to legacy sizes).
+
+### issue-triage commands
+
+```bash
+/issue-triage list                    # tree of open issues
+/issue-triage list --untriaged        # missing size or priority
+/issue-triage set 42 --size M --priority High --lane b --type feat
+/issue-triage set 91 --blocked-by 117
+/issue-triage set 164 --parent 163
+/issue-triage create --title "..." --size S --priority Medium --type feat --parent 163
+```
+
+Cross-repo refs use `owner/repo#N`:
+
+```bash
+/issue-triage set 42 --blocked-by Roxabi/lyra#728
+GITHUB_REPO=Roxabi/voiceCLI /issue-triage create --title "..." --blocked-by Roxabi/lyra#728
+```
+
+Full reference: [`plugins/roxabi-issues/skills/issue-triage/SKILL.md`](../plugins/roxabi-issues/skills/issue-triage/SKILL.md).
+
+---
+
+## Dependency relations
+
+Roxabi Live maps GitHub's native relations to graph edges:
+
+| Relation | GitHub | Edge `kind` | Effect on status |
+|----------|--------|-------------|------------------|
+| Blocker | `blocked-by` / `blocking` | `blocks` | Open blocker → issue is **blocked** |
+| Parent/child | `parent` / sub-issues | `parent` | Structural hierarchy (epic fan-out) |
+
+**Status rules** (computed in the client via `packages/shared`; the API can filter by status server-side):
+
+- `closed` → **done**
+- Any open issue blocking this one → **blocked**
+- Otherwise → **ready**
+
+Set blockers with `/issue-triage set N --blocked-by M` or GitHub's UI. Parent/child with `--parent` / `--add-child`.
+
+### Deferral vs decomposition
+
+| Pattern | Parent-child? | When |
+|---------|---------------|------|
+| Epic → planned phase | Yes — child of epic | Up-front spec split |
+| Issue → follow-up (deferred) | No — **sibling** under shared parent | Post-hoc "do later" |
+| `--blocked-by` on follow-up | Yes | Traceability to origin issue |
+
+---
+
+## What agents should read from the cockpit
+
+After triage, agents use Roxabi Live to answer:
+
+- **What can I start now?** — filter status = `ready`, optionally by lane/size/priority/repo.
+- **What am I blocked on?** — graph view or issue detail shows open blockers.
+- **What's the epic scope?** — parent/child tree in list view or graph.
+
+API (session cookie required — sign in via the app):
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /api/graph` | Full dependency graph for visible repos |
+| `GET /api/issues` | Filtered issue list |
+| `GET /api/issues/{owner/repo#N}` | Single issue |
+
+Browser traffic is same-origin on `app.live.roxabi.dev` (app worker proxies to API).
+
+---
+
+## Recommended agent pipeline
+
+1. **`/issue-triage`** — create or triage the issue (size, priority, lane, type, blockers, parent).
+2. **`/frame` / `/spec` / `/plan`** (dev-core) — frame and plan from triaged metadata.
+3. **`/dev #N`** — implement; cockpit shows when dependent issues become ready.
+4. **On deferral** — create a **sibling** follow-up with `--blocked-by` pointing to the origin issue.
+
+Complexity score κ (1–10) can be appended to the issue body as `<!-- complexity: N -->` for tier selection (S / F-lite / F-full). See the skill doc for the formula.
+
+---
+
+## ZK-sensitive issues
+
+When ZK encryption is enabled, issue titles may appear as `[redacted]` in the cockpit for users without the account key. Graph structure (blockers, parent/child, status) stays visible. Agents working on ZK-sealed issues need the user's unlocked session — see [`docs/ZK_ENCRYPTION.md`](ZK_ENCRYPTION.md).
+
+---
+
+## Topology (for agents crawling the repo)
+
+| Host | Role |
+|------|------|
+| `live.roxabi.dev` | Marketing (Astro, CF Pages) |
+| `app.live.roxabi.dev` | React SPA + same-origin API proxy |
+| `api.live.roxabi.dev` | Hono API, webhooks, cron (server-to-server) |
+
+Code layout: `apps/api`, `apps/app`, `apps/marketing`, `packages/shared`, `plugins/roxabi-issues`.
+
+---
+
+## Further reading
+
+- [`llms.txt`](../llms.txt) — compact index for LLM crawlers
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — system design
+- [`CLAUDE.md`](../CLAUDE.md) — maintainer/agent instructions for this repo
+- [`plugins/roxabi-issues/skills/issue-triage/README.md`](../plugins/roxabi-issues/skills/issue-triage/README.md) — skill quick reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,29 +1,28 @@
 # Getting Started — Local Development
 
-This guide covers running **roxabi-live** locally as a Cloudflare Worker. For production and self-hosted deployment, see [docs/DEPLOY.md](DEPLOY.md).
+This guide covers running **roxabi-live** locally. For production and self-hosted deployment, see [docs/DEPLOY.md](DEPLOY.md).
 
 ## Prerequisites
 
-- **Node.js 20** — verify with `node --version` (should print `v20.x`)
-- **npm** — bundled with Node; no global wrangler install required
+- **Bun 1.3+** — `bun --version`
+- **Node 22+** — required by the root `package.json` engines field
 
-No Python, no `uv`, no system-level dependencies beyond Node 20.
+No Python runtime is needed for the app itself. `uv sync --group dev` installs license-check and pre-commit tooling only.
 
 ## Clone and Install
 
 ```bash
-git clone https://github.com/<YOUR_ORG>/<YOUR_FORK>.git
-# <!-- TODO: replace with your fork URL -->
+git clone https://github.com/Roxabi/roxabi-live.git
 cd roxabi-live
-cd worker && npm ci
+bun install
 ```
 
 ## Local Secrets
 
-Wrangler reads secrets from `worker/.dev.vars` automatically during `wrangler dev`. Create the file — it is gitignored and must never be committed:
+Wrangler reads secrets from `apps/api/.dev.vars` during `wrangler dev`. Create the file — it is gitignored:
 
 ```ini
-# worker/.dev.vars
+# apps/api/.dev.vars
 GITHUB_WEBHOOK_SECRET=<your-org-level-webhook-secret>
 GITHUB_APP_ID=<your-app-numeric-id>
 GITHUB_APP_CLIENT_ID=<your-app-oauth-client-id>
@@ -40,38 +39,51 @@ NOTIFY_URL=<optional-alert-webhook-url>
 
 | Goal | Required secrets |
 |---|---|
-| Browse `/health`, `/api/version`, static frontend — no auth | None — wrangler dev works with an empty `.dev.vars` |
-| Exercise the OAuth login flow end-to-end | `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_ORG` |
-| Receive and verify org webhooks locally | `GITHUB_WEBHOOK_SECRET` (plus a tunnel to expose `localhost:8787`) |
+| Browse `/health`, `/api/version` — no auth | None — wrangler dev works with an empty `.dev.vars` |
+| Exercise OAuth end-to-end | `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_ORG` |
+| Receive org webhooks locally | `GITHUB_WEBHOOK_SECRET` + tunnel to expose `localhost:8787` |
 | Encrypt/decrypt install tokens | `INSTALL_TOKEN_KEY` |
-| Trigger manual sync via `POST /admin/sync` | `ADMIN_TOKEN` (omitting it disables the Worker-level Bearer check; CF Access guards prod) |
+| Trigger `POST /admin/sync` | `ADMIN_TOKEN` |
 
-> For most contributors, read-only local dev without any secrets is sufficient. The production deployment is the reference deployment for auth flows.
+> For most contributors, read-only local dev without secrets is sufficient.
 
 ### Where to obtain each value
 
 | Secret | How to obtain |
 |---|---|
-| `GITHUB_APP_ID` | GitHub App settings page → **App ID** (numeric) |
-| `GITHUB_APP_CLIENT_ID` | GitHub App settings page → **Client ID** |
-| `GITHUB_APP_CLIENT_SECRET` | GitHub App settings page → **Generate a new client secret** |
-| `GITHUB_APP_PRIVATE_KEY` | GitHub App settings → **Generate a private key** → convert to PKCS#8 DER → `base64 -w0` |
-| `GITHUB_APP_WEBHOOK_SECRET` | GitHub App settings → **Webhook secret** (App-level, distinct from org webhook) |
-| `GITHUB_WEBHOOK_SECRET` | GitHub org → Settings → Webhooks → your webhook entry → **Secret** |
-| `INSTALL_TOKEN_KEY` | Generate locally: `openssl rand -base64 32` |
-| `GITHUB_ORG` | Your GitHub org slug (e.g. `acme`) |
-| `ADMIN_TOKEN` | Any opaque string; generate with `openssl rand -hex 32` |
-| `NOTIFY_URL` | Optional — any webhook URL for circuit-breaker alerts (e.g. Discord incoming webhook) |
+| `GITHUB_APP_ID` | GitHub App settings → **App ID** (numeric) |
+| `GITHUB_APP_CLIENT_ID` | GitHub App settings → **Client ID** |
+| `GITHUB_APP_CLIENT_SECRET` | GitHub App settings → **Generate a new client secret** |
+| `GITHUB_APP_PRIVATE_KEY` | Generate private key → PKCS#8 DER → `base64 -w0` |
+| `GITHUB_APP_WEBHOOK_SECRET` | GitHub App settings → **Webhook secret** |
+| `GITHUB_WEBHOOK_SECRET` | GitHub org webhook entry → **Secret** |
+| `INSTALL_TOKEN_KEY` | `openssl rand -base64 32` |
+| `GITHUB_ORG` | Your GitHub org slug |
+| `ADMIN_TOKEN` | `openssl rand -hex 32` (optional) |
 
-## Run the Dev Server
+Full self-hosting steps: [docs/DEPLOY.md](DEPLOY.md).
+
+## Run the Dev Servers
+
+**API worker** (Hono, D1 preview, port 8787):
 
 ```bash
-cd worker && npx wrangler dev
+cd apps/api && bunx wrangler dev
 ```
 
-The Worker starts at **http://localhost:8787**. Wrangler provisions a local D1 preview automatically — no external database setup is needed.
+**React SPA** (proxies API in dev):
 
-Verify the setup:
+```bash
+cd apps/app && bun run dev
+```
+
+**Marketing** (optional):
+
+```bash
+bun run dev:marketing
+```
+
+Verify the API:
 
 | Endpoint | Auth | What to expect |
 |---|---|---|
@@ -81,24 +93,27 @@ Verify the setup:
 
 ## Apply Migrations Locally
 
-On first run the local D1 preview is empty. Apply all migrations once:
+On first run the local D1 preview is empty:
 
 ```bash
-cd worker && npx wrangler d1 migrations apply DB --local --config ../wrangler.toml
+cd apps/api && bunx wrangler d1 migrations apply DB --local
 ```
 
-Subsequent `wrangler dev` runs reuse the persisted local DB state.
+## Monorepo Layout
+
+| Path | Role |
+|------|------|
+| `apps/api` | API worker — sync, webhooks, auth, D1 |
+| `apps/app` | React SPA + edge proxy worker |
+| `apps/marketing` | Astro landing site |
+| `packages/shared` | Shared TypeScript types |
+| `plugins/roxabi-issues` | `issue-triage` Claude Code skill |
+| `frontend/` | Legacy vanilla shell (still ASSETS-bound on API worker) |
+
+## Agent workflow
+
+To use Roxabi Live with coding agents, see [docs/agent-workflow.md](agent-workflow.md) and install the `roxabi-issues` plugin.
 
 ## Production / Self-Hosting
 
-See [docs/DEPLOY.md](DEPLOY.md) for:
-
-- Cloudflare account and Worker setup
-- D1 database and R2 bucket provisioning
-- GitHub App creation, wrangler secret injection, and Workers Builds setup
-- Auto-deploy on push to `staging` / `main` (break-glass `npm run deploy:*`)
-- Cloudflare Access configuration for `/admin/*`
-
-## Legacy Note
-
-The pre-2026-06 Python/FastAPI app is decommissioned and removed from the repo (2026-06-20). Runtime is Worker + `frontend/` only. `uv sync --group dev` installs license-check tooling, not an application server.
+See [docs/DEPLOY.md](DEPLOY.md) for Cloudflare setup, GitHub App configuration, and deploy automation.

--- a/infra/pages-marketing-staging.json
+++ b/infra/pages-marketing-staging.json
@@ -9,7 +9,7 @@
     "destination_dir": "apps/marketing/dist"
   },
   "source": {
-    "path_includes": ["apps/marketing/*", "packages/*", "package.json", "bun.lock"]
+    "path_includes": ["apps/marketing/*", "packages/*", "package.json", "bun.lock", "llms.txt"]
   },
   "productionEnv": {
     "PUBLIC_APP_URL": "https://app-staging.live.roxabi.dev"

--- a/infra/pages-marketing.json
+++ b/infra/pages-marketing.json
@@ -9,7 +9,7 @@
     "destination_dir": "apps/marketing/dist"
   },
   "source": {
-    "path_includes": ["apps/marketing/*", "packages/*", "package.json", "bun.lock"]
+    "path_includes": ["apps/marketing/*", "packages/*", "package.json", "bun.lock", "llms.txt"]
   },
   "productionEnv": {
     "PUBLIC_APP_URL": "https://app.live.roxabi.dev"

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,8 @@
 
 - Cockpit (sign in): https://app.live.roxabi.dev
 - Marketing: https://live.roxabi.dev
-- Agent guide: https://live.roxabi.dev/for-agents
+- Agent guide (FR): https://live.roxabi.dev/for-agents
+- Agent guide (EN): https://live.roxabi.dev/en/for-agents
 - API (server-to-server; browser uses app proxy): https://api.live.roxabi.dev
 
 ## Start here (agents & humans)
@@ -54,7 +55,7 @@ Invoke: `/issue-triage`
 
 - `GET /api/graph` — dependency graph JSON
 - `GET /api/issues` — filtered issue list
-- `GET /api/issues/{owner/repo#N}` — single issue
+- `GET /api/issues/{owner}/{repo}%23{N}` — single issue (URL-encoded `#`)
 
 ## Optional
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,62 @@
+# Roxabi Live
+
+> Operations cockpit for GitHub issue dependency graphs. Reads native blocked-by and parent/child relations, computes ready/blocked/done, and helps orchestrate parallel coding-agent fleets. GitHub stays the source of truth.
+
+## Product URLs
+
+- Cockpit (sign in): https://app.live.roxabi.dev
+- Marketing: https://live.roxabi.dev
+- Agent guide: https://live.roxabi.dev/for-agents
+- API (server-to-server; browser uses app proxy): https://api.live.roxabi.dev
+
+## Start here (agents & humans)
+
+Docs track the `main` branch (stable). Roxabi development happens on `staging` first.
+
+- Agent workflow (GitHub + /issue-triage + cockpit): https://github.com/Roxabi/roxabi-live/blob/main/docs/agent-workflow.md
+- Issue triage skill (full command reference): https://github.com/Roxabi/roxabi-live/blob/main/plugins/roxabi-issues/skills/issue-triage/SKILL.md
+- Architecture: https://github.com/Roxabi/roxabi-live/blob/main/docs/ARCHITECTURE.md
+- Local dev: https://github.com/Roxabi/roxabi-live/blob/main/docs/getting-started.md
+- Self-hosting: https://github.com/Roxabi/roxabi-live/blob/main/docs/DEPLOY.md
+
+## Label vocabulary (required for cockpit sync)
+
+- Lane: `graph:lane/<id>` (e.g. `graph:lane/b`)
+- Size: `size:<S>` or bare `XS|S|M|L|XL`; canonical tiers `S`, `F-lite`, `F-full`
+- Priority: `P0-critical`, `P1-high`, `P2-medium`, `P3-low` (issue-triage canonical); also `P0`…`P3`, `priority:high|medium|low`
+
+Set via `/issue-triage` or GitHub UI. Org issue type (`--type`: feat, fix, epic, …) is separate from labels. Roxabi Live does not use GitHub Projects V2.
+
+## Dependency relations
+
+- Blockers: GitHub `blocked-by` / `blocking` → cockpit status **blocked** while blocker is open
+- Parent/child: GitHub sub-issues → structural hierarchy in graph and list views
+- Computed status: closed → **done**; open blocker → **blocked**; else **ready** (`packages/shared` client; `GET /api/graph?status=` filters server-side)
+
+## Plugin install (Claude Code)
+
+```
+claude plugin marketplace add Roxabi/roxabi-live
+claude plugin install roxabi-issues
+```
+
+Invoke: `/issue-triage`
+
+## Monorepo layout
+
+- `apps/api` — Hono Worker, sync, webhooks, D1
+- `apps/app` — React SPA, proxies API via service binding
+- `apps/marketing` — Astro landing (apex domain)
+- `plugins/roxabi-issues` — issue-triage skill (bun)
+- `packages/shared` — shared TypeScript types
+
+## API (session auth via app)
+
+- `GET /api/graph` — dependency graph JSON
+- `GET /api/issues` — filtered issue list
+- `GET /api/issues/{owner/repo#N}` — single issue
+
+## Optional
+
+- ZK encryption (redacted titles): https://github.com/Roxabi/roxabi-live/blob/main/docs/ZK_ENCRYPTION.md
+- Maintainer instructions: https://github.com/Roxabi/roxabi-live/blob/main/CLAUDE.md

--- a/plugins/roxabi-issues/skills/issue-triage/SKILL.md
+++ b/plugins/roxabi-issues/skills/issue-triage/SKILL.md
@@ -18,7 +18,7 @@ Create GitHub issues, assign Size/Priority labels, manage blockedBy dependencies
 2. ∀ issue: determine Size, Priority, κ (see [Complexity Scoring](#complexity-scoring))
 3. Set values: `τ set <number> --size <S> --priority <P>`
 4. Create issues: `τ create --title "Title" [--body "Body"] [--label "bug,frontend"] [--size M] [--priority High] [--type feat] [--lane b] [--parent 163]`
-5. → DP(B)if unsure about Size ∨ Priority.
+5. → ask userif unsure about Size ∨ Priority.
 
 ## Size Guidelines
 
@@ -183,7 +183,7 @@ gh issue edit <number> --body "$BODY
 | 4-6 | **F-lite** | Worktree + subagents + /code-review | Task subagents (1-2 domain + tester) |
 | 7-10 | **F-full** | Bootstrap + worktree + agent team + /code-review | TeamCreate (3+ agents, test-first) |
 
-κ is advisory. Human judgment overrides. → DP(B)if score ≠ intuition.
+κ is advisory. Human judgment overrides. → ask userif score ≠ intuition.
 
 See [Tier Classification Reference](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/tier-classification.md) for full rules.
 Reference: `artifacts/analyses/280-token-consumption.mdx` for scoring examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 license = { text = "AGPL-3.0-or-later" }
 name = "roxabi-live"
-version = "0.22.2"
+version = "0.22.3"
 description = "Roxabi Live — repo tooling (Worker + frontend are the application)"
 requires-python = ">=3.12,<3.13"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "roxabi-live"
-version = "0.22.2"
+version = "0.22.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Promotion: staging → main (v0.22.3)

## [0.22.3] - 2026-07-02

### Added

* **docs:** monorepo doc refresh for v0.22 three-host topology ([#293](https://github.com/Roxabi/roxabi-live/pull/293))
* **docs:** agent workflow guide, `llms.txt`, and marketing `/for-agents` pages ([#293](https://github.com/Roxabi/roxabi-live/pull/293))

### Fixed

* **docs:** address code-review findings — DEPLOY paths, `P0-critical` label sync, marketing app links ([#293](https://github.com/Roxabi/roxabi-live/pull/293))
* **sync:** map `P0-critical` priority label from issue-triage ([#293](https://github.com/Roxabi/roxabi-live/pull/293))

### Changed

* **chore:** add `context-lint` GitHub workflow for Grok + Claude harness paths
* **plugins:** drop decision presentation protocol from issue-triage skill

## Pre-flight

- [x] CI passing on staging
- [x] Open PR on staging acknowledged (#288 docs landing — non-blocking)
- [x] Deploy preview skipped (no `deploy-preview.yml` on this repo)
- [x] Release notes committed to staging (`chore(release): 0.22.3`)

---
Generated with Claude Code via `/promote`