### PR TITLE
fix(app): avoid full graph scan when bootstrap sync completes

### DIFF
--- a/apps/app/src/hooks/useSyncProgressMonitor.ts
+++ b/apps/app/src/hooks/useSyncProgressMonitor.ts
@@ -76,7 +76,8 @@ export function useSyncProgressMonitor(): SyncStatus | null {
       }
     }
     if (wasActive.current && !active) {
-      void applyGraphUpdate(true);
+      // Sync just finished — delta only; a full scan here burns ~125k graph_rows.
+      void applyGraphUpdate(false);
     }
     wasActive.current = active;
   }, [data, queryClient]);


### PR DESCRIPTION
## Problem

When bootstrap sync finished, `useSyncProgressMonitor` forced a **full** `/api/graph` refetch (~125k `graph_rows` on staging). Combined with earlier invalidate storms, this contributed to exhausting the paid 2.5M daily budget.

## Fix

On sync completion, apply a **delta** merge instead of `refetchGraphOnce` (full scan).

Per-repo deltas already ran during bootstrap (`applyGraphDelta` while `active`).

## Staging ops

`graph_rows` for tenant 1 reset to 0 via D1 (2026-07-03 ~13:20 UTC).