### PR TITLE
ci(landing): skip suite on processed PR merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 permissions:
   contents: read
+  checks: read
+  pull-requests: read
 
 env:
   NODE_VERSION: "22"
@@ -19,8 +21,39 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/staging' }}
 
 jobs:
+  # Processed PR merge → skip suite. Naked push → run suite.
+  # ~/projects/ssot/conventions.ssot.md § CI landing
+  classify:
+    name: Classify push
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      path: ${{ steps.out.outputs.path }}
+    steps:
+      - id: out
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          path=naked
+          prs="$(gh api "repos/${REPO}/commits/${SHA}/pulls")"
+          n="$(printf '%s' "$prs" | jq --arg sha "$SHA" '[.[] | select(.merged == true and .merge_commit_sha == $sha)] | length')"
+          if [ "$n" -gt 0 ]; then
+            head="$(printf '%s' "$prs" | jq -r --arg sha "$SHA" '[.[] | select(.merged == true and .merge_commit_sha == $sha)][0].head.sha')"
+            conc="$(gh api --paginate "repos/${REPO}/commits/${head}/check-runs" --jq '[.check_runs[] | select((.name | ascii_downcase) == "ci") | .conclusion] | map(select(. == "success")) | if length > 0 then "success" else "missing" end')"
+            if [ "$conc" = "success" ]; then
+              path=pr-merge
+            fi
+          fi
+          echo "path=${path}" >> "$GITHUB_OUTPUT"
+          echo "landing path: ${path}"
+
   ci:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [classify]
+    if: always() && !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'push' || needs.classify.outputs.path == 'naked')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -45,7 +78,8 @@ jobs:
         run: uv run tools/license_check.py
 
   api:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [classify]
+    if: always() && !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'push' || needs.classify.outputs.path == 'naked')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -68,7 +102,8 @@ jobs:
         run: bun --filter @roxabi-live/api test
 
   app:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [classify]
+    if: always() && !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'push' || needs.classify.outputs.path == 'naked')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -91,7 +126,8 @@ jobs:
         run: bun --filter @roxabi-live/marketing build
 
   plugin:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [classify]
+    if: always() && !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'push' || needs.classify.outputs.path == 'naked')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/context-lint.yml
+++ b/.github/workflows/context-lint.yml
@@ -19,10 +19,42 @@ on:
 
 permissions:
   contents: read
+  checks: read
+  pull-requests: read
 
 jobs:
+  classify:
+    name: Classify push
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      path: ${{ steps.out.outputs.path }}
+    steps:
+      - id: out
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          path=naked
+          prs="$(gh api "repos/${REPO}/commits/${SHA}/pulls")"
+          n="$(printf '%s' "$prs" | jq --arg sha "$SHA" '[.[] | select(.merged == true and .merge_commit_sha == $sha)] | length')"
+          if [ "$n" -gt 0 ]; then
+            head="$(printf '%s' "$prs" | jq -r --arg sha "$SHA" '[.[] | select(.merged == true and .merge_commit_sha == $sha)][0].head.sha')"
+            conc="$(gh api --paginate "repos/${REPO}/commits/${head}/check-runs" --jq '[.check_runs[] | select((.name | ascii_downcase) == "ci") | .conclusion] | map(select(. == "success")) | if length > 0 then "success" else "missing" end')"
+            if [ "$conc" = "success" ]; then
+              path=pr-merge
+            fi
+          fi
+          echo "path=${path}" >> "$GITHUB_OUTPUT"
+          echo "landing path: ${path}"
+
   context-lint:
     name: Context lint
+    needs: [classify]
+    if: always() && !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'push' || needs.classify.outputs.path == 'naked')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,6 +2,8 @@ name: Secret Scan
 
 permissions:
   contents: read
+  checks: read
+  pull-requests: read
 
 on:
   push:
@@ -15,7 +17,37 @@ concurrency:
   cancel-in-progress: false   # never preempt a security scan
 
 jobs:
+  classify:
+    name: Classify push
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      path: ${{ steps.out.outputs.path }}
+    steps:
+      - id: out
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          path=naked
+          prs="$(gh api "repos/${REPO}/commits/${SHA}/pulls")"
+          n="$(printf '%s' "$prs" | jq --arg sha "$SHA" '[.[] | select(.merged == true and .merge_commit_sha == $sha)] | length')"
+          if [ "$n" -gt 0 ]; then
+            head="$(printf '%s' "$prs" | jq -r --arg sha "$SHA" '[.[] | select(.merged == true and .merge_commit_sha == $sha)][0].head.sha')"
+            conc="$(gh api --paginate "repos/${REPO}/commits/${head}/check-runs" --jq '[.check_runs[] | select((.name | ascii_downcase) == "ci") | .conclusion] | map(select(. == "success")) | if length > 0 then "success" else "missing" end')"
+            if [ "$conc" = "success" ]; then
+              path=pr-merge
+            fi
+          fi
+          echo "path=${path}" >> "$GITHUB_OUTPUT"
+          echo "landing path: ${path}"
+
   trufflehog:
+    needs: [classify]
+    if: always() && !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'push' || needs.classify.outputs.path == 'naked')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary
- Job `classify` on `ci.yml` / `secret-scan.yml` / `context-lint.yml`: processed PR merge → skip suite; naked push → run suite.
- Policy: `~/projects/ssot/conventions.ssot.md` § CI landing. Pilot: Roxabi/roxabi-plugins #412.

## Test plan
- [ ] PR CI still runs the suite (classify skipped on `pull_request`)
- [ ] After merge, push run: `classify` → `path=pr-merge`, suite skipped
- [ ] Ruleset follow-up: required check `ci`, strict, bypass=[]