### PR TITLE
feat(api): incremental graph fetch via graph_changelog (#295 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: |
           bun --filter @roxabi-live/shared typecheck
           bun --filter @roxabi-live/app typecheck
+      - name: Test (shared — vitest)
+        run: bun --filter @roxabi-live/shared test
       - name: Test (app — vitest)
         run: bun --filter @roxabi-live/app test
       # Marketing: gate on a successful Astro build (astro check has pre-existing

--- a/apps/api/migrations/0024_graph_changelog.sql
+++ b/apps/api/migrations/0024_graph_changelog.sql
@@ -1,0 +1,10 @@
+-- Per-issue graph mutation log for incremental /api/graph?since=… fetches (#295 follow-up).
+
+CREATE TABLE IF NOT EXISTS graph_changelog (
+  issue_key  TEXT NOT NULL,
+  bumped_at  TEXT NOT NULL,
+  op         TEXT NOT NULL DEFAULT 'upsert' CHECK (op IN ('upsert', 'delete')),
+  PRIMARY KEY (issue_key, bumped_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_changelog_bumped_at ON graph_changelog(bumped_at);

--- a/apps/api/src/api/graph-test-helpers.ts
+++ b/apps/api/src/api/graph-test-helpers.ts
@@ -87,8 +87,16 @@ export function makeGraphTestApp() {
 
 type RepoAccessRow = { repo: string; is_private: number };
 
+export type GraphChangelogRow = { issue_key: string; op: string; bumped_at: string };
+
+export interface GraphEnvOptions {
+  corpusVersion?: string;
+  changelogRows?: GraphChangelogRow[];
+}
+
 function graphDbRows(
   sql: string,
+  args: unknown[] | undefined,
   labels: unknown[],
   prState: unknown[],
   issues: unknown[],
@@ -98,13 +106,16 @@ function graphDbRows(
   repoAccess: RepoAccessRow[],
   zkOptIn: boolean,
   sealedIssueKeys: string[],
+  options: GraphEnvOptions = {},
 ): FakeResult[] {
   const lower = sql.toLowerCase();
   if (lower.includes("from graph_changelog")) {
-    return [];
+    const since = String(args?.[0] ?? "");
+    const rows = (options.changelogRows ?? []).filter((r) => r.bumped_at > since);
+    return rows.map((r) => ({ issue_key: r.issue_key, op: r.op }));
   }
   if (lower.includes("max(v) as version") || lower.includes("max(last_synced_at)")) {
-    return [{ version: "" }];
+    return [{ version: options.corpusVersion ?? "" }];
   }
   if (lower.includes("from sync_control") && lower.includes("data_version")) {
     return [{ v: "" }];
@@ -144,6 +155,7 @@ export function makeGraphEnv(
   zkOptIn = false,
   sealedIssueKeys: string[] = [],
   repoAccess?: RepoAccessRow[],
+  options?: GraphEnvOptions,
 ): Env {
   const visibleRepos = overrideVisible ?? [
     ...new Set((issues as Array<{ repo: string }>).map((i) => i.repo)),
@@ -160,6 +172,7 @@ export function makeGraphEnv(
       args,
       graphDbRows(
         sql,
+        args,
         labels,
         prState,
         issues,
@@ -169,6 +182,7 @@ export function makeGraphEnv(
         accessRows,
         zkOptIn,
         sealedIssueKeys,
+        options,
       ),
       0,
     ),
@@ -186,10 +200,11 @@ export function makeGraphEnvWithCapture(
   const capturedSqls: string[] = [];
   const visibleRepos = [...new Set((issues as Array<{ repo: string }>).map((i) => i.repo))];
   const accessRows = visibleRepos.map((repo) => ({ repo, is_private: 0 }));
-  const { db } = captureDb((sql, _args) => {
+  const { db } = captureDb((sql, args) => {
     capturedSqls.push(sql);
     return graphDbRows(
       sql,
+      args,
       labels,
       prState,
       issues,

--- a/apps/api/src/api/graph-test-helpers.ts
+++ b/apps/api/src/api/graph-test-helpers.ts
@@ -100,6 +100,15 @@ function graphDbRows(
   sealedIssueKeys: string[],
 ): FakeResult[] {
   const lower = sql.toLowerCase();
+  if (lower.includes("from graph_changelog")) {
+    return [];
+  }
+  if (lower.includes("max(v) as version") || lower.includes("max(last_synced_at)")) {
+    return [{ version: "" }];
+  }
+  if (lower.includes("from sync_control") && lower.includes("data_version")) {
+    return [{ v: "" }];
+  }
   const issueRows = issues as Array<{ repo: string; updated_at?: string | null }>;
   if (lower.includes("group by repo")) {
     return aggregateRepoActivity(issueRows);

--- a/apps/api/src/api/graph.test.ts
+++ b/apps/api/src/api/graph.test.ts
@@ -259,7 +259,7 @@ describe("GET /api/graph", () => {
       const res = await testApp.request("/api/graph", {}, makeGraphEnv([], [], [], []));
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body).toEqual({ nodes: [], edges: [], repos: [] });
+      expect(body).toEqual({ nodes: [], edges: [], repos: [], mode: "full", version: "" });
     });
   });
 
@@ -499,7 +499,7 @@ describe("GET /api/graph", () => {
       const { env, capturedSqls } = makeGraphEnvWithCapture([], [], [], [], []);
       const res = await testApp.request("/api/graph", {}, env);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ nodes: [], edges: [], repos: [] });
+      expect(await res.json()).toEqual({ nodes: [], edges: [], repos: [], mode: "full", version: "" });
       expect(capturedSqls.some((s) => s.includes("has_active_branch"))).toBe(false);
       expect(capturedSqls.some((s) => s.includes("FROM edges"))).toBe(false);
       expect(capturedSqls.some((s) => s.includes("FROM repos"))).toBe(false);

--- a/apps/api/src/api/graph.test.ts
+++ b/apps/api/src/api/graph.test.ts
@@ -505,4 +505,70 @@ describe("GET /api/graph", () => {
       expect(capturedSqls.some((s) => s.includes("FROM repos"))).toBe(false);
     });
   });
+
+  describe("delta fetch (?since=)", () => {
+    const corpusVersion = "2026-07-03T12:00:00.000Z";
+    const since = "2026-07-03T10:00:00.000Z";
+
+    it("returns empty delta when changelog has no rows since cursor", async () => {
+      const issue = graphIssue(1);
+      const env = makeGraphEnv([], [], [issue], [], [], undefined, false, [], undefined, {
+        corpusVersion,
+        changelogRows: [],
+      });
+      const res = await testApp.request(`/api/graph?since=${since}`, {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        mode: string;
+        nodes: unknown[];
+        removed_keys: string[];
+        version: string;
+      }>();
+      expect(body).toMatchObject({
+        mode: "delta",
+        nodes: [],
+        edges: [],
+        repos: [],
+        removed_keys: [],
+        version: corpusVersion,
+      });
+    });
+
+    it("returns patched nodes and removed_keys from changelog", async () => {
+      const issue1 = graphIssue(1, { title: "One" });
+      const deletedKey = `${GRAPH_REPO}#99`;
+      const env = makeGraphEnv([], [], [issue1], [], [], undefined, false, [], undefined, {
+        corpusVersion,
+        changelogRows: [
+          { issue_key: issue1.key, op: "upsert", bumped_at: "2026-07-03T11:00:00.000Z" },
+          { issue_key: deletedKey, op: "delete", bumped_at: "2026-07-03T11:30:00.000Z" },
+        ],
+      });
+      const res = await testApp.request(`/api/graph?since=${since}`, {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        mode: string;
+        nodes: Array<{ key: string; title: string | null }>;
+        removed_keys: string[];
+      }>();
+      expect(body.mode).toBe("delta");
+      expect(body.nodes.map((n) => n.key)).toContain(issue1.key);
+      expect(body.removed_keys).toEqual([deletedKey]);
+    });
+
+    it("treats malformed since as full fetch", async () => {
+      const issue = graphIssue(1, { title: "Full" });
+      const env = makeGraphEnv([], [], [issue], [], [], undefined, false, [], undefined, {
+        corpusVersion,
+        changelogRows: [
+          { issue_key: issue.key, op: "upsert", bumped_at: "2026-07-03T11:00:00.000Z" },
+        ],
+      });
+      const res = await testApp.request("/api/graph?since=not-a-date", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json<{ mode: string; nodes: unknown[] }>();
+      expect(body.mode).toBe("full");
+      expect(body.nodes).toHaveLength(1);
+    });
+  });
 });

--- a/apps/api/src/api/graph.ts
+++ b/apps/api/src/api/graph.ts
@@ -1,48 +1,38 @@
 /**
  * GET /api/graph — v6 graph payload (nodes + edges).
  *
- * Ported from src/roxabi_live/dep_graph/v6/api.py::build_graph_json.
- * Response shape MUST stay { nodes: Node[], edges: Edge[] } — byte-compatible
- * with the Python source consumed by the v6 frontend (state.js).
- *
- * Five D1 reads (a)-(e), tenant-scoped to resolveVisibleRepos(c):
- *   (a) labels — grouped into Map<issueKey, string[]>
- *   (b) open pr_state — build Map<issueKey, {has_reviewed_label:number}[]>
- *   (c) issues — one row per issue
- *   (d) edges — all src_key/dst_key/kind rows
- *   (e) repos — registry rows + is_private + per-repo issue_count / last_updated_at
+ * Full fetch: scans visible repos. Delta fetch (?since=<version>): reads only
+ * issues touched since that corpus version via graph_changelog (#295 follow-up).
  */
 
 import type { Context } from "hono";
 import { resolveVisibleRepos } from "../auth/repoAccess";
 import type { AuthEnv } from "../auth/types";
-import { loadZkSealedIssueKeysForUser, redactIssueTitle } from "../auth/zk";
+import { loadZkSealedIssueKeysForUser } from "../auth/zk";
+import { buildGraphPayload, expandGraphKeys } from "../graph/build-payload";
+import { collectGraphChangesSince } from "../graph/changelog";
 import {
-  filterNodesByStatus,
   parseClosedUnderOpenEpicQuery,
   parseStatusQuery,
 } from "../graph/status";
+import { getCorpusVersion } from "../graph/corpus-version";
 import {
   computeEtag,
   etagMatches,
-  getGlobalDataVersion,
   getTenantPlan,
   sealVersionForKeys,
 } from "../quota";
 import {
   graphQuotaDeniedResponse,
+  MIN_DELTA_GRAPH_ROWS,
   recordGraphRowsSpend,
   reserveGraphRowsBudget,
 } from "../quota/read-budget";
-import { parseMilestone } from "../sync/parse";
 
-const LANE_LABEL_PREFIX = "graph:lane/";
+/** Max dirty issues before falling back to a full rebuild. */
+export const MAX_DELTA_KEYS = 400;
 
 export type DevState = "idle" | "dev" | "pr_open" | "pr_reviewed";
-
-interface PrInfo {
-  has_reviewed_label: number;
-}
 
 export interface Node {
   key: string;
@@ -71,74 +61,21 @@ export interface Edge {
   kind: string;
 }
 
-function parseAssignees(raw: string | null): string[] {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
-  } catch {
-    return [];
-  }
+function parseSinceQuery(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.length > 64) return null;
+  return trimmed;
 }
 
-/** Fallback: derive lane from `graph:lane/X` label when board field unset. */
-function laneFromLabels(labels: string[]): string | null {
-  for (const lbl of labels) {
-    if (lbl.startsWith(LANE_LABEL_PREFIX)) {
-      return lbl.slice(LANE_LABEL_PREFIX.length);
-    }
-  }
-  return null;
+function visibleRepoSet(visible: string[]): Set<string> {
+  return new Set(visible);
 }
 
-/**
- * Compute dev_state for a single issue node.
- *
- * Priority (highest wins):
- *   pr_reviewed — any open PR linked to this issue has has_reviewed_label=1
- *   pr_open     — any open PR linked to this issue (no reviewed label)
- *   dev         — has_active_branch=1, no open PR
- *   idle        — no branch, no open PR; also forced for closed issues
- */
-function computeDevState(issueState: string, hasActiveBranch: number, openPrs: PrInfo[]): DevState {
-  if (issueState === "closed") return "idle";
-  if (openPrs.some((pr) => pr.has_reviewed_label)) return "pr_reviewed";
-  if (openPrs.length > 0) return "pr_open";
-  if (hasActiveBranch) return "dev";
-  return "idle";
-}
-
-interface LabelRow {
-  issue_key: string;
-  name: string;
-}
-
-interface PrStateRow {
-  closing_issue_keys: string | null;
-  has_reviewed_label: number;
-}
-
-interface IssueRow {
-  key: string;
-  repo: string;
-  number: number;
-  title: string | null;
-  state: string;
-  url: string | null;
-  milestone: string | null;
-  lane: string | null;
-  priority: string | null;
-  size: string | null;
-  status: string | null;
-  is_stub: number;
-  has_active_branch: number;
-  assignees: string | null;
-}
-
-interface EdgeRow {
-  src_key: string;
-  dst_key: string;
-  kind: string;
+function keyInVisibleRepos(key: string, visible: Set<string>): boolean {
+  const hash = key.lastIndexOf("#");
+  if (hash <= 0) return false;
+  return visible.has(key.slice(0, hash));
 }
 
 export const graphRoute = async (c: Context<AuthEnv>) => {
@@ -150,7 +87,7 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
   const visible = await resolveVisibleRepos(c);
 
   if (visible.length === 0) {
-    return c.json({ nodes: [], edges: [], repos: [] });
+    return c.json({ nodes: [], edges: [], repos: [], mode: "full", version: "" });
   }
 
   const searchParams = new URL(c.req.url).searchParams;
@@ -158,175 +95,131 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
   const closedUnderOpenEpic = parseClosedUnderOpenEpicQuery(
     searchParams.get("closed_under_open_epic"),
   );
+  const since = parseSinceQuery(searchParams.get("since"));
 
-  const dataVersion = await getGlobalDataVersion(c.env.DB);
+  const corpusVersion = await getCorpusVersion(c.env.DB);
+
   const etag = await computeEtag([
-    dataVersion,
+    corpusVersion,
     visible.slice().sort().join(","),
     await sealVersionForKeys(sealedKeys),
     searchParams.get("status") ?? "",
     searchParams.get("closed_under_open_epic") ?? "",
+    since ?? "",
   ]);
 
   if (etagMatches(c.req.header("if-none-match"), etag)) {
     return c.body(null, 304, { ETag: etag });
   }
 
+  const useDelta = since != null && since.length > 0 && since < corpusVersion;
   let tenantPlan: Awaited<ReturnType<typeof getTenantPlan>> | undefined;
+
   if (session?.tenantId) {
     tenantPlan = await getTenantPlan(c.env.DB, session.tenantId);
-    if (!(await reserveGraphRowsBudget(c.env.DB, session.tenantId, tenantPlan))) {
+    const minHeadroom = useDelta ? MIN_DELTA_GRAPH_ROWS : undefined;
+    if (!(await reserveGraphRowsBudget(c.env.DB, session.tenantId, tenantPlan, minHeadroom))) {
       return graphQuotaDeniedResponse(c);
     }
   }
 
-  const ph = visible.map(() => "?").join(",");
+  const tenantId = session?.tenantId ?? null;
   let rowsRead = 0;
 
-  // (a) labels → Map<issueKey, string[]> — scoped to visible issues only
-  const labelRows = await c.env.DB.prepare(
-    `SELECT issue_key, name FROM labels WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
-  )
-    .bind(...visible)
-    .all<LabelRow>();
-  rowsRead += labelRows.meta?.rows_read ?? 0;
-  const labelsByIssue = new Map<string, string[]>();
-  for (const row of labelRows.results) {
-    const existing = labelsByIssue.get(row.issue_key);
-    if (existing) {
-      existing.push(row.name);
-    } else {
-      labelsByIssue.set(row.issue_key, [row.name]);
-    }
-  }
+  if (useDelta) {
+    const changes = await collectGraphChangesSince(c.env.DB, since);
+    const visibleSet = visibleRepoSet(visible);
+    const removed_keys: string[] = [];
+    const seedKeys = new Set<string>();
 
-  // (b) open pr_state → Map<issueKey, PrInfo[]>
-  // pr_state has a repo column; scope to visible repos so PR metadata for non-visible
-  // repos is excluded. openPrsByIssue is read by key only for visible issues, but
-  // scoping here prevents any row for non-visible repos from entering the map.
-  const prRows = await c.env.DB.prepare(
-    `SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open' AND repo IN (${ph})`,
-  )
-    .bind(...visible)
-    .all<PrStateRow>();
-  rowsRead += prRows.meta?.rows_read ?? 0;
-  const openPrsByIssue = new Map<string, PrInfo[]>();
-  for (const row of prRows.results) {
-    if (!row.closing_issue_keys) continue;
-    let keys: string[];
-    try {
-      keys = JSON.parse(row.closing_issue_keys) as string[];
-    } catch {
-      continue;
-    }
-    const prInfo: PrInfo = { has_reviewed_label: Number(row.has_reviewed_label) };
-    for (const key of keys) {
-      const existing = openPrsByIssue.get(key);
-      if (existing) {
-        existing.push(prInfo);
-      } else {
-        openPrsByIssue.set(key, [prInfo]);
+    for (const change of changes) {
+      if (change.op === "delete") {
+        if (keyInVisibleRepos(change.issue_key, visibleSet)) {
+          removed_keys.push(change.issue_key);
+        }
+        continue;
+      }
+      if (keyInVisibleRepos(change.issue_key, visibleSet)) {
+        seedKeys.add(change.issue_key);
       }
     }
+
+    if (seedKeys.size > MAX_DELTA_KEYS) {
+      const full = await buildGraphPayload({
+        db: c.env.DB,
+        visible,
+        sealedKeys,
+        tenantId,
+        statusFilter,
+        closedUnderOpenEpic,
+      });
+      rowsRead += full.rowsRead;
+      if (session?.tenantId && tenantPlan) {
+        if (!(await recordGraphRowsSpend(c.env.DB, session.tenantId, rowsRead, tenantPlan))) {
+          return graphQuotaDeniedResponse(c);
+        }
+      }
+      return c.json(
+        { ...full, mode: "full", version: corpusVersion },
+        200,
+        { ETag: etag, "Cache-Control": "private, no-cache" },
+      );
+    }
+
+    if (seedKeys.size === 0 && removed_keys.length === 0) {
+      if (session?.tenantId && tenantPlan) {
+        await recordGraphRowsSpend(c.env.DB, session.tenantId, rowsRead, tenantPlan);
+      }
+      return c.json(
+        { mode: "delta", nodes: [], edges: [], repos: [], removed_keys: [], version: corpusVersion },
+        200,
+        { ETag: etag, "Cache-Control": "private, no-cache" },
+      );
+    }
+
+    const expanded = await expandGraphKeys(c.env.DB, [...seedKeys], visible);
+    rowsRead += expanded.rowsRead;
+
+    const delta = await buildGraphPayload({
+      db: c.env.DB,
+      visible,
+      sealedKeys,
+      tenantId,
+      keys: expanded.keys,
+      statusFilter,
+      closedUnderOpenEpic,
+    });
+    rowsRead += delta.rowsRead;
+
+    if (session?.tenantId && tenantPlan) {
+      if (!(await recordGraphRowsSpend(c.env.DB, session.tenantId, rowsRead, tenantPlan))) {
+        return graphQuotaDeniedResponse(c);
+      }
+    }
+
+    return c.json(
+      {
+        mode: "delta",
+        nodes: delta.nodes,
+        edges: delta.edges,
+        repos: delta.repos,
+        removed_keys,
+        version: corpusVersion,
+      },
+      200,
+      { ETag: etag, "Cache-Control": "private, no-cache" },
+    );
   }
 
-  // (c) issues — scoped to visible repos
-  const issueRows = await c.env.DB.prepare(
-    `SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, lane, priority, size, status, is_stub, has_active_branch, assignees FROM issues WHERE repo IN (${ph})`,
-  )
-    .bind(...visible)
-    .all<IssueRow>();
-  rowsRead += issueRows.meta?.rows_read ?? 0;
-
-  let nodes: Node[] = issueRows.results.map((row) => {
-    const issueLabels = labelsByIssue.get(row.key) ?? [];
-    const { code, name, sortKey } = parseMilestone(row.milestone);
-    const openPrs = openPrsByIssue.get(row.key) ?? [];
-    const devState = computeDevState(row.state, Number(row.has_active_branch ?? 0), openPrs);
-    return {
-      key: row.key,
-      repo: row.repo,
-      number: row.number,
-      title: redactIssueTitle(row.title, row.key, sealedKeys),
-      state: row.state,
-      dev_state: devState,
-      url: row.url,
-      milestone: row.milestone,
-      milestone_code: code,
-      milestone_name: name,
-      milestone_sort_key: sortKey,
-      labels: issueLabels,
-      priority: row.priority,
-      lane: row.lane || laneFromLabels(issueLabels),
-      size: row.size,
-      status: row.status,
-      is_stub: Boolean(row.is_stub),
-      assignees: parseAssignees(row.assignees),
-    };
+  const full = await buildGraphPayload({
+    db: c.env.DB,
+    visible,
+    sealedKeys,
+    tenantId,
+    statusFilter,
+    closedUnderOpenEpic,
   });
-
-  // (d) edges — both endpoints must be in visible repos; dangling edges to invisible
-  // nodes are dropped (graph only draws an edge when both nodes are present)
-  const edgeRows = await c.env.DB.prepare(
-    `SELECT src_key, dst_key, kind FROM edges WHERE src_key IN (SELECT key FROM issues WHERE repo IN (${ph})) AND dst_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
-  )
-    .bind(...visible, ...visible)
-    .all<EdgeRow>();
-  rowsRead += edgeRows.meta?.rows_read ?? 0;
-
-  let edges: Edge[] = edgeRows.results.map((row) => ({
-    src: row.src_key,
-    dst: row.dst_key,
-    kind: row.kind,
-  }));
-
-  if (statusFilter !== null) {
-    nodes = filterNodesByStatus(nodes, edges, statusFilter, { closedUnderOpenEpic });
-    const keys = new Set(nodes.map((n) => n.key));
-    edges = edges.filter((e) => keys.has(e.src) && keys.has(e.dst));
-  }
-
-  // (e) repos — registry + visibility + activity stats for filter dropdown ordering
-  interface RepoRow {
-    repo: string;
-    archived: number;
-    is_private: number;
-  }
-  interface RepoActivityRow {
-    repo: string;
-    issue_count: number;
-    last_updated_at: string | null;
-  }
-  const tenantId = session?.tenantId ?? null;
-  const [repoRows, activityRows] = await Promise.all([
-    c.env.DB.prepare(
-      `SELECT r.repo, r.archived, COALESCE(tra.is_private, 1) AS is_private
-       FROM repos r
-       LEFT JOIN tenant_repo_access tra
-         ON tra.tenant_id = ? AND tra.repo = r.repo
-       WHERE r.repo IN (${ph})`,
-    )
-      .bind(tenantId, ...visible)
-      .all<RepoRow>(),
-    c.env.DB.prepare(
-      `SELECT repo, COUNT(*) AS issue_count, MAX(updated_at) AS last_updated_at
-       FROM issues WHERE repo IN (${ph}) GROUP BY repo`,
-    )
-      .bind(...visible)
-      .all<RepoActivityRow>(),
-  ]);
-  rowsRead += (repoRows.meta?.rows_read ?? 0) + (activityRows.meta?.rows_read ?? 0);
-  const activityByRepo = new Map((activityRows.results ?? []).map((row) => [row.repo, row]));
-  const repos = (repoRows.results ?? []).map((r) => {
-    const activity = activityByRepo.get(r.repo);
-    return {
-      repo: r.repo,
-      archived: Boolean(r.archived),
-      is_private: Number(r.is_private) !== 0,
-      issue_count: activity?.issue_count ?? 0,
-      last_updated_at: activity?.last_updated_at ?? null,
-    };
-  });
+  rowsRead += full.rowsRead;
 
   if (session?.tenantId && tenantPlan) {
     if (!(await recordGraphRowsSpend(c.env.DB, session.tenantId, rowsRead, tenantPlan))) {
@@ -334,8 +227,9 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
     }
   }
 
-  return c.json({ nodes, edges, repos }, 200, {
-    ETag: etag,
-    "Cache-Control": "private, no-cache",
-  });
+  return c.json(
+    { ...full, mode: "full", version: corpusVersion },
+    200,
+    { ETag: etag, "Cache-Control": "private, no-cache" },
+  );
 };

--- a/apps/api/src/api/graph.ts
+++ b/apps/api/src/api/graph.ts
@@ -61,10 +61,12 @@ export interface Edge {
   kind: string;
 }
 
+const CORPUS_VERSION_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+
 function parseSinceQuery(raw: string | null): string | null {
   if (!raw) return null;
   const trimmed = raw.trim();
-  if (!trimmed || trimmed.length > 64) return null;
+  if (!trimmed || trimmed.length > 64 || !CORPUS_VERSION_RE.test(trimmed)) return null;
   return trimmed;
 }
 
@@ -127,15 +129,16 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
   let rowsRead = 0;
 
   if (useDelta) {
-    const changes = await collectGraphChangesSince(c.env.DB, since);
+    const { changes, rowsRead: changelogRows } = await collectGraphChangesSince(c.env.DB, since);
+    rowsRead += changelogRows;
     const visibleSet = visibleRepoSet(visible);
-    const removed_keys: string[] = [];
+    const removedSet = new Set<string>();
     const seedKeys = new Set<string>();
 
     for (const change of changes) {
       if (change.op === "delete") {
         if (keyInVisibleRepos(change.issue_key, visibleSet)) {
-          removed_keys.push(change.issue_key);
+          removedSet.add(change.issue_key);
         }
         continue;
       }
@@ -143,6 +146,7 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
         seedKeys.add(change.issue_key);
       }
     }
+    const removed_keys = [...removedSet];
 
     if (seedKeys.size > MAX_DELTA_KEYS) {
       const full = await buildGraphPayload({
@@ -179,6 +183,28 @@ export const graphRoute = async (c: Context<AuthEnv>) => {
 
     const expanded = await expandGraphKeys(c.env.DB, [...seedKeys], visible);
     rowsRead += expanded.rowsRead;
+
+    if (expanded.keys.length > MAX_DELTA_KEYS) {
+      const full = await buildGraphPayload({
+        db: c.env.DB,
+        visible,
+        sealedKeys,
+        tenantId,
+        statusFilter,
+        closedUnderOpenEpic,
+      });
+      rowsRead += full.rowsRead;
+      if (session?.tenantId && tenantPlan) {
+        if (!(await recordGraphRowsSpend(c.env.DB, session.tenantId, rowsRead, tenantPlan))) {
+          return graphQuotaDeniedResponse(c);
+        }
+      }
+      return c.json(
+        { ...full, mode: "full", version: corpusVersion },
+        200,
+        { ETag: etag, "Cache-Control": "private, no-cache" },
+      );
+    }
 
     const delta = await buildGraphPayload({
       db: c.env.DB,

--- a/apps/api/src/api/version.ts
+++ b/apps/api/src/api/version.ts
@@ -1,4 +1,5 @@
 import type { Context } from "hono";
+import { getCorpusVersion } from "../graph/corpus-version";
 import { etagMatches } from "../quota";
 import type { Env } from "../types";
 
@@ -18,14 +19,7 @@ import type { Env } from "../types";
  * which path produced it. Resolves #133.
  */
 export const versionRoute = async (c: Context<{ Bindings: Env }>) => {
-  const row = await c.env.DB.prepare(
-    `SELECT MAX(v) AS version FROM (
-       SELECT COALESCE(MAX(last_synced_at), '') AS v FROM sync_state
-       UNION ALL
-       SELECT COALESCE(value, '') AS v FROM sync_control WHERE key = 'data_version' AND tenant_id = 0
-     )`,
-  ).first<{ version: string | null }>();
-  const version = row?.version ?? "";
+  const version = await getCorpusVersion(c.env.DB);
   const etag = `"${version}"`;
   if (etagMatches(c.req.header("if-none-match"), etag)) {
     return c.body(null, 304, { ETag: etag, "Cache-Control": "max-age=10" });

--- a/apps/api/src/graph/build-payload.ts
+++ b/apps/api/src/graph/build-payload.ts
@@ -2,303 +2,26 @@
  * Shared graph corpus assembly for full and delta /api/graph responses.
  */
 
-import { redactIssueTitle } from "../auth/zk";
 import { filterNodesByStatus, type GraphStatus } from "../graph/status";
-import { parseMilestone } from "../sync/parse";
+import {
+  issueRowToNode,
+  loadEdgesForKeys,
+  loadFullGraphRows,
+  loadIssuesForKeys,
+  loadLabelsForKeys,
+  loadOpenPrsByIssue,
+  loadRepos,
+} from "./graph-payload-loaders";
 
-const LANE_LABEL_PREFIX = "graph:lane/";
+export type {
+  DevState,
+  GraphBuildResult,
+  GraphEdge,
+  GraphNode,
+  RepoSummary,
+} from "./graph-payload-types";
 
-export type DevState = "idle" | "dev" | "pr_open" | "pr_reviewed";
-
-export interface GraphNode {
-  key: string;
-  repo: string;
-  number: number;
-  title: string | null;
-  state: string;
-  dev_state: DevState;
-  url: string | null;
-  milestone: string | null;
-  milestone_code: string | null;
-  milestone_name: string | null;
-  milestone_sort_key: number;
-  labels: string[];
-  priority: string | null;
-  lane: string | null;
-  size: string | null;
-  status: string | null;
-  is_stub: boolean;
-  assignees: string[];
-}
-
-export interface GraphEdge {
-  src: string;
-  dst: string;
-  kind: string;
-}
-
-interface PrInfo {
-  has_reviewed_label: number;
-}
-
-interface LabelRow {
-  issue_key: string;
-  name: string;
-}
-
-interface PrStateRow {
-  closing_issue_keys: string | null;
-  has_reviewed_label: number;
-}
-
-interface IssueRow {
-  key: string;
-  repo: string;
-  number: number;
-  title: string | null;
-  state: string;
-  url: string | null;
-  milestone: string | null;
-  lane: string | null;
-  priority: string | null;
-  size: string | null;
-  status: string | null;
-  is_stub: number;
-  has_active_branch: number;
-  assignees: string | null;
-}
-
-interface EdgeRow {
-  src_key: string;
-  dst_key: string;
-  kind: string;
-}
-
-export interface RepoSummary {
-  repo: string;
-  archived: boolean;
-  is_private: boolean;
-  issue_count: number;
-  last_updated_at: string | null;
-}
-
-export interface GraphBuildResult {
-  nodes: GraphNode[];
-  edges: GraphEdge[];
-  repos: RepoSummary[];
-  rowsRead: number;
-}
-
-function parseAssignees(raw: string | null): string[] {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
-  } catch {
-    return [];
-  }
-}
-
-function laneFromLabels(labels: string[]): string | null {
-  for (const lbl of labels) {
-    if (lbl.startsWith(LANE_LABEL_PREFIX)) {
-      return lbl.slice(LANE_LABEL_PREFIX.length);
-    }
-  }
-  return null;
-}
-
-function computeDevState(issueState: string, hasActiveBranch: number, openPrs: PrInfo[]): DevState {
-  if (issueState === "closed") return "idle";
-  if (openPrs.some((pr) => pr.has_reviewed_label)) return "pr_reviewed";
-  if (openPrs.length > 0) return "pr_open";
-  if (hasActiveBranch) return "dev";
-  return "idle";
-}
-
-function issueRowToNode(
-  row: IssueRow,
-  labelsByIssue: Map<string, string[]>,
-  openPrsByIssue: Map<string, PrInfo[]>,
-  sealedKeys: Set<string>,
-): GraphNode {
-  const issueLabels = labelsByIssue.get(row.key) ?? [];
-  const { code, name, sortKey } = parseMilestone(row.milestone);
-  const openPrs = openPrsByIssue.get(row.key) ?? [];
-  const devState = computeDevState(row.state, Number(row.has_active_branch ?? 0), openPrs);
-  return {
-    key: row.key,
-    repo: row.repo,
-    number: row.number,
-    title: redactIssueTitle(row.title, row.key, sealedKeys),
-    state: row.state,
-    dev_state: devState,
-    url: row.url,
-    milestone: row.milestone,
-    milestone_code: code,
-    milestone_name: name,
-    milestone_sort_key: sortKey,
-    labels: issueLabels,
-    priority: row.priority,
-    lane: row.lane || laneFromLabels(issueLabels),
-    size: row.size,
-    status: row.status,
-    is_stub: Boolean(row.is_stub),
-    assignees: parseAssignees(row.assignees),
-  };
-}
-
-async function loadOpenPrsByIssue(
-  db: D1Database,
-  visible: string[],
-): Promise<{ map: Map<string, PrInfo[]>; rowsRead: number }> {
-  const ph = visible.map(() => "?").join(",");
-  const prRows = await db
-    .prepare(
-      `SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open' AND repo IN (${ph})`,
-    )
-    .bind(...visible)
-    .all<PrStateRow>();
-  let rowsRead = prRows.meta?.rows_read ?? 0;
-  const openPrsByIssue = new Map<string, PrInfo[]>();
-  for (const row of prRows.results) {
-    if (!row.closing_issue_keys) continue;
-    let keys: string[];
-    try {
-      keys = JSON.parse(row.closing_issue_keys) as string[];
-    } catch {
-      continue;
-    }
-    const prInfo: PrInfo = { has_reviewed_label: Number(row.has_reviewed_label) };
-    for (const key of keys) {
-      const existing = openPrsByIssue.get(key);
-      if (existing) {
-        existing.push(prInfo);
-      } else {
-        openPrsByIssue.set(key, [prInfo]);
-      }
-    }
-  }
-  return { map: openPrsByIssue, rowsRead };
-}
-
-async function loadLabelsForKeys(
-  db: D1Database,
-  keys: string[],
-): Promise<{ map: Map<string, string[]>; rowsRead: number }> {
-  if (keys.length === 0) return { map: new Map(), rowsRead: 0 };
-  const ph = keys.map(() => "?").join(",");
-  const labelRows = await db
-    .prepare(`SELECT issue_key, name FROM labels WHERE issue_key IN (${ph})`)
-    .bind(...keys)
-    .all<LabelRow>();
-  const rowsRead = labelRows.meta?.rows_read ?? 0;
-  const labelsByIssue = new Map<string, string[]>();
-  for (const row of labelRows.results) {
-    const existing = labelsByIssue.get(row.issue_key);
-    if (existing) {
-      existing.push(row.name);
-    } else {
-      labelsByIssue.set(row.issue_key, [row.name]);
-    }
-  }
-  return { map: labelsByIssue, rowsRead };
-}
-
-async function loadIssuesForKeys(
-  db: D1Database,
-  keys: string[],
-  visible: string[],
-): Promise<{ rows: IssueRow[]; rowsRead: number }> {
-  if (keys.length === 0) return { rows: [], rowsRead: 0 };
-  const keyPh = keys.map(() => "?").join(",");
-  const repoPh = visible.map(() => "?").join(",");
-  const issueRows = await db
-    .prepare(
-      `SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, lane, priority, size, status, is_stub, has_active_branch, assignees
-       FROM issues WHERE key IN (${keyPh}) AND repo IN (${repoPh})`,
-    )
-    .bind(...keys, ...visible)
-    .all<IssueRow>();
-  return { rows: issueRows.results, rowsRead: issueRows.meta?.rows_read ?? 0 };
-}
-
-async function loadEdgesForKeys(
-  db: D1Database,
-  keys: string[],
-): Promise<{ edges: GraphEdge[]; rowsRead: number }> {
-  if (keys.length === 0) return { edges: [], rowsRead: 0 };
-  const ph = keys.map(() => "?").join(",");
-  const edgeRows = await db
-    .prepare(
-      `SELECT src_key, dst_key, kind FROM edges
-       WHERE src_key IN (${ph}) AND dst_key IN (${ph})`,
-    )
-    .bind(...keys, ...keys)
-    .all<EdgeRow>();
-  return {
-    edges: edgeRows.results.map((row) => ({
-      src: row.src_key,
-      dst: row.dst_key,
-      kind: row.kind,
-    })),
-    rowsRead: edgeRows.meta?.rows_read ?? 0,
-  };
-}
-
-async function loadRepos(
-  db: D1Database,
-  visible: string[],
-  tenantId: number | null,
-  repoFilter?: string[],
-): Promise<{ repos: RepoSummary[]; rowsRead: number }> {
-  const targetRepos = repoFilter?.length ? repoFilter.filter((r) => visible.includes(r)) : visible;
-  if (targetRepos.length === 0) return { repos: [], rowsRead: 0 };
-
-  const ph = targetRepos.map(() => "?").join(",");
-  interface RepoRow {
-    repo: string;
-    archived: number;
-    is_private: number;
-  }
-  interface RepoActivityRow {
-    repo: string;
-    issue_count: number;
-    last_updated_at: string | null;
-  }
-  const [repoRows, activityRows] = await Promise.all([
-    db
-      .prepare(
-        `SELECT r.repo, r.archived, COALESCE(tra.is_private, 1) AS is_private
-         FROM repos r
-         LEFT JOIN tenant_repo_access tra
-           ON tra.tenant_id = ? AND tra.repo = r.repo
-         WHERE r.repo IN (${ph})`,
-      )
-      .bind(tenantId, ...targetRepos)
-      .all<RepoRow>(),
-    db
-      .prepare(
-        `SELECT repo, COUNT(*) AS issue_count, MAX(updated_at) AS last_updated_at
-         FROM issues WHERE repo IN (${ph}) GROUP BY repo`,
-      )
-      .bind(...targetRepos)
-      .all<RepoActivityRow>(),
-  ]);
-  const rowsRead = (repoRows.meta?.rows_read ?? 0) + (activityRows.meta?.rows_read ?? 0);
-  const activityByRepo = new Map((activityRows.results ?? []).map((row) => [row.repo, row]));
-  const repos = (repoRows.results ?? []).map((r) => {
-    const activity = activityByRepo.get(r.repo);
-    return {
-      repo: r.repo,
-      archived: Boolean(r.archived),
-      is_private: Number(r.is_private) !== 0,
-      issue_count: activity?.issue_count ?? 0,
-      last_updated_at: activity?.last_updated_at ?? null,
-    };
-  });
-  return { repos, rowsRead };
-}
+import type { GraphBuildResult, GraphEdge, GraphNode } from "./graph-payload-types";
 
 /** Expand dirty keys with direct edge neighbors still in visible repos. */
 export async function expandGraphKeys(
@@ -345,7 +68,7 @@ export async function buildGraphPayload(opts: BuildGraphOptions): Promise<GraphB
   const { map: openPrsByIssue, rowsRead: prRows } = await loadOpenPrsByIssue(db, visible);
   rowsRead += prRows;
 
-  let issueRows: IssueRow[];
+  let issueRows: Awaited<ReturnType<typeof loadIssuesForKeys>>["rows"];
   let labelsByIssue: Map<string, string[]>;
   let edges: GraphEdge[];
 
@@ -362,45 +85,11 @@ export async function buildGraphPayload(opts: BuildGraphOptions): Promise<GraphB
     edges = edgeResult.edges;
     rowsRead += edgeResult.rowsRead;
   } else {
-    const ph = visible.map(() => "?").join(",");
-    const labelRows = await db
-      .prepare(
-        `SELECT issue_key, name FROM labels WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
-      )
-      .bind(...visible)
-      .all<LabelRow>();
-    rowsRead += labelRows.meta?.rows_read ?? 0;
-    labelsByIssue = new Map<string, string[]>();
-    for (const row of labelRows.results) {
-      const existing = labelsByIssue.get(row.issue_key);
-      if (existing) {
-        existing.push(row.name);
-      } else {
-        labelsByIssue.set(row.issue_key, [row.name]);
-      }
-    }
-
-    const issueResult = await db
-      .prepare(
-        `SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, lane, priority, size, status, is_stub, has_active_branch, assignees FROM issues WHERE repo IN (${ph})`,
-      )
-      .bind(...visible)
-      .all<IssueRow>();
-    issueRows = issueResult.results;
-    rowsRead += issueResult.meta?.rows_read ?? 0;
-
-    const edgeRows = await db
-      .prepare(
-        `SELECT src_key, dst_key, kind FROM edges WHERE src_key IN (SELECT key FROM issues WHERE repo IN (${ph})) AND dst_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
-      )
-      .bind(...visible, ...visible)
-      .all<EdgeRow>();
-    rowsRead += edgeRows.meta?.rows_read ?? 0;
-    edges = edgeRows.results.map((row) => ({
-      src: row.src_key,
-      dst: row.dst_key,
-      kind: row.kind,
-    }));
+    const full = await loadFullGraphRows(db, visible);
+    issueRows = full.issueRows;
+    labelsByIssue = full.labelsByIssue;
+    edges = full.edges;
+    rowsRead += full.rowsRead;
   }
 
   let nodes: GraphNode[] = issueRows.map((row) =>
@@ -413,9 +102,7 @@ export async function buildGraphPayload(opts: BuildGraphOptions): Promise<GraphB
     edges = edges.filter((e) => nodeKeys.has(e.src) && nodeKeys.has(e.dst));
   }
 
-  const repoFilter = keys
-    ? [...new Set(nodes.map((n) => n.repo))]
-    : undefined;
+  const repoFilter = keys ? [...new Set(nodes.map((n) => n.repo))] : undefined;
   const repoResult = await loadRepos(db, visible, tenantId, repoFilter);
   rowsRead += repoResult.rowsRead;
 

--- a/apps/api/src/graph/build-payload.ts
+++ b/apps/api/src/graph/build-payload.ts
@@ -1,0 +1,423 @@
+/**
+ * Shared graph corpus assembly for full and delta /api/graph responses.
+ */
+
+import { redactIssueTitle } from "../auth/zk";
+import { filterNodesByStatus, type GraphStatus } from "../graph/status";
+import { parseMilestone } from "../sync/parse";
+
+const LANE_LABEL_PREFIX = "graph:lane/";
+
+export type DevState = "idle" | "dev" | "pr_open" | "pr_reviewed";
+
+export interface GraphNode {
+  key: string;
+  repo: string;
+  number: number;
+  title: string | null;
+  state: string;
+  dev_state: DevState;
+  url: string | null;
+  milestone: string | null;
+  milestone_code: string | null;
+  milestone_name: string | null;
+  milestone_sort_key: number;
+  labels: string[];
+  priority: string | null;
+  lane: string | null;
+  size: string | null;
+  status: string | null;
+  is_stub: boolean;
+  assignees: string[];
+}
+
+export interface GraphEdge {
+  src: string;
+  dst: string;
+  kind: string;
+}
+
+interface PrInfo {
+  has_reviewed_label: number;
+}
+
+interface LabelRow {
+  issue_key: string;
+  name: string;
+}
+
+interface PrStateRow {
+  closing_issue_keys: string | null;
+  has_reviewed_label: number;
+}
+
+interface IssueRow {
+  key: string;
+  repo: string;
+  number: number;
+  title: string | null;
+  state: string;
+  url: string | null;
+  milestone: string | null;
+  lane: string | null;
+  priority: string | null;
+  size: string | null;
+  status: string | null;
+  is_stub: number;
+  has_active_branch: number;
+  assignees: string | null;
+}
+
+interface EdgeRow {
+  src_key: string;
+  dst_key: string;
+  kind: string;
+}
+
+export interface RepoSummary {
+  repo: string;
+  archived: boolean;
+  is_private: boolean;
+  issue_count: number;
+  last_updated_at: string | null;
+}
+
+export interface GraphBuildResult {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  repos: RepoSummary[];
+  rowsRead: number;
+}
+
+function parseAssignees(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function laneFromLabels(labels: string[]): string | null {
+  for (const lbl of labels) {
+    if (lbl.startsWith(LANE_LABEL_PREFIX)) {
+      return lbl.slice(LANE_LABEL_PREFIX.length);
+    }
+  }
+  return null;
+}
+
+function computeDevState(issueState: string, hasActiveBranch: number, openPrs: PrInfo[]): DevState {
+  if (issueState === "closed") return "idle";
+  if (openPrs.some((pr) => pr.has_reviewed_label)) return "pr_reviewed";
+  if (openPrs.length > 0) return "pr_open";
+  if (hasActiveBranch) return "dev";
+  return "idle";
+}
+
+function issueRowToNode(
+  row: IssueRow,
+  labelsByIssue: Map<string, string[]>,
+  openPrsByIssue: Map<string, PrInfo[]>,
+  sealedKeys: Set<string>,
+): GraphNode {
+  const issueLabels = labelsByIssue.get(row.key) ?? [];
+  const { code, name, sortKey } = parseMilestone(row.milestone);
+  const openPrs = openPrsByIssue.get(row.key) ?? [];
+  const devState = computeDevState(row.state, Number(row.has_active_branch ?? 0), openPrs);
+  return {
+    key: row.key,
+    repo: row.repo,
+    number: row.number,
+    title: redactIssueTitle(row.title, row.key, sealedKeys),
+    state: row.state,
+    dev_state: devState,
+    url: row.url,
+    milestone: row.milestone,
+    milestone_code: code,
+    milestone_name: name,
+    milestone_sort_key: sortKey,
+    labels: issueLabels,
+    priority: row.priority,
+    lane: row.lane || laneFromLabels(issueLabels),
+    size: row.size,
+    status: row.status,
+    is_stub: Boolean(row.is_stub),
+    assignees: parseAssignees(row.assignees),
+  };
+}
+
+async function loadOpenPrsByIssue(
+  db: D1Database,
+  visible: string[],
+): Promise<{ map: Map<string, PrInfo[]>; rowsRead: number }> {
+  const ph = visible.map(() => "?").join(",");
+  const prRows = await db
+    .prepare(
+      `SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open' AND repo IN (${ph})`,
+    )
+    .bind(...visible)
+    .all<PrStateRow>();
+  let rowsRead = prRows.meta?.rows_read ?? 0;
+  const openPrsByIssue = new Map<string, PrInfo[]>();
+  for (const row of prRows.results) {
+    if (!row.closing_issue_keys) continue;
+    let keys: string[];
+    try {
+      keys = JSON.parse(row.closing_issue_keys) as string[];
+    } catch {
+      continue;
+    }
+    const prInfo: PrInfo = { has_reviewed_label: Number(row.has_reviewed_label) };
+    for (const key of keys) {
+      const existing = openPrsByIssue.get(key);
+      if (existing) {
+        existing.push(prInfo);
+      } else {
+        openPrsByIssue.set(key, [prInfo]);
+      }
+    }
+  }
+  return { map: openPrsByIssue, rowsRead };
+}
+
+async function loadLabelsForKeys(
+  db: D1Database,
+  keys: string[],
+): Promise<{ map: Map<string, string[]>; rowsRead: number }> {
+  if (keys.length === 0) return { map: new Map(), rowsRead: 0 };
+  const ph = keys.map(() => "?").join(",");
+  const labelRows = await db
+    .prepare(`SELECT issue_key, name FROM labels WHERE issue_key IN (${ph})`)
+    .bind(...keys)
+    .all<LabelRow>();
+  const rowsRead = labelRows.meta?.rows_read ?? 0;
+  const labelsByIssue = new Map<string, string[]>();
+  for (const row of labelRows.results) {
+    const existing = labelsByIssue.get(row.issue_key);
+    if (existing) {
+      existing.push(row.name);
+    } else {
+      labelsByIssue.set(row.issue_key, [row.name]);
+    }
+  }
+  return { map: labelsByIssue, rowsRead };
+}
+
+async function loadIssuesForKeys(
+  db: D1Database,
+  keys: string[],
+  visible: string[],
+): Promise<{ rows: IssueRow[]; rowsRead: number }> {
+  if (keys.length === 0) return { rows: [], rowsRead: 0 };
+  const keyPh = keys.map(() => "?").join(",");
+  const repoPh = visible.map(() => "?").join(",");
+  const issueRows = await db
+    .prepare(
+      `SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, lane, priority, size, status, is_stub, has_active_branch, assignees
+       FROM issues WHERE key IN (${keyPh}) AND repo IN (${repoPh})`,
+    )
+    .bind(...keys, ...visible)
+    .all<IssueRow>();
+  return { rows: issueRows.results, rowsRead: issueRows.meta?.rows_read ?? 0 };
+}
+
+async function loadEdgesForKeys(
+  db: D1Database,
+  keys: string[],
+): Promise<{ edges: GraphEdge[]; rowsRead: number }> {
+  if (keys.length === 0) return { edges: [], rowsRead: 0 };
+  const ph = keys.map(() => "?").join(",");
+  const edgeRows = await db
+    .prepare(
+      `SELECT src_key, dst_key, kind FROM edges
+       WHERE src_key IN (${ph}) AND dst_key IN (${ph})`,
+    )
+    .bind(...keys, ...keys)
+    .all<EdgeRow>();
+  return {
+    edges: edgeRows.results.map((row) => ({
+      src: row.src_key,
+      dst: row.dst_key,
+      kind: row.kind,
+    })),
+    rowsRead: edgeRows.meta?.rows_read ?? 0,
+  };
+}
+
+async function loadRepos(
+  db: D1Database,
+  visible: string[],
+  tenantId: number | null,
+  repoFilter?: string[],
+): Promise<{ repos: RepoSummary[]; rowsRead: number }> {
+  const targetRepos = repoFilter?.length ? repoFilter.filter((r) => visible.includes(r)) : visible;
+  if (targetRepos.length === 0) return { repos: [], rowsRead: 0 };
+
+  const ph = targetRepos.map(() => "?").join(",");
+  interface RepoRow {
+    repo: string;
+    archived: number;
+    is_private: number;
+  }
+  interface RepoActivityRow {
+    repo: string;
+    issue_count: number;
+    last_updated_at: string | null;
+  }
+  const [repoRows, activityRows] = await Promise.all([
+    db
+      .prepare(
+        `SELECT r.repo, r.archived, COALESCE(tra.is_private, 1) AS is_private
+         FROM repos r
+         LEFT JOIN tenant_repo_access tra
+           ON tra.tenant_id = ? AND tra.repo = r.repo
+         WHERE r.repo IN (${ph})`,
+      )
+      .bind(tenantId, ...targetRepos)
+      .all<RepoRow>(),
+    db
+      .prepare(
+        `SELECT repo, COUNT(*) AS issue_count, MAX(updated_at) AS last_updated_at
+         FROM issues WHERE repo IN (${ph}) GROUP BY repo`,
+      )
+      .bind(...targetRepos)
+      .all<RepoActivityRow>(),
+  ]);
+  const rowsRead = (repoRows.meta?.rows_read ?? 0) + (activityRows.meta?.rows_read ?? 0);
+  const activityByRepo = new Map((activityRows.results ?? []).map((row) => [row.repo, row]));
+  const repos = (repoRows.results ?? []).map((r) => {
+    const activity = activityByRepo.get(r.repo);
+    return {
+      repo: r.repo,
+      archived: Boolean(r.archived),
+      is_private: Number(r.is_private) !== 0,
+      issue_count: activity?.issue_count ?? 0,
+      last_updated_at: activity?.last_updated_at ?? null,
+    };
+  });
+  return { repos, rowsRead };
+}
+
+/** Expand dirty keys with direct edge neighbors still in visible repos. */
+export async function expandGraphKeys(
+  db: D1Database,
+  seedKeys: string[],
+  visible: string[],
+): Promise<{ keys: string[]; rowsRead: number }> {
+  if (seedKeys.length === 0) return { keys: [], rowsRead: 0 };
+  const ph = seedKeys.map(() => "?").join(",");
+  const repoPh = visible.map(() => "?").join(",");
+  const edgeRows = await db
+    .prepare(
+      `SELECT DISTINCT e.src_key, e.dst_key
+       FROM edges e
+       WHERE (e.src_key IN (${ph}) OR e.dst_key IN (${ph}))
+         AND e.src_key IN (SELECT key FROM issues WHERE repo IN (${repoPh}))
+         AND e.dst_key IN (SELECT key FROM issues WHERE repo IN (${repoPh}))`,
+    )
+    .bind(...seedKeys, ...seedKeys, ...visible, ...visible)
+    .all<{ src_key: string; dst_key: string }>();
+  const rowsRead = edgeRows.meta?.rows_read ?? 0;
+  const expanded = new Set(seedKeys);
+  for (const row of edgeRows.results) {
+    expanded.add(row.src_key);
+    expanded.add(row.dst_key);
+  }
+  return { keys: [...expanded], rowsRead };
+}
+
+export interface BuildGraphOptions {
+  db: D1Database;
+  visible: string[];
+  sealedKeys: Set<string>;
+  tenantId: number | null;
+  keys?: string[];
+  statusFilter: Set<GraphStatus> | null;
+  closedUnderOpenEpic: boolean;
+}
+
+export async function buildGraphPayload(opts: BuildGraphOptions): Promise<GraphBuildResult> {
+  const { db, visible, sealedKeys, tenantId, keys, statusFilter, closedUnderOpenEpic } = opts;
+  let rowsRead = 0;
+
+  const { map: openPrsByIssue, rowsRead: prRows } = await loadOpenPrsByIssue(db, visible);
+  rowsRead += prRows;
+
+  let issueRows: IssueRow[];
+  let labelsByIssue: Map<string, string[]>;
+  let edges: GraphEdge[];
+
+  if (keys) {
+    const labelResult = await loadLabelsForKeys(db, keys);
+    labelsByIssue = labelResult.map;
+    rowsRead += labelResult.rowsRead;
+
+    const issueResult = await loadIssuesForKeys(db, keys, visible);
+    issueRows = issueResult.rows;
+    rowsRead += issueResult.rowsRead;
+
+    const edgeResult = await loadEdgesForKeys(db, keys);
+    edges = edgeResult.edges;
+    rowsRead += edgeResult.rowsRead;
+  } else {
+    const ph = visible.map(() => "?").join(",");
+    const labelRows = await db
+      .prepare(
+        `SELECT issue_key, name FROM labels WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+      )
+      .bind(...visible)
+      .all<LabelRow>();
+    rowsRead += labelRows.meta?.rows_read ?? 0;
+    labelsByIssue = new Map<string, string[]>();
+    for (const row of labelRows.results) {
+      const existing = labelsByIssue.get(row.issue_key);
+      if (existing) {
+        existing.push(row.name);
+      } else {
+        labelsByIssue.set(row.issue_key, [row.name]);
+      }
+    }
+
+    const issueResult = await db
+      .prepare(
+        `SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, lane, priority, size, status, is_stub, has_active_branch, assignees FROM issues WHERE repo IN (${ph})`,
+      )
+      .bind(...visible)
+      .all<IssueRow>();
+    issueRows = issueResult.results;
+    rowsRead += issueResult.meta?.rows_read ?? 0;
+
+    const edgeRows = await db
+      .prepare(
+        `SELECT src_key, dst_key, kind FROM edges WHERE src_key IN (SELECT key FROM issues WHERE repo IN (${ph})) AND dst_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+      )
+      .bind(...visible, ...visible)
+      .all<EdgeRow>();
+    rowsRead += edgeRows.meta?.rows_read ?? 0;
+    edges = edgeRows.results.map((row) => ({
+      src: row.src_key,
+      dst: row.dst_key,
+      kind: row.kind,
+    }));
+  }
+
+  let nodes: GraphNode[] = issueRows.map((row) =>
+    issueRowToNode(row, labelsByIssue, openPrsByIssue, sealedKeys),
+  );
+
+  if (statusFilter !== null) {
+    nodes = filterNodesByStatus(nodes, edges, statusFilter, { closedUnderOpenEpic });
+    const nodeKeys = new Set(nodes.map((n) => n.key));
+    edges = edges.filter((e) => nodeKeys.has(e.src) && nodeKeys.has(e.dst));
+  }
+
+  const repoFilter = keys
+    ? [...new Set(nodes.map((n) => n.repo))]
+    : undefined;
+  const repoResult = await loadRepos(db, visible, tenantId, repoFilter);
+  rowsRead += repoResult.rowsRead;
+
+  return { nodes, edges, repos: repoResult.repos, rowsRead };
+}

--- a/apps/api/src/graph/changelog.test.ts
+++ b/apps/api/src/graph/changelog.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { makeFakeDb, makeFakeStmt } from "../test-utils";
+import {
+  collectGraphChangesSince,
+  graphChangelogStmts,
+} from "./changelog";
+
+describe("graph_changelog", () => {
+  it("collectGraphChangesSince returns rows after cursor", async () => {
+    const rows: Array<{ issue_key: string; op: string; bumped_at: string }> = [];
+    const db = makeFakeDb((sql, args) => {
+      if (sql.includes("INSERT OR IGNORE INTO graph_changelog")) {
+        rows.push({
+          issue_key: String(args?.[0]),
+          bumped_at: String(args?.[1]),
+          op: String(args?.[2]),
+        });
+        return makeFakeStmt(sql, args, [], 1);
+      }
+      if (sql.includes("FROM graph_changelog")) {
+        const since = String(args?.[0]);
+        const filtered = rows
+          .filter((r) => r.bumped_at > since)
+          .map((r) => ({ issue_key: r.issue_key, op: r.op }));
+        return makeFakeStmt(sql, args, filtered, filtered.length);
+      }
+      return makeFakeStmt(sql, args, [], 0);
+    });
+
+    await db.batch(
+      graphChangelogStmts(db, "2026-07-01T10:00:00.000Z", [
+        { issue_key: "Roxabi/roxabi-live#1", op: "upsert" },
+      ]),
+    );
+    await db.batch(
+      graphChangelogStmts(db, "2026-07-02T10:00:00.000Z", [
+        { issue_key: "Roxabi/roxabi-live#2", op: "upsert" },
+        { issue_key: "Roxabi/roxabi-live#9", op: "delete" },
+      ]),
+    );
+
+    const changes = await collectGraphChangesSince(db, "2026-07-01T12:00:00.000Z");
+    expect(changes).toEqual([
+      { issue_key: "Roxabi/roxabi-live#2", op: "upsert" },
+      { issue_key: "Roxabi/roxabi-live#9", op: "delete" },
+    ]);
+  });
+});

--- a/apps/api/src/graph/changelog.test.ts
+++ b/apps/api/src/graph/changelog.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { makeFakeDb, makeFakeStmt } from "../test-utils";
 import {
+  collapseGraphChanges,
   collectGraphChangesSince,
   graphChangelogStmts,
 } from "./changelog";
 
 describe("graph_changelog", () => {
+  it("collapseGraphChanges keeps delete over upsert for the same key", () => {
+    expect(
+      collapseGraphChanges([
+        { issue_key: "Roxabi/roxabi-live#1", op: "upsert" },
+        { issue_key: "Roxabi/roxabi-live#1", op: "delete" },
+      ]),
+    ).toEqual([{ issue_key: "Roxabi/roxabi-live#1", op: "delete" }]);
+  });
+
   it("collectGraphChangesSince returns rows after cursor", async () => {
     const rows: Array<{ issue_key: string; op: string; bumped_at: string }> = [];
     const db = makeFakeDb((sql, args) => {
@@ -39,7 +49,7 @@ describe("graph_changelog", () => {
       ]),
     );
 
-    const changes = await collectGraphChangesSince(db, "2026-07-01T12:00:00.000Z");
+    const { changes } = await collectGraphChangesSince(db, "2026-07-01T12:00:00.000Z");
     expect(changes).toEqual([
       { issue_key: "Roxabi/roxabi-live#2", op: "upsert" },
       { issue_key: "Roxabi/roxabi-live#9", op: "delete" },

--- a/apps/api/src/graph/changelog.ts
+++ b/apps/api/src/graph/changelog.ts
@@ -1,0 +1,99 @@
+/**
+ * graph_changelog — records issue-level graph mutations for delta fetches.
+ */
+
+export type GraphChangeOp = "upsert" | "delete";
+
+export interface GraphChangeRow {
+  issue_key: string;
+  op: GraphChangeOp;
+}
+
+/** Prepare INSERT statements for one or more issue keys. */
+export function graphChangelogStmts(
+  db: D1Database,
+  bumpedAt: string,
+  changes: Array<{ issue_key: string; op?: GraphChangeOp }>,
+): D1PreparedStatement[] {
+  const stmts: D1PreparedStatement[] = [];
+  for (const { issue_key, op = "upsert" } of changes) {
+    if (!issue_key) continue;
+    stmts.push(
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO graph_changelog (issue_key, bumped_at, op)
+           VALUES (?, ?, ?)`,
+        )
+        .bind(issue_key, bumpedAt, op),
+    );
+  }
+  return stmts;
+}
+
+/** Stamp every issue in a repo (branch sync resets has_active_branch). */
+export function graphChangelogForRepoStmt(
+  db: D1Database,
+  repo: string,
+  bumpedAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT OR IGNORE INTO graph_changelog (issue_key, bumped_at, op)
+       SELECT key, ?, 'upsert' FROM issues WHERE repo = ?`,
+    )
+    .bind(bumpedAt, repo);
+}
+
+/** Stamp issues whose milestone title matches (milestone rename). */
+export function graphChangelogForRepoMilestoneStmt(
+  db: D1Database,
+  repo: string,
+  milestone: string,
+  bumpedAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT OR IGNORE INTO graph_changelog (issue_key, bumped_at, op)
+       SELECT key, ?, 'upsert' FROM issues WHERE repo = ? AND milestone = ?`,
+    )
+    .bind(bumpedAt, repo, milestone);
+}
+
+/** Issues upserted during a sync page (bulk, one stmt per repo batch). */
+export function graphChangelogForRepoSinceStmt(
+  db: D1Database,
+  repo: string,
+  sinceIso: string,
+  bumpedAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT OR IGNORE INTO graph_changelog (issue_key, bumped_at, op)
+       SELECT key, ?, 'upsert' FROM issues WHERE repo = ? AND updated_at >= ?`,
+    )
+    .bind(bumpedAt, repo, sinceIso);
+}
+
+export async function collectGraphChangesSince(
+  db: D1Database,
+  since: string,
+): Promise<GraphChangeRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT issue_key, op FROM graph_changelog
+       WHERE bumped_at > ?
+       ORDER BY bumped_at ASC`,
+    )
+    .bind(since)
+    .all<GraphChangeRow>();
+  return result.results ?? [];
+}
+
+/** Drop entries older than N days (best-effort housekeeping). */
+export async function pruneGraphChangelog(db: D1Database, keepDays = 14): Promise<void> {
+  const cutoff = new Date(Date.now() - keepDays * 86_400_000).toISOString();
+  await db
+    .prepare(`DELETE FROM graph_changelog WHERE bumped_at < ?`)
+    .bind(cutoff)
+    .run();
+}

--- a/apps/api/src/graph/changelog.ts
+++ b/apps/api/src/graph/changelog.ts
@@ -9,6 +9,23 @@ export interface GraphChangeRow {
   op: GraphChangeOp;
 }
 
+/** Collapse duplicate keys in one batch — last op wins (delete > upsert when both). */
+export function collapseGraphChanges(
+  changes: Array<{ issue_key: string; op?: GraphChangeOp }>,
+): Array<{ issue_key: string; op: GraphChangeOp }> {
+  const byKey = new Map<string, GraphChangeOp>();
+  for (const { issue_key, op = "upsert" } of changes) {
+    if (!issue_key) continue;
+    const prev = byKey.get(issue_key);
+    if (prev === "delete" || op === "delete") {
+      byKey.set(issue_key, "delete");
+    } else {
+      byKey.set(issue_key, "upsert");
+    }
+  }
+  return [...byKey.entries()].map(([issue_key, op]) => ({ issue_key, op }));
+}
+
 /** Prepare INSERT statements for one or more issue keys. */
 export function graphChangelogStmts(
   db: D1Database,
@@ -74,10 +91,15 @@ export function graphChangelogForRepoSinceStmt(
     .bind(bumpedAt, repo, sinceIso);
 }
 
+export interface GraphChangesSince {
+  changes: GraphChangeRow[];
+  rowsRead: number;
+}
+
 export async function collectGraphChangesSince(
   db: D1Database,
   since: string,
-): Promise<GraphChangeRow[]> {
+): Promise<GraphChangesSince> {
   const result = await db
     .prepare(
       `SELECT issue_key, op FROM graph_changelog
@@ -86,7 +108,10 @@ export async function collectGraphChangesSince(
     )
     .bind(since)
     .all<GraphChangeRow>();
-  return result.results ?? [];
+  return {
+    changes: result.results ?? [],
+    rowsRead: result.meta?.rows_read ?? 0,
+  };
 }
 
 /** Drop entries older than N days (best-effort housekeeping). */

--- a/apps/api/src/graph/corpus-version.ts
+++ b/apps/api/src/graph/corpus-version.ts
@@ -1,0 +1,15 @@
+/**
+ * Corpus version token — MAX(sync_state.last_synced_at, data_version).
+ * Shared by /api/version and /api/graph delta gating.
+ */
+
+const CORPUS_VERSION_SQL = `SELECT MAX(v) AS version FROM (
+  SELECT COALESCE(MAX(last_synced_at), '') AS v FROM sync_state
+  UNION ALL
+  SELECT COALESCE(value, '') AS v FROM sync_control WHERE key = 'data_version' AND tenant_id = 0
+)`;
+
+export async function getCorpusVersion(db: D1Database): Promise<string> {
+  const row = await db.prepare(CORPUS_VERSION_SQL).first<{ version: string | null }>();
+  return row?.version ?? "";
+}

--- a/apps/api/src/graph/graph-payload-loaders.ts
+++ b/apps/api/src/graph/graph-payload-loaders.ts
@@ -1,0 +1,311 @@
+/**
+ * D1 loaders + row→node mapping for graph payload assembly.
+ */
+
+import { redactIssueTitle } from "../auth/zk";
+import { parseMilestone } from "../sync/parse";
+import type { DevState, GraphEdge, GraphNode, RepoSummary } from "./graph-payload-types";
+
+const LANE_LABEL_PREFIX = "graph:lane/";
+
+interface PrInfo {
+  has_reviewed_label: number;
+}
+
+interface LabelRow {
+  issue_key: string;
+  name: string;
+}
+
+interface PrStateRow {
+  closing_issue_keys: string | null;
+  has_reviewed_label: number;
+}
+
+interface IssueRow {
+  key: string;
+  repo: string;
+  number: number;
+  title: string | null;
+  state: string;
+  url: string | null;
+  milestone: string | null;
+  lane: string | null;
+  priority: string | null;
+  size: string | null;
+  status: string | null;
+  is_stub: number;
+  has_active_branch: number;
+  assignees: string | null;
+}
+
+interface EdgeRow {
+  src_key: string;
+  dst_key: string;
+  kind: string;
+}
+
+function parseAssignees(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function laneFromLabels(labels: string[]): string | null {
+  for (const lbl of labels) {
+    if (lbl.startsWith(LANE_LABEL_PREFIX)) {
+      return lbl.slice(LANE_LABEL_PREFIX.length);
+    }
+  }
+  return null;
+}
+
+function computeDevState(issueState: string, hasActiveBranch: number, openPrs: PrInfo[]): DevState {
+  if (issueState === "closed") return "idle";
+  if (openPrs.some((pr) => pr.has_reviewed_label)) return "pr_reviewed";
+  if (openPrs.length > 0) return "pr_open";
+  if (hasActiveBranch) return "dev";
+  return "idle";
+}
+
+export function issueRowToNode(
+  row: IssueRow,
+  labelsByIssue: Map<string, string[]>,
+  openPrsByIssue: Map<string, PrInfo[]>,
+  sealedKeys: Set<string>,
+): GraphNode {
+  const issueLabels = labelsByIssue.get(row.key) ?? [];
+  const { code, name, sortKey } = parseMilestone(row.milestone);
+  const openPrs = openPrsByIssue.get(row.key) ?? [];
+  const devState = computeDevState(row.state, Number(row.has_active_branch ?? 0), openPrs);
+  return {
+    key: row.key,
+    repo: row.repo,
+    number: row.number,
+    title: redactIssueTitle(row.title, row.key, sealedKeys),
+    state: row.state,
+    dev_state: devState,
+    url: row.url,
+    milestone: row.milestone,
+    milestone_code: code,
+    milestone_name: name,
+    milestone_sort_key: sortKey,
+    labels: issueLabels,
+    priority: row.priority,
+    lane: row.lane || laneFromLabels(issueLabels),
+    size: row.size,
+    status: row.status,
+    is_stub: Boolean(row.is_stub),
+    assignees: parseAssignees(row.assignees),
+  };
+}
+
+export async function loadOpenPrsByIssue(
+  db: D1Database,
+  visible: string[],
+): Promise<{ map: Map<string, PrInfo[]>; rowsRead: number }> {
+  const ph = visible.map(() => "?").join(",");
+  const prRows = await db
+    .prepare(
+      `SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open' AND repo IN (${ph})`,
+    )
+    .bind(...visible)
+    .all<PrStateRow>();
+  let rowsRead = prRows.meta?.rows_read ?? 0;
+  const openPrsByIssue = new Map<string, PrInfo[]>();
+  for (const row of prRows.results) {
+    if (!row.closing_issue_keys) continue;
+    let keys: string[];
+    try {
+      keys = JSON.parse(row.closing_issue_keys) as string[];
+    } catch {
+      continue;
+    }
+    const prInfo: PrInfo = { has_reviewed_label: Number(row.has_reviewed_label) };
+    for (const key of keys) {
+      const existing = openPrsByIssue.get(key);
+      if (existing) {
+        existing.push(prInfo);
+      } else {
+        openPrsByIssue.set(key, [prInfo]);
+      }
+    }
+  }
+  return { map: openPrsByIssue, rowsRead };
+}
+
+export async function loadLabelsForKeys(
+  db: D1Database,
+  keys: string[],
+): Promise<{ map: Map<string, string[]>; rowsRead: number }> {
+  if (keys.length === 0) return { map: new Map(), rowsRead: 0 };
+  const ph = keys.map(() => "?").join(",");
+  const labelRows = await db
+    .prepare(`SELECT issue_key, name FROM labels WHERE issue_key IN (${ph})`)
+    .bind(...keys)
+    .all<LabelRow>();
+  const rowsRead = labelRows.meta?.rows_read ?? 0;
+  const labelsByIssue = new Map<string, string[]>();
+  for (const row of labelRows.results) {
+    const existing = labelsByIssue.get(row.issue_key);
+    if (existing) {
+      existing.push(row.name);
+    } else {
+      labelsByIssue.set(row.issue_key, [row.name]);
+    }
+  }
+  return { map: labelsByIssue, rowsRead };
+}
+
+export async function loadIssuesForKeys(
+  db: D1Database,
+  keys: string[],
+  visible: string[],
+): Promise<{ rows: IssueRow[]; rowsRead: number }> {
+  if (keys.length === 0) return { rows: [], rowsRead: 0 };
+  const keyPh = keys.map(() => "?").join(",");
+  const repoPh = visible.map(() => "?").join(",");
+  const issueRows = await db
+    .prepare(
+      `SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, lane, priority, size, status, is_stub, has_active_branch, assignees
+       FROM issues WHERE key IN (${keyPh}) AND repo IN (${repoPh})`,
+    )
+    .bind(...keys, ...visible)
+    .all<IssueRow>();
+  return { rows: issueRows.results, rowsRead: issueRows.meta?.rows_read ?? 0 };
+}
+
+export async function loadEdgesForKeys(
+  db: D1Database,
+  keys: string[],
+): Promise<{ edges: GraphEdge[]; rowsRead: number }> {
+  if (keys.length === 0) return { edges: [], rowsRead: 0 };
+  const ph = keys.map(() => "?").join(",");
+  const edgeRows = await db
+    .prepare(
+      `SELECT src_key, dst_key, kind FROM edges
+       WHERE src_key IN (${ph}) AND dst_key IN (${ph})`,
+    )
+    .bind(...keys, ...keys)
+    .all<EdgeRow>();
+  return {
+    edges: edgeRows.results.map((row) => ({
+      src: row.src_key,
+      dst: row.dst_key,
+      kind: row.kind,
+    })),
+    rowsRead: edgeRows.meta?.rows_read ?? 0,
+  };
+}
+
+export async function loadFullGraphRows(
+  db: D1Database,
+  visible: string[],
+): Promise<{
+  issueRows: IssueRow[];
+  labelsByIssue: Map<string, string[]>;
+  edges: GraphEdge[];
+  rowsRead: number;
+}> {
+  const ph = visible.map(() => "?").join(",");
+  let rowsRead = 0;
+
+  const labelRows = await db
+    .prepare(
+      `SELECT issue_key, name FROM labels WHERE issue_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+    )
+    .bind(...visible)
+    .all<LabelRow>();
+  rowsRead += labelRows.meta?.rows_read ?? 0;
+  const labelsByIssue = new Map<string, string[]>();
+  for (const row of labelRows.results) {
+    const existing = labelsByIssue.get(row.issue_key);
+    if (existing) {
+      existing.push(row.name);
+    } else {
+      labelsByIssue.set(row.issue_key, [row.name]);
+    }
+  }
+
+  const issueResult = await db
+    .prepare(
+      `SELECT key, repo, number, JSON_EXTRACT(payload,'$.title') AS title, state, url, milestone, lane, priority, size, status, is_stub, has_active_branch, assignees FROM issues WHERE repo IN (${ph})`,
+    )
+    .bind(...visible)
+    .all<IssueRow>();
+  const issueRows = issueResult.results;
+  rowsRead += issueResult.meta?.rows_read ?? 0;
+
+  const edgeRows = await db
+    .prepare(
+      `SELECT src_key, dst_key, kind FROM edges WHERE src_key IN (SELECT key FROM issues WHERE repo IN (${ph})) AND dst_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+    )
+    .bind(...visible, ...visible)
+    .all<EdgeRow>();
+  rowsRead += edgeRows.meta?.rows_read ?? 0;
+  const edges = edgeRows.results.map((row) => ({
+    src: row.src_key,
+    dst: row.dst_key,
+    kind: row.kind,
+  }));
+
+  return { issueRows, labelsByIssue, edges, rowsRead };
+}
+
+export async function loadRepos(
+  db: D1Database,
+  visible: string[],
+  tenantId: number | null,
+  repoFilter?: string[],
+): Promise<{ repos: RepoSummary[]; rowsRead: number }> {
+  const targetRepos = repoFilter?.length ? repoFilter.filter((r) => visible.includes(r)) : visible;
+  if (targetRepos.length === 0) return { repos: [], rowsRead: 0 };
+
+  const ph = targetRepos.map(() => "?").join(",");
+  interface RepoRow {
+    repo: string;
+    archived: number;
+    is_private: number;
+  }
+  interface RepoActivityRow {
+    repo: string;
+    issue_count: number;
+    last_updated_at: string | null;
+  }
+  const [repoRows, activityRows] = await Promise.all([
+    db
+      .prepare(
+        `SELECT r.repo, r.archived, COALESCE(tra.is_private, 1) AS is_private
+         FROM repos r
+         LEFT JOIN tenant_repo_access tra
+           ON tra.tenant_id = ? AND tra.repo = r.repo
+         WHERE r.repo IN (${ph})`,
+      )
+      .bind(tenantId, ...targetRepos)
+      .all<RepoRow>(),
+    db
+      .prepare(
+        `SELECT repo, COUNT(*) AS issue_count, MAX(updated_at) AS last_updated_at
+         FROM issues WHERE repo IN (${ph}) GROUP BY repo`,
+      )
+      .bind(...targetRepos)
+      .all<RepoActivityRow>(),
+  ]);
+  const rowsRead = (repoRows.meta?.rows_read ?? 0) + (activityRows.meta?.rows_read ?? 0);
+  const activityByRepo = new Map((activityRows.results ?? []).map((row) => [row.repo, row]));
+  const repos = (repoRows.results ?? []).map((r) => {
+    const activity = activityByRepo.get(r.repo);
+    return {
+      repo: r.repo,
+      archived: Boolean(r.archived),
+      is_private: Number(r.is_private) !== 0,
+      issue_count: activity?.issue_count ?? 0,
+      last_updated_at: activity?.last_updated_at ?? null,
+    };
+  });
+  return { repos, rowsRead };
+}

--- a/apps/api/src/graph/graph-payload-types.ts
+++ b/apps/api/src/graph/graph-payload-types.ts
@@ -1,0 +1,43 @@
+export type DevState = "idle" | "dev" | "pr_open" | "pr_reviewed";
+
+export interface GraphNode {
+  key: string;
+  repo: string;
+  number: number;
+  title: string | null;
+  state: string;
+  dev_state: DevState;
+  url: string | null;
+  milestone: string | null;
+  milestone_code: string | null;
+  milestone_name: string | null;
+  milestone_sort_key: number;
+  labels: string[];
+  priority: string | null;
+  lane: string | null;
+  size: string | null;
+  status: string | null;
+  is_stub: boolean;
+  assignees: string[];
+}
+
+export interface GraphEdge {
+  src: string;
+  dst: string;
+  kind: string;
+}
+
+export interface RepoSummary {
+  repo: string;
+  archived: boolean;
+  is_private: boolean;
+  issue_count: number;
+  last_updated_at: string | null;
+}
+
+export interface GraphBuildResult {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  repos: RepoSummary[];
+  rowsRead: number;
+}

--- a/apps/api/src/quota/read-budget.ts
+++ b/apps/api/src/quota/read-budget.ts
@@ -10,6 +10,9 @@ import { type TenantPlan, limitForMetric } from "./limits";
 /** Conservative lower bound for one full graph rebuild @ ~5k issues. */
 export const MIN_GRAPH_REBUILD_ROWS = 25_000;
 
+/** Lower headroom gate for incremental graph deltas. */
+export const MIN_DELTA_GRAPH_ROWS = 1_000;
+
 export function graphQuotaDeniedResponse(c: Context<AuthEnv>): Response {
   const retryAfter = secondsUntilUtcMidnight();
   return c.json({ error: "quota_exceeded", metric: "graph_rows", retry_after: retryAfter }, 429, {
@@ -22,10 +25,11 @@ export async function reserveGraphRowsBudget(
   db: D1Database,
   tenantId: number,
   plan: TenantPlan,
+  minHeadroom = MIN_GRAPH_REBUILD_ROWS,
 ): Promise<boolean> {
   const used = await getQuotaUsed(db, tenantId, "graph_rows");
   const limit = limitForMetric(plan, "graph_rows");
-  return used < limit && limit - used >= MIN_GRAPH_REBUILD_ROWS;
+  return used < limit && limit - used >= minHeadroom;
 }
 
 export async function recordGraphRowsSpend(

--- a/apps/api/src/sync/repo-branches.ts
+++ b/apps/api/src/sync/repo-branches.ts
@@ -3,6 +3,7 @@
  * sync.ts (file-length gate). applyActiveBranches is shared with syncRepoBundle.
  */
 
+import { graphChangelogForRepoStmt } from "../graph/changelog";
 import { MAX_PAGES } from "./constants";
 import { ghGraphql } from "./graphql";
 import { BRANCH_ISSUE_RE } from "./label-vocab";
@@ -45,9 +46,14 @@ export async function applyActiveBranches(
           .bind(repo, ...chunk),
       );
     }
-    await db.batch(stmts);
+    const bumpedAt = new Date().toISOString();
+    await db.batch([...stmts, graphChangelogForRepoStmt(db, repo, bumpedAt)]);
   } else {
-    await db.prepare("UPDATE issues SET has_active_branch=0 WHERE repo=?").bind(repo).run();
+    const bumpedAt = new Date().toISOString();
+    await db.batch([
+      db.prepare("UPDATE issues SET has_active_branch=0 WHERE repo=?").bind(repo),
+      graphChangelogForRepoStmt(db, repo, bumpedAt),
+    ]);
   }
 }
 

--- a/apps/api/src/sync/repo-issues.ts
+++ b/apps/api/src/sync/repo-issues.ts
@@ -3,6 +3,10 @@
  * engine. Split out of sync.ts (file-length gate).
  */
 
+import {
+  graphChangelogForRepoSinceStmt,
+  graphChangelogForRepoStmt,
+} from "../graph/changelog";
 import { MAX_PAGES } from "./constants";
 import { batchChunked } from "./control";
 import { ghGraphql } from "./graphql";
@@ -127,10 +131,16 @@ export async function syncRepoIssues(
     if (!cursor) break;
   }
 
-  // Write sync_state ONCE after full loop
+  // Write sync_state ONCE after full loop + stamp graph_changelog for delta fetches.
   const nowIso = new Date().toISOString();
-  await db
-    .prepare("INSERT OR REPLACE INTO sync_state(repo,last_cursor,last_synced_at) VALUES(?,NULL,?)")
-    .bind(repo, nowIso)
-    .run();
+  const changelogStmt = fullSync || since == null
+    ? graphChangelogForRepoStmt(db, repo, nowIso)
+    : graphChangelogForRepoSinceStmt(db, repo, since, nowIso);
+  await db.batch([
+    db.prepare("INSERT OR REPLACE INTO sync_state(repo,last_cursor,last_synced_at) VALUES(?,NULL,?)").bind(
+      repo,
+      nowIso,
+    ),
+    changelogStmt,
+  ]);
 }

--- a/apps/api/src/sync/sync-run.test.ts
+++ b/apps/api/src/sync/sync-run.test.ts
@@ -156,8 +156,10 @@ describe("runSync", () => {
       expect.stringContaining("no repos discovered across all installations — nothing to sync"),
     );
 
-    // No DELETE statements should have been issued
-    const deleteStmts = db._recorded.filter((s) => s.sql.includes("DELETE"));
+    // No repo-prune DELETE statements (graph_changelog housekeeping is allowed)
+    const deleteStmts = db._recorded.filter(
+      (s) => s.sql.includes("DELETE") && !s.sql.includes("graph_changelog"),
+    );
     expect(deleteStmts).toHaveLength(0);
   });
 });

--- a/apps/api/src/sync/sync.test.ts
+++ b/apps/api/src/sync/sync.test.ts
@@ -810,12 +810,13 @@ describe("syncBranches", () => {
 
     await syncBranches(db, "fake-token", "Roxabi", "lyra");
 
-    // No matched numbers → single reset UPDATE, no batch
+    // No matched numbers → reset UPDATE + graph_changelog stamp (batched)
     const batchMock = (db as unknown as { batch: ReturnType<typeof vi.fn> }).batch;
-    expect(batchMock).not.toHaveBeenCalled();
+    expect(batchMock).toHaveBeenCalled();
     const resetStmt = capturedStmts.find((s) => s.sql.includes("has_active_branch=0"));
     expect(resetStmt).toBeDefined();
     expect(resetStmt?.args).toEqual(["Roxabi/lyra"]);
+    expect(capturedStmts.some((s) => s.sql.includes("graph_changelog"))).toBe(true);
   });
 });
 

--- a/apps/api/src/sync/sync.ts
+++ b/apps/api/src/sync/sync.ts
@@ -16,6 +16,7 @@
  * Advisory distributed lock via sync_control.sync_running (stale after 900 s).
  */
 
+import { pruneGraphChangelog } from "../graph/changelog";
 import { getInstallationToken } from "../auth/installToken";
 import { loadZkSealedIssueKeys } from "../auth/zk";
 import { zkStructureOnlyEnabled } from "../auth/zk-flags";
@@ -300,6 +301,7 @@ export async function runSync(env: Env, opts?: RunSyncOptions): Promise<void> {
     outcome = "error";
     console.error("[sync] error:", err);
   } finally {
+    await pruneGraphChangelog(db).catch(() => {});
     await releaseSyncLock(db);
     const quotaTenants = await Promise.all(
       [...billedTenantIds].map(async (tenantId) => ({

--- a/apps/api/src/webhook/handlers-issues.ts
+++ b/apps/api/src/webhook/handlers-issues.ts
@@ -21,6 +21,12 @@ import {
   upsertIssueFromWebhook,
 } from "./mutations";
 
+export interface WebhookMutation {
+  mutated: boolean;
+  /** Issue keys to record in graph_changelog (caller batches with data_version bump). */
+  graphChanges: Array<{ issue_key: string; op: "upsert" | "delete" }>;
+}
+
 /**
  * Derive an issue key from a partial issue object plus an optional repo override.
  * Verbatim port of _issue_key() from handlers.py.
@@ -49,7 +55,7 @@ export async function handleIssues(
   payload: Record<string, unknown>,
   db: D1Database,
   env: Env,
-): Promise<void> {
+): Promise<WebhookMutation> {
   const action = payload.action as string | undefined;
   const issue = payload.issue as Record<string, unknown>;
   const repo =
@@ -60,7 +66,7 @@ export async function handleIssues(
 
   if (action === "deleted" || action === "transferred") {
     await deleteIssue(db, key).run();
-    return;
+    return { mutated: true, graphChanges: [{ issue_key: key, op: "delete" }] };
   }
 
   const rawLabels: unknown[] = (issue.labels as unknown[] | undefined) ?? [];
@@ -102,6 +108,7 @@ export async function handleIssues(
 
   // Atomic upsert + label replacement via db.batch (SC9).
   await db.batch([upsertIssueFromWebhook(db, issuePartial), ...replaceLabels(db, key, names)]);
+  return { mutated: true, graphChanges: [{ issue_key: key, op: "upsert" }] };
 }
 
 /**
@@ -171,15 +178,15 @@ export async function handleDeps(
   payload: Record<string, unknown>,
   db: D1Database,
   env: Env,
-): Promise<number> {
+): Promise<WebhookMutation> {
   const action = payload.action as string | undefined;
 
   if (action === "blocking_added" || action === "blocking_removed") {
-    return 0;
+    return { mutated: false, graphChanges: [] };
   }
 
   if (action !== "blocked_by_added" && action !== "blocked_by_removed") {
-    return 0;
+    return { mutated: false, graphChanges: [] };
   }
 
   const blockingIssue = (payload.blocking_issue as Record<string, unknown> | undefined) ?? null;
@@ -191,7 +198,7 @@ export async function handleDeps(
     console.warn(
       `[webhook] handle_deps: unexpected payload shape for ${action} — keys=${Object.keys(payload).join(",")}`,
     );
-    return 0;
+    return { mutated: false, graphChanges: [] };
   }
 
   // Cross-repo case: blocking_issue absent — point-fetch the downstream issue's
@@ -204,7 +211,7 @@ export async function handleDeps(
       console.warn(
         `[webhook] handle_deps: cannot resolve token — malformed repository.full_name=${JSON.stringify(fullName)}`,
       );
-      return 0;
+      return { mutated: false, graphChanges: [] };
     }
     const owner = fullName.slice(0, slashIdx);
     const name = fullName.slice(slashIdx + 1);
@@ -213,9 +220,16 @@ export async function handleDeps(
       token = await resolveInstallToken(db, env, owner, name);
     } catch (err) {
       console.warn(`[webhook] handle_deps: resolveInstallToken failed for ${fullName}`, err);
-      return 0;
+      return { mutated: false, graphChanges: [] };
     }
-    return await pointFetchAndUpsertDeps(db, token, blockedIssue, repoObj);
+    const changed = await pointFetchAndUpsertDeps(db, token, blockedIssue, repoObj);
+    const blockedKey = issueKey(
+      blockedIssue,
+      (payload.repository as Record<string, unknown> | undefined) ?? null,
+    );
+    return changed > 0
+      ? { mutated: true, graphChanges: [{ issue_key: blockedKey, op: "upsert" }] }
+      : { mutated: false, graphChanges: [] };
   }
 
   // Same-repo fast path: both sides are in the payload — use them directly.
@@ -227,15 +241,33 @@ export async function handleDeps(
 
   if (action === "blocked_by_added") {
     const result = await addEdge(db, blockerKey, blockedKey, "blocks").run();
-    return result.meta.changes ?? 0;
+    const changed = result.meta.changes ?? 0;
+    return changed > 0
+      ? {
+          mutated: true,
+          graphChanges: [
+            { issue_key: blockerKey, op: "upsert" },
+            { issue_key: blockedKey, op: "upsert" },
+          ],
+        }
+      : { mutated: false, graphChanges: [] };
   }
 
   if (action === "blocked_by_removed") {
     const result = await removeEdge(db, blockerKey, blockedKey, "blocks").run();
-    return result.meta.changes ?? 0;
+    const changed = result.meta.changes ?? 0;
+    return changed > 0
+      ? {
+          mutated: true,
+          graphChanges: [
+            { issue_key: blockerKey, op: "upsert" },
+            { issue_key: blockedKey, op: "upsert" },
+          ],
+        }
+      : { mutated: false, graphChanges: [] };
   }
 
-  return 0;
+  return { mutated: false, graphChanges: [] };
 }
 
 /**
@@ -249,15 +281,15 @@ export async function handleDeps(
 export async function handleSubIssues(
   payload: Record<string, unknown>,
   db: D1Database,
-): Promise<number> {
+): Promise<WebhookMutation> {
   const action = payload.action as string | undefined;
 
   if (action === "parent_issue_added" || action === "parent_issue_removed") {
-    return 0;
+    return { mutated: false, graphChanges: [] };
   }
 
   if (action !== "sub_issue_added" && action !== "sub_issue_removed") {
-    return 0;
+    return { mutated: false, graphChanges: [] };
   }
 
   const parentIssue = payload.parent_issue as Record<string, unknown> | undefined;
@@ -272,7 +304,7 @@ export async function handleSubIssues(
     console.warn(
       `[webhook] handle_sub_issues: unexpected payload shape for ${action} — keys=${Object.keys(payload).sort().join(",")}`,
     );
-    return 0;
+    return { mutated: false, graphChanges: [] };
   }
 
   let parentKey: string;
@@ -284,14 +316,32 @@ export async function handleSubIssues(
     console.warn(
       `[webhook] handle_sub_issues: malformed payload for ${action} — keys=${Object.keys(payload).sort().join(",")}`,
     );
-    return 0;
+    return { mutated: false, graphChanges: [] };
   }
 
   if (action === "sub_issue_added") {
     const result = await addEdge(db, parentKey, childKey, "parent").run();
-    return result.meta.changes ?? 0;
+    const changed = result.meta.changes ?? 0;
+    return changed > 0
+      ? {
+          mutated: true,
+          graphChanges: [
+            { issue_key: parentKey, op: "upsert" },
+            { issue_key: childKey, op: "upsert" },
+          ],
+        }
+      : { mutated: false, graphChanges: [] };
   }
   // sub_issue_removed
   const result = await removeEdge(db, parentKey, childKey, "parent").run();
-  return result.meta.changes ?? 0;
+  const changed = result.meta.changes ?? 0;
+  return changed > 0
+    ? {
+        mutated: true,
+        graphChanges: [
+          { issue_key: parentKey, op: "upsert" },
+          { issue_key: childKey, op: "upsert" },
+        ],
+      }
+    : { mutated: false, graphChanges: [] };
 }

--- a/apps/api/src/webhook/handlers-ref.ts
+++ b/apps/api/src/webhook/handlers-ref.ts
@@ -17,6 +17,7 @@ import {
 } from "../quota";
 import { BRANCH_ISSUE_RE, syncBranches } from "../sync/sync";
 import type { Env } from "../types";
+import { graphChangelogForRepoMilestoneStmt } from "../graph/changelog";
 import { renameMilestone, setActiveBranch, upsertPrState } from "./mutations";
 
 /**
@@ -29,9 +30,9 @@ import { renameMilestone, setActiveBranch, upsertPrState } from "./mutations";
 export async function handleRefCreate(
   payload: Record<string, unknown>,
   db: D1Database,
-): Promise<boolean> {
+): Promise<Array<{ issue_key: string; op: "upsert" }>> {
   if (payload.ref_type !== "branch") {
-    return false;
+    return [];
   }
   const ref = (payload.ref as string | undefined) ?? "";
   const repo = (payload.repository as Record<string, unknown> | undefined)?.full_name as
@@ -40,11 +41,11 @@ export async function handleRefCreate(
   const repoStr = repo ?? "";
   const m = BRANCH_ISSUE_RE.exec(ref);
   if (!m) {
-    return false;
+    return [];
   }
   const number = Number.parseInt(m[1], 10);
   await setActiveBranch(db, repoStr, number, 1).run();
-  return true;
+  return [{ issue_key: `${repoStr}#${number}`, op: "upsert" }];
 }
 
 /**
@@ -131,7 +132,7 @@ export async function handleRefDelete(
 export async function handlePullRequest(
   payload: Record<string, unknown>,
   db: D1Database,
-): Promise<boolean> {
+): Promise<Array<{ issue_key: string; op: "upsert" }>> {
   const pr = (payload.pull_request as Record<string, unknown> | undefined) ?? {};
   const repo = (payload.repository as Record<string, unknown> | undefined)?.full_name as
     | string
@@ -142,7 +143,7 @@ export async function handlePullRequest(
     console.warn(
       `[webhook] pull_request webhook missing PR number; payload keys: ${Object.keys(pr).join(",")}`,
     );
-    return false;
+    return [];
   }
 
   const rawState = String(pr.state ?? "open");
@@ -177,7 +178,7 @@ export async function handlePullRequest(
     closingIssueKeysJson,
     updatedAt,
   ).run();
-  return true;
+  return closingIssueKeys.map((issue_key) => ({ issue_key, op: "upsert" as const }));
 }
 
 /**
@@ -208,6 +209,10 @@ export async function handleMilestone(
       | string
       | undefined) ?? "",
   );
-  await renameMilestone(db, repo, oldTitle, newTitle).run();
+  const iso = new Date().toISOString();
+  await db.batch([
+    renameMilestone(db, repo, oldTitle, newTitle),
+    graphChangelogForRepoMilestoneStmt(db, repo, newTitle, iso),
+  ]);
   return true;
 }

--- a/apps/api/src/webhook/handlers.test.ts
+++ b/apps/api/src/webhook/handlers.test.ts
@@ -362,7 +362,7 @@ describe("handleDeps", () => {
         const result = await handleDeps(payload, db, baseEnv);
 
         // Assert — no-op
-        expect(result).toBe(0);
+        expect(result).toEqual({ mutated: false, graphChanges: [] });
         expect(stmts()).toHaveLength(0);
         expect(vi.mocked(db.batch)).not.toHaveBeenCalled();
       },
@@ -409,8 +409,8 @@ describe("handleDeps", () => {
       // Act — must NOT throw
       const result = await handleDeps(payload, db, { ...baseEnv, DB: db });
 
-      // Assert — returns 0, does not propagate error
-      expect(result).toBe(0);
+      // Assert — no mutation, does not propagate error
+      expect(result).toEqual({ mutated: false, graphChanges: [] });
     });
 
     it("swallows non-GraphQLError — catch-all returns 0 for any error type", async () => {
@@ -428,7 +428,7 @@ describe("handleDeps", () => {
       const result = await handleDeps(payload, db, { ...baseEnv, DB: db });
 
       // Assert — catch swallows all errors, not just GraphQLError
-      expect(result).toBe(0);
+      expect(result).toEqual({ mutated: false, graphChanges: [] });
     });
 
     // RED (S3 — future multi-tenant): handleDeps cross-repo path must use resolveInstallToken,
@@ -550,7 +550,7 @@ describe("handleSubIssues", () => {
         const result = await handleSubIssues(payload, db);
 
         // Assert — no-op
-        expect(result).toBe(0);
+        expect(result).toEqual({ mutated: false, graphChanges: [] });
         expect(stmts()).toHaveLength(0);
       },
     );

--- a/apps/api/src/webhook/handlers.ts
+++ b/apps/api/src/webhook/handlers.ts
@@ -13,6 +13,7 @@
 import type { Context } from "hono";
 import type { Env } from "../types";
 
+import { graphChangelogStmts } from "../graph/changelog";
 import { getTenantPlan, markRepoDirty, spendQuota } from "../quota";
 import { handleMember, handleMembership, handleRepository } from "./handlers-access";
 import { handleInstallation, handleInstallationRepositories } from "./handlers-app";
@@ -146,19 +147,25 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
   }
 
   let mutated = false;
+  const graphChanges: Array<{ issue_key: string; op: "upsert" | "delete" }> = [];
 
   try {
     if (event === "issues") {
-      await handleIssues(payload, db, c.env);
-      mutated = true;
+      const result = await handleIssues(payload, db, c.env);
+      mutated = result.mutated;
+      graphChanges.push(...result.graphChanges);
     } else if (event === "issue_dependencies") {
-      const changed = await handleDeps(payload, db, c.env);
-      mutated = changed > 0;
+      const result = await handleDeps(payload, db, c.env);
+      mutated = result.mutated;
+      graphChanges.push(...result.graphChanges);
     } else if (event === "sub_issues") {
-      const changed = await handleSubIssues(payload, db);
-      mutated = changed > 0;
+      const result = await handleSubIssues(payload, db);
+      mutated = result.mutated;
+      graphChanges.push(...result.graphChanges);
     } else if (event === "create") {
-      mutated = await handleRefCreate(payload, db);
+      const changes = await handleRefCreate(payload, db);
+      graphChanges.push(...changes);
+      mutated = changes.length > 0;
     } else if (event === "delete") {
       const deleteQuota =
         tenant != null
@@ -166,7 +173,9 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
           : undefined;
       mutated = await handleRefDelete(payload, db, c.env, deleteQuota);
     } else if (event === "pull_request") {
-      mutated = await handlePullRequest(payload, db);
+      const changes = await handlePullRequest(payload, db);
+      graphChanges.push(...changes);
+      mutated = changes.length > 0;
     } else if (event === "milestone") {
       mutated = await handleMilestone(payload, db);
       // App lifecycle events self-bump data_version inside their atomic batch — do not set `mutated`.
@@ -188,7 +197,7 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
 
   if (mutated) {
     const iso = new Date().toISOString();
-    await db.batch([bumpDataVersion(db, iso)]);
+    await db.batch([...graphChangelogStmts(db, iso, graphChanges), bumpDataVersion(db, iso)]);
   }
 
   return c.json({ ok: true });

--- a/apps/api/src/webhook/handlers.ts
+++ b/apps/api/src/webhook/handlers.ts
@@ -13,7 +13,7 @@
 import type { Context } from "hono";
 import type { Env } from "../types";
 
-import { graphChangelogStmts } from "../graph/changelog";
+import { collapseGraphChanges, graphChangelogStmts } from "../graph/changelog";
 import { getTenantPlan, markRepoDirty, spendQuota } from "../quota";
 import { handleMember, handleMembership, handleRepository } from "./handlers-access";
 import { handleInstallation, handleInstallationRepositories } from "./handlers-app";
@@ -197,7 +197,10 @@ export async function webhookRoute(c: Context<{ Bindings: Env }>): Promise<Respo
 
   if (mutated) {
     const iso = new Date().toISOString();
-    await db.batch([...graphChangelogStmts(db, iso, graphChanges), bumpDataVersion(db, iso)]);
+    await db.batch([
+      ...graphChangelogStmts(db, iso, collapseGraphChanges(graphChanges)),
+      bumpDataVersion(db, iso),
+    ]);
   }
 
   return c.json({ ok: true });

--- a/apps/app/src/hooks/useGraphData.ts
+++ b/apps/app/src/hooks/useGraphData.ts
@@ -7,40 +7,22 @@
  * (status[], closed_under_open_epic) join the queryKey in slice 3.
  */
 
-import { ApiError, apiFetchConditional } from "@/lib/api";
-import { getGraphEtag, setGraphEtag } from "@/lib/etag-cache";
+import { GRAPH_QUERY_KEY, fetchGraph } from "@/lib/graph-fetch";
 import {
   type AnnotatedNode,
   type GraphEdge,
-  type GraphResponse,
   type RepoSummary,
   annotateNodes,
 } from "@roxabi-live/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-export const GRAPH_QUERY_KEY = ["graph"] as const;
+export { GRAPH_QUERY_KEY };
 
 export function useGraphData() {
   const query = useQuery({
     queryKey: GRAPH_QUERY_KEY,
-    queryFn: async ({ client }) => {
-      try {
-        const result = await apiFetchConditional<GraphResponse>("/api/graph", getGraphEtag());
-        if (result.notModified) {
-          const cached = client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY);
-          if (cached) return cached;
-        }
-        setGraphEtag(result.etag);
-        return result.data as GraphResponse;
-      } catch (err) {
-        if (err instanceof ApiError && err.status === 429) {
-          const cached = client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY);
-          if (cached) return cached;
-        }
-        throw err;
-      }
-    },
+    queryFn: ({ client }) => fetchGraph(client),
   });
 
   const nodes = useMemo<AnnotatedNode[]>(

--- a/apps/app/src/hooks/useSyncProgressMonitor.ts
+++ b/apps/app/src/hooks/useSyncProgressMonitor.ts
@@ -7,11 +7,10 @@
  */
 
 import { apiFetch } from "@/lib/api";
-import { fetchGraphDelta } from "@/lib/graph-fetch";
+import { applyGraphDelta, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 import type { SyncStatus } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
-import { GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 
 const SYNC_POLL_MS = 2000;
 
@@ -37,14 +36,14 @@ export function useSyncProgressMonitor(): SyncStatus | null {
     if (!data) return;
     const active = data.sync_in_progress || data.sync_running;
     const applyGraphUpdate = async (forceFull = false) => {
-      if (!forceFull) {
-        const delta = await fetchGraphDelta(queryClient);
-        if (delta) {
-          queryClient.setQueryData(GRAPH_QUERY_KEY, delta);
-          return;
-        }
+      if (forceFull || active) {
+        void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+        return;
       }
-      void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+      const outcome = await applyGraphDelta(queryClient);
+      if (outcome === "fallback") {
+        void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+      }
     };
 
     if (data.repos_synced > lastSynced.current) {

--- a/apps/app/src/hooks/useSyncProgressMonitor.ts
+++ b/apps/app/src/hooks/useSyncProgressMonitor.ts
@@ -7,10 +7,11 @@
  */
 
 import { apiFetch } from "@/lib/api";
+import { fetchGraphDelta } from "@/lib/graph-fetch";
 import type { SyncStatus } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
-import { GRAPH_QUERY_KEY } from "./useGraphData";
+import { GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 
 const SYNC_POLL_MS = 2000;
 
@@ -35,12 +36,23 @@ export function useSyncProgressMonitor(): SyncStatus | null {
   useEffect(() => {
     if (!data) return;
     const active = data.sync_in_progress || data.sync_running;
+    const applyGraphUpdate = async (forceFull = false) => {
+      if (!forceFull) {
+        const delta = await fetchGraphDelta(queryClient);
+        if (delta) {
+          queryClient.setQueryData(GRAPH_QUERY_KEY, delta);
+          return;
+        }
+      }
+      void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+    };
+
     if (data.repos_synced > lastSynced.current) {
       lastSynced.current = data.repos_synced;
-      void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+      void applyGraphUpdate();
     }
     if (wasActive.current && !active) {
-      void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+      void applyGraphUpdate(true);
     }
     wasActive.current = active;
   }, [data, queryClient]);

--- a/apps/app/src/hooks/useVersionPoll.ts
+++ b/apps/app/src/hooks/useVersionPoll.ts
@@ -1,16 +1,17 @@
 /**
- * useVersionPoll — poll /api/version every 15 s and invalidate the graph query
- * when the corpus version token changes (hourly cron or a mutating webhook
- * bumps it). Mirrors frontend/app.js::fetchVersion. The first observed value is
- * a baseline, not a change, so it never refetches on mount.
+ * useVersionPoll — poll /api/version every 15 s and apply a graph delta when the
+ * corpus version token changes (hourly cron or a mutating webhook bumps it).
+ * The first observed value is a baseline, not a change, so it never refetches on
+ * mount.
  */
 
 import { apiFetchConditional } from "@/lib/api";
-import { clearGraphEtag, getVersionEtag, setVersionEtag } from "@/lib/etag-cache";
+import { getVersionEtag, setVersionEtag } from "@/lib/etag-cache";
+import { fetchGraphDelta } from "@/lib/graph-fetch";
 import type { VersionResponse } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
-import { GRAPH_QUERY_KEY } from "./useGraphData";
+import { GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 
 const VERSION_POLL_MS = 15_000;
 
@@ -41,8 +42,14 @@ export function useVersionPoll(): void {
     }
     if (lastSeen.current !== version) {
       lastSeen.current = version;
-      clearGraphEtag();
-      void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+      void (async () => {
+        const delta = await fetchGraphDelta(queryClient);
+        if (delta) {
+          queryClient.setQueryData(GRAPH_QUERY_KEY, delta);
+        } else {
+          void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+        }
+      })();
     }
   }, [data?.version, queryClient]);
 }

--- a/apps/app/src/hooks/useVersionPoll.ts
+++ b/apps/app/src/hooks/useVersionPoll.ts
@@ -7,11 +7,10 @@
 
 import { apiFetchConditional } from "@/lib/api";
 import { getVersionEtag, setVersionEtag } from "@/lib/etag-cache";
-import { fetchGraphDelta } from "@/lib/graph-fetch";
+import { applyGraphDelta, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 import type { VersionResponse } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
-import { GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 
 const VERSION_POLL_MS = 15_000;
 
@@ -41,11 +40,10 @@ export function useVersionPoll(): void {
       return;
     }
     if (lastSeen.current !== version) {
-      lastSeen.current = version;
       void (async () => {
-        const delta = await fetchGraphDelta(queryClient);
-        if (delta) {
-          queryClient.setQueryData(GRAPH_QUERY_KEY, delta);
+        const outcome = await applyGraphDelta(queryClient);
+        if (outcome === "applied" || outcome === "noop") {
+          lastSeen.current = version;
         } else {
           void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
         }

--- a/apps/app/src/lib/etag-cache.ts
+++ b/apps/app/src/lib/etag-cache.ts
@@ -1,6 +1,7 @@
 /** Module-level ETag tokens for conditional GET (#295). */
 
 let graphEtag: string | null = null;
+let graphVersion: string | null = null;
 let versionEtag: string | null = null;
 
 export function getGraphEtag(): string | null {
@@ -13,6 +14,18 @@ export function setGraphEtag(etag: string | null): void {
 
 export function clearGraphEtag(): void {
   graphEtag = null;
+}
+
+export function getGraphVersion(): string | null {
+  return graphVersion;
+}
+
+export function setGraphVersion(version: string | null): void {
+  graphVersion = version;
+}
+
+export function clearGraphVersion(): void {
+  graphVersion = null;
 }
 
 export function getVersionEtag(): string | null {

--- a/apps/app/src/lib/graph-fetch.ts
+++ b/apps/app/src/lib/graph-fetch.ts
@@ -1,0 +1,65 @@
+/**
+ * Unified /api/graph fetch — full load, conditional GET, and ?since= delta merge.
+ */
+
+import { ApiError, apiFetchConditional } from "@/lib/api";
+import { getGraphEtag, getGraphVersion, setGraphEtag, setGraphVersion } from "@/lib/etag-cache";
+import { type GraphResponse, mergeGraphDelta } from "@roxabi-live/shared";
+import type { QueryClient } from "@tanstack/react-query";
+
+export const GRAPH_QUERY_KEY = ["graph"] as const;
+
+export interface FetchGraphOptions {
+  since?: string | null;
+}
+
+function graphPath(opts?: FetchGraphOptions): string {
+  if (!opts?.since) return "/api/graph";
+  const params = new URLSearchParams({ since: opts.since });
+  return `/api/graph?${params.toString()}`;
+}
+
+/** TanStack queryFn — shared by useGraphData and useDecryptedGraph. */
+export async function fetchGraph(
+  client: QueryClient,
+  opts?: FetchGraphOptions,
+): Promise<GraphResponse> {
+  try {
+    const result = await apiFetchConditional<GraphResponse>(graphPath(opts), getGraphEtag());
+    if (result.notModified) {
+      const cached = client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY);
+      if (cached) return cached;
+    }
+
+    const payload = result.data;
+    if (!payload) {
+      const cached = client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY);
+      if (cached) return cached;
+      throw new ApiError(500, "empty graph response");
+    }
+
+    let merged = payload;
+    if (payload.mode === "delta" && opts?.since) {
+      const cached = client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY);
+      merged = mergeGraphDelta(cached, payload);
+    }
+
+    setGraphEtag(result.etag);
+    if (merged.version) setGraphVersion(merged.version);
+
+    return merged;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 429) {
+      const cached = client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY);
+      if (cached) return cached;
+    }
+    throw err;
+  }
+}
+
+/** Refetch only the delta since the last known corpus version. */
+export async function fetchGraphDelta(client: QueryClient): Promise<GraphResponse | null> {
+  const since = getGraphVersion();
+  if (!since) return null;
+  return fetchGraph(client, { since });
+}

--- a/apps/app/src/lib/graph-fetch.ts
+++ b/apps/app/src/lib/graph-fetch.ts
@@ -13,10 +13,33 @@ export interface FetchGraphOptions {
   since?: string | null;
 }
 
+export type GraphDeltaOutcome = "applied" | "noop" | "fallback";
+
 function graphPath(opts?: FetchGraphOptions): string {
   if (!opts?.since) return "/api/graph";
   const params = new URLSearchParams({ since: opts.since });
   return `/api/graph?${params.toString()}`;
+}
+
+function graphSince(client: QueryClient): string | null {
+  return getGraphVersion() ?? client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY)?.version ?? null;
+}
+
+let deltaApplyChain: Promise<void> = Promise.resolve();
+
+/** Serialize delta apply so concurrent poll/sync hooks cannot race on setQueryData. */
+async function withDeltaLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = deltaApplyChain;
+  let release!: () => void;
+  deltaApplyChain = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
 }
 
 /** TanStack queryFn — shared by useGraphData and useDecryptedGraph. */
@@ -57,9 +80,49 @@ export async function fetchGraph(
   }
 }
 
+/** Apply a graph delta since the last known corpus version. */
+export async function applyGraphDelta(client: QueryClient): Promise<GraphDeltaOutcome> {
+  const since = graphSince(client);
+  if (!since) return "fallback";
+  if (!client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY)) return "fallback";
+
+  return withDeltaLock(async () => {
+    const cached = client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY);
+    if (!cached) return "fallback";
+
+    try {
+      const result = await apiFetchConditional<GraphResponse>(graphPath({ since }), getGraphEtag());
+      if (result.notModified) return "noop";
+
+      const payload = result.data;
+      if (!payload) return "fallback";
+
+      if (
+        payload.mode === "delta" &&
+        payload.version &&
+        cached.version &&
+        payload.version <= cached.version
+      ) {
+        return "noop";
+      }
+
+      const merged =
+        payload.mode === "delta" ? mergeGraphDelta(cached, payload) : payload;
+
+      client.setQueryData(GRAPH_QUERY_KEY, merged);
+      setGraphEtag(result.etag);
+      if (merged.version) setGraphVersion(merged.version);
+      return "applied";
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 429 && cached) return "noop";
+      return "fallback";
+    }
+  });
+}
+
 /** Refetch only the delta since the last known corpus version. */
 export async function fetchGraphDelta(client: QueryClient): Promise<GraphResponse | null> {
-  const since = getGraphVersion();
-  if (!since) return null;
-  return fetchGraph(client, { since });
+  const outcome = await applyGraphDelta(client);
+  if (outcome === "fallback") return null;
+  return client.getQueryData<GraphResponse>(GRAPH_QUERY_KEY) ?? null;
 }

--- a/apps/app/src/zk/useDecryptedGraph.ts
+++ b/apps/app/src/zk/useDecryptedGraph.ts
@@ -10,8 +10,7 @@
  * change that rotates the session key.
  */
 
-import { GRAPH_QUERY_KEY } from "@/hooks/useGraphData";
-import { apiFetch } from "@/lib/api";
+import { GRAPH_QUERY_KEY, fetchGraph } from "@/lib/graph-fetch";
 import {
   type AnnotatedNode,
   type GraphEdge,
@@ -36,7 +35,7 @@ export function useDecryptedGraph() {
 
   const query = useQuery({
     queryKey: GRAPH_QUERY_KEY,
-    queryFn: () => apiFetch<GraphResponse>("/api/graph"),
+    queryFn: ({ client }) => fetchGraph(client),
   });
   const data = query.data;
 

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "typescript": "^5.7.2",
+        "vitest": "^3.2.6",
       },
     },
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,9 +8,11 @@
     "./brand": "./src/brand.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^3.2.6"
   }
 }

--- a/packages/shared/src/graph-delta.test.ts
+++ b/packages/shared/src/graph-delta.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { mergeGraphDelta } from "./graph-delta";
+import type { GraphResponse } from "./types";
+
+const base: GraphResponse = {
+  nodes: [
+    {
+      key: "Roxabi/roxabi-live#1",
+      repo: "Roxabi/roxabi-live",
+      number: 1,
+      title: "One",
+      state: "open",
+      dev_state: "idle",
+      url: null,
+      milestone: null,
+      milestone_code: null,
+      milestone_name: null,
+      milestone_sort_key: 0,
+      labels: [],
+      priority: null,
+      lane: null,
+      size: null,
+      status: null,
+      is_stub: false,
+      assignees: [],
+    },
+    {
+      key: "Roxabi/roxabi-live#2",
+      repo: "Roxabi/roxabi-live",
+      number: 2,
+      title: "Two",
+      state: "open",
+      dev_state: "idle",
+      url: null,
+      milestone: null,
+      milestone_code: null,
+      milestone_name: null,
+      milestone_sort_key: 0,
+      labels: [],
+      priority: null,
+      lane: null,
+      size: null,
+      status: null,
+      is_stub: false,
+      assignees: [],
+    },
+  ],
+  edges: [{ src: "Roxabi/roxabi-live#1", dst: "Roxabi/roxabi-live#2", kind: "blocks" }],
+  repos: [
+    {
+      repo: "Roxabi/roxabi-live",
+      archived: false,
+      is_private: false,
+      issue_count: 2,
+      last_updated_at: null,
+    },
+  ],
+  version: "2026-07-01T00:00:00.000Z",
+};
+
+describe("mergeGraphDelta", () => {
+  it("updates touched nodes and edges without rescanning untouched nodes", () => {
+    const delta: GraphResponse = {
+      mode: "delta",
+      version: "2026-07-02T00:00:00.000Z",
+      removed_keys: [],
+      nodes: [{ ...base.nodes[0], title: "One updated" }],
+      edges: [],
+      repos: [],
+    };
+    const merged = mergeGraphDelta(base, delta);
+    expect(merged.nodes.find((n) => n.key.endsWith("#1"))?.title).toBe("One updated");
+    expect(merged.nodes.find((n) => n.key.endsWith("#2"))?.title).toBe("Two");
+    expect(merged.edges).toEqual(base.edges);
+  });
+
+  it("removes deleted keys and incident edges", () => {
+    const delta: GraphResponse = {
+      mode: "delta",
+      version: "2026-07-02T00:00:00.000Z",
+      removed_keys: ["Roxabi/roxabi-live#2"],
+      nodes: [],
+      edges: [],
+      repos: [],
+    };
+    const merged = mergeGraphDelta(base, delta);
+    expect(merged.nodes.map((n) => n.key)).toEqual(["Roxabi/roxabi-live#1"]);
+    expect(merged.edges).toEqual([]);
+  });
+});

--- a/packages/shared/src/graph-delta.ts
+++ b/packages/shared/src/graph-delta.ts
@@ -1,0 +1,64 @@
+/**
+ * Client-side merge for incremental /api/graph?since=… responses.
+ */
+
+import type { GraphEdge, GraphNode, GraphResponse, RepoSummary } from "./types.ts";
+
+function edgeId(edge: GraphEdge): string {
+  return `${edge.src}\0${edge.dst}\0${edge.kind}`;
+}
+
+/** Merge a delta payload into a cached full graph (or return delta as full when no base). */
+export function mergeGraphDelta(
+  base: GraphResponse | undefined,
+  delta: GraphResponse,
+): GraphResponse {
+  if (delta.mode !== "delta" || !base) {
+    return {
+      nodes: delta.nodes,
+      edges: delta.edges,
+      repos: delta.repos,
+      mode: delta.mode ?? "full",
+      version: delta.version,
+      removed_keys: delta.removed_keys,
+    };
+  }
+
+  const removed = new Set(delta.removed_keys ?? []);
+  const touched = new Set<string>([
+    ...delta.nodes.map((n) => n.key),
+    ...removed,
+  ]);
+
+  const nodeByKey = new Map<string, GraphNode>(base.nodes.map((n) => [n.key, n]));
+  for (const node of delta.nodes) {
+    nodeByKey.set(node.key, node);
+  }
+  for (const key of removed) {
+    nodeByKey.delete(key);
+  }
+
+  const edgeById = new Map<string, GraphEdge>();
+  const hasEdgePatch = delta.edges.length > 0;
+  for (const edge of base.edges) {
+    if (removed.has(edge.src) || removed.has(edge.dst)) continue;
+    if (hasEdgePatch && (touched.has(edge.src) || touched.has(edge.dst))) continue;
+    edgeById.set(edgeId(edge), edge);
+  }
+  for (const edge of delta.edges) {
+    edgeById.set(edgeId(edge), edge);
+  }
+
+  const repoByName = new Map<string, RepoSummary>(base.repos.map((r) => [r.repo, r]));
+  for (const repo of delta.repos) {
+    repoByName.set(repo.repo, repo);
+  }
+
+  return {
+    nodes: [...nodeByKey.values()],
+    edges: [...edgeById.values()],
+    repos: [...repoByName.values()],
+    mode: "full",
+    version: delta.version ?? base.version,
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from "./types.ts";
 
 // Pure graph status + annotation logic (ported from frontend/state.js).
 export * from "./graph.ts";
+export * from "./graph-delta.ts";
 
 // Pivot/group dimension helpers (ported from frontend/state.js).
 export * from "./dims.ts";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -66,6 +66,12 @@ export interface GraphResponse {
   nodes: GraphNode[];
   edges: GraphEdge[];
   repos: RepoSummary[];
+  /** `delta` = merge into client cache; `full` = replace cache. */
+  mode?: "full" | "delta";
+  /** Corpus version token (matches /api/version when bumped via data_version). */
+  version?: string;
+  /** Issue keys removed since the client's `since` cursor (delta only). */
+  removed_keys?: string[];
 }
 
 /** GET /api/issues — one list row (worker/src/api/issues.ts listIssuesRoute). */


### PR DESCRIPTION
## Summary
- Add `graph_changelog` table + instrumentation (webhooks, sync) to record per-issue graph mutations
- `GET /api/graph?since=<version>` returns delta payloads (touched nodes/edges + `removed_keys`) instead of rescanning ~2k issues on every `data_version` bump
- Client: unified `fetchGraph` (ETag + delta merge); `useVersionPoll` / `useSyncProgressMonitor` apply deltas instead of invalidating full cache
- Quota: delta fetches reserve 1k `graph_rows` headroom vs 25k for full rebuild; fallback to full when >400 dirty keys

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #295 follow-up (delta fetch) | Ad-hoc |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/graph-delta-fetch` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (817 API) | Passed |

## Test Plan
- [ ] Deploy + apply migration `0024_graph_changelog.sql` on prod D1
- [ ] Hard refresh app → first load full; subsequent webhook bumps fetch delta only
- [ ] Reset tenant 4 `graph_rows` quota after deploy
- [ ] Verify quota banner clears and graph updates on version poll

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| Changelog records upsert/delete | `changelog.test.ts :: graph_changelog` | ✅ |
| Delta merge on client | `graph-delta.test.ts :: mergeGraphDelta` | ✅ (local) |
| Sync stamps changelog on branch reset | `sync.test.ts` (batch assertion) | ✅ |
| Graph route returns mode/version | `graph.test.ts` (existing shape tests) | ✅ |

Related to #295

---
Generated with Claude Code via `/pr`