### PR TITLE
ci: skip full CI on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}
 
 concurrency:
@@ -19,13 +20,14 @@ concurrency:
 
 jobs:
   ci:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install dependencies
         run: uv sync --frozen --group dev
@@ -43,6 +45,7 @@ jobs:
         run: uv run tools/license_check.py
 
   api:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -65,6 +68,7 @@ jobs:
         run: bun --filter @roxabi-live/api test
 
   app:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -87,6 +91,7 @@ jobs:
         run: bun --filter @roxabi-live/marketing build
 
   plugin:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
- Skip full CI jobs when `pull_request.draft` is true (WIP pushes no longer burn Actions minutes).
- Listen for `ready_for_review` so undrafting re-triggers CI.
- Leave secret-scan / pr-title / context-lint unchanged; `reviewed` stays the merge gate only.

## Test plan
- [ ] Open a draft PR → CI jobs show as skipped
- [ ] Mark ready for review → CI runs
- [ ] Push to a ready PR → CI still runs
- [ ] Push to main/staging → CI unchanged
