### PR TITLE
fix(api): stop edges subquery burning millions of graph_rows

### DIFF
--- a/apps/api/src/graph/build-payload.ts
+++ b/apps/api/src/graph/build-payload.ts
@@ -36,9 +36,10 @@ export async function expandGraphKeys(
     .prepare(
       `SELECT DISTINCT e.src_key, e.dst_key
        FROM edges e
+       INNER JOIN issues si ON si.key = e.src_key
+       INNER JOIN issues di ON di.key = e.dst_key
        WHERE (e.src_key IN (${ph}) OR e.dst_key IN (${ph}))
-         AND e.src_key IN (SELECT key FROM issues WHERE repo IN (${repoPh}))
-         AND e.dst_key IN (SELECT key FROM issues WHERE repo IN (${repoPh}))`,
+         AND si.repo IN (${repoPh}) AND di.repo IN (${repoPh})`,
     )
     .bind(...seedKeys, ...seedKeys, ...visible, ...visible)
     .all<{ src_key: string; dst_key: string }>();

--- a/apps/api/src/graph/graph-payload-loaders.ts
+++ b/apps/api/src/graph/graph-payload-loaders.ts
@@ -258,7 +258,11 @@ export async function loadFullGraphRows(
 
   const edgeRows = await db
     .prepare(
-      `SELECT src_key, dst_key, kind FROM edges WHERE src_key IN (SELECT key FROM issues WHERE repo IN (${ph})) AND dst_key IN (SELECT key FROM issues WHERE repo IN (${ph}))`,
+      `SELECT e.src_key, e.dst_key, e.kind
+       FROM edges e
+       INNER JOIN issues si ON si.key = e.src_key
+       INNER JOIN issues di ON di.key = e.dst_key
+       WHERE si.repo IN (${ph}) AND di.repo IN (${ph})`,
     )
     .bind(...visible, ...visible)
     .all<EdgeRow>();


### PR DESCRIPTION
## Root cause (confirmed via D1 `rows_read`)

Full graph load used:
```sql
edges WHERE src_key IN (SELECT key FROM issues WHERE repo IN (...))
        AND dst_key IN (SELECT key FROM issues WHERE repo IN (...))
```

**Staging:** 1 714 edges returned, **3 767 162 rows_read** — one `/api/graph` exhausts the entire 2.5M paid quota.

**Optimized JOIN:** same result, **~6 008 rows_read**.

## Fix

`loadFullGraphRows` + `expandGraphKeys` — JOIN `issues` for repo scoping.

## Ops

Reset `graph_rows` on staging tenant 1 + prod tenant 4.