### PR TITLE
refactor(shared): centralize runtime tunables in config/runtime.json

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "deploy:production": "wrangler deploy"
   },
   "dependencies": {
+    "@roxabi-live/shared": "workspace:*",
     "hono": "^4.6.14"
   },
   "devDependencies": {

--- a/apps/api/src/api/graph.ts
+++ b/apps/api/src/api/graph.ts
@@ -5,6 +5,7 @@
  * issues touched since that corpus version via graph_changelog (#295 follow-up).
  */
 
+import { runtimeConfig } from "@roxabi-live/shared";
 import type { Context } from "hono";
 import { resolveVisibleRepos } from "../auth/repoAccess";
 import type { AuthEnv } from "../auth/types";
@@ -29,8 +30,8 @@ import {
   reserveGraphRowsBudget,
 } from "../quota/read-budget";
 
-/** Max dirty issues before falling back to a full rebuild. */
-export const MAX_DELTA_KEYS = 400;
+/** Max dirty issues before falling back to a full rebuild (runtime.json). */
+export const MAX_DELTA_KEYS = runtimeConfig.graph.maxDeltaKeys;
 
 export type DevState = "idle" | "dev" | "pr_open" | "pr_reviewed";
 

--- a/apps/api/src/graph/changelog.ts
+++ b/apps/api/src/graph/changelog.ts
@@ -2,6 +2,8 @@
  * graph_changelog — records issue-level graph mutations for delta fetches.
  */
 
+import { runtimeConfig } from "@roxabi-live/shared";
+
 export type GraphChangeOp = "upsert" | "delete";
 
 export interface GraphChangeRow {
@@ -115,7 +117,10 @@ export async function collectGraphChangesSince(
 }
 
 /** Drop entries older than N days (best-effort housekeeping). */
-export async function pruneGraphChangelog(db: D1Database, keepDays = 14): Promise<void> {
+export async function pruneGraphChangelog(
+  db: D1Database,
+  keepDays = runtimeConfig.graph.changelogKeepDays,
+): Promise<void> {
   const cutoff = new Date(Date.now() - keepDays * 86_400_000).toISOString();
   await db
     .prepare(`DELETE FROM graph_changelog WHERE bumped_at < ?`)

--- a/apps/api/src/quota/coalesce.ts
+++ b/apps/api/src/quota/coalesce.ts
@@ -2,6 +2,8 @@
  * Lossless webhook deferral — mark repos dirty for later reconcile (#295 S3).
  */
 
+import { runtimeConfig } from "@roxabi-live/shared";
+
 /** Clear sync watermark so bootstrap/maintenance picks the repo up again. */
 export async function markRepoDirty(db: D1Database, repo: string): Promise<void> {
   await db
@@ -14,7 +16,7 @@ export async function markRepoDirty(db: D1Database, repo: string): Promise<void>
     .run();
 }
 
-const BRANCH_SCAN_DEBOUNCE_MS = 5 * 60 * 1000;
+const BRANCH_SCAN_DEBOUNCE_MS = runtimeConfig.sync.branchScanDebounceMs;
 
 /**
  * Returns true when a full branch re-scan should run now; false when debounced

--- a/apps/api/src/quota/enforcement.test.ts
+++ b/apps/api/src/quota/enforcement.test.ts
@@ -1,11 +1,14 @@
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { getQuotaUsed, spendQuota, spendQuotaClamped } from "./ledger";
+import { limitForMetric } from "./limits";
 import {
   MIN_GRAPH_REBUILD_ROWS,
   recordGraphRowsSpend,
   reserveGraphRowsBudget,
 } from "./read-budget";
+
+const FREE_GRAPH_ROWS = limitForMetric("free", "graph_rows");
 
 function sqliteAsD1(db: Database.Database): D1Database {
   const wrap = (sql: string, args: unknown[] = []) => {
@@ -56,7 +59,7 @@ describe("quota enforcement integration", () => {
     seedSchema(sqlite);
     const d1 = sqliteAsD1(sqlite);
 
-    await spendQuota(d1, 1, "graph_rows", 125_000 - MIN_GRAPH_REBUILD_ROWS + 1, "free", true);
+    await spendQuota(d1, 1, "graph_rows", FREE_GRAPH_ROWS - MIN_GRAPH_REBUILD_ROWS + 1, "free", true);
 
     await expect(reserveGraphRowsBudget(d1, 1, "free")).resolves.toBe(false);
     await expect(reserveGraphRowsBudget(d1, 1, "free")).resolves.toBe(false);
@@ -71,10 +74,10 @@ describe("quota enforcement integration", () => {
     await expect(recordGraphRowsSpend(d1, 1, 10_000, "free")).resolves.toBe(false);
 
     const used = await getQuotaUsed(d1, 1, "graph_rows");
-    expect(used).toBe(125_000);
+    expect(used).toBe(FREE_GRAPH_ROWS);
 
     const { ok } = await spendQuotaClamped(d1, 1, "graph_rows", 1, "free");
     expect(ok).toBe(false);
-    expect(await getQuotaUsed(d1, 1, "graph_rows")).toBe(125_000);
+    expect(await getQuotaUsed(d1, 1, "graph_rows")).toBe(FREE_GRAPH_ROWS);
   });
 });

--- a/apps/api/src/quota/limits.ts
+++ b/apps/api/src/quota/limits.ts
@@ -1,49 +1,16 @@
 /**
  * Per-tenant daily quota limits keyed by plan (#295).
- * Sized for ~20 active free tenants staying within Workers Paid included pools.
+ * Values: packages/shared/config/runtime.json
  */
 
-export type TenantPlan = "free" | "paid";
-
-export type QuotaMetric =
-  | "webhook_events"
-  | "gh_fetches"
-  | "graph_rows"
-  | "sync_writes"
-  | "sync_pages";
-
-export const QUOTA_METRICS: readonly QuotaMetric[] = [
-  "webhook_events",
-  "gh_fetches",
-  "graph_rows",
-  "sync_writes",
-  "sync_pages",
-] as const;
-
-const FREE_LIMITS: Record<QuotaMetric, number> = {
-  webhook_events: 500,
-  gh_fetches: 150,
-  graph_rows: 125_000,
-  sync_writes: 1_250,
-  sync_pages: 50,
-};
-
-const PAID_LIMITS: Record<QuotaMetric, number> = {
-  webhook_events: 5_000,
-  gh_fetches: 1_500,
-  graph_rows: 2_500_000,
-  sync_writes: 25_000,
-  sync_pages: 500,
-};
-
-export function limitsForPlan(plan: TenantPlan): Record<QuotaMetric, number> {
-  return plan === "paid" ? PAID_LIMITS : FREE_LIMITS;
-}
-
-export function limitForMetric(plan: TenantPlan, metric: QuotaMetric): number {
-  return limitsForPlan(plan)[metric];
-}
-
-export function normalizePlan(raw: string | null | undefined): TenantPlan {
-  return raw === "paid" ? "paid" : "free";
-}
+export type {
+  QuotaMetric,
+  QuotaPlanLimits,
+  TenantPlan,
+} from "@roxabi-live/shared";
+export {
+  QUOTA_METRICS,
+  normalizeTenantPlan as normalizePlan,
+  quotaLimitForMetric as limitForMetric,
+  quotaLimitsForPlan as limitsForPlan,
+} from "@roxabi-live/shared";

--- a/apps/api/src/quota/read-budget.ts
+++ b/apps/api/src/quota/read-budget.ts
@@ -1,17 +1,18 @@
 /**
  * Graph/issues read-path quota enforcement (#295).
+ * Headroom gates: packages/shared/config/runtime.json → quota.graphRead
  */
 
+import { runtimeConfig } from "@roxabi-live/shared";
 import type { Context } from "hono";
 import type { AuthEnv } from "../auth/types";
 import { getQuotaUsed, spendQuotaClamped } from "./ledger";
 import { type TenantPlan, limitForMetric } from "./limits";
 
-/** Conservative lower bound for one full graph rebuild @ ~5k issues. */
-export const MIN_GRAPH_REBUILD_ROWS = 25_000;
+export const MIN_GRAPH_REBUILD_ROWS =
+  runtimeConfig.quota.graphRead.minFullRebuildHeadroomRows;
 
-/** Lower headroom gate for incremental graph deltas. */
-export const MIN_DELTA_GRAPH_ROWS = 1_000;
+export const MIN_DELTA_GRAPH_ROWS = runtimeConfig.quota.graphRead.minDeltaHeadroomRows;
 
 export function graphQuotaDeniedResponse(c: Context<AuthEnv>): Response {
   const retryAfter = secondsUntilUtcMidnight();

--- a/apps/api/src/sync/constants.ts
+++ b/apps/api/src/sync/constants.ts
@@ -1,23 +1,28 @@
 /**
  * Pagination + windowing constants for the corpus sync engine.
+ * Values: packages/shared/config/runtime.json → sync
  */
 
-export const MAX_PAGES = 500;
+import { runtimeConfig } from "@roxabi-live/shared";
+
+const { sync } = runtimeConfig;
+
+export const MAX_PAGES = sync.maxPages;
 /**
  * Repos synced per cron tick. Capped at 20 to stay under the Workers Free
  * 50-subrequest/invocation budget: a FULL reconcile (#80, since=null) costs
  * ~1 subrequest per issue page, and the largest repo (roxabi-factory, ~1k
  * issues) alone is ~11 pages — so a single run cannot reconcile all repos.
  */
-export const WINDOW = 20;
+export const WINDOW = sync.window;
 /** Bootstrap: one full-reconcile repo per waitUntil (stays under 50-subreq cap). */
-export const BOOTSTRAP_WINDOW = 1;
+export const BOOTSTRAP_WINDOW = sync.bootstrapWindow;
 /**
  * Rotation slots. Coverage ceiling = WINDOW * NUM_SLOTS = 40 repos; with the
  * daily cron each repo is full-reconciled every NUM_SLOTS days (= 2). 36 repos
  * today → fits in 2 slots, no wasted tick. Beyond 40 repos, raise this / WINDOW
  * (watch the subreq budget) or migrate to the dormant Queues fan-out (wrangler.toml).
  */
-export const NUM_SLOTS = 2;
+export const NUM_SLOTS = sync.numSlots;
 /** Cap GraphQL repo probes per discovery pass (#295 — kills quadratic bootstrap). */
-export const MAX_DISCOVERY_PROBES_PER_PASS = 10;
+export const MAX_DISCOVERY_PROBES_PER_PASS = sync.maxDiscoveryProbesPerPass;

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "es2022",
+    "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "lib": ["es2022"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,

--- a/apps/app/src/hooks/useGraphData.ts
+++ b/apps/app/src/hooks/useGraphData.ts
@@ -13,6 +13,7 @@ import {
   type GraphEdge,
   type RepoSummary,
   annotateNodes,
+  runtimeConfig,
 } from "@roxabi-live/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
@@ -23,7 +24,7 @@ export function useGraphData() {
   const query = useQuery({
     queryKey: GRAPH_QUERY_KEY,
     queryFn: ({ client }) => fetchGraph(client),
-    staleTime: 60_000,
+    staleTime: runtimeConfig.client.graphQueryStaleTimeMs,
     refetchOnWindowFocus: false,
   });
 

--- a/apps/app/src/hooks/useQuotaStatus.ts
+++ b/apps/app/src/hooks/useQuotaStatus.ts
@@ -3,6 +3,7 @@
  */
 
 import { apiFetch } from "@/lib/api";
+import { runtimeConfig } from "@roxabi-live/shared";
 import { useQuery } from "@tanstack/react-query";
 
 export type QuotaMetric =
@@ -27,7 +28,7 @@ export interface TenantQuotaStatus {
   any_exhausted: boolean;
 }
 
-const QUOTA_POLL_MS = 60_000;
+const QUOTA_POLL_MS = runtimeConfig.client.pollIntervalMs.quota;
 
 export function useQuotaStatus() {
   return useQuery({

--- a/apps/app/src/hooks/useSyncProgressMonitor.ts
+++ b/apps/app/src/hooks/useSyncProgressMonitor.ts
@@ -8,11 +8,11 @@
 
 import { apiFetch } from "@/lib/api";
 import { applyGraphDelta, fetchGraph, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
-import type { SyncStatus } from "@roxabi-live/shared";
+import { type SyncStatus, runtimeConfig } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
-const SYNC_POLL_MS = 2000;
+const SYNC_POLL_MS = runtimeConfig.client.pollIntervalMs.syncStatus;
 
 async function refetchGraphOnce(client: ReturnType<typeof useQueryClient>): Promise<void> {
   await client.fetchQuery({

--- a/apps/app/src/hooks/useVersionPoll.ts
+++ b/apps/app/src/hooks/useVersionPoll.ts
@@ -8,11 +8,11 @@
 import { apiFetchConditional } from "@/lib/api";
 import { getVersionEtag, setVersionEtag } from "@/lib/etag-cache";
 import { applyGraphDelta, fetchGraph, GRAPH_QUERY_KEY } from "@/lib/graph-fetch";
-import type { VersionResponse } from "@roxabi-live/shared";
+import { type VersionResponse, runtimeConfig } from "@roxabi-live/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
-const VERSION_POLL_MS = 15_000;
+const VERSION_POLL_MS = runtimeConfig.client.pollIntervalMs.version;
 
 function graphIsReady(client: ReturnType<typeof useQueryClient>): boolean {
   return client.getQueryState(GRAPH_QUERY_KEY)?.status === "success";

--- a/apps/app/src/zk/useDecryptedGraph.ts
+++ b/apps/app/src/zk/useDecryptedGraph.ts
@@ -17,6 +17,7 @@ import {
   type GraphResponse,
   type RepoSummary,
   annotateNodes,
+  runtimeConfig,
 } from "@roxabi-live/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
@@ -36,7 +37,7 @@ export function useDecryptedGraph() {
   const query = useQuery({
     queryKey: GRAPH_QUERY_KEY,
     queryFn: ({ client }) => fetchGraph(client),
-    staleTime: 60_000,
+    staleTime: runtimeConfig.client.graphQueryStaleTimeMs,
     refetchOnWindowFocus: false,
   });
   const data = query.data;

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
       "name": "@roxabi-live/api",
       "version": "0.0.0",
       "dependencies": {
+        "@roxabi-live/shared": "workspace:*",
         "hono": "^4.6.14",
       },
       "devDependencies": {

--- a/packages/shared/config/runtime.json
+++ b/packages/shared/config/runtime.json
@@ -1,0 +1,44 @@
+{
+  "quota": {
+    "plans": {
+      "free": {
+        "webhook_events": 500,
+        "gh_fetches": 150,
+        "graph_rows": 125000,
+        "sync_writes": 1250,
+        "sync_pages": 50
+      },
+      "paid": {
+        "webhook_events": 5000,
+        "gh_fetches": 1500,
+        "graph_rows": 2500000,
+        "sync_writes": 25000,
+        "sync_pages": 500
+      }
+    },
+    "graphRead": {
+      "minFullRebuildHeadroomRows": 25000,
+      "minDeltaHeadroomRows": 1000
+    }
+  },
+  "graph": {
+    "maxDeltaKeys": 400,
+    "changelogKeepDays": 14
+  },
+  "sync": {
+    "maxPages": 500,
+    "window": 20,
+    "bootstrapWindow": 1,
+    "numSlots": 2,
+    "maxDiscoveryProbesPerPass": 10,
+    "branchScanDebounceMs": 300000
+  },
+  "client": {
+    "pollIntervalMs": {
+      "version": 15000,
+      "syncStatus": 2000,
+      "quota": 60000
+    },
+    "graphQueryStaleTimeMs": 60000
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./brand": "./src/brand.ts"
+    "./brand": "./src/brand.ts",
+    "./config": "./src/runtime-config.ts",
+    "./config/runtime.json": "./config/runtime.json"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,3 +24,6 @@ export * from "./dims.ts";
 export * from "./layout.ts";
 export * from "./tone.ts";
 export * from "./hover.ts";
+
+// Runtime tunables (SSOT: packages/shared/config/runtime.json).
+export * from "./runtime-config.ts";

--- a/packages/shared/src/runtime-config.test.ts
+++ b/packages/shared/src/runtime-config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { quotaLimitForMetric, runtimeConfig } from "./runtime-config";
+
+describe("runtime-config", () => {
+  it("loads quota limits from runtime.json", () => {
+    expect(quotaLimitForMetric("free", "graph_rows")).toBe(125_000);
+    expect(quotaLimitForMetric("paid", "graph_rows")).toBe(2_500_000);
+  });
+
+  it("exposes graph and client tunables", () => {
+    expect(runtimeConfig.graph.maxDeltaKeys).toBe(400);
+    expect(runtimeConfig.client.pollIntervalMs.version).toBe(15_000);
+    expect(runtimeConfig.sync.maxPages).toBe(500);
+  });
+});

--- a/packages/shared/src/runtime-config.ts
+++ b/packages/shared/src/runtime-config.ts
@@ -1,0 +1,75 @@
+/**
+ * Runtime tunables — loaded from packages/shared/config/runtime.json (SSOT).
+ * Edit the JSON to change limits, quotas, and poll intervals without touching TS.
+ */
+
+import raw from "../config/runtime.json";
+
+export type TenantPlan = "free" | "paid";
+
+export type QuotaMetric =
+  | "webhook_events"
+  | "gh_fetches"
+  | "graph_rows"
+  | "sync_writes"
+  | "sync_pages";
+
+export interface QuotaPlanLimits {
+  webhook_events: number;
+  gh_fetches: number;
+  graph_rows: number;
+  sync_writes: number;
+  sync_pages: number;
+}
+
+export interface RuntimeConfig {
+  quota: {
+    plans: Record<TenantPlan, QuotaPlanLimits>;
+    graphRead: {
+      minFullRebuildHeadroomRows: number;
+      minDeltaHeadroomRows: number;
+    };
+  };
+  graph: {
+    maxDeltaKeys: number;
+    changelogKeepDays: number;
+  };
+  sync: {
+    maxPages: number;
+    window: number;
+    bootstrapWindow: number;
+    numSlots: number;
+    maxDiscoveryProbesPerPass: number;
+    branchScanDebounceMs: number;
+  };
+  client: {
+    pollIntervalMs: {
+      version: number;
+      syncStatus: number;
+      quota: number;
+    };
+    graphQueryStaleTimeMs: number;
+  };
+}
+
+export const runtimeConfig: RuntimeConfig = raw as RuntimeConfig;
+
+export const QUOTA_METRICS: readonly QuotaMetric[] = [
+  "webhook_events",
+  "gh_fetches",
+  "graph_rows",
+  "sync_writes",
+  "sync_pages",
+] as const;
+
+export function quotaLimitsForPlan(plan: TenantPlan): QuotaPlanLimits {
+  return runtimeConfig.quota.plans[plan];
+}
+
+export function quotaLimitForMetric(plan: TenantPlan, metric: QuotaMetric): number {
+  return runtimeConfig.quota.plans[plan][metric];
+}
+
+export function normalizeTenantPlan(raw: string | null | undefined): TenantPlan {
+  return raw === "paid" ? "paid" : "free";
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -10,7 +10,8 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
-    "types": []
+    "types": [],
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "config"]
 }


### PR DESCRIPTION
## Summary

Sort les chiffres et limites (quotas, sync, graph delta, poll intervals) hors du code TypeScript vers un fichier JSON unique, modifiable sans toucher au TS.

**SSOT:** `packages/shared/config/runtime.json`

## Contenu du config

| Section | Exemples |
|---------|----------|
| `quota.plans` | limites free/paid (graph_rows, gh_fetches, sync_pages, …) |
| `quota.graphRead` | headroom min pour full rebuild / delta |
| `graph` | maxDeltaKeys, changelogKeepDays |
| `sync` | maxPages, window, bootstrapWindow, debounce branch scan |
| `client` | poll intervals (version, syncStatus, quota), graph staleTime |

## Usage

```ts
import { runtimeConfig, quotaLimitForMetric } from "@roxabi-live/shared";
// ou sous-chemin direct :
import { runtimeConfig } from "@roxabi-live/shared/config";
```

Modifier `runtime.json` → redéployer (pas de rebuild TS nécessaire pour changer les valeurs si le JSON est bundlé au build).

## Fichiers migrés

- API: `quota/limits`, `read-budget`, `graph`, `changelog`, `sync/constants`, `coalesce`
- App: `useVersionPoll`, `useSyncProgressMonitor`, `useQuotaStatus`, `useGraphData`, `useDecryptedGraph`

## Tests

- `runtime-config.test.ts` (valeurs JSON)
- 821 tests API passent
- typecheck api + app + shared OK

## Notes

- Export JSON aussi via `@roxabi-live/shared/config/runtime.json` pour lecture directe si besoin
- `apps/api/tsconfig.json`: `allowImportingTsExtensions` pour consommer le package shared workspace