### PR TITLE
fix(auth): multi-account install/configure options in Settings

### DIFF
--- a/apps/api/src/api/me.test.ts
+++ b/apps/api/src/api/me.test.ts
@@ -165,7 +165,12 @@ describe("meRoute", () => {
 
   it("surfaces installation rows returned by D1 in the response body", async () => {
     // Arrange — FakeD1 returns one installation row
-    const fakeRow = { tenant_id: 9, account_login: "Roxabi", account_type: "Organization" };
+    const fakeRow = {
+      tenant_id: 9,
+      installation_id: 555,
+      account_login: "Roxabi",
+      account_type: "Organization",
+    };
     const { db } = captureDbWithRows([fakeRow]);
     const app = makeApp(db);
 
@@ -174,16 +179,27 @@ describe("meRoute", () => {
 
     // Assert
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { installations: (typeof fakeRow)[] };
+    const body = (await res.json()) as {
+      installations: Array<{
+        tenant_id: number;
+        account_login: string;
+        account_type: string;
+        configure_url: string;
+        installation_id?: number;
+      }>;
+    };
     expect(body.installations).toHaveLength(1);
     expect(body.installations[0]).toMatchObject({
       tenant_id: 9,
       account_login: "Roxabi",
       account_type: "Organization",
+      configure_url: "https://github.com/organizations/Roxabi/settings/installations/555",
     });
+    // installation_id is used server-side only (#171 — not raw-exported)
+    expect(body.installations[0]).not.toHaveProperty("installation_id");
   });
 
-  it("installations SELECT does NOT project installation_id (#171 — unnecessary exposure removed)", async () => {
+  it("installations SELECT projects installation_id for configure_url only", async () => {
     // Arrange
     const { db, stmts } = captureDb();
     const app = makeApp(db);
@@ -191,10 +207,10 @@ describe("meRoute", () => {
     // Act
     await app.request("/api/me", {}, makeEnv(db));
 
-    // Assert — installation_id is internal infra detail, not surfaced to clients
+    // Assert — needed to build configure_url; not returned raw on the wire
     const installStmt = stmts().find((s) => s.sql.includes("user_installations"));
     expect(installStmt).toBeDefined();
-    expect(installStmt?.sql).not.toContain("installation_id");
+    expect(installStmt?.sql).toContain("installation_id");
   });
 
   it("response includes active_tenant_id from the session (#148 SC7)", async () => {
@@ -240,23 +256,66 @@ describe("meRoute", () => {
     expect(body.install_targets.map((t) => t.login)).toEqual(["alice", "Roxabi"]);
   });
 
-  it("suppresses install_targets once a tenant is linked", async () => {
+  it("keeps install_targets once a tenant is linked (Settings add-install)", async () => {
+    const targetsJson = JSON.stringify([
+      { id: 42, login: "alice", type: "User" },
+      { id: 77, login: "OtherOrg", type: "Organization" },
+    ]);
     const { db } = captureDb((sql) => {
       if (sql.includes("install_targets_json")) {
-        return [{ zk_opt_in: 1, install_targets_json: "[]", consent_at: "2026-01-01T00:00:00Z" }];
+        return [{ zk_opt_in: 1, install_targets_json: targetsJson, consent_at: "2026-01-01T00:00:00Z" }];
       }
       if (sql.includes("user_installations")) {
-        return [{ tenant_id: 9, account_login: "Roxabi", account_type: "Organization" }];
+        return [
+          {
+            tenant_id: 9,
+            installation_id: 555,
+            account_login: "Roxabi",
+            account_type: "Organization",
+          },
+        ];
       }
       return [];
     });
     const res = await makeApp(db).request("/api/me", {}, makeEnv(db));
     const body = (await res.json()) as {
       install_pending: boolean;
-      install_targets: unknown[];
+      install_targets: Array<{ login: string }>;
+      install_options: Array<{ kind: string; login?: string }>;
+      installations: Array<{ configure_url: string }>;
     };
     expect(body.install_pending).toBe(false);
-    expect(body.install_targets).toEqual([]);
+    expect(body.install_targets.map((t) => t.login)).toEqual(["alice", "OtherOrg"]);
+    expect(body.installations[0]?.configure_url).toContain("/installations/555");
+    // Linked org excluded; personal + other org + picker remain
+    expect(body.install_options.map((o) => o.kind)).toEqual(["personal", "org", "picker"]);
+    expect(body.install_options.find((o) => o.kind === "org")?.login).toBe("OtherOrg");
+  });
+
+  it("always offers personal + picker install_options when ready with empty targets", async () => {
+    const { db } = captureDb((sql) => {
+      if (sql.includes("install_targets_json")) {
+        return [{ zk_opt_in: 1, install_targets_json: null, consent_at: "2026-01-01T00:00:00Z" }];
+      }
+      if (sql.includes("user_installations")) {
+        return [
+          {
+            tenant_id: 9,
+            installation_id: 555,
+            account_login: "Roxabi",
+            account_type: "Organization",
+          },
+        ];
+      }
+      return [];
+    });
+    const res = await makeApp(db).request("/api/me", {}, makeEnv(db));
+    const body = (await res.json()) as {
+      install_options: Array<{ kind: string; login?: string; url: string }>;
+    };
+    expect(body.install_options.map((o) => o.kind)).toEqual(["personal", "picker"]);
+    expect(body.install_options[0]?.login).toBe("alice");
+    expect(body.install_options[0]?.url).toContain("target_id=42");
   });
 
   it("installations SELECT filters soft-deleted tenants", async () => {

--- a/apps/api/src/api/me.ts
+++ b/apps/api/src/api/me.ts
@@ -84,7 +84,7 @@ export async function buildMePayload(env: Env, session: SessionContext): Promise
     configure_url: githubConfigureUrl(r.installation_id, r.account_login, r.account_type),
   }));
   const installPending = session.tenantId == null || installations.length === 0;
-  const installTargets = installTargetsFromUserRow(installPending, userRow?.install_targets_json);
+  const installTargets = installTargetsFromUserRow(userRow?.install_targets_json);
   const onboardingStep = deriveOnboardingStep(session, installations, userRow?.consent_at ?? null);
 
   return {

--- a/apps/api/src/api/me.ts
+++ b/apps/api/src/api/me.ts
@@ -3,6 +3,7 @@
  * /logout  — revoke session cookie.
  */
 
+import type { MePayload } from "@roxabi-live/shared";
 import type { Context } from "hono";
 import { AUTH_NO_CACHE, clearSessionCookieHeaders, readSessionToken } from "../auth/cookies";
 import { githubConfigureUrl } from "../auth/github-install";
@@ -16,30 +17,8 @@ import type { AuthEnv, SessionContext } from "../auth/types";
 import { zkAccountKeyEnabled } from "../auth/zk-flags";
 import type { Env } from "../types";
 
-export interface MePayload {
-  user: {
-    github_id: number;
-    github_login: string;
-    zk_opt_in: boolean;
-    zk_enrolled: boolean;
-    zk_account_key_enabled: boolean;
-  };
-  active_tenant_id: number | null;
-  /** @deprecated use onboarding_step */
-  install_pending: boolean;
-  /** @deprecated use install_options */
-  install_targets: Array<{ id: number; login: string; type: string }>;
-  install_options: Array<{ kind: string; login?: string; url: string }>;
-  installations: Array<{
-    tenant_id: number;
-    account_login: string;
-    account_type: string;
-    /** GitHub deep-link to manage repos for this install (installation_id not raw-exported). */
-    configure_url: string;
-  }>;
-  onboarding_step: "install" | "consent" | "ready";
-  consent_at: string | null;
-}
+/** Wire contract SSOT: `@roxabi-live/shared` MePayload. */
+export type { MePayload };
 
 /** Shared /api/me body builder — used by GET /api/me and POST /api/install/refresh. */
 export async function buildMePayload(env: Env, session: SessionContext): Promise<MePayload> {

--- a/apps/api/src/api/me.ts
+++ b/apps/api/src/api/me.ts
@@ -5,6 +5,7 @@
 
 import type { Context } from "hono";
 import { AUTH_NO_CACHE, clearSessionCookieHeaders, readSessionToken } from "../auth/cookies";
+import { githubConfigureUrl } from "../auth/github-install";
 import {
   buildInstallOptions,
   deriveOnboardingStep,
@@ -33,6 +34,8 @@ export interface MePayload {
     tenant_id: number;
     account_login: string;
     account_type: string;
+    /** GitHub deep-link to manage repos for this install (installation_id not raw-exported). */
+    configure_url: string;
   }>;
   onboarding_step: "install" | "consent" | "ready";
   consent_at: string | null;
@@ -57,15 +60,29 @@ export async function buildMePayload(env: Env, session: SessionContext): Promise
     .first<{ ok: number }>();
 
   const rows = await env.DB.prepare(
-    `SELECT ui.tenant_id AS tenant_id, t.account_login AS account_login, t.account_type AS account_type
+    `SELECT ui.tenant_id AS tenant_id,
+            t.installation_id AS installation_id,
+            t.account_login AS account_login,
+            t.account_type AS account_type
        FROM user_installations ui
        JOIN tenants t ON t.id = ui.tenant_id
        WHERE ui.user_id = ? AND t.deleted_at IS NULL AND t.suspended_at IS NULL`,
   )
     .bind(session.userId)
-    .all<{ tenant_id: number; account_login: string; account_type: string }>();
+    .all<{
+      tenant_id: number;
+      installation_id: number;
+      account_login: string;
+      account_type: string;
+    }>();
 
-  const installations = rows.results;
+  const installations = (rows.results ?? []).map((r) => ({
+    tenant_id: r.tenant_id,
+    account_login: r.account_login,
+    account_type: r.account_type,
+    // installation_id stays server-side; only the configure deep-link is exported.
+    configure_url: githubConfigureUrl(r.installation_id, r.account_login, r.account_type),
+  }));
   const installPending = session.tenantId == null || installations.length === 0;
   const installTargets = installTargetsFromUserRow(installPending, userRow?.install_targets_json);
   const onboardingStep = deriveOnboardingStep(session, installations, userRow?.consent_at ?? null);
@@ -81,7 +98,14 @@ export async function buildMePayload(env: Env, session: SessionContext): Promise
     active_tenant_id: session.tenantId,
     install_pending: installPending,
     install_targets: installTargets,
-    install_options: buildInstallOptions(installTargets, env.GITHUB_APP_SLUG),
+    install_options: buildInstallOptions(installTargets, env.GITHUB_APP_SLUG, {
+      installedLogins: installations.map((i) => i.account_login),
+      personalFallback: {
+        id: session.githubId,
+        login: session.githubLogin,
+        type: "User",
+      },
+    }),
     installations,
     onboarding_step: onboardingStep,
     consent_at: userRow?.consent_at ?? null,

--- a/apps/api/src/auth/github-install.test.ts
+++ b/apps/api/src/auth/github-install.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_GITHUB_APP_SLUG,
+  githubConfigureUrl,
   githubInstallUrl,
   parseInstallTargets,
   resolveGithubAppSlug,
@@ -40,6 +41,20 @@ describe("githubInstallUrl", () => {
     const url = new URL(githubInstallUrl({ id: 99, login: "Roxabi", type: "Organization" }));
     expect(url.searchParams.get("target_id")).toBe("99");
     expect(url.searchParams.get("target_type")).toBe("Organization");
+  });
+});
+
+describe("githubConfigureUrl", () => {
+  it("uses user settings path for personal installs", () => {
+    expect(githubConfigureUrl(99, "alice", "User")).toBe(
+      "https://github.com/settings/installations/99",
+    );
+  });
+
+  it("uses org settings path for organisation installs", () => {
+    expect(githubConfigureUrl(55, "Roxabi", "Organization")).toBe(
+      "https://github.com/organizations/Roxabi/settings/installations/55",
+    );
   });
 });
 

--- a/apps/api/src/auth/github-install.test.ts
+++ b/apps/api/src/auth/github-install.test.ts
@@ -56,6 +56,12 @@ describe("githubConfigureUrl", () => {
       "https://github.com/organizations/Roxabi/settings/installations/55",
     );
   });
+
+  it("encodes reserved characters in organisation login path segment", () => {
+    expect(githubConfigureUrl(7, "acme/corp", "Organization")).toBe(
+      "https://github.com/organizations/acme%2Fcorp/settings/installations/7",
+    );
+  });
 });
 
 describe("parseInstallTargets", () => {

--- a/apps/api/src/auth/github-install.ts
+++ b/apps/api/src/auth/github-install.ts
@@ -34,6 +34,22 @@ export function githubInstallUrl(target?: InstallTarget, appSlug?: string): stri
   return url.toString();
 }
 
+/**
+ * Deep-link to GitHub's installation settings (repo selection / suspend / uninstall).
+ * User installs live under /settings/installations; org installs under
+ * /organizations/{login}/settings/installations.
+ */
+export function githubConfigureUrl(
+  installationId: number,
+  accountLogin: string,
+  accountType: InstallTargetType | string,
+): string {
+  if (accountType === "Organization") {
+    return `https://github.com/organizations/${encodeURIComponent(accountLogin)}/settings/installations/${installationId}`;
+  }
+  return `https://github.com/settings/installations/${installationId}`;
+}
+
 /** Parse install_targets_json from users — invalid JSON yields []. */
 export function parseInstallTargets(raw: string | null | undefined): InstallTarget[] {
   if (!raw) return [];

--- a/apps/api/src/auth/install-targets.ts
+++ b/apps/api/src/auth/install-targets.ts
@@ -1,0 +1,72 @@
+/**
+ * Cache of personal + org install targets for Settings / InstallGate.
+ * Fetched from GitHub during OAuth; stored on users.install_targets_json.
+ */
+
+import type { InstallTarget } from "./github-install";
+import { githubRestGet } from "./github-rest";
+
+/**
+ * Personal + orgs the user can install the App on.
+ * `orgsFetched` is true only when GitHub returned a parseable org list — callers
+ * must not overwrite a cached `install_targets_json` when it is false.
+ */
+export async function fetchInstallTargets(
+  accessToken: string,
+  ghUser: { id: number; login: string },
+): Promise<{ targets: InstallTarget[]; orgsFetched: boolean }> {
+  const orgsRes = await githubRestGet(
+    "https://api.github.com/user/orgs?per_page=100",
+    accessToken,
+  );
+  let orgs: Array<{ id: number; login: string }> = [];
+  let orgsFetched = false;
+  if (orgsRes.ok) {
+    try {
+      const body = (await orgsRes.json()) as unknown;
+      if (Array.isArray(body)) {
+        orgs = body as Array<{ id: number; login: string }>;
+        orgsFetched = true;
+      }
+    } catch {
+      orgsFetched = false;
+    }
+  }
+  const targets: InstallTarget[] = [
+    { id: ghUser.id, login: ghUser.login, type: "User" },
+    ...orgs.map((o) => ({
+      id: o.id,
+      login: o.login,
+      type: "Organization" as const,
+    })),
+  ];
+  return { targets, orgsFetched };
+}
+
+/**
+ * Upsert user row. When `replaceTargets` is false, keep existing
+ * `install_targets_json` on conflict (GitHub /user/orgs flaked).
+ */
+export async function upsertUserWithInstallTargets(
+  db: D1Database,
+  ghUser: { id: number; login: string },
+  targets: InstallTarget[],
+  replaceTargets: boolean,
+): Promise<{ id: number } | null> {
+  return db
+    .prepare(
+      `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
+       VALUES (?, ?, 1, ?)
+       ON CONFLICT(github_id) DO UPDATE SET
+         github_login=excluded.github_login,
+         zk_opt_in=1,
+         install_targets_json = CASE
+           WHEN ? THEN excluded.install_targets_json
+           ELSE users.install_targets_json
+         END,
+         updated_at=datetime('now')
+       RETURNING id`,
+    )
+    .bind(ghUser.id, ghUser.login, JSON.stringify(targets), replaceTargets ? 1 : 0)
+    .first<{ id: number }>();
+}

--- a/apps/api/src/auth/link-install.test.ts
+++ b/apps/api/src/auth/link-install.test.ts
@@ -32,7 +32,8 @@ describe("tryLinkInstallPendingSession", () => {
 
     expect(tenantId).toBe(9);
     expect(captured.some((s) => s.sql.includes("UPDATE sessions SET tenant_id"))).toBe(true);
-    expect(captured.some((s) => s.sql.includes("install_targets_json = NULL"))).toBe(true);
+    // install_targets_json is kept for Settings "add another install"
+    expect(captured.some((s) => s.sql.includes("install_targets_json = NULL"))).toBe(false);
   });
 
   it("returns null when multiple installations exist", async () => {

--- a/apps/api/src/auth/link-install.ts
+++ b/apps/api/src/auth/link-install.ts
@@ -49,12 +49,8 @@ export async function tryLinkInstallPendingSession(
     return null;
   }
 
-  await db
-    .prepare(
-      `UPDATE users SET install_targets_json = NULL, updated_at = datetime('now') WHERE id = ?`,
-    )
-    .bind(session.userId)
-    .run();
+  // Keep install_targets_json: Settings uses it so the user can install on
+  // additional orgs/accounts after the first link (do not clear here).
 
   return tenantId;
 }

--- a/apps/api/src/auth/oauth.test.ts
+++ b/apps/api/src/auth/oauth.test.ts
@@ -557,29 +557,20 @@ describe("callbackRoute", () => {
       accessToken: string,
       user: { id: number; login: string },
       installations: Array<{ id: number; account: { login: string; type: string } }>,
+      orgs: Array<{ id: number; login: string }> = [],
     ) {
-      let callCount = 0;
-      const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => {
-        callCount++;
-        if (callCount === 1) {
-          // Token exchange
-          return new Response(JSON.stringify({ access_token: accessToken }), {
+      const mockFetch = vi.fn(async (url: string, _init?: RequestInit) => {
+        const u = String(url);
+        const json = (body: unknown) =>
+          new Response(JSON.stringify(body), {
             status: 200,
             headers: { "Content-Type": "application/json" },
           });
-        }
-        if (callCount === 2) {
-          // /user
-          return new Response(JSON.stringify(user), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        // /user/installations
-        return new Response(JSON.stringify({ installations }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
+        if (u.includes("login/oauth/access_token")) return json({ access_token: accessToken });
+        if (u.includes("/user/installations")) return json({ installations });
+        if (u.includes("/user/orgs")) return json(orgs);
+        if (u.includes("api.github.com/user")) return json(user);
+        return json({});
       });
       vi.stubGlobal("fetch", mockFetch);
       return mockFetch;
@@ -930,32 +921,25 @@ describe("callbackRoute", () => {
       // #158: surface tenant RETURNING ids through batch results.
       applyBatchOverride(db);
 
-      // Stub fetch so both calls hit GitHub APIs successfully
-      let fetchCallCount = 0;
+      // Stub fetch so GitHub API calls succeed (URL-matched; includes /user/orgs)
       vi.stubGlobal(
         "fetch",
-        vi.fn(async (_url: string) => {
-          fetchCallCount++;
-          // Cycle through token → user → installations for each OAuth callback
-          const pos = ((fetchCallCount - 1) % 3) + 1;
-          if (pos === 1) {
-            return new Response(JSON.stringify({ access_token: "tok-abc" }), {
+        vi.fn(async (url: string) => {
+          const u = String(url);
+          const json = (body: unknown) =>
+            new Response(JSON.stringify(body), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             });
-          }
-          if (pos === 2) {
-            return new Response(JSON.stringify({ id: 42, login: "alice" }), {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            });
-          }
-          return new Response(
-            JSON.stringify({
+          if (u.includes("login/oauth/access_token")) return json({ access_token: "tok-abc" });
+          if (u.includes("/user/installations")) {
+            return json({
               installations: [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          );
+            });
+          }
+          if (u.includes("/user/orgs")) return json([]);
+          if (u.includes("api.github.com/user")) return json({ id: 42, login: "alice" });
+          return json({});
         }),
       );
 
@@ -1357,21 +1341,24 @@ describe("callbackRoute", () => {
     }
 
     function stubGithub(): void {
-      let n = 0;
       vi.stubGlobal(
         "fetch",
-        vi.fn(async () => {
-          n++;
+        vi.fn(async (url: string) => {
+          const u = String(url);
           const json = (b: unknown) =>
             new Response(JSON.stringify(b), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             });
-          if (n === 1) return json({ access_token: "tok" });
-          if (n === 2) return json({ id: 42, login: "alice" });
-          return json({
-            installations: [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
-          });
+          if (u.includes("login/oauth/access_token")) return json({ access_token: "tok" });
+          if (u.includes("/user/installations")) {
+            return json({
+              installations: [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+            });
+          }
+          if (u.includes("/user/orgs")) return json([]);
+          if (u.includes("api.github.com/user")) return json({ id: 42, login: "alice" });
+          return json({});
         }),
       );
     }

--- a/apps/api/src/auth/oauth.test.ts
+++ b/apps/api/src/auth/oauth.test.ts
@@ -693,6 +693,93 @@ describe("callbackRoute", () => {
       expect(usersStmt?.sql).toContain("ON CONFLICT(github_id)");
     });
 
+    it("persists install_targets_json (personal + orgs) when installations non-empty", async () => {
+      const stateValue = "b1".repeat(16);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
+
+      stubFetchSequence(
+        "t",
+        { id: 42, login: "alice" },
+        [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+        [{ id: 77, login: "OtherOrg" }],
+      );
+
+      const { app, env } = makeApp(db);
+      await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+
+      const usersStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("users") &&
+          s.sql.toLowerCase().includes("install_targets_json") &&
+          s.sql.toUpperCase().includes("ON CONFLICT"),
+      );
+      expect(usersStmt).toBeDefined();
+      // bind: github_id, login, targetsJson, replaceTargets(1 when orgs ok)
+      const targets = JSON.parse(String(usersStmt?.args[2])) as Array<{
+        login: string;
+        type: string;
+      }>;
+      expect(targets).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ login: "alice", type: "User" }),
+          expect.objectContaining({ login: "OtherOrg", type: "Organization" }),
+        ]),
+      );
+      expect(usersStmt?.args[3]).toBe(1);
+      expect(usersStmt?.sql).toMatch(/CASE\s+WHEN\s+\?\s+THEN\s+excluded\.install_targets_json/i);
+    });
+
+    it("does not replace install_targets_json when /user/orgs fails (linked path)", async () => {
+      const stateValue = "b2".repeat(16);
+      const captured: FakeStmt[] = [];
+      const db = makeHappyPathDb(captured);
+
+      // Custom fetch: orgs returns 500 so orgsFetched=false → replaceTargets=0
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          const u = String(url);
+          const json = (body: unknown, status = 200) =>
+            new Response(JSON.stringify(body), {
+              status,
+              headers: { "Content-Type": "application/json" },
+            });
+          if (u.includes("login/oauth/access_token")) return json({ access_token: "t" });
+          if (u.includes("/user/installations")) {
+            return json({
+              installations: [{ id: 9, account: { login: "Roxabi", type: "Organization" } }],
+            });
+          }
+          if (u.includes("/user/orgs")) return json({ message: "boom" }, 500);
+          if (u.includes("api.github.com/user")) return json({ id: 42, login: "alice" });
+          return json({});
+        }),
+      );
+
+      const { app, env } = makeApp(db);
+      const res = await app.request(
+        `http://localhost/oauth/callback?code=mycode&state=${stateValue}`,
+        { method: "GET" },
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const usersStmt = captured.find(
+        (s) =>
+          s.sql.toLowerCase().includes("users") &&
+          s.sql.toLowerCase().includes("install_targets_json") &&
+          s.sql.toUpperCase().includes("ON CONFLICT"),
+      );
+      expect(usersStmt).toBeDefined();
+      // replaceTargets flag is 0 → keep prior cache on conflict
+      expect(usersStmt?.args[3]).toBe(0);
+    });
+
     it("issues tenants upsert with ON CONFLICT(installation_id)", async () => {
       // Arrange
       const stateValue = "c".repeat(32);

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -317,9 +317,10 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
     });
   }
 
-  // Shared: personal + orgs (defensive parse). Install-pending always writes
-  // targets (personal-only is fine if orgs flaked). Linked users only replace
-  // the cache when orgs were successfully fetched — never wipe on GitHub outage.
+  // Shared: personal + orgs (defensive parse). Both install-pending and linked
+  // paths only replace cached install_targets_json when /user/orgs succeeded —
+  // never wipe a rich cache on GitHub outage. New users still get personal-only
+  // via INSERT VALUES when orgs flake.
   const { targets: installTargets, orgsFetched } = await fetchInstallTargets(
     access_token,
     ghUser,
@@ -331,7 +332,7 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
       c.env.DB,
       ghUser,
       installTargets,
-      /* replaceTargets */ true,
+      orgsFetched,
     );
 
     if (!userRow) {

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -11,6 +11,7 @@
 import type { Context } from "hono";
 import type { Env } from "../types";
 import { authRedirect, readSessionToken, sanitizeAuthRedirect, stripInstallParam } from "./cookies";
+import type { InstallTarget } from "./github-install";
 import { githubRestGet } from "./github-rest";
 import { tryLinkInstallPendingSession } from "./link-install";
 import { serveLoginPrompt } from "./login-prompt";
@@ -20,6 +21,71 @@ import { pickSessionTenantId, supersedeStaleTenants } from "./tenant-supersede";
 import { createUserTokenHandoff } from "./userTokenHandoff";
 import { zkAccountKeyEnabled } from "./zk-flags";
 import { createZkReauthCode } from "./zk-reauth";
+
+/**
+ * Personal + orgs the user can install the App on.
+ * `orgsFetched` is true only when GitHub returned a parseable org list — callers
+ * must not overwrite a cached `install_targets_json` when it is false.
+ */
+export async function fetchInstallTargets(
+  accessToken: string,
+  ghUser: { id: number; login: string },
+): Promise<{ targets: InstallTarget[]; orgsFetched: boolean }> {
+  const orgsRes = await githubRestGet(
+    "https://api.github.com/user/orgs?per_page=100",
+    accessToken,
+  );
+  let orgs: Array<{ id: number; login: string }> = [];
+  let orgsFetched = false;
+  if (orgsRes.ok) {
+    try {
+      const body = (await orgsRes.json()) as unknown;
+      if (Array.isArray(body)) {
+        orgs = body as Array<{ id: number; login: string }>;
+        orgsFetched = true;
+      }
+    } catch {
+      orgsFetched = false;
+    }
+  }
+  const targets: InstallTarget[] = [
+    { id: ghUser.id, login: ghUser.login, type: "User" },
+    ...orgs.map((o) => ({
+      id: o.id,
+      login: o.login,
+      type: "Organization" as const,
+    })),
+  ];
+  return { targets, orgsFetched };
+}
+
+/**
+ * Upsert user row. When `replaceTargets` is false, keep existing
+ * `install_targets_json` on conflict (GitHub /user/orgs flaked).
+ */
+export async function upsertUserWithInstallTargets(
+  db: D1Database,
+  ghUser: { id: number; login: string },
+  targets: InstallTarget[],
+  replaceTargets: boolean,
+): Promise<{ id: number } | null> {
+  return db
+    .prepare(
+      `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
+       VALUES (?, ?, 1, ?)
+       ON CONFLICT(github_id) DO UPDATE SET
+         github_login=excluded.github_login,
+         zk_opt_in=1,
+         install_targets_json = CASE
+           WHEN ? THEN excluded.install_targets_json
+           ELSE users.install_targets_json
+         END,
+         updated_at=datetime('now')
+       RETURNING id`,
+    )
+    .bind(ghUser.id, ghUser.login, JSON.stringify(targets), replaceTargets ? 1 : 0)
+    .first<{ id: number }>();
+}
 
 export type LoginIntent = "signin" | "install" | "reauth" | "zk" | "prompt";
 
@@ -251,35 +317,22 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
     });
   }
 
+  // Shared: personal + orgs (defensive parse). Install-pending always writes
+  // targets (personal-only is fine if orgs flaked). Linked users only replace
+  // the cache when orgs were successfully fetched — never wipe on GitHub outage.
+  const { targets: installTargets, orgsFetched } = await fetchInstallTargets(
+    access_token,
+    ghUser,
+  );
+
   // No installations — mint install-pending session and show our install guide
   if (installations.length === 0) {
-    const orgsRes = await githubRestGet(
-      "https://api.github.com/user/orgs?per_page=100",
-      access_token,
+    const userRow = await upsertUserWithInstallTargets(
+      c.env.DB,
+      ghUser,
+      installTargets,
+      /* replaceTargets */ true,
     );
-    const orgs = orgsRes.ok ? ((await orgsRes.json()) as Array<{ id: number; login: string }>) : [];
-
-    const installTargets = [
-      { id: ghUser.id, login: ghUser.login, type: "User" as const },
-      ...orgs.map((o) => ({
-        id: o.id,
-        login: o.login,
-        type: "Organization" as const,
-      })),
-    ];
-
-    const userRow = await c.env.DB.prepare(
-      `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
-       VALUES (?, ?, 1, ?)
-       ON CONFLICT(github_id) DO UPDATE SET
-         github_login=excluded.github_login,
-         zk_opt_in=1,
-         install_targets_json=excluded.install_targets_json,
-         updated_at=datetime('now')
-       RETURNING id`,
-    )
-      .bind(ghUser.id, ghUser.login, JSON.stringify(installTargets))
-      .first<{ id: number }>();
 
     if (!userRow) {
       return c.json({ error: "db_error" }, 500);
@@ -290,45 +343,13 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
     return completeOAuthSession(c, rawToken, redirectAfter, rememberSession);
   }
 
-  // Cache install targets (personal + orgs) even when the user already has
-  // installations — Settings needs them to offer "install on another account".
-  const orgsResLinked = await githubRestGet(
-    "https://api.github.com/user/orgs?per_page=100",
-    access_token,
+  // Upsert user — get internal id (keep prior install_targets_json if orgs fetch failed)
+  const userRow = await upsertUserWithInstallTargets(
+    c.env.DB,
+    ghUser,
+    installTargets,
+    orgsFetched,
   );
-  let orgsLinked: Array<{ id: number; login: string }> = [];
-  if (orgsResLinked.ok) {
-    try {
-      const body = (await orgsResLinked.json()) as unknown;
-      if (Array.isArray(body)) {
-        orgsLinked = body as Array<{ id: number; login: string }>;
-      }
-    } catch {
-      orgsLinked = [];
-    }
-  }
-  const installTargetsLinked = [
-    { id: ghUser.id, login: ghUser.login, type: "User" as const },
-    ...orgsLinked.map((o) => ({
-      id: o.id,
-      login: o.login,
-      type: "Organization" as const,
-    })),
-  ];
-
-  // Upsert user — get internal id
-  const userRow = await c.env.DB.prepare(
-    `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
-     VALUES (?, ?, 1, ?)
-     ON CONFLICT(github_id) DO UPDATE SET
-       github_login=excluded.github_login,
-       zk_opt_in=1,
-       install_targets_json=excluded.install_targets_json,
-       updated_at=datetime('now')
-     RETURNING id`,
-  )
-    .bind(ghUser.id, ghUser.login, JSON.stringify(installTargetsLinked))
-    .first<{ id: number }>();
 
   if (!userRow) {
     return c.json({ error: "db_error" }, 500);

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -11,8 +11,8 @@
 import type { Context } from "hono";
 import type { Env } from "../types";
 import { authRedirect, readSessionToken, sanitizeAuthRedirect, stripInstallParam } from "./cookies";
-import type { InstallTarget } from "./github-install";
 import { githubRestGet } from "./github-rest";
+import { fetchInstallTargets, upsertUserWithInstallTargets } from "./install-targets";
 import { tryLinkInstallPendingSession } from "./link-install";
 import { serveLoginPrompt } from "./login-prompt";
 import { completeOAuthSession } from "./post-oauth";
@@ -21,71 +21,6 @@ import { pickSessionTenantId, supersedeStaleTenants } from "./tenant-supersede";
 import { createUserTokenHandoff } from "./userTokenHandoff";
 import { zkAccountKeyEnabled } from "./zk-flags";
 import { createZkReauthCode } from "./zk-reauth";
-
-/**
- * Personal + orgs the user can install the App on.
- * `orgsFetched` is true only when GitHub returned a parseable org list — callers
- * must not overwrite a cached `install_targets_json` when it is false.
- */
-export async function fetchInstallTargets(
-  accessToken: string,
-  ghUser: { id: number; login: string },
-): Promise<{ targets: InstallTarget[]; orgsFetched: boolean }> {
-  const orgsRes = await githubRestGet(
-    "https://api.github.com/user/orgs?per_page=100",
-    accessToken,
-  );
-  let orgs: Array<{ id: number; login: string }> = [];
-  let orgsFetched = false;
-  if (orgsRes.ok) {
-    try {
-      const body = (await orgsRes.json()) as unknown;
-      if (Array.isArray(body)) {
-        orgs = body as Array<{ id: number; login: string }>;
-        orgsFetched = true;
-      }
-    } catch {
-      orgsFetched = false;
-    }
-  }
-  const targets: InstallTarget[] = [
-    { id: ghUser.id, login: ghUser.login, type: "User" },
-    ...orgs.map((o) => ({
-      id: o.id,
-      login: o.login,
-      type: "Organization" as const,
-    })),
-  ];
-  return { targets, orgsFetched };
-}
-
-/**
- * Upsert user row. When `replaceTargets` is false, keep existing
- * `install_targets_json` on conflict (GitHub /user/orgs flaked).
- */
-export async function upsertUserWithInstallTargets(
-  db: D1Database,
-  ghUser: { id: number; login: string },
-  targets: InstallTarget[],
-  replaceTargets: boolean,
-): Promise<{ id: number } | null> {
-  return db
-    .prepare(
-      `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
-       VALUES (?, ?, 1, ?)
-       ON CONFLICT(github_id) DO UPDATE SET
-         github_login=excluded.github_login,
-         zk_opt_in=1,
-         install_targets_json = CASE
-           WHEN ? THEN excluded.install_targets_json
-           ELSE users.install_targets_json
-         END,
-         updated_at=datetime('now')
-       RETURNING id`,
-    )
-    .bind(ghUser.id, ghUser.login, JSON.stringify(targets), replaceTargets ? 1 : 0)
-    .first<{ id: number }>();
-}
 
 export type LoginIntent = "signin" | "install" | "reauth" | "zk" | "prompt";
 

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -290,18 +290,44 @@ export async function callbackRoute(c: Context<{ Bindings: Env }>): Promise<Resp
     return completeOAuthSession(c, rawToken, redirectAfter, rememberSession);
   }
 
+  // Cache install targets (personal + orgs) even when the user already has
+  // installations — Settings needs them to offer "install on another account".
+  const orgsResLinked = await githubRestGet(
+    "https://api.github.com/user/orgs?per_page=100",
+    access_token,
+  );
+  let orgsLinked: Array<{ id: number; login: string }> = [];
+  if (orgsResLinked.ok) {
+    try {
+      const body = (await orgsResLinked.json()) as unknown;
+      if (Array.isArray(body)) {
+        orgsLinked = body as Array<{ id: number; login: string }>;
+      }
+    } catch {
+      orgsLinked = [];
+    }
+  }
+  const installTargetsLinked = [
+    { id: ghUser.id, login: ghUser.login, type: "User" as const },
+    ...orgsLinked.map((o) => ({
+      id: o.id,
+      login: o.login,
+      type: "Organization" as const,
+    })),
+  ];
+
   // Upsert user — get internal id
   const userRow = await c.env.DB.prepare(
     `INSERT INTO users (github_id, github_login, zk_opt_in, install_targets_json)
-     VALUES (?, ?, 1, NULL)
+     VALUES (?, ?, 1, ?)
      ON CONFLICT(github_id) DO UPDATE SET
        github_login=excluded.github_login,
        zk_opt_in=1,
-       install_targets_json=NULL,
+       install_targets_json=excluded.install_targets_json,
        updated_at=datetime('now')
      RETURNING id`,
   )
-    .bind(ghUser.id, ghUser.login)
+    .bind(ghUser.id, ghUser.login, JSON.stringify(installTargetsLinked))
     .first<{ id: number }>();
 
   if (!userRow) {

--- a/apps/api/src/auth/onboarding.test.ts
+++ b/apps/api/src/auth/onboarding.test.ts
@@ -23,11 +23,32 @@ describe("deriveOnboardingStep", () => {
 });
 
 describe("buildInstallOptions", () => {
-  it("builds personal, org, and picker options", () => {
+  it("builds personal, org, and always appends picker", () => {
     const opts = buildInstallOptions([
       { id: 1, login: "alice", type: "User" },
       { id: 2, login: "Roxabi", type: "Organization" },
     ]);
-    expect(opts.map((o) => o.kind)).toEqual(["personal", "org"]);
+    expect(opts.map((o) => o.kind)).toEqual(["personal", "org", "picker"]);
+  });
+
+  it("skips already-installed logins and still offers picker", () => {
+    const opts = buildInstallOptions(
+      [
+        { id: 1, login: "alice", type: "User" },
+        { id: 2, login: "Roxabi", type: "Organization" },
+      ],
+      undefined,
+      { installedLogins: ["Roxabi"] },
+    );
+    expect(opts.map((o) => o.kind)).toEqual(["personal", "picker"]);
+    expect(opts.find((o) => o.kind === "personal")?.login).toBe("alice");
+  });
+
+  it("uses personalFallback when targets are empty", () => {
+    const opts = buildInstallOptions([], undefined, {
+      personalFallback: { id: 42, login: "alice", type: "User" },
+    });
+    expect(opts.map((o) => o.kind)).toEqual(["personal", "picker"]);
+    expect(opts[0]?.login).toBe("alice");
   });
 });

--- a/apps/api/src/auth/onboarding.test.ts
+++ b/apps/api/src/auth/onboarding.test.ts
@@ -51,4 +51,24 @@ describe("buildInstallOptions", () => {
     expect(opts.map((o) => o.kind)).toEqual(["personal", "picker"]);
     expect(opts[0]?.login).toBe("alice");
   });
+
+  it("filters installed logins case-insensitively", () => {
+    const opts = buildInstallOptions(
+      [
+        { id: 1, login: "alice", type: "User" },
+        { id: 2, login: "Roxabi", type: "Organization" },
+      ],
+      undefined,
+      { installedLogins: ["roxabi"] },
+    );
+    expect(opts.map((o) => o.kind)).toEqual(["personal", "picker"]);
+  });
+
+  it("drops personalFallback when personal is already installed → picker only", () => {
+    const opts = buildInstallOptions([{ id: 1, login: "alice", type: "User" }], undefined, {
+      installedLogins: ["alice"],
+      personalFallback: { id: 1, login: "alice", type: "User" },
+    });
+    expect(opts.map((o) => o.kind)).toEqual(["picker"]);
+  });
 });

--- a/apps/api/src/auth/onboarding.ts
+++ b/apps/api/src/auth/onboarding.ts
@@ -13,12 +13,46 @@ export interface InstallOption {
   url: string;
 }
 
-export function buildInstallOptions(targets: InstallTarget[], appSlug?: string): InstallOption[] {
-  const personal = targets.find((t) => t.type === "User");
-  const orgs = targets.filter((t) => t.type === "Organization");
+export interface BuildInstallOptionsOpts {
+  /** Logins already linked (case-insensitive) — excluded from "add install" options. */
+  installedLogins?: Iterable<string>;
+  /** Ensure a personal option exists even when install_targets_json is empty/stale. */
+  personalFallback?: InstallTarget;
+}
+
+function normLogin(login: string): string {
+  return login.toLowerCase();
+}
+
+/**
+ * Build deep-links for installing the App on accounts the user can access.
+ * Always ends with a picker so orgs outside our cached target list remain reachable
+ * (Settings "add another org" and InstallGate both need this).
+ */
+export function buildInstallOptions(
+  targets: InstallTarget[],
+  appSlug?: string,
+  opts: BuildInstallOptionsOpts = {},
+): InstallOption[] {
+  const installed = new Set(
+    [...(opts.installedLogins ?? [])].map((l) => normLogin(l)).filter(Boolean),
+  );
+
+  const byKey = new Map<string, InstallTarget>();
+  for (const t of targets) {
+    byKey.set(`${t.type}:${normLogin(t.login)}`, t);
+  }
+  if (opts.personalFallback) {
+    const key = `User:${normLogin(opts.personalFallback.login)}`;
+    if (!byKey.has(key)) byKey.set(key, opts.personalFallback);
+  }
+
+  const merged = [...byKey.values()];
+  const personal = merged.find((t) => t.type === "User");
+  const orgs = merged.filter((t) => t.type === "Organization");
 
   const options: InstallOption[] = [];
-  if (personal) {
+  if (personal && !installed.has(normLogin(personal.login))) {
     options.push({
       kind: "personal",
       login: personal.login,
@@ -26,15 +60,15 @@ export function buildInstallOptions(targets: InstallTarget[], appSlug?: string):
     });
   }
   for (const org of orgs) {
+    if (installed.has(normLogin(org.login))) continue;
     options.push({
       kind: "org",
       login: org.login,
       url: githubInstallUrl(org, appSlug),
     });
   }
-  if (orgs.length === 0) {
-    options.push({ kind: "picker", url: githubInstallUrl(undefined, appSlug) });
-  }
+  // Always offer the GitHub account/org picker for installs we don't know about yet.
+  options.push({ kind: "picker", url: githubInstallUrl(undefined, appSlug) });
   return options;
 }
 
@@ -49,9 +83,10 @@ export function deriveOnboardingStep(
   return "ready";
 }
 
+/** Always surface cached install targets — Settings needs them after onboarding too. */
 export function installTargetsFromUserRow(
-  installPending: boolean,
+  _installPending: boolean,
   raw: string | null | undefined,
 ): InstallTarget[] {
-  return installPending ? parseInstallTargets(raw) : [];
+  return parseInstallTargets(raw);
 }

--- a/apps/api/src/auth/onboarding.ts
+++ b/apps/api/src/auth/onboarding.ts
@@ -84,9 +84,6 @@ export function deriveOnboardingStep(
 }
 
 /** Always surface cached install targets — Settings needs them after onboarding too. */
-export function installTargetsFromUserRow(
-  _installPending: boolean,
-  raw: string | null | undefined,
-): InstallTarget[] {
+export function installTargetsFromUserRow(raw: string | null | undefined): InstallTarget[] {
   return parseInstallTargets(raw);
 }

--- a/apps/app/src/auth/InstallGate.tsx
+++ b/apps/app/src/auth/InstallGate.tsx
@@ -7,40 +7,16 @@
  */
 
 import { OnboardingSteps } from "@/auth/OnboardingSteps";
+import { installOptionCopy } from "@/auth/installOptionCopy";
 import { installRefresh, useLogout } from "@/auth/useAuthMutations";
 import { ME_QUERY_KEY } from "@/auth/useMe";
 import { Button } from "@/components/ui/button";
 import { useT } from "@/i18n";
-import type { InstallOption, MePayload } from "@roxabi-live/shared";
+import type { MePayload } from "@roxabi-live/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const DEFAULT_FALLBACK = "/login?intent=install&redirect=%2F";
-
-function optionCopy(
-  opt: InstallOption,
-  t: (key: string) => string,
-): { title: string; name: string; hint: string } {
-  if (opt.kind === "picker") {
-    return {
-      title: t("auth.install.option.orgTitle"),
-      name: t("auth.install.option.pickerName"),
-      hint: t("auth.install.option.pickerHint"),
-    };
-  }
-  if (opt.kind === "personal") {
-    return {
-      title: t("auth.install.option.personalTitle"),
-      name: opt.login ?? "",
-      hint: t("auth.install.option.personalHint"),
-    };
-  }
-  return {
-    title: t("auth.install.option.orgTitle"),
-    name: opt.login ?? "",
-    hint: t("auth.install.option.orgHint"),
-  };
-}
 
 export function InstallGate({ me }: { me: MePayload }) {
   const t = useT();
@@ -112,7 +88,10 @@ export function InstallGate({ me }: { me: MePayload }) {
 
         <div className="space-y-2">
           {options.map((opt) => {
-            const c = optionCopy(opt, t);
+            const c = installOptionCopy(opt, t, {
+              personal: t("auth.install.option.personalHint"),
+              org: t("auth.install.option.orgHint"),
+            });
             return (
               <a
                 key={`${opt.kind}:${opt.login ?? "picker"}`}

--- a/apps/app/src/auth/SettingsDialog.tsx
+++ b/apps/app/src/auth/SettingsDialog.tsx
@@ -12,41 +12,21 @@
  */
 
 import { clearDisplayName, getDisplayName, setDisplayName } from "@/auth/displayName";
+import { installOptionCopy } from "@/auth/installOptionCopy";
 import { useLogout } from "@/auth/useAuthMutations";
+import { ME_QUERY_KEY } from "@/auth/useMe";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { type TFunc, useT } from "@/i18n";
+import { useT } from "@/i18n";
 import { type ApiError, apiFetch } from "@/lib/api";
 import { PassphraseChangeSection } from "@/zk/PassphraseChangeSection";
 import { hasEnrolledThisSession } from "@/zk/enroll";
 import { clearZkReauthProof, getZkReauthProof } from "@/zk/github";
 import { clearLocalZkState } from "@/zk/reset";
 import { requestSettingsReauth } from "@/zk/settingsReauth";
-import type { InstallOption, MePayload } from "@roxabi-live/shared";
-import { useMutation } from "@tanstack/react-query";
+import type { MePayload } from "@roxabi-live/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-
-function optionCopy(opt: InstallOption, t: TFunc): { title: string; name: string; hint: string } {
-  if (opt.kind === "picker") {
-    return {
-      title: t("auth.install.option.orgTitle"),
-      name: t("auth.install.option.pickerName"),
-      hint: t("auth.install.option.pickerHint"),
-    };
-  }
-  if (opt.kind === "personal") {
-    return {
-      title: t("auth.install.option.personalTitle"),
-      name: opt.login ?? "",
-      hint: t("settings.repos.addPersonalHint"),
-    };
-  }
-  return {
-    title: t("auth.install.option.orgTitle"),
-    name: opt.login ?? "",
-    hint: t("settings.repos.addOrgHint"),
-  };
-}
 
 export function SettingsDialog({
   me,
@@ -70,10 +50,29 @@ export function SettingsDialog({
   const login = me.user.github_login;
   const logout = useLogout();
   const t = useT();
+  const qc = useQueryClient();
   const [name, setName] = useState(() => getDisplayName(login));
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const installations = me.installations ?? [];
   const installOptions = me.install_options ?? [];
+
+  // Refresh /api/me when Settings opens or the user returns from a GitHub tab
+  // (configure / add-install open target=_blank).
+  useEffect(() => {
+    if (!open) return;
+    qc.invalidateQueries({ queryKey: ME_QUERY_KEY });
+    const onReturn = () => {
+      if (document.visibilityState === "visible") {
+        qc.invalidateQueries({ queryKey: ME_QUERY_KEY });
+      }
+    };
+    window.addEventListener("focus", onReturn);
+    document.addEventListener("visibilitychange", onReturn);
+    return () => {
+      window.removeEventListener("focus", onReturn);
+      document.removeEventListener("visibilitychange", onReturn);
+    };
+  }, [open, qc]);
 
   const deleteAccount = useMutation<{ redirected: boolean }, ApiError, void>({
     mutationFn: async () => {
@@ -197,7 +196,10 @@ export function SettingsDialog({
               <p className="text-xs text-muted-foreground">{t("settings.repos.addHint")}</p>
               <div className="space-y-2">
                 {installOptions.map((opt) => {
-                  const c = optionCopy(opt, t);
+                  const c = installOptionCopy(opt, t, {
+                    personal: t("settings.repos.addPersonalHint"),
+                    org: t("settings.repos.addOrgHint"),
+                  });
                   return (
                     <a
                       key={`${opt.kind}:${opt.login ?? "picker"}`}

--- a/apps/app/src/auth/SettingsDialog.tsx
+++ b/apps/app/src/auth/SettingsDialog.tsx
@@ -4,31 +4,48 @@
  * the reauth-gated delete (deferred from slice 7) are wired here in slice 10:
  * both privileged actions bounce through OAuth step-up via requestSettingsReauth
  * and resume on return (?settings=passphrase / ?settings=delete).
+ *
+ * Repositories: list linked installations with per-install "Configure" deep-links,
+ * plus install_options cards (personal / org / picker) to add another account —
+ * mirrors InstallGate so Settings is not a single link that lands on the only
+ * existing GitHub install.
  */
 
 import { clearDisplayName, getDisplayName, setDisplayName } from "@/auth/displayName";
 import { useLogout } from "@/auth/useAuthMutations";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { useT } from "@/i18n";
+import { type TFunc, useT } from "@/i18n";
 import { type ApiError, apiFetch } from "@/lib/api";
 import { PassphraseChangeSection } from "@/zk/PassphraseChangeSection";
 import { hasEnrolledThisSession } from "@/zk/enroll";
 import { clearZkReauthProof, getZkReauthProof } from "@/zk/github";
 import { clearLocalZkState } from "@/zk/reset";
 import { requestSettingsReauth } from "@/zk/settingsReauth";
-import type { MePayload } from "@roxabi-live/shared";
+import type { InstallOption, MePayload } from "@roxabi-live/shared";
 import { useMutation } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 
-function configureUrl(me: MePayload): string | null {
-  const opts = me.install_options ?? [];
-  return (
-    opts.find((o) => o.kind === "personal")?.url ??
-    opts.find((o) => o.kind === "picker")?.url ??
-    opts[0]?.url ??
-    null
-  );
+function optionCopy(opt: InstallOption, t: TFunc): { title: string; name: string; hint: string } {
+  if (opt.kind === "picker") {
+    return {
+      title: t("auth.install.option.orgTitle"),
+      name: t("auth.install.option.pickerName"),
+      hint: t("auth.install.option.pickerHint"),
+    };
+  }
+  if (opt.kind === "personal") {
+    return {
+      title: t("auth.install.option.personalTitle"),
+      name: opt.login ?? "",
+      hint: t("settings.repos.addPersonalHint"),
+    };
+  }
+  return {
+    title: t("auth.install.option.orgTitle"),
+    name: opt.login ?? "",
+    hint: t("settings.repos.addOrgHint"),
+  };
 }
 
 export function SettingsDialog({
@@ -55,8 +72,8 @@ export function SettingsDialog({
   const t = useT();
   const [name, setName] = useState(() => getDisplayName(login));
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const installUrl = configureUrl(me);
   const installations = me.installations ?? [];
+  const installOptions = me.install_options ?? [];
 
   const deleteAccount = useMutation<{ redirected: boolean }, ApiError, void>({
     mutationFn: async () => {
@@ -140,34 +157,68 @@ export function SettingsDialog({
           </p>
         </section>
 
-        <section className="space-y-2">
+        <section className="space-y-3">
           <h3 className="text-sm font-semibold text-foreground">{t("settings.repos.heading")}</h3>
-          <p className="text-xs text-muted-foreground">
-            {t("settings.repos.hint")}
-          </p>
+          <p className="text-xs text-muted-foreground">{t("settings.repos.hint")}</p>
+
           {installations.length ? (
-            <ul className="space-y-1 text-sm">
+            <ul className="space-y-2">
               {installations.map((i) => (
-                <li key={i.tenant_id} className="text-foreground">
-                  <strong>{i.account_login}</strong>{" "}
-                  <span className="text-muted-foreground">({i.account_type})</span>
+                <li
+                  key={i.tenant_id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border px-3 py-2 text-sm"
+                >
+                  <span className="text-foreground">
+                    <strong>{i.account_login}</strong>{" "}
+                    <span className="text-muted-foreground">({i.account_type})</span>
+                  </span>
+                  {i.configure_url ? (
+                    <a
+                      href={i.configure_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-primary underline-offset-4 hover:underline"
+                    >
+                      {t("settings.repos.configure")}
+                    </a>
+                  ) : null}
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="text-sm text-muted-foreground">
-              {t("settings.repos.empty")}
-            </p>
+            <p className="text-sm text-muted-foreground">{t("settings.repos.empty")}</p>
           )}
-          {installUrl && (
-            <a
-              href={installUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-block text-sm text-primary underline-offset-4 hover:underline"
-            >
-              {t("settings.repos.configure")}
-            </a>
+
+          {installOptions.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t("settings.repos.addHeading")}
+              </h4>
+              <p className="text-xs text-muted-foreground">{t("settings.repos.addHint")}</p>
+              <div className="space-y-2">
+                {installOptions.map((opt) => {
+                  const c = optionCopy(opt, t);
+                  return (
+                    <a
+                      key={`${opt.kind}:${opt.login ?? "picker"}`}
+                      href={opt.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block rounded-md border border-border p-3 transition-colors hover:border-primary hover:bg-card/60"
+                      data-testid={`settings-install-${opt.kind}`}
+                    >
+                      <span className="block text-xs uppercase tracking-wide text-muted-foreground">
+                        {c.title}
+                      </span>
+                      {c.name ? (
+                        <span className="block font-medium text-foreground">{c.name}</span>
+                      ) : null}
+                      <span className="block text-xs text-muted-foreground">{c.hint}</span>
+                    </a>
+                  );
+                })}
+              </div>
+            </div>
           )}
         </section>
 

--- a/apps/app/src/auth/SettingsDialog.tsx
+++ b/apps/app/src/auth/SettingsDialog.tsx
@@ -172,16 +172,16 @@ export function SettingsDialog({
                     <strong>{i.account_login}</strong>{" "}
                     <span className="text-muted-foreground">({i.account_type})</span>
                   </span>
-                  {i.configure_url ? (
-                    <a
-                      href={i.configure_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-primary underline-offset-4 hover:underline"
-                    >
-                      {t("settings.repos.configure")}
-                    </a>
-                  ) : null}
+                  <a
+                    href={i.configure_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={t("settings.repos.configureAria", { login: i.account_login })}
+                    data-testid={`settings-configure-${i.account_login}`}
+                    className="text-sm text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {t("settings.repos.configure")}
+                  </a>
                 </li>
               ))}
             </ul>
@@ -204,8 +204,8 @@ export function SettingsDialog({
                       href={opt.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="block rounded-md border border-border p-3 transition-colors hover:border-primary hover:bg-card/60"
-                      data-testid={`settings-install-${opt.kind}`}
+                      className="block rounded-md border border-border p-3 transition-colors hover:border-primary hover:bg-card/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      data-testid={`settings-install-${opt.kind}-${opt.login ?? "picker"}`}
                     >
                       <span className="block text-xs uppercase tracking-wide text-muted-foreground">
                         {c.title}

--- a/apps/app/src/auth/installOptionCopy.ts
+++ b/apps/app/src/auth/installOptionCopy.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared title/name/hint mapping for GitHub App install option cards.
+ * Used by InstallGate (onboarding) and SettingsDialog (add installation).
+ */
+
+import type { TFunc } from "@/i18n";
+import type { InstallOption } from "@roxabi-live/shared";
+
+export function installOptionCopy(
+  opt: InstallOption,
+  t: TFunc,
+  hints: { personal: string; org: string },
+): { title: string; name: string; hint: string } {
+  if (opt.kind === "picker") {
+    return {
+      title: t("auth.install.option.orgTitle"),
+      name: t("auth.install.option.pickerName"),
+      hint: t("auth.install.option.pickerHint"),
+    };
+  }
+  if (opt.kind === "personal") {
+    return {
+      title: t("auth.install.option.personalTitle"),
+      name: opt.login ?? "",
+      hint: hints.personal,
+    };
+  }
+  return {
+    title: t("auth.install.option.orgTitle"),
+    name: opt.login ?? "",
+    hint: hints.org,
+  };
+}

--- a/apps/app/src/dev/authFixture.ts
+++ b/apps/app/src/dev/authFixture.ts
@@ -44,18 +44,36 @@ export const fixtureMe: Record<"install" | "consent" | "ready" | "multiTenant", 
     ...base(),
     active_tenant_id: 1,
     install_pending: false,
-    installations: [{ tenant_id: 1, account_login: "roxabi", account_type: "Organization" }],
+    installations: [
+      {
+        tenant_id: 1,
+        account_login: "roxabi",
+        account_type: "Organization",
+        configure_url: "https://github.com/organizations/roxabi/settings/installations/1001",
+      },
+    ],
     onboarding_step: "consent",
   },
   ready: {
     ...base(),
     active_tenant_id: 1,
     install_pending: false,
-    installations: [{ tenant_id: 1, account_login: "roxabi", account_type: "Organization" }],
+    installations: [
+      {
+        tenant_id: 1,
+        account_login: "roxabi",
+        account_type: "Organization",
+        configure_url: "https://github.com/organizations/roxabi/settings/installations/1001",
+      },
+    ],
     install_options: [
       {
-        kind: "org",
-        login: "roxabi",
+        kind: "personal",
+        login: "octofleet",
+        url: "https://github.com/apps/roxabi-live/installations/new?target_id=4242&target_type=User",
+      },
+      {
+        kind: "picker",
         url: "https://github.com/apps/roxabi-live/installations/new",
       },
     ],
@@ -67,8 +85,24 @@ export const fixtureMe: Record<"install" | "consent" | "ready" | "multiTenant", 
     active_tenant_id: 1,
     install_pending: false,
     installations: [
-      { tenant_id: 1, account_login: "roxabi", account_type: "Organization" },
-      { tenant_id: 2, account_login: "octofleet", account_type: "User" },
+      {
+        tenant_id: 1,
+        account_login: "roxabi",
+        account_type: "Organization",
+        configure_url: "https://github.com/organizations/roxabi/settings/installations/1001",
+      },
+      {
+        tenant_id: 2,
+        account_login: "octofleet",
+        account_type: "User",
+        configure_url: "https://github.com/settings/installations/1002",
+      },
+    ],
+    install_options: [
+      {
+        kind: "picker",
+        url: "https://github.com/apps/roxabi-live/installations/new",
+      },
     ],
     onboarding_step: "ready",
     consent_at: "2026-06-25T10:00:00Z",

--- a/apps/app/src/i18n/en.ts
+++ b/apps/app/src/i18n/en.ts
@@ -33,9 +33,14 @@ export const en: Translations = {
     },
     repos: {
       heading: "Repositories",
-      hint: "Add or remove repositories that the GitHub App can access.",
+      hint: "Manage linked installations, or install the App on another account / organisation.",
       empty: "No linked installation yet.",
-      configure: "Configure repositories on GitHub",
+      configure: "Configure repositories",
+      addHeading: "Add an installation",
+      addHint:
+        "Pick a personal account, a known organisation, or the GitHub picker for another org.",
+      addPersonalHint: "Install on your personal repositories (or update existing access)",
+      addOrgHint: "Install on this organisation — all repositories or a selection",
     },
     deleteAccount: {
       heading: "Delete account",

--- a/apps/app/src/i18n/en.ts
+++ b/apps/app/src/i18n/en.ts
@@ -36,6 +36,7 @@ export const en: Translations = {
       hint: "Manage linked installations, or install the App on another account / organisation.",
       empty: "No linked installation yet.",
       configure: "Configure repositories",
+      configureAria: "Configure repositories for {login}",
       addHeading: "Add an installation",
       addHint:
         "Pick a personal account, a known organisation, or the GitHub picker for another org.",

--- a/apps/app/src/i18n/fr.ts
+++ b/apps/app/src/i18n/fr.ts
@@ -35,6 +35,7 @@ export const fr = {
       hint: "Gérez les installations liées, ou installez l'App sur un autre compte / organisation.",
       empty: "Aucune installation liée pour l'instant.",
       configure: "Configurer les dépôts",
+      configureAria: "Configurer les dépôts pour {login}",
       addHeading: "Ajouter une installation",
       addHint:
         "Choisissez un compte personnel, une organisation connue, ou le sélecteur GitHub pour une autre org.",

--- a/apps/app/src/i18n/fr.ts
+++ b/apps/app/src/i18n/fr.ts
@@ -32,9 +32,14 @@ export const fr = {
     },
     repos: {
       heading: "Dépôts",
-      hint: "Ajoutez ou retirez les dépôts auxquels l'App GitHub accède.",
+      hint: "Gérez les installations liées, ou installez l'App sur un autre compte / organisation.",
       empty: "Aucune installation liée pour l'instant.",
-      configure: "Configurer les dépôts sur GitHub",
+      configure: "Configurer les dépôts",
+      addHeading: "Ajouter une installation",
+      addHint:
+        "Choisissez un compte personnel, une organisation connue, ou le sélecteur GitHub pour une autre org.",
+      addPersonalHint: "Installer sur vos dépôts personnels (ou modifier l'accès existant)",
+      addOrgHint: "Installer sur cette organisation — tous les dépôts ou une sélection",
     },
     deleteAccount: {
       heading: "Supprimer le compte",

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -43,11 +43,7 @@ export function openSettings(me) {
   const displayName = getDisplayName(login);
   const themePref = getThemePref();
   const installations = me.installations ?? [];
-  const installUrl =
-    (me.install_options ?? []).find((o) => o.kind === "personal")?.url ??
-    (me.install_options ?? []).find((o) => o.kind === "picker")?.url ??
-    (me.install_options ?? [])[0]?.url ??
-    null;
+  const installOptions = me.install_options ?? [];
 
   gate.innerHTML = `
     <div class="settings-dialog" role="dialog" aria-modal="true" aria-labelledby="settings-title">
@@ -110,19 +106,42 @@ export function openSettings(me) {
 
         <section class="settings-section">
           <h3>Repositories</h3>
-          <p class="settings-hint">Add or remove repositories the GitHub App can access.</p>
+          <p class="settings-hint">Manage linked installations, or install the App on another account / organisation.</p>
           ${
             installations.length
               ? `<ul class="settings-list">${installations
-                  .map(
-                    (i) => `
-              <li><strong>${escHtml(i.account_login)}</strong> <span class="settings-muted">(${escHtml(i.account_type)})</span></li>
-            `,
-                  )
+                  .map((i) => {
+                    const cfg = i.configure_url
+                      ? `<a class="settings-link-btn" href="${escHtml(i.configure_url)}" target="_blank" rel="noopener noreferrer" aria-label="Configure repositories for ${escHtml(i.account_login)}">Configure</a>`
+                      : "";
+                    return `
+              <li class="settings-install-row">
+                <span><strong>${escHtml(i.account_login)}</strong> <span class="settings-muted">(${escHtml(i.account_type)})</span></span>
+                ${cfg}
+              </li>`;
+                  })
                   .join("")}</ul>`
               : '<p class="settings-muted">No installation linked yet.</p>'
           }
-          <a class="settings-link-btn" href="${escHtml(installUrl)}" target="_blank" rel="noopener noreferrer">Configure repositories on GitHub</a>
+          ${
+            installOptions.length
+              ? `<div class="settings-add-install">
+            <h4 class="settings-subhead">Add an installation</h4>
+            <p class="settings-hint">Pick a personal account, a known organisation, or the GitHub picker for another org.</p>
+            <ul class="settings-list">${installOptions
+              .map((opt) => {
+                const label =
+                  opt.kind === "picker"
+                    ? "Choose on GitHub"
+                    : opt.kind === "personal"
+                      ? `Personal · ${escHtml(opt.login ?? "")}`
+                      : `Organisation · ${escHtml(opt.login ?? "")}`;
+                return `<li><a class="settings-link-btn" href="${escHtml(opt.url)}" target="_blank" rel="noopener noreferrer">${label}</a></li>`;
+              })
+              .join("")}</ul>
+          </div>`
+              : ""
+          }
         </section>
 
         <section class="settings-section">

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -110,16 +110,13 @@ export function openSettings(me) {
           ${
             installations.length
               ? `<ul class="settings-list">${installations
-                  .map((i) => {
-                    const cfg = i.configure_url
-                      ? `<a class="settings-link-btn" href="${escHtml(i.configure_url)}" target="_blank" rel="noopener noreferrer" aria-label="Configure repositories for ${escHtml(i.account_login)}">Configure</a>`
-                      : "";
-                    return `
+                  .map(
+                    (i) => `
               <li class="settings-install-row">
                 <span><strong>${escHtml(i.account_login)}</strong> <span class="settings-muted">(${escHtml(i.account_type)})</span></span>
-                ${cfg}
-              </li>`;
-                  })
+                <a class="settings-link-btn" href="${escHtml(i.configure_url)}" target="_blank" rel="noopener noreferrer" aria-label="Configure repositories for ${escHtml(i.account_login)}">Configure</a>
+              </li>`,
+                  )
                   .join("")}</ul>`
               : '<p class="settings-muted">No installation linked yet.</p>'
           }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -148,6 +148,8 @@ export interface Installation {
   tenant_id: number;
   account_login: string;
   account_type: string;
+  /** GitHub URL to manage repos / uninstall for this installation. */
+  configure_url?: string;
 }
 
 export type OnboardingStep = "install" | "consent" | "ready";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -149,7 +149,7 @@ export interface Installation {
   account_login: string;
   account_type: string;
   /** GitHub URL to manage repos / uninstall for this installation. */
-  configure_url?: string;
+  configure_url: string;
 }
 
 export type OnboardingStep = "install" | "consent" | "ready";

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -9,7 +9,7 @@
 apps/api/src/sync/sync.test.ts  # 1758 lines — #180 integration harness for runSync; #216 structure-only (+biome reflow)
 apps/api/src/api/zk-key-backup.test.ts  # 506 lines — #216 backup API security + CAS/reauth tests; fp enforcement + atomic UPSERT tests
 apps/api/src/webhook/handlers.test.ts  # 945 lines — #180 webhook handler contract tests
-apps/api/src/auth/oauth.test.ts  # 1162 lines — #180 OAuth + install-pending; github-rest fallback test
+apps/api/src/auth/oauth.test.ts  # 1227 lines — #180 OAuth + install-pending; linked-path install_targets + orgs-fail non-replace tests
 apps/api/src/api/issues.test.ts  # 710 lines — #180 tenant-scoped issues API tests; #216 zk redaction
 apps/api/src/api/graph.test.ts  # 776 lines — tenant-scoped graph + zk + repo activity stats tests
 apps/api/src/migrations.test.ts  # 323 lines — schema tests incl. users.consent_at (0020)
@@ -17,4 +17,4 @@ apps/api/src/webhook/mutations.test.ts  # 587 lines — #180 webhook mutation te
 apps/api/src/webhook/handlers-app.test.ts  # 538 lines — #180 app lifecycle + sender→user_installations tests (+biome reflow)
 apps/api/src/auth/installToken.test.ts  # 470 lines — #180 install token + pagination tests
 apps/api/src/auth/session.test.ts  # 370 lines — #180 session + remember-me TTL tests
-apps/api/src/api/me.test.ts  # 335 lines — onboarding_step + install_options + suspended tenant filter tests
+apps/api/src/api/me.test.ts  # 385 lines — onboarding_step + install_options + configure_url + multi-install Settings tests


### PR DESCRIPTION
## Summary

- Settings no longer uses a single **Configure** link that opens the already-linked GitHub App install.
- Each linked installation gets a **Configure repositories** deep-link (GitHub install settings).
- **Add an installation** section lists install options: personal account, known orgs not yet installed, and the GitHub account/org picker.
- API keeps `install_targets_json` after first link, always returns `install_options` (with personal fallback from session), and refreshes targets on OAuth when installations already exist.
- `installation_id` is used server-side only to build `configure_url` (not raw-exported).

## Test plan

- [ ] Deploy to staging; open Settings on `app-staging.live.roxabi.dev`
- [ ] With one org linked: see that install + **Configure repositories** for it
- [ ] **Add an installation**: personal account card (if not installed) + **Choose on GitHub** picker
- [ ] Personal card deep-links with `target_id` / `target_type=User`
- [ ] Picker opens `…/installations/new` (select another org)
- [ ] After OAuth re-login, known orgs not yet installed appear as org cards
- [ ] Install on a second org → webhook/link → both installs listed with configure links
- [ ] Unit tests: `vitest` onboarding, me, oauth, link-install, github-install