### PR TITLE
fix(app): stop graph invalidate storm exhausting graph_rows quota

### DIFF
--- a/apps/app/src/hooks/useGraphData.ts
+++ b/apps/app/src/hooks/useGraphData.ts
@@ -23,6 +23,8 @@ export function useGraphData() {
   const query = useQuery({
     queryKey: GRAPH_QUERY_KEY,
     queryFn: ({ client }) => fetchGraph(client),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
 
   const nodes = useMemo<AnnotatedNode[]>(

--- a/apps/app/src/hooks/useSyncProgressMonitor.ts
+++ b/apps/app/src/hooks/useSyncProgressMonitor.ts
@@ -1,18 +1,25 @@
 /**
  * useSyncProgressMonitor — poll /api/sync/status every 2 s while a bootstrap
  * sync is in progress (ported from frontend/initial-sync.js). Stops polling once
- * the corpus is ready or the sync halts. Invalidates the graph query as repos
- * land and when the sync completes, so the board fills in live. Returns the
- * latest status for SyncProgressBanner (null until the first response).
+ * the corpus is ready or the sync halts. Refetches the graph as repos land and
+ * when the sync completes, so the board fills in live. Returns the latest status
+ * for SyncProgressBanner (null until the first response).
  */
 
 import { apiFetch } from "@/lib/api";
-import { applyGraphDelta, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
+import { applyGraphDelta, fetchGraph, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 import type { SyncStatus } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
 const SYNC_POLL_MS = 2000;
+
+async function refetchGraphOnce(client: ReturnType<typeof useQueryClient>): Promise<void> {
+  await client.fetchQuery({
+    queryKey: GRAPH_QUERY_KEY,
+    queryFn: ({ client: qc }) => fetchGraph(qc),
+  });
+}
 
 export function useSyncProgressMonitor(): SyncStatus | null {
   const queryClient = useQueryClient();
@@ -35,20 +42,38 @@ export function useSyncProgressMonitor(): SyncStatus | null {
   useEffect(() => {
     if (!data) return;
     const active = data.sync_in_progress || data.sync_running;
+    const graphReady = queryClient.getQueryState(GRAPH_QUERY_KEY)?.status === "success";
+
     const applyGraphUpdate = async (forceFull = false) => {
+      if (!graphReady) return;
+
       if (forceFull || active) {
-        void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+        try {
+          await refetchGraphOnce(queryClient);
+        } catch {
+          /* quota — best effort */
+        }
         return;
       }
+
       const outcome = await applyGraphDelta(queryClient);
       if (outcome === "fallback") {
-        void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
+        try {
+          await refetchGraphOnce(queryClient);
+        } catch {
+          /* quota */
+        }
       }
     };
 
     if (data.repos_synced > lastSynced.current) {
       lastSynced.current = data.repos_synced;
-      void applyGraphUpdate();
+      if (active) {
+        // During bootstrap, delta only — a full scan per repo exhausts graph_rows.
+        if (graphReady) void applyGraphDelta(queryClient);
+      } else {
+        void applyGraphUpdate(false);
+      }
     }
     if (wasActive.current && !active) {
       void applyGraphUpdate(true);

--- a/apps/app/src/hooks/useVersionPoll.ts
+++ b/apps/app/src/hooks/useVersionPoll.ts
@@ -7,12 +7,24 @@
 
 import { apiFetchConditional } from "@/lib/api";
 import { getVersionEtag, setVersionEtag } from "@/lib/etag-cache";
-import { applyGraphDelta, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
+import { applyGraphDelta, fetchGraph, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
 import type { VersionResponse } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
 const VERSION_POLL_MS = 15_000;
+
+function graphIsReady(client: ReturnType<typeof useQueryClient>): boolean {
+  return client.getQueryState(GRAPH_QUERY_KEY)?.status === "success";
+}
+
+/** Deduped graph refetch — never use invalidateQueries (storm of parallel full scans). */
+async function refetchGraphOnce(client: ReturnType<typeof useQueryClient>): Promise<void> {
+  await client.fetchQuery({
+    queryKey: GRAPH_QUERY_KEY,
+    queryFn: ({ client: qc }) => fetchGraph(qc),
+  });
+}
 
 export function useVersionPoll(): void {
   const queryClient = useQueryClient();
@@ -39,15 +51,21 @@ export function useVersionPoll(): void {
       lastSeen.current = version;
       return;
     }
-    if (lastSeen.current !== version) {
-      void (async () => {
-        const outcome = await applyGraphDelta(queryClient);
-        if (outcome === "applied" || outcome === "noop") {
-          lastSeen.current = version;
-        } else {
-          void queryClient.invalidateQueries({ queryKey: GRAPH_QUERY_KEY });
-        }
-      })();
-    }
+    if (lastSeen.current === version) return;
+    if (!graphIsReady(queryClient)) return;
+
+    void (async () => {
+      const outcome = await applyGraphDelta(queryClient);
+      if (outcome === "applied" || outcome === "noop") {
+        lastSeen.current = version;
+        return;
+      }
+      try {
+        await refetchGraphOnce(queryClient);
+        lastSeen.current = version;
+      } catch {
+        /* quota or network — keep lastSeen stale so we retry on next bump */
+      }
+    })();
   }, [data?.version, queryClient]);
 }

--- a/apps/app/src/zk/useDecryptedGraph.ts
+++ b/apps/app/src/zk/useDecryptedGraph.ts
@@ -36,6 +36,8 @@ export function useDecryptedGraph() {
   const query = useQuery({
     queryKey: GRAPH_QUERY_KEY,
     queryFn: ({ client }) => fetchGraph(client),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
   const data = query.data;
 


### PR DESCRIPTION
## Root cause
Each webhook-driven `/api/version` bump triggered `invalidateQueries(['graph'])`, spawning a new full `/api/graph` scan (~125k–200k D1 rows). On staging this exhausted even the **paid** 2.5M daily limit within minutes.

## Fix
- `useVersionPoll`: gate on successful initial graph load; use deduped `fetchQuery` instead of `invalidateQueries`
- `useSyncProgressMonitor`: delta-only during bootstrap sync; single `fetchQuery` on completion
- `useGraphData` / `useDecryptedGraph`: `staleTime: 60s`, `refetchOnWindowFocus: false`

## Ops
- Staging tenant 1 `graph_rows` reset to 0 (plan remains `paid`)

Fixes 429 on staging after #301/#302