### PR TITLE
fix(api): staging graph quota burn — scoped pr_state + session cursor

### DIFF
--- a/apps/api/src/graph/build-payload.ts
+++ b/apps/api/src/graph/build-payload.ts
@@ -65,7 +65,7 @@ export async function buildGraphPayload(opts: BuildGraphOptions): Promise<GraphB
   const { db, visible, sealedKeys, tenantId, keys, statusFilter, closedUnderOpenEpic } = opts;
   let rowsRead = 0;
 
-  const { map: openPrsByIssue, rowsRead: prRows } = await loadOpenPrsByIssue(db, visible);
+  const { map: openPrsByIssue, rowsRead: prRows } = await loadOpenPrsByIssue(db, visible, keys);
   rowsRead += prRows;
 
   let issueRows: Awaited<ReturnType<typeof loadIssuesForKeys>>["rows"];

--- a/apps/api/src/graph/graph-payload-loaders.ts
+++ b/apps/api/src/graph/graph-payload-loaders.ts
@@ -104,18 +104,33 @@ export function issueRowToNode(
   };
 }
 
+function repoFromIssueKey(key: string): string | null {
+  const hash = key.lastIndexOf("#");
+  return hash > 0 ? key.slice(0, hash) : null;
+}
+
 export async function loadOpenPrsByIssue(
   db: D1Database,
   visible: string[],
+  issueKeys?: string[],
 ): Promise<{ map: Map<string, PrInfo[]>; rowsRead: number }> {
-  const ph = visible.map(() => "?").join(",");
+  const visibleSet = new Set(visible);
+  const repos =
+    issueKeys && issueKeys.length > 0
+      ? [...new Set(issueKeys.map(repoFromIssueKey).filter((r): r is string => r != null && visibleSet.has(r)))]
+      : visible;
+  if (repos.length === 0) return { map: new Map(), rowsRead: 0 };
+
+  const ph = repos.map(() => "?").join(",");
   const prRows = await db
     .prepare(
       `SELECT closing_issue_keys, has_reviewed_label FROM pr_state WHERE state = 'open' AND repo IN (${ph})`,
     )
-    .bind(...visible)
+    .bind(...repos)
     .all<PrStateRow>();
   let rowsRead = prRows.meta?.rows_read ?? 0;
+  const keyFilter =
+    issueKeys && issueKeys.length > 0 ? new Set(issueKeys) : null;
   const openPrsByIssue = new Map<string, PrInfo[]>();
   for (const row of prRows.results) {
     if (!row.closing_issue_keys) continue;
@@ -127,6 +142,7 @@ export async function loadOpenPrsByIssue(
     }
     const prInfo: PrInfo = { has_reviewed_label: Number(row.has_reviewed_label) };
     for (const key of keys) {
+      if (keyFilter && !keyFilter.has(key)) continue;
       const existing = openPrsByIssue.get(key);
       if (existing) {
         existing.push(prInfo);

--- a/apps/app/src/lib/etag-cache.ts
+++ b/apps/app/src/lib/etag-cache.ts
@@ -1,31 +1,55 @@
-/** Module-level ETag tokens for conditional GET (#295). */
+/** Module-level ETag tokens for conditional GET (#295). Persisted to sessionStorage for delta cursors. */
+
+const GRAPH_ETAG_KEY = "roxabi:graph-etag";
+const GRAPH_VERSION_KEY = "roxabi:graph-version";
 
 let graphEtag: string | null = null;
 let graphVersion: string | null = null;
 let versionEtag: string | null = null;
 
+function readSession(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(key: string, value: string | null): void {
+  try {
+    if (value == null) sessionStorage.removeItem(key);
+    else sessionStorage.setItem(key, value);
+  } catch {
+    /* private mode / SSR */
+  }
+}
+
 export function getGraphEtag(): string | null {
-  return graphEtag;
+  return graphEtag ?? readSession(GRAPH_ETAG_KEY);
 }
 
 export function setGraphEtag(etag: string | null): void {
   graphEtag = etag;
+  writeSession(GRAPH_ETAG_KEY, etag);
 }
 
 export function clearGraphEtag(): void {
   graphEtag = null;
+  writeSession(GRAPH_ETAG_KEY, null);
 }
 
 export function getGraphVersion(): string | null {
-  return graphVersion;
+  return graphVersion ?? readSession(GRAPH_VERSION_KEY);
 }
 
 export function setGraphVersion(version: string | null): void {
   graphVersion = version;
+  writeSession(GRAPH_VERSION_KEY, version);
 }
 
 export function clearGraphVersion(): void {
   graphVersion = null;
+  writeSession(GRAPH_VERSION_KEY, null);
 }
 
 export function getVersionEtag(): string | null {


### PR DESCRIPTION
## Summary
- One full graph load on ~1940 issues was exhausting the entire free-tier `graph_rows` budget (125k) in a single request
- Delta builds now scope `pr_state` reads to touched repos/issues only
- Client persists graph ETag/version in `sessionStorage` for cheaper conditional GET after hard refresh

## Ops (already applied on staging D1)
- Tenant 1 → `plan=paid` (2.5M graph_rows limit for staging testing)
- `graph_rows` reset to 0

## Test Plan
- [ ] Hard refresh https://app-staging.live.roxabi.dev — no quota banner
- [ ] Network tab: subsequent version bumps use `?since=` delta, not full `/api/graph`